### PR TITLE
Auto populate empty configuration in recipe install

### DIFF
--- a/assets/src/components/repos/Configuration.js
+++ b/assets/src/components/repos/Configuration.js
@@ -399,6 +399,10 @@ function RecipeConfiguration({ recipe, context: ctx, setOpen }) {
     })
   ), [setContext, context, repository, ind])
 
+  useEffect(() => {
+    if (!(repository.name in context)) setContext({ ...context, [repository.name]: {} })
+  }, [setContext, repository, context])
+
   const next = useCallback(() => {
     if (!hasNext) return mutation()
     const nextInd = findIndex(ind + 1, context, sections)


### PR DESCRIPTION
## Summary

We need to at least always provide an empty map when installing recipes, otherwise plural build will trip up



## Test Plan
tested locally


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.