### PR TITLE
Bump logs fetch limit to help loki

### DIFF
--- a/assets/src/components/Logs.js
+++ b/assets/src/components/Logs.js
@@ -32,6 +32,7 @@ import { LOG_FILTER_Q } from './graphql/plural'
 import { AnsiLine } from './utils/AnsiText'
 
 const POLL_INTERVAL = 10 * 1000
+const LIMIT = 1000
 
 const Level = {
   ERROR: 'e',
@@ -332,7 +333,7 @@ export default function Logs({ application: { name }, query }) {
   const [loader, setLoader] = useState(null)
 
   const { data, loading, fetchMore, refetch } = useQuery(LOGS_Q, {
-    variables: { query },
+    variables: { query, limit: LIMIT },
     pollInterval: live ? POLL_INTERVAL : 0,
   })
 

--- a/assets/src/components/graphql/dashboards.js
+++ b/assets/src/components/graphql/dashboards.js
@@ -69,8 +69,8 @@ export const DASHBOARD_Q = gql`
 `
 
 export const LOGS_Q = gql`
-  query Logs($query: String!, $start: Long) {
-    logs(query: $query, start: $start, limit: 200) {
+  query Logs($query: String!, $start: Long, $limit: Int!) {
+    logs(query: $query, start: $start, limit: $limit) {
       ...LogStreamFragment
     }
   }


### PR DESCRIPTION
## Summary

Loki in distributed mode is pretty slow, fetching a lot at once will help reduce total query count and keep it relatively sane

## Test Plan
local


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.