### PR TITLE
run plural apply on pushes to master

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -104,24 +104,3 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
       if: always()
-  deploy:
-    runs-on: ubuntu-latest
-    needs: publish
-    steps:
-    - uses: actions/checkout@v2
-    - uses: hashicorp/setup-terraform@v1
-    - uses: azure/setup-helm@v1
-      with:
-        version: latest
-    - name: installing plural
-      uses: pluralsh/setup-plural@v0.1.2
-      with:
-        config: ${{ secrets.PLURAL_CONF }}
-    - run: make deploy
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        fields: workflow,job,repo,message,commit,author
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
-      if: always()

--- a/.github/workflows/push-to-plural.yaml
+++ b/.github/workflows/push-to-plural.yaml
@@ -1,0 +1,30 @@
+name: CD / Console
+
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "plural/**"
+jobs:
+  deploy:
+    name: Push Console artifact to Plural
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: hashicorp/setup-terraform@v1
+    - uses: azure/setup-helm@v1
+      with:
+        version: latest
+    - name: installing plural
+      uses: pluralsh/setup-plural@v0.1.2
+      with:
+        config: ${{ secrets.PLURAL_CONF }}
+    - run: make deploy
+    - uses: 8398a7/action-slack@v3
+      with:
+        status: ${{ job.status }}
+        fields: workflow,job,repo,message,commit,author
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
+      if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 jobs:
   build:
-    name: Build Docker image
+    name: Test Build Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
With the new Release process `plural apply` was only set to run when new git tags are created. However, that workflow is mainly aimed at creating a new build of the console and not the necessarily the artifact (which Renovate will do). So `plural apply` should be run on the master branch when the plural artifact is updated with the new container tag.