### PR TITLE
Show error message on restricted recipe console installs

### DIFF
--- a/assets/src/components/graphql/plural.js
+++ b/assets/src/components/graphql/plural.js
@@ -38,6 +38,7 @@ export const RecipeFragment = gql`
     id
     name
     description
+    restricted
     provider
     oidcEnabled
   }

--- a/assets/src/components/repos/Configuration.js
+++ b/assets/src/components/repos/Configuration.js
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery } from 'react-apollo'
 import { Box, Text, TextInput, ThemeContext } from 'grommet'
-import { Button, GqlError, SecondaryButton } from 'forge-core'
+import { Alert, AlertStatus, Button, GqlError, SecondaryButton } from 'forge-core'
 
 import Toggle from 'react-toggle'
 
@@ -481,11 +481,25 @@ function RecipeConfiguration({ recipe, context: ctx, setOpen }) {
 
 const buildContext = contexts => contexts.reduce((acc, { repository, context }) => ({ ...acc, [repository]: context }), {})
 
+function RestrictedRecipe() {
+  return (
+    <Box pad="small">
+      <Alert 
+        status={AlertStatus.ERROR}
+        header="Cannot install recipe"
+        description="This recipe has been marked restricted because it requires configuration, like ssh keys, that are only able to be securely configured locally"
+      />
+    </Box>
+  )
+}
+
 export function Configuration({ recipe, setOpen }) {
   const { data } = useQuery(RECIPE_Q, {
     variables: { id: recipe.id },
     fetchPolicy: 'cache-and-network',
   })
+
+  const { restricted } = recipe
 
   return (
     <Box
@@ -500,7 +514,8 @@ export function Configuration({ recipe, setOpen }) {
         fill
         style={{ minHeight: '150px' }}
       >
-        {data && (
+        {restricted && <RestrictedRecipe />}
+        {data && !restricted && (
           <RecipeConfiguration 
             recipe={data.recipe} 
             context={buildContext(data.context)} 

--- a/assets/src/setupProxy.js
+++ b/assets/src/setupProxy.js
@@ -1,7 +1,7 @@
 const { createProxyMiddleware } = require('http-proxy-middleware')
 
 const proxy = createProxyMiddleware({
-  target: process.env.BASE_URL || 'https://console.kubeflow-aws.com',
+  target: process.env.BASE_URL || 'https://console.plural.sh',
   changeOrigin: true,
   ws: true,
 })


### PR DESCRIPTION
## Summary

We have the ability to block difficult recipes from being installed in the console but currently didn't wire it up.  This shows the appropriate error when that is attempted.


## Test Plan
verified with `make web`


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.