### PR TITLE
remoce oidc redirect uri templating

### DIFF
--- a/plural/repository.yaml
+++ b/plural/repository.yaml
@@ -6,7 +6,7 @@ darkIcon: plural/icons/console-white.png
 notes: plural/notes.tpl
 gitUrl: https://github.com/pluralsh/console
 oauthSettings:
-  uriFormat: https://{domain}/oauth/callback
+  uriFormat: "{domain}"
   authMethod: POST
 tags:
 - tag: kubernetes


### PR DESCRIPTION
## Summary
When testing locally we need more flexibility in terms of the allowed redirect URIs for the console OIDC provider. This PR enables us to be more flexible allowing any input.
