### PR TITLE
Refactor deployer and runner

### DIFF
--- a/lib/console/deployer.ex
+++ b/lib/console/deployer.ex
@@ -1,9 +1,10 @@
 defmodule Console.Deployer do
   use GenServer
-  alias Console.Commands.{Plural, Command}
+  import Console.Deployer.Operations
+
+  alias Console.Commands.Command
   alias Console.Services.{Builds, Users, LeaderElection}
   alias Console.Schema.Build
-  alias Console.Plural.Context
   require Logger
 
   @poll_interval 10_000
@@ -149,64 +150,6 @@ defmodule Console.Deployer do
     :ok
   end
 
-  defp perform(storage, %Build{repository: repo, type: :bounce} = build) do
-    with_build(build, [{storage, :init, []}, {Plural, :bounce, [repo]}], storage)
-  end
-
-  defp perform(storage, %Build{type: :deploy, repository: repo, message: message} = build) do
-    with_build(build, [
-      {storage, :init, []},
-      {Plural, :build, [repo]},
-      {Plural, :diff, [repo]},
-      {Plural, :deploy, [repo]},
-      {storage, :revise, [commit_message(message, repo)]},
-      {storage, :push, []}
-    ], storage)
-  end
-
-  defp perform(storage, %Build{type: :destroy, repository: repo} = build) do
-    with_build(build, [
-      {storage, :init, []},
-      {Plural, :destroy, [repo]},
-      {storage, :revise, ["destroyed application #{repo}"]},
-      {storage, :push, []}
-    ], storage)
-  end
-
-  defp perform(storage, %Build{type: :install, context: %{"configuration" => conf, "bundle" => b}, message: message} = build) do
-    with_build(build, [
-      {storage, :init, []},
-      {Context, :merge, [conf, %Context.Bundle{repository: b["repository"], name: b["name"]}]},
-      {Plural, :build, []},
-      {Plural, :install, [b["repository"]]},
-      {storage, :revise, [commit_message(message, b["repository"])]},
-      {storage, :push, []}
-    ], storage)
-  end
-
-  defp perform(storage, %Build{type: :install, context: %{"configuration" => conf, "bundles" => bs} = ctx, message: message} = build) do
-    with_build(build, [
-      {storage, :init, []},
-      {Context, :merge, [conf, Enum.map(bs, fn b -> %Context.Bundle{repository: b["repository"], name: b["name"]} end), ctx["buckets"], ctx["domains"]]},
-      {Plural, :build, []},
-      {Plural, :install, [Enum.map(bs, & &1["repository"])]},
-      {storage, :revise, [message]},
-      {storage, :push, []}
-    ], storage)
-  end
-
-  defp perform(storage, %Build{type: :approval, repository: repo, message: message} = build) do
-    with_build(build, [
-      {storage, :init, []},
-      {Plural, :build, [repo]},
-      {Plural, :diff, [repo]},
-      :approval,
-      {Plural, :deploy, [repo]},
-      {storage, :revise, [commit_message(message, repo)]},
-      {storage, :push, []}
-    ], storage)
-  end
-
   defp update(storage, repo, content, tool, msg) do
     Command.set_build(nil)
     bot = Users.get_bot!("console")
@@ -223,14 +166,6 @@ defmodule Console.Deployer do
       do: {:ok, res}
   end
 
-  defp with_build(%Build{} = build, operations, storage) do
-    {:ok, pid} = Console.Runner.start_link(build, operations, storage)
-    Swarm.register_name(build.id, pid)
-    Console.Runner.register(pid)
-    ref = Process.monitor(pid)
-    {pid, ref}
-  end
-
   defp ping(%State{build: %Build{} = build} = state) do
     case Builds.ping(build) do
       {:ok, build} -> %{state | build: build}
@@ -244,7 +179,4 @@ defmodule Console.Deployer do
     |> Enum.filter(& &1 != self())
     |> Enum.each(&GenServer.cast(&1, msg))
   end
-
-  defp commit_message(nil, repo), do: "console deployment for #{repo}"
-  defp commit_message(message, repo), do: "console deployment for #{repo} -- #{message}"
 end

--- a/lib/console/deployer/operations.ex
+++ b/lib/console/deployer/operations.ex
@@ -1,0 +1,77 @@
+defmodule Console.Deployer.Operations do
+  alias Console.Schema.Build
+  alias Console.Commands.{Plural}
+  alias Console.Plural.Context
+
+  def perform(storage, %Build{repository: repo, type: :bounce} = build) do
+    with_build(build, [
+      {storage, :init, []},
+      {Plural, :bounce, [repo]}
+    ], storage)
+  end
+
+  def perform(storage, %Build{type: :deploy, repository: repo, message: message} = build) do
+    with_build(build, [
+      {storage, :init, []},
+      {Plural, :build, [repo]},
+      {Plural, :diff, [repo]},
+      {Plural, :deploy, [repo]},
+      {storage, :revise, [commit_message(message, repo)]},
+      {storage, :push, []}
+    ], storage)
+  end
+
+  def perform(storage, %Build{type: :install, context: %{"configuration" => conf, "bundle" => b}, message: message} = build) do
+    with_build(build, [
+      {storage, :init, []},
+      {Context, :merge, [conf, %Context.Bundle{repository: b["repository"], name: b["name"]}]},
+      {Plural, :build, []},
+      {Plural, :install, [b["repository"]]},
+      {storage, :revise, [commit_message(message, b["repository"])]},
+      {storage, :push, []}
+    ], storage)
+  end
+
+  def perform(storage, %Build{type: :install, context: %{"configuration" => conf, "bundles" => bs} = ctx, message: message} = build) do
+    with_build(build, [
+      {storage, :init, []},
+      {Context, :merge, [conf, Enum.map(bs, fn b -> %Context.Bundle{repository: b["repository"], name: b["name"]} end), ctx["buckets"], ctx["domains"]]},
+      {Plural, :build, []},
+      {Plural, :install, [Enum.map(bs, & &1["repository"])]},
+      {storage, :revise, [message]},
+      {storage, :push, []}
+    ], storage)
+  end
+
+  def perform(storage, %Build{type: :approval, repository: repo, message: message} = build) do
+    with_build(build, [
+      {storage, :init, []},
+      {Plural, :build, [repo]},
+      {Plural, :diff, [repo]},
+      :approval,
+      {Plural, :deploy, [repo]},
+      {storage, :revise, [commit_message(message, repo)]},
+      {storage, :push, []}
+    ], storage)
+  end
+
+  def perform(storage, %Build{type: :destroy, repository: repo} = build) do
+    with_build(build, [
+      {storage, :init, []},
+      {Plural, :destroy, [repo]},
+      {storage, :revise, ["destroyed application #{repo}"]},
+      {storage, :push, []}
+    ], storage)
+  end
+
+  def with_build(%Build{} = build, operations, storage) do
+    {:ok, pid} = Console.Runner.start_link(build, operations, storage)
+    Swarm.register_name(build.id, pid)
+    Console.Runner.register(pid)
+    ref = Process.monitor(pid)
+    {pid, ref}
+  end
+
+  defp commit_message(nil, repo), do: "console deployment for #{repo}"
+  defp commit_message(message, repo), do: "console deployment for #{repo} -- #{message}"
+end

--- a/lib/console/graphql/resolvers/plural.ex
+++ b/lib/console/graphql/resolvers/plural.ex
@@ -82,7 +82,7 @@ defmodule Console.GraphQl.Resolvers.Plural do
 
   def update_configuration(%{repository: repo, content: content} = args, _) do
     tool = args[:tool] || :helm
-    with {:ok, conf} <- Console.Deployer.update(repo, content, tool, args[:message]) do
+    with {:ok, conf, _} <- Console.Deployer.update(repo, content, tool, args[:message]) do
       {:ok, %{configuration: %{tool => conf}}}
     end
   end

--- a/lib/console/runner.ex
+++ b/lib/console/runner.ex
@@ -48,7 +48,7 @@ defmodule Console.Runner do
 
   def handle_info(_, state), do: {:noreply, state}
 
-  defp continue(state, [], build), do: {:stop, {:shutdown, :succeed}, state}
+  defp continue(state, [], _), do: {:stop, {:shutdown, :succeed}, state}
   defp continue(state, ops, build) do
     send self(), :kick
     {:noreply, %{state | operations: ops, build: build}}

--- a/lib/console/runner.ex
+++ b/lib/console/runner.ex
@@ -9,7 +9,13 @@ defmodule Console.Runner do
     GenServer.start_link(__MODULE__, {build, operations, storage})
   end
 
+  def start(build, operations, storage) do
+    GenServer.start(__MODULE__, {build, operations, storage})
+  end
+
   def kick(), do: Swarm.publish(:builds, :kick)
+
+  def ping(pid), do: GenServer.call(pid, :ping)
 
   def register(pid), do: Swarm.join(:builds, pid)
 
@@ -20,29 +26,35 @@ defmodule Console.Runner do
     {:ok, %State{build: build, operations: operations, storage: storage}}
   end
 
-  def handle_info(:kick, %State{operations: ops, build: build, storage: storage} = state) do
+  def handle_call(:ping, _, %State{operations: ops} = state), do: {:reply, {:pong, ops}, state}
+
+  def handle_info(:kick, %State{operations: []} = state), do: {:stop, {:shutdown, :succeed}, state}
+
+  def handle_info(:kick, %State{operations: [:approval | ops], build: build} = state) do
+    {:ok, build} = Builds.pending(build)
+    {:noreply, %{state | operations: ops, build: build}}
+  end
+
+  def handle_info(:kick, %State{operations: [{m, f, a} | ops], build: build, storage: storage} = state) do
     {:ok, build} = Builds.running(build)
-    case execute_stack(ops) do
-      {:ok, _} -> {:stop, {:shutdown, :succeed}, state}
-      {:approval, rest} ->
-          {:ok, build} = Builds.pending(build)
-          {:noreply, %{state | operations: rest, build: build}}
+    case apply(m, f, a) do
+      :ok -> continue(state, ops, build)
+      {:ok, _} -> continue(state, ops, build)
       _ ->
         storage.reset()
         {:stop, {:shutdown, :fail}, state}
     end
   end
+
   def handle_info(_, state), do: {:noreply, state}
+
+  defp continue(state, [], build), do: {:stop, {:shutdown, :succeed}, state}
+  defp continue(state, ops, build) do
+    send self(), :kick
+    {:noreply, %{state | operations: ops, build: build}}
+  end
 
   def terminate({:shutdown, :succeed}, %{build: build}), do: Builds.succeed(build)
   def terminate({:shutdown, :fail}, %{build: build}), do: Builds.fail(build)
   def terminate(_, %{build: build}), do: Builds.cancel(build)
-
-  defp execute_stack(stack, last \\ :ok)
-  defp execute_stack([:approval | rest], _), do: {:approval, rest}
-  defp execute_stack([{m, f, a} | rest], _) do
-    with {:ok, _} = last <- apply(m, f, a),
-      do: execute_stack(rest, last)
-  end
-  defp execute_stack([], last), do: last
 end

--- a/test/console/deployer_test.exs
+++ b/test/console/deployer_test.exs
@@ -80,7 +80,7 @@ defmodule Console.DeployerTest do
 
       expect(File, :write, fn _, _ -> :ok end)
 
-      {:ok, "content"} = Console.Deployer.update("repo", "content", :helm)
+      {:ok, "content", _} = Console.Deployer.update("repo", "content", :helm)
     end
   end
 end

--- a/test/console/runner_test.exs
+++ b/test/console/runner_test.exs
@@ -1,0 +1,58 @@
+defmodule Console.RunnerTest do
+  use Console.DataCase, async: false
+  use Mimic
+  import Console.TestHelpers
+
+  setup :set_mimic_global
+
+  describe "#start/3" do
+    test "it can execute a sequence of operations and mark a build as successful" do
+      build = insert(:build)
+
+      expect(Console.Storage.Git, :revision, fn -> {:ok, "1234"} end)
+
+      {:ok, pid} = Console.Runner.start(build, [
+        {__MODULE__, :echo, [self(), "first"]},
+        {__MODULE__, :echo, [self(), "second"]},
+      ], Console.Storage.Git)
+
+      ref = Process.monitor(pid)
+
+      assert_receive {:hey, "first"}
+      assert_receive {:hey, "second"}
+
+      assert_receive {:DOWN, ^ref, :process, _, _}
+
+      assert refetch(build).status == :successful
+    end
+
+    test "if a build requires approval, it needs to be manually kicked" do
+      build = insert(:build)
+
+      expect(Console.Storage.Git, :revision, fn -> {:ok, "1234"} end)
+
+      {:ok, pid} = Console.Runner.start(build, [
+        {__MODULE__, :echo, [self(), "first"]},
+        :approval,
+        {__MODULE__, :echo, [self(), "second"]},
+      ], Console.Storage.Git)
+
+      ref = Process.monitor(pid)
+
+      assert_receive {:hey, "first"}
+
+      :timer.sleep(500)
+      assert refetch(build).status == :pending
+
+      send pid, :kick
+
+      assert_receive {:hey, "second"}
+
+      assert_receive {:DOWN, ^ref, :process, _, _}
+
+      assert refetch(build).status == :successful
+    end
+  end
+
+  def echo(pid, arg), do: {:ok, send(pid, {:hey, arg})}
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -14,6 +14,18 @@ defmodule Console.TestHelpers do
     Enum.map(list, &id/1)
   end
 
+  def wait(query, valid, elapsed \\ 0)
+  def wait(_, _, elapsed) when elapsed > 5_000, do: :error
+  def wait(query, valid, elapsed) do
+    res = query.()
+    case valid.(res) do
+      true -> {:ok, res}
+      _ ->
+        :timer.sleep(200)
+        wait(query, valid, elapsed + 200)
+    end
+  end
+
   def id(%{id: id}), do: id
   def id(%{"id" => id}), do: id
   def id(id) when is_binary(id), do: id


### PR DESCRIPTION
## Summary

This makes some changes to the deployer and runner in the console, responsible for build execution:

* moves some helper functions to a separate function to clean up the code
* moves execution of build operations to sequential callbacks instead of a single one
  * this makes cancellation easier because it can get in-between messages

## Test Plan
added unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.