### PR TITLE
Allow for multi-url recipes to be used for installation

### DIFF
--- a/lib/console/plural/models.ex
+++ b/lib/console/plural/models.ex
@@ -19,7 +19,7 @@ defmodule Console.Plural.Repository do
 end
 
 defmodule Console.Plural.OIDCSettings do
-  defstruct [:authMethod, :domainKey, :uriFormat, :subdomain]
+  defstruct [:authMethod, :domainKey, :uriFormat, :uriFormats, :subdomain]
 end
 
 defmodule Console.Plural.ProviderBinding do

--- a/lib/console/plural/queries.ex
+++ b/lib/console/plural/queries.ex
@@ -55,6 +55,7 @@ defmodule Console.Plural.Queries do
       oidcSettings {
         domainKey
         uriFormat
+        uriFormats
         authMethod
         subdomain
       }


### PR DESCRIPTION
## Summary
This provides console support for multi-url oidc setup

## Test Plan
Regression on existing unit tests


## Checklist

- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.