### PR TITLE
Add release notes template for automatic release generation.

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+# This is the release notes template that helps automatically generate our releases from labels.
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - plural-bot
+      - renovate
+      - dependabot
+  categories:
+    - title: Breaking Changes ⚠️
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - bug-fix


### PR DESCRIPTION
## Main Changes
Added a YML file that lets GitHub automatically write our release notes / changelogs for us, excluding bots and only including PRs with the `enhancement`, `bug-fix`, or `breaking-change` labels.