### PR TITLE
fix dockerfile for renovate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ ENV TERRAFORM_VERSION=v1.2.7
 # renovate: datasource=github-releases depName=pluralsh/plural-cli
 ENV CLI_VERSION=v0.4.9
 
-# renovate: datasource=github-tags depName=kubernetes/kubectl
+# renovate: datasource=github-tags depName=kubernetes/kubernetes
 ENV KUBECTL_VERSION=v1.24.3
 
 RUN apk add --update --no-cache curl ca-certificates unzip wget openssl build-base && \


### PR DESCRIPTION
## Summary
Changes the dockerfile so Renovate gets the kubectl version from the kubernetes repository since the kubectl repo doesn't have good tagging.

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.