### PR TITLE
Auto-Create Incidents on failed console builds

### DIFF
--- a/lib/console/graphql/helpers.ex
+++ b/lib/console/graphql/helpers.ex
@@ -1,6 +1,4 @@
 defmodule Console.GraphQl.Helpers do
-  import Absinthe.Resolution.Helpers
-
   def resolve_changeset(%Ecto.Changeset{errors: errors}) do
     Enum.map(errors, fn {field, {msg, _}} -> "#{field} #{msg}" end)
   end

--- a/lib/console/graphql/middleware/allow_jwt.ex
+++ b/lib/console/graphql/middleware/allow_jwt.ex
@@ -1,6 +1,5 @@
 defmodule Console.Middleware.AllowJwt do
   @behaviour Absinthe.Middleware
-  alias Console.Schema.User
 
   def call(%{context: ctx} = res, _config), do: %{res | context: Map.put(ctx, :allow_jwt, true)}
 end

--- a/lib/console/graphql/resolvers/user.ex
+++ b/lib/console/graphql/resolvers/user.ex
@@ -43,7 +43,7 @@ defmodule Console.GraphQl.Resolvers.User do
   end
 
   defp oidc_uri(args) do
-    OpenIDConnect.authorization_uri(:plural, hydrate_redirect_uri(%{state: state_token}, args))
+    OpenIDConnect.authorization_uri(:plural, hydrate_redirect_uri(%{state: state_token()}, args))
   end
 
   defp state_token() do

--- a/lib/console/guardian.ex
+++ b/lib/console/guardian.ex
@@ -28,6 +28,6 @@ defmodule Console.Guardian do
     |> Console.Services.Rbac.preload()
   end
 
-  def allow(%User{} = user), do: true
+  def allow(%User{}), do: true
   def allow(_), do: false
 end

--- a/lib/console/pubsub/protocols/recurse.ex
+++ b/lib/console/pubsub/protocols/recurse.ex
@@ -44,6 +44,8 @@ defimpl Console.PubSub.Recurse, for: Console.PubSub.BuildFailed do
     |> Console.Repo.update_all(set: [completed_at: DateTime.utc_now(), exit_code: 1])
     |> elem(1)
     |> Enum.each(&Broadcaster.notify(%CommandCompleted{item: &1}))
+
+    Console.Services.Builds.failed_incident(build)
   end
 end
 

--- a/lib/console/schema/command.ex
+++ b/lib/console/schema/command.ex
@@ -28,7 +28,7 @@ defmodule Console.Schema.Command do
 
     def into(command) do
       {command, fn
-        %{stdout: stdo} = command, {:cont, line} when is_binary(line) ->
+        %{stdout: _} = command, {:cont, line} when is_binary(line) ->
           IO.write(line)
           maybe_persist(command, line)
           |> Base.broadcast(:update)

--- a/lib/console/services/observability.ex
+++ b/lib/console/services/observability.ex
@@ -25,11 +25,11 @@ defmodule Console.Services.Observability do
     vpa_name = vpa_name(kind, namespace, name)
     case Client.get_vertical_pod_autoscaler(namespace, vpa_name) do
       {:ok, result} -> {:ok, result}
-      _ -> Client.create_vertical_pod_autoscaler(namespace, vpa_name, vpa_template(kind, namespace, name))
+      _ -> Client.create_vertical_pod_autoscaler(namespace, vpa_name, vpa_template(kind, name))
     end
   end
 
-  defp vpa_template(kind, namespace, name) do
+  defp vpa_template(kind, name) do
     %VerticalPodAutoscaler{
       spec: %VerticalPodAutoscaler.Spec{
         update_policy: %VerticalPodAutoscaler.UpdatePolicy{update_mode: "Off"},


### PR DESCRIPTION
## Summary

We want visibility into the failure of deployments via the console, creating incidents is a quick way to do this, and we likely should create a dedicated way to track this as well in app.plural.sh

## Test Plan
Added unit testing

## Checklist
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

Close #44 