### PR TITLE
Handle console migration wait flakiness

### DIFF
--- a/lib/console/services/plural.ex
+++ b/lib/console/services/plural.ex
@@ -5,6 +5,8 @@ defmodule Console.Services.Plural do
   alias Kube.Application
   use Nebulex.Caching
 
+  @ttl Nebulex.Time.expiry_time(1, :hour)
+
   @decorate cacheable(cache: Console.Cache, key: {:app, name}, opts: [ttl: @ttl], match: &allow/1)
   def application(name) do
     Kube.Client.get_application(name)

--- a/plural/helm/console/Chart.yaml
+++ b/plural/helm/console/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "0.2.0"
 description: A chart for plural console
 name: console
-version: 0.7.11
+version: 0.7.12

--- a/plural/helm/console/templates/deployment.yaml
+++ b/plural/helm/console/templates/deployment.yaml
@@ -1,12 +1,11 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: console
   labels:
 {{ include "console.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  serviceName: console-headless
   selector:
     matchLabels:
       app.kubernetes.io/name: console
@@ -32,12 +31,10 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.shutdownDelay }}
       initContainers:
-      - name: wait-for-migration
-        image: gcr.io/pluralsh/groundnuty/k8s-wait-for:v1.3
-        imagePullPolicy: Always
-        args:
-        - job
-        - {{ include "console.migration-name" . }}
+      - name: wait-for-pg
+        image: gcr.io/pluralsh/busybox:latest
+        imagePullPolicy: IfNotPresent
+        command: [ "/bin/sh", "-c", "until nc -zv plural-console 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: console
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/plural/helm/console/values.yaml
+++ b/plural/helm/console/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: dkr.plural.sh/console/console
-  tag: '0.2.1' ## PLRL-REPLACE[  tag: '%s']
+  tag: '0.2.2' ## PLRL-REPLACE[  tag: '%s']
   pullPolicy: Always
 
 serviceAccount:

--- a/rel/config/console.exs
+++ b/rel/config/console.exs
@@ -22,7 +22,7 @@ config :libcluster,
       config: [
         mode: :ip,
         kubernetes_node_basename: "console",
-        kubernetes_selector: "app.kubernetes.io/name=console",
+        kubernetes_selector: "app=console",
         kubernetes_namespace: get_env("NAMESPACE"),
         polling_interval: 10_000
       ]


### PR DESCRIPTION
## Summary

There are a few issues with the way the console is currently deployed.

* we explicitly wait for migration jobs to complete, which is fine on first deploy, but can become an issue if a console pod is killed later and the job is reaped beforehand
* we use statefulsets which were necessary when attempting to implement leader election, but a constant headache when these restarts hit

This replaces the migration wait with a pg wait and replaces the statefulset with a deployment

## Test Plan
ran against our cluster using `plural link`


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.