### PR TITLE
Cache command output locally

### DIFF
--- a/lib/console/commands/command.ex
+++ b/lib/console/commands/command.ex
@@ -24,7 +24,8 @@ defmodule Console.Commands.Command do
   end
 
   defp complete(%Command{} = command, exit_code) do
-    with {:ok, command} <- Builds.complete(command, exit_code) do
+    with {:ok, command} <- Builds.complete(command, exit_code),
+         :ok <- Builds.clear_cache(command) do
       case exit_code do
         0 -> {:ok, command}
         _ -> {:error, command}

--- a/lib/console/graphql/build.ex
+++ b/lib/console/graphql/build.ex
@@ -56,7 +56,10 @@ defmodule Console.GraphQl.Build do
     field :id,           non_null(:id)
     field :command,      non_null(:string)
     field :exit_code,    :integer
-    field :stdout,       :string
+    field :stdout,       :string, resolve: fn
+      %{completed_at: nil} = cmd, _, _ -> Core.Services.Builds.get_line(cmd)
+      %{stdout: stdo}, _, _ -> stdo
+    end
     field :completed_at, :datetime
     field :build,        :build, resolve: dataloader(Build)
 

--- a/lib/console/schema/command.ex
+++ b/lib/console/schema/command.ex
@@ -24,7 +24,7 @@ defmodule Console.Schema.Command do
     do: from(c in query, order_by: ^order)
 
   defimpl Collectable, for: __MODULE__ do
-    alias Console.Services.Base
+    alias Console.Services.{Base, Builds}
 
     def into(command) do
       {command, fn
@@ -39,7 +39,8 @@ defmodule Console.Schema.Command do
 
     defp maybe_persist(%{stdout: stdo} = cmd, line) do
       stdo = safe_concat(stdo, line)
-      with true <- String.contains?(line, "\n"),
+      with _ <- Builds.cache_line(cmd, stdo),
+           true <- String.contains?(line, "\n"),
            {:ok, command} <- Ecto.Changeset.change(cmd, %{stdout: stdo})
                              |> Console.Repo.update() do
         command

--- a/lib/console/services/builds.ex
+++ b/lib/console/services/builds.ex
@@ -123,6 +123,15 @@ defmodule Console.Services.Builds do
     |> notify(:complete)
   end
 
+  def cache_line(%Command{id: id}, stdo), do: Console.Cache.put({:command, id}, stdo, ttl: 360_000)
+
+  def get_line(%Command{id: id, stdout: stdo}) do
+    with nil <- Console.Cache.get({:command, id}),
+      do: stdo
+  end
+
+  def clear_cache(%Command{id: id}), do: Console.Cache.delete({:command, id})
+
   def poll(id) do
     start_transaction()
     |> add_operation(:lock, fn _ -> lock("deployer", id) end)

--- a/test/console/commands/command_test.exs
+++ b/test/console/commands/command_test.exs
@@ -15,4 +15,15 @@ defmodule Console.Commands.CommandTest do
       assert command.completed_at
     end
   end
+
+  describe "Collectible" do
+    test "commands implement the collectible protocol and caches the contents" do
+      command = insert(:command)
+      command = Enum.into(["one", "two", "three", "four\n"], command)
+
+      assert command.stdout == "onetwothreefour\n"
+      assert refetch(command).stdout == "onetwothreefour\n"
+      assert Console.Services.Builds.get_line(%{command | stdout: nil}) == "onetwothreefour\n"
+    end
+  end
 end

--- a/test/console/commands/tee_test.exs
+++ b/test/console/commands/tee_test.exs
@@ -4,10 +4,7 @@ defmodule Console.Commands.TeeTest do
 
   describe "Collectible" do
     test "tee implements the collectible protocol for strings" do
-      res =
-        ~w(one two three)
-        |> Enum.into(Tee.new())
-
+      res = Enum.into(~w(one two three), Tee.new())
       assert Tee.output(res) == "onetwothree"
     end
 


### PR DESCRIPTION
## Summary
We currently only persist command output per-line, which works except that a lot of commands have very long pauses per-line.  Use in-memory caching to save overusing the database for this, and have a fallback when the cache misses to what's currently persisted to approximate a continuous db-write.


## Test Plan
existing tests pass, will try a live test after merge


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.