### PR TITLE
Use annotations instead of labels

### DIFF
--- a/lib/console/graphql/kubernetes/vpn.ex
+++ b/lib/console/graphql/kubernetes/vpn.ex
@@ -13,7 +13,7 @@ defmodule Console.GraphQl.Kubernetes.VPN do
     end
 
     field :user, :user, resolve: fn
-      %{metadata: %{labels: %{"vpn.plural.sh/email" => email}}}, _, %{context: %{loader: loader}} when is_binary(email) ->
+      %{metadata: %{annotations: %{"vpn.plural.sh/email" => email}}}, _, %{context: %{loader: loader}} when is_binary(email) ->
         loader
         |> Dataloader.load(UserLoader, :email, email)
         |> on_load(fn loader ->

--- a/lib/console/services/vpn.ex
+++ b/lib/console/services/vpn.ex
@@ -35,7 +35,7 @@ defmodule Console.Services.VPN do
 
   @spec accessible(WireguardPeer.t, User.t) :: peer_resp
   def accessible(peer, %User{roles: %{admin: true}}), do: {:ok, peer}
-  def accessible(%WireguardPeer{metadata: %{labels: %{"vpn.plural.sh/email" => e}}} = peer, %User{email: e}),
+  def accessible(%WireguardPeer{metadata: %{annotations: %{"vpn.plural.sh/email" => e}}} = peer, %User{email: e}),
     do: {:ok, peer}
   def accessible(_, _), do: {:error, "cannot access this wireguard peer"}
 

--- a/test/console/graphql/queries/kubernetes_queries_test.exs
+++ b/test/console/graphql/queries/kubernetes_queries_test.exs
@@ -418,7 +418,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "myWireguardPeers" do
     test "you can list your own peers" do
       user = insert(:user)
-      peers = [wireguard_peer("first", insert(:user)), wireguard_peer("second", insert(:user))]
+      [f, s | _] = peers = [wireguard_peer("first", user), wireguard_peer("second", user), wireguard_peer("third", insert(:user))]
       expect(Kazan, :run, fn _ -> {:ok, %{items: peers}} end)
 
       {:ok, %{data: %{"myWireguardPeers" => found}}} = run_query("""
@@ -430,8 +430,8 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
         }
       """, %{}, %{current_user: user})
 
-      assert Enum.map(found, & &1["metadata"]["name"]) == Enum.map(peers, & &1.metadata.name)
-      assert Enum.all?(found, & &1["user"]["id"])
+      assert Enum.map(found, & &1["metadata"]["name"]) == Enum.map([f, s], & &1.metadata.name)
+      assert Enum.all?(found, & &1["user"]["id"] == user.id)
     end
   end
 

--- a/test/support/kubernetes_scaffolds.ex
+++ b/test/support/kubernetes_scaffolds.ex
@@ -245,7 +245,7 @@ defmodule KubernetesScaffolds do
 
   def wireguard_peer(name) do
     %Kube.WireguardPeer{
-      metadata: %{name: name, namespage: "wireguard", labels: %{}},
+      metadata: %{name: name, namespage: "wireguard", annotations: %{}},
       spec: %Kube.WireguardPeer.Spec{wireguard_ref: "wireguard"},
       status: %Kube.WireguardPeer.Status{ready: true, config_ref: %Core.SecretKeySelector{name: "n", key: "k"}}
     }
@@ -253,7 +253,7 @@ defmodule KubernetesScaffolds do
 
   def wireguard_peer(name, %Schema.User{email: email}) do
     peer = wireguard_peer(name)
-    put_in(peer.metadata.labels["vpn.plural.sh/email"], email)
+    put_in(peer.metadata.annotations["vpn.plural.sh/email"], email)
   end
 
   def wireguard_server() do


### PR DESCRIPTION
k8s labels don't permit special chars, so need to use annotations unfortunately


## Test Plan
modified unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.