### PR TITLE
fix: CI by reading .tool-versions and pin ubuntu

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   e2e:
     name: End-to-end test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CYPRESS_EMAIL: ${{ secrets.CYPRESS_EMAIL }}
       CYPRESS_PASSWORD: ${{ secrets.CYPRESS_PASSWORD }}
@@ -50,7 +50,7 @@ jobs:
 
   test:
     name: Unit test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
@@ -64,7 +64,7 @@ jobs:
       - run: yarn test
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       security-events: write
     name: CodeQL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -6,7 +6,7 @@ name: Deploy to Firebase Hosting on PR
 jobs:
   build_and_preview:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} && ${{ github.actor != 'plural-bot' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: cd assets && yarn install --immutable && CI=false yarn build

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   label:
     name: Check that PR has required labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: mheap/github-action-required-labels@v2
         with:

--- a/.github/workflows/publish-cypress.yaml
+++ b/.github/workflows/publish-cypress.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   publish:
     name: Build and push Console container
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,13 +6,13 @@ on:
       - 'v*.*.*'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.11.4' # Define the elixir version [required]
-          otp-version: '23.1' # Define the OTP version [required]
+          version-file: .tool-versions
+          version-type: strict
       - uses: azure/setup-helm@v3
         with:
           version: latest
@@ -40,7 +40,7 @@ jobs:
         if: always()
   publish:
     name: Build and push Console container
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: test
     permissions:
       contents: 'read'
@@ -111,7 +111,7 @@ jobs:
       if: always()
   release:
     name: Create GitHub release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: publish
     permissions:
       contents: write

--- a/.github/workflows/push-to-plural.yaml
+++ b/.github/workflows/push-to-plural.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     name: Push Console artifact to Plural
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Test Build Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,13 +26,13 @@ jobs:
           build-args: GIT_COMMIT=${{ github.sha }}
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.11.4' # Define the elixir version [required]
-          otp-version: '23.1' # Define the OTP version [required]
+          version-file: .tool-versions
+          version-type: strict
       - uses: azure/setup-helm@v3
         with:
           version: latest

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 23.3
-elixir 1.11.0
+elixir 1.11.4


### PR DESCRIPTION
## Summary
The setup of Erlang 23 will fail if `ubuntu-latest` is used in the actions. This PR pins the ubuntu version for all the tests so they are consistent. It also has the CI setup Erlang and Elixir based on the `.tool-versions` file, so that the version run by CI is consistent with the version used during development.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.