### PR TITLE
Speed up pods view

### DIFF
--- a/assets/src/components/apps/app/components/component/info/Ingress.tsx
+++ b/assets/src/components/apps/app/components/component/info/Ingress.tsx
@@ -62,7 +62,6 @@ export default function Ingress() {
   const loadBalancer = ingress.status?.loadBalancer
   const hasIngress = !!loadBalancer?.ingress && !isEmpty(loadBalancer.ingress)
   const rules = ingress.spec?.rules || []
-  console.log(loadBalancer.ingress)
 
   return (
     <Flex direction="column">
@@ -71,7 +70,7 @@ export default function Ingress() {
           <H2 marginBottom="medium">Status</H2>
           <Card padding="large">
             <PropWide
-              title={loadBalancer.ingress[0].ip ? "IP" : "Hostname"}
+              title={loadBalancer.ingress[0].ip ? 'IP' : 'Hostname'}
               fontWeight={600}
             >
               {loadBalancer.ingress[0].ip || loadBalancer.ingress[0].hostname || '-'}

--- a/assets/src/components/apps/app/components/component/info/Ingress.tsx
+++ b/assets/src/components/apps/app/components/component/info/Ingress.tsx
@@ -62,6 +62,7 @@ export default function Ingress() {
   const loadBalancer = ingress.status?.loadBalancer
   const hasIngress = !!loadBalancer?.ingress && !isEmpty(loadBalancer.ingress)
   const rules = ingress.spec?.rules || []
+  console.log(loadBalancer.ingress)
 
   return (
     <Flex direction="column">
@@ -70,10 +71,10 @@ export default function Ingress() {
           <H2 marginBottom="medium">Status</H2>
           <Card padding="large">
             <PropWide
-              title="IP"
+              title={loadBalancer.ingress[0].ip ? "IP" : "Hostname"}
               fontWeight={600}
             >
-              {loadBalancer.ingress[0].ip || '-'}
+              {loadBalancer.ingress[0].ip || loadBalancer.ingress[0].hostname || '-'}
             </PropWide>
           </Card>
         </>

--- a/assets/src/components/cluster/constants.ts
+++ b/assets/src/components/cluster/constants.ts
@@ -1,4 +1,5 @@
 export const POLL_INTERVAL = 10 * 1000
+export const SHORT_POLL_INTERVAL = 3 * 1000
 
 export const COMPONENT_LABEL = 'platform.plural.sh/component'
 export const KIND_LABEL = 'platform.plural.sh/kind'

--- a/assets/src/components/cluster/containers/ContainersList.tsx
+++ b/assets/src/components/cluster/containers/ContainersList.tsx
@@ -188,7 +188,7 @@ export const ColActions = ({
 }) => columnHelper.display({
   id: 'actions',
   cell: ({ row: { original: { name, readiness } } }: any) => (
-    readiness && readiness !== Readiness.Complete && (
+    readiness && readiness === Readiness.Ready && (
       <Flex
         flexDirection="row"
         gap="xxsmall"
@@ -290,7 +290,7 @@ export function ContainersList({
       data={tableData}
       columns={columns}
       enableColumnResizing
-      onRowClick={(e, { original }: Row<ContainerTableRow>) => navigate(`/pods/${namespace}/${podName}/shell/${original?.name}`)}
+      onRowClick={(e, { original }: Row<ContainerTableRow>) => original?.readiness === Readiness.Ready && navigate(`/pods/${namespace}/${podName}/shell/${original?.name}`)}
       {...TABLE_HEIGHT}
     />
   )

--- a/assets/src/components/cluster/queries.js
+++ b/assets/src/components/cluster/queries.js
@@ -14,6 +14,7 @@ import {
   NodeFragment,
   NodeMetricFragment,
   PodFragment,
+  PodMiniFragment,
   ServiceFragment,
   StatefulSetFragment,
   VerticalPodAutoscalerFragment,
@@ -258,13 +259,9 @@ export const CERTIFICATE_Q = gql`
 `
 
 export const PODS_Q = gql`
-  query Pods($namespaces: [String], $cursor: String) {
-    pods(namespaces: $namespaces, after: $cursor) {
-      edges {
-        node {
-          ...PodFragment
-        }
-      }
+  query Pods($namespaces: [String]) {
+    cachedPods(namespaces: $namespaces) {
+      ...PodMiniFragment
     }
     namespaces {
       metadata {
@@ -281,7 +278,7 @@ export const PODS_Q = gql`
       }
     }
   }
-  ${PodFragment}
+  ${PodMiniFragment}
   ${MetadataFragment}
 `
 

--- a/assets/src/components/graphql/kubernetes.js
+++ b/assets/src/components/graphql/kubernetes.js
@@ -58,6 +58,36 @@ export const Container = gql`
   ${ResourcesFragment}
 `
 
+export const PodMiniFragment = gql`
+fragment PodMiniFragment on Pod {
+  metadata { ...MetadataFragment }
+  status {
+    phase
+    podIp
+    reason
+    containerStatuses { ...ContainerStatus }
+    initContainerStatuses { ...ContainerStatus }
+    conditions {
+      lastProbeTime
+      lastTransitionTime
+      message
+      reason
+      status
+      type
+    }
+  }
+  spec {
+    nodeName
+    serviceAccountName
+    containers { ...Container }
+    initContainers { ...Container }
+  }
+}
+${Container}
+${ContainerStatus}
+${MetadataFragment}
+`
+
 export const PodFragment = gql`
   fragment PodFragment on Pod {
     metadata { ...MetadataFragment }
@@ -154,7 +184,7 @@ export const IngressFragment = gql`
     metadata { ...MetadataFragment }
     status {
       loadBalancer {
-        ingress { ip }
+        ingress { ip hostname }
       }
     }
     spec {

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -35,7 +35,7 @@ export type ApplicationDelta = {
 
 export type ApplicationDescriptor = {
   __typename?: 'ApplicationDescriptor';
-  description: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   icons?: Maybe<Array<Maybe<Scalars['String']>>>;
   links?: Maybe<Array<Maybe<ApplicationLink>>>;
   type: Scalars['String'];
@@ -182,9 +182,19 @@ export type BuildEdge = {
   node?: Maybe<Build>;
 };
 
+export type BuildInfo = {
+  __typename?: 'BuildInfo';
+  all?: Maybe<Scalars['Int']>;
+  failed?: Maybe<Scalars['Int']>;
+  queued?: Maybe<Scalars['Int']>;
+  running?: Maybe<Scalars['Int']>;
+  successful?: Maybe<Scalars['Int']>;
+};
+
 export enum BuildType {
   Approval = 'APPROVAL',
   Bounce = 'BOUNCE',
+  Dedicated = 'DEDICATED',
   Deploy = 'DEPLOY',
   Destroy = 'DESTROY',
   Install = 'INSTALL'
@@ -292,6 +302,7 @@ export type ConfigurationItem = {
   default?: Maybe<Scalars['String']>;
   documentation?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
+  optional?: Maybe<Scalars['Boolean']>;
   placeholder?: Maybe<Scalars['String']>;
   type?: Maybe<Scalars['String']>;
   validation?: Maybe<ConfigurationValidation>;
@@ -1002,6 +1013,11 @@ export type PrometheusDatasource = {
   query: Scalars['String'];
 };
 
+export enum ReadType {
+  Build = 'BUILD',
+  Notification = 'NOTIFICATION'
+}
+
 export type Recipe = {
   __typename?: 'Recipe';
   description?: Maybe<Scalars['String']>;
@@ -1154,6 +1170,7 @@ export type RootMutationType = {
   installRecipe?: Maybe<Build>;
   installStack?: Maybe<Build>;
   loginLink?: Maybe<User>;
+  markRead?: Maybe<User>;
   oauthCallback?: Maybe<User>;
   overlayConfiguration?: Maybe<Build>;
   readNotifications?: Maybe<User>;
@@ -1283,6 +1300,11 @@ export type RootMutationTypeLoginLinkArgs = {
 };
 
 
+export type RootMutationTypeMarkReadArgs = {
+  type?: InputMaybe<ReadType>;
+};
+
+
 export type RootMutationTypeOauthCallbackArgs = {
   code: Scalars['String'];
   redirect?: InputMaybe<Scalars['String']>;
@@ -1349,7 +1371,9 @@ export type RootQueryType = {
   auditMetrics?: Maybe<Array<Maybe<AuditMetric>>>;
   audits?: Maybe<AuditConnection>;
   build?: Maybe<Build>;
+  buildInfo?: Maybe<BuildInfo>;
   builds?: Maybe<BuildConnection>;
+  cachedPods?: Maybe<Array<Maybe<Pod>>>;
   certificate?: Maybe<Certificate>;
   clusterInfo?: Maybe<ClusterInfo>;
   configuration?: Maybe<ConsoleConfiguration>;
@@ -1422,6 +1446,11 @@ export type RootQueryTypeBuildsArgs = {
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
+};
+
+
+export type RootQueryTypeCachedPodsArgs = {
+  namespaces?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
 
 
@@ -1592,6 +1621,7 @@ export type RootQueryTypeRolesArgs = {
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
+  q?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -1943,6 +1973,7 @@ export type User = {
   __typename?: 'User';
   backgroundColor?: Maybe<Scalars['String']>;
   boundRoles?: Maybe<Array<Maybe<Role>>>;
+  buildTimestamp?: Maybe<Scalars['DateTime']>;
   deletedAt?: Maybe<Scalars['DateTime']>;
   email: Scalars['String'];
   id: Scalars['ID'];

--- a/lib/console/plural/queries.ex
+++ b/lib/console/plural/queries.ex
@@ -154,8 +154,8 @@ defmodule Console.Plural.Queries do
   """
 
   @search_repositories """
-    query SearchRepos($query: String!, $first: Int) {
-      searchRepositories(query: $query, first: $first) {
+    query SearchRepos($query: String!, $first: Int, $cursor: String) {
+      repositories(q: $query, first: $first, after: $cursor) {
         pageInfo { ...PageInfo }
         edges { node { ...RepositoryFragment } }
       }

--- a/lib/console/plural/repositories.ex
+++ b/lib/console/plural/repositories.ex
@@ -14,23 +14,23 @@ defmodule Console.Plural.Repositories do
   }
 
   defmodule Query do
-    defstruct [:installations, :searchRepositories, :recipes, :recipe, :installation, :stack]
+    defstruct [:installations, :repositories, :recipes, :recipe, :installation, :stack]
   end
 
   defmodule Mutation do
     defstruct [:installRecipe, :upsertOidcProvider, :installStack]
   end
 
-  def search_repositories(query, first) do
+  def search_repositories(query, first, cursor \\ nil) do
     search_repositories_query()
     |> Client.run(
-      prune_variables(%{query: query, first: first}),
-      %Query{searchRepositories: %Connection{
+      prune_variables(%{query: query, first: first, cursor: cursor}),
+      %Query{repositories: %Connection{
         pageInfo: %PageInfo{},
         edges: [%Edge{node: %Repository{}}]
       }}
     )
-    |> when_ok(fn %{searchRepositories: result} -> result end)
+    |> when_ok(fn %{repositories: result} -> result end)
   end
 
   def list_recipes(id, cursor) do

--- a/test/console/graphql/queries/plural_queries_test.exs
+++ b/test/console/graphql/queries/plural_queries_test.exs
@@ -54,7 +54,7 @@ defmodule Console.GraphQl.PluralQueriesTest do
 
       repositories = [%{id: "id", name: "repo", description: "a repository"}]
       expect(HTTPoison, :post, fn _, ^body, _ ->
-        {:ok, %{body: Jason.encode!(%{data: %{searchRepositories: as_connection(repositories)}})}}
+        {:ok, %{body: Jason.encode!(%{data: %{repositories: as_connection(repositories)}})}}
       end)
 
       {:ok, %{data: %{"repositories" => %{"pageInfo" => page_info, "edges" => [edge]}}}} = run_query("""


### PR DESCRIPTION
## Summary

I think a lot of the performance here is getting drained at the graphql layer, at which point we just need to paginate, but this should shave a few seconds off.  Two main things are:

* use the cached pods endpoint
* don't query the raw field on each pod, which causes gql to serialize the full yaml structure for each one which adds up


## Test Plan
local


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.