### PR TITLE
Add better templating for repo encryption key

### DIFF
--- a/plural/helm/console/Chart.yaml
+++ b/plural/helm/console/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.3.4
+appVersion: 0.3.6
 description: A chart for plural console
 name: console
 version: 0.7.27

--- a/plural/helm/console/values.yaml
+++ b/plural/helm/console/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 
 image:
   repository: dkr.plural.sh/console/console
-  tag: '0.3.4' ## PLRL-REPLACE[  tag: '%s']
+  tag: '0.3.6' ## PLRL-REPLACE[  tag: '%s']
   pullPolicy: IfNotPresent
 
 serviceAccount:

--- a/plural/helm/console/values.yaml.tpl
+++ b/plural/helm/console/values.yaml.tpl
@@ -68,9 +68,8 @@ secrets:
   identity: {{ readFile $identity | quote }}
 {{ else if ne (dig "console" "secrets" "identity" "default" .) "default" }}
   identity: {{ .console.secrets.identity | quote }}
-{{ else }}
-  key: {{ readFile (homeDir ".plural" "key") | quote }}
 {{ end }}
+  key: {{ dedupe . "console.secrets.key" (readFile (homeDir ".plural" "key")) | quote }}
 {{ else }}
   git_url: ''
   repo_root: ''


### PR DESCRIPTION
## Summary

If you've shared a repo, we don't template in the enc key anymore, which can be a weird state if someone's shared prior to a deploy


## Test Plan
local link


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.