### PR TITLE
fix: better elixir/erlang install steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,25 @@ Once elixir is available, all server dependencies are managed via docker-compose
 
 ```sh
 make testup
+mix local.hex
+mix deps.get
 mix test
 ```
 
+### Troubleshooting
+#### Installing Erlang 
+If `asdf install` fails with `cannot find required auxiliary files: install-sh config.guess config.sub` then run:
 
+```sh
+brew install autoconf@2.69 && \
+brew link --overwrite autoconf@2.69 && \
+autoconf -V
+```
 
+For Mac Machines, if unable to download Erlang via `asdf` then run:
+
+```sh
+brew install erlang@23
+cp -r /opt/homebrew/opt/erlang@23/lib/erlang ~/.asdf/installs/erlang/23.1.5
+asdf reshim erlang 23.1.5
+```


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you with us! -->

## Summary
The README explanation of compilation of tests is missing a few steps. Also added troubleshooting for cases in which our version of erlang breaks because of systems with an unsupported version of Openssl

## Test Plan
No relevant change to tests

## Checklist
- [X] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.