### PR TITLE
add action to generate github release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,10 +4,6 @@ changelog:
   exclude:
     labels:
       - ignore-for-release
-    authors:
-      - plural-bot
-      - renovate
-      - dependabot
   categories:
     - title: Breaking Changes ⚠️
       labels:
@@ -18,3 +14,9 @@ changelog:
     - title: Bug Fixes 🐛
       labels:
         - bug-fix
+    - title: Dependency Updates
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -109,3 +109,17 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
       if: always()
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+      discussions: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        generate_release_notes: true


### PR DESCRIPTION
## Summary
Adds an action to create a GitHub release when a new release tag is created.


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.