### PR TITLE
Improve console resilience

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -29,7 +29,7 @@ config :console, Console.Cron,
 
 config :console, :watchers, [
   Console.Watchers.Application,
-  Console.Watchers.Plural,
+  # Console.Watchers.Plural,
   Console.Watchers.Upgrade,
   Console.Watchers.Pod
 ]


### PR DESCRIPTION
## Summary
If the plural rtc service is down, this watcher will crash and eventually bring a console pod down.  Since the functionality is still unused, we should remove it to favor reliability for now, and then perhaps make it more robust in the future.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.