### PR TITLE
Use updated elixir k8s client

### DIFF
--- a/lib/console/graphql/resolvers/kubernetes.ex
+++ b/lib/console/graphql/resolvers/kubernetes.ex
@@ -2,7 +2,7 @@ defmodule Console.GraphQl.Resolvers.Kubernetes do
   alias Kube.Client
   alias Kazan.Apis.Core.V1, as: Core
   alias Kazan.Apis.Apps.V1, as: Apps
-  alias Kazan.Apis.Extensions.V1beta1, as: Extensions
+  alias Kazan.Apis.Networking.V1, as: Networking
   alias Kazan.Apis.Batch.V1beta1, as: Batch
   alias Kazan.Apis.Batch.V1, as: BatchV1
   alias Kazan.Models.Apimachinery.Meta.V1.{LabelSelector, LabelSelectorRequirement}
@@ -60,7 +60,7 @@ defmodule Console.GraphQl.Resolvers.Kubernetes do
 
   def resolve_ingress(%{namespace: ns, name: name}, _) do
     Console.namespace(ns)
-    |> Extensions.read_namespaced_ingress!(name)
+    |> Networking.read_namespaced_ingress!(name)
     |> Kazan.run()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -99,7 +99,7 @@ defmodule Console.MixProject do
       {:poison, "~> 3.1"},
       {:mojito, "~> 0.3.0"},
       {:reverse_proxy_plug, "~> 1.2.1"},
-      {:kazan, "~> 0.11", github: "michaeljguarino/kazan"},
+      {:kazan, "~> 0.11", github: "michaeljguarino/kazan", branch: "k8s-1.23"},
       {:comeonin, "~> 5.1.2"},
       {:argon2_elixir, "~> 2.0"},
       {:prometheus_ex, "~> 3.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -54,7 +54,7 @@
   "inet_cidr": {:hex, :inet_cidr, "1.0.4", "a05744ab7c221ca8e395c926c3919a821eb512e8f36547c062f62c4ca0cf3d6e", [:mix], [], "hexpm", "64a2d30189704ae41ca7dbdd587f5291db5d1dda1414e0774c29ffc81088c1bc"},
   "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
   "jose": {:hex, :jose, "1.11.2", "f4c018ccf4fdce22c71e44d471f15f723cb3efab5d909ab2ba202b5bf35557b3", [:mix, :rebar3], [], "hexpm", "98143fbc48d55f3a18daba82d34fe48959d44538e9697c08f34200fa5f0947d2"},
-  "kazan": {:git, "https://github.com/michaeljguarino/kazan.git", "c87c8884b6bbc8848860b2387dc2650ae08dfbfd", []},
+  "kazan": {:git, "https://github.com/michaeljguarino/kazan.git", "97c1a7b56b8ff85e5fa3d5ff267052e0020c1ee8", [branch: "k8s-1.23"]},
   "libcluster": {:hex, :libcluster, "3.2.1", "b2cd5b447cde25d5897749bee6f7aaeb6c96ac379481024e9b6ba495dabeb97d", [:mix], [{:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "89f225612d135edce9def56f43bf18d575d88ac4680e3f6161283f2e55cadca4"},
   "libring": {:hex, :libring, "1.5.0", "44313eb6862f5c9168594a061e9d5f556a9819da7c6444706a9e2da533396d70", [:mix], [], "hexpm", "04e843d4fdcff49a62d8e03778d17c6cb2a03fe2d14020d3825a1761b55bd6cc"},
   "merkle_map": {:hex, :merkle_map, "0.2.1", "01a88c87a6b9fb594c67c17ebaf047ee55ffa34e74297aa583ed87148006c4c8", [:mix], [], "hexpm", "fed4d143a5c8166eee4fa2b49564f3c4eace9cb252f0a82c1613bba905b2d04d"},

--- a/test/support/kubernetes_scaffolds.ex
+++ b/test/support/kubernetes_scaffolds.ex
@@ -1,7 +1,7 @@
 defmodule KubernetesScaffolds do
   alias Kazan.Apis.Core.V1, as: Core
   alias Kazan.Apis.Apps.V1, as: Apps
-  alias Kazan.Apis.Extensions.V1beta1, as: Extensions
+  alias Kazan.Apis.Networking.V1, as: Networking
   alias Kazan.Apis.Batch.V1beta1, as: Batch
   alias Kazan.Apis.Batch.V1, as: BatchV1
   alias Kazan.Models.Apimachinery.Meta.V1.{LabelSelector, ObjectMeta}
@@ -53,15 +53,15 @@ defmodule KubernetesScaffolds do
   end
 
   def ingress(namespace, name) do
-    %Extensions.Ingress{
+    %Networking.Ingress{
       metadata: %{name: name, namespace: namespace},
-      status: %Extensions.IngressStatus{load_balancer: %{ingress: [%{ip: "1.2.3.4"}]}},
-      spec: %Extensions.IngressSpec{
-        tls: [%Extensions.IngressTLS{hosts: ["example.com"]}],
-        rules: [%Extensions.IngressRule{
+      status: %Networking.IngressStatus{load_balancer: %{ingress: [%{ip: "1.2.3.4"}]}},
+      spec: %Networking.IngressSpec{
+        tls: [%Networking.IngressTLS{hosts: ["example.com"]}],
+        rules: [%Networking.IngressRule{
           host: "example.com",
-          http: %Extensions.HTTPIngressRuleValue{
-            paths: [%Extensions.HTTPIngressPath{path: "*"}]
+          http: %Networking.HTTPIngressRuleValue{
+            paths: [%Networking.HTTPIngressPath{path: "*"}]
           }
         }]
       }


### PR DESCRIPTION
## Summary

The ingress deprecation broke ingress views on newer k8s versions, we need to bump our supported client to handle this


## Test Plan
existing tests, will test on our console as well before release


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.