### PR TITLE
Fix SMTP update

### DIFF
--- a/lib/console/services/plural.ex
+++ b/lib/console/services/plural.ex
@@ -38,14 +38,14 @@ defmodule Console.Services.Plural do
   end
 
   def update_smtp(smtp) do
-    Console.Deployer.exec(fn storage ->
-      with {:ok, _} <- storage.reset(),
-           {:ok, context} <- Context.get(),
-           {:ok, _} <- Context.write(%{context | smtp: smtp}),
-           {:ok, _} <- storage.revise("update workspace smtp configuration"),
-           {:ok, _} <- storage.push(),
-        do: {:ok, smtp}
-    end)
+    with {:ok, context} <- Context.get() do
+      Console.Deployer.exec(fn storage ->
+        with {:ok, _} <- Context.write(%{context | smtp: smtp}),
+             {:ok, _} <- storage.revise("update workspace smtp configuration"),
+             {:ok, _} <- storage.push(),
+          do: {:ok, smtp}
+      end)
+    end
   end
 
   def install_recipe(id, context, oidc, %User{} = user) do

--- a/test/console/services/plural_test.exs
+++ b/test/console/services/plural_test.exs
@@ -292,9 +292,7 @@ defmodule Console.Services.PluralTest do
         send me, val
         {:ok, val}
       end
-      expect(Command, :cmd, 5, fn
-        "git", ["reset", "--hard", "origin/master"], _ -> echo.(:reset)
-        "git", ["clean", "-f"], _ -> echo.(:clean)
+      expect(Command, :cmd, 3, fn
         "git", ["add", "."], _ -> echo.(:add)
         "git", ["commit", "-m", _], _ -> echo.(:commit)
         "git", ["push"], _ -> echo.(:push)
@@ -302,8 +300,6 @@ defmodule Console.Services.PluralTest do
 
       {:ok, _} = Plural.update_smtp(%{service: "smtp.service.com"})
 
-      assert_receive :reset
-      assert_receive :clean
       assert_receive :add
       assert_receive :commit
       assert_receive :push


### PR DESCRIPTION
## Summary
I think the change to implement leader election w/ console deployers screwed with this logic a bit causing us to try to call the genserver w/in its own callback, effectively deadlocking.  This should unblock.


## Test Plan
fixed unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.