### PR TITLE
Use local GraphQL schema for TS generation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,3 +82,39 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
         if: always()
+  updateSchema:
+    name: Check that Schema is up to date
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+      - name: Restore dependencies cache
+        uses: actions/cache@v3
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-1-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-1
+      - name: Restore _build
+        uses: actions/cache@v3
+        with:
+          path: _build
+          key: ${{ runner.os }}-mix-1-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-1
+      - name: get dependencies
+        run: mix deps.get
+      - name: update schema
+        run: MIX_ENV=test mix absinthe.schema.sdl --schema Console.GraphQl  schema/schema.graphql
+      - name: Verify Changed files
+        uses: tj-actions/verify-changed-files@v13
+        id: verify-changed-files
+        with:
+          files: |
+            schema/schema.graphql
+      - name: Schema changed
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: |
+          echo "::error Schema has changed changed. Please run 'make update-schema' and commit the changes."
+          exit 1

--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,7 @@ release-vsn: # tags and pushes a new release
 	git pull --rebase; \
 	git tag -a $$tag -m "new release"; \
 	git push origin $$tag
+
+update-schema:
+	MIX_ENV=test mix absinthe.schema.sdl --schema Console.GraphQl  schema/schema.graphql
+	cd assets && yarn graphql:codegen

--- a/assets/codegen.yml
+++ b/assets/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: "https://console.plural.sh/gql"
+schema: "../schema/schema.graphql"
 generates:
   src/generated/graphql.ts:
     plugins:

--- a/assets/package.json
+++ b/assets/package.json
@@ -19,7 +19,7 @@
     "fix:css": "stylelint src/**/*.css --fix",
     "e2e:start": "concurrently -kill-others --success first \"yarn start\" \"wait-on -c waitOnConfig.json -v https-get://localhost:3000 && cd e2e/ && npx cypress run\"",
     "e2e:open": "concurrently -kill-others --success first \"yarn start\" \"wait-on -c waitOnConfig.json -v https-get://localhost:3000 && cd e2e/ && npx cypress open\"",
-    "codegen": "graphql-codegen --config codegen.yml"
+    "graphql:codegen": "graphql-codegen --config codegen.yml"
   },
   "engines": {
     "node": ">=16.15.0"

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -12,6 +12,12 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  /**
+   * The `DateTime` scalar type represents a date and time in the UTC
+   * timezone. The DateTime appears in a JSON response as an ISO8601 formatted
+   * string, including UTC timezone ("Z"). The parsed date and time string will
+   * be converted to UTC if there is an offset.
+   */
   DateTime: Date;
   Long: any;
   Map: Map<string, unknown>;
@@ -126,6 +132,11 @@ export enum AutoscalingTarget {
   Deployment = 'DEPLOYMENT',
   Statefulset = 'STATEFULSET'
 }
+
+export type AvailableFeatures = {
+  __typename?: 'AvailableFeatures';
+  vpn?: Maybe<Scalars['Boolean']>;
+};
 
 export type BindingAttributes = {
   groupId?: InputMaybe<Scalars['ID']>;
@@ -334,12 +345,14 @@ export type ConfigurationValidation = {
 
 export type ConsoleConfiguration = {
   __typename?: 'ConsoleConfiguration';
+  features?: Maybe<AvailableFeatures>;
   gitCommit?: Maybe<Scalars['String']>;
   gitStatus?: Maybe<GitStatus>;
   isDemoProject?: Maybe<Scalars['Boolean']>;
   isSandbox?: Maybe<Scalars['Boolean']>;
   manifest?: Maybe<PluralManifest>;
   pluralLogin?: Maybe<Scalars['Boolean']>;
+  vpnEnabled?: Maybe<Scalars['Boolean']>;
 };
 
 export type Container = {
@@ -513,6 +526,12 @@ export type Event = {
   message?: Maybe<Scalars['String']>;
   reason?: Maybe<Scalars['String']>;
   type?: Maybe<Scalars['String']>;
+};
+
+export type FileContent = {
+  __typename?: 'FileContent';
+  content?: Maybe<Scalars['String']>;
+  path?: Maybe<Scalars['String']>;
 };
 
 export type GitStatus = {
@@ -1064,6 +1083,7 @@ export type Repository = {
   __typename?: 'Repository';
   configuration?: Maybe<Configuration>;
   description?: Maybe<Scalars['String']>;
+  docs?: Maybe<Array<Maybe<FileContent>>>;
   grafanaDns?: Maybe<Scalars['String']>;
   icon?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -1155,6 +1175,7 @@ export type RootMutationType = {
   createGroup?: Maybe<Group>;
   createGroupMember?: Maybe<GroupMember>;
   createInvite?: Maybe<Invite>;
+  createPeer?: Maybe<WireguardPeer>;
   createRole?: Maybe<Role>;
   createUpgradePolicy?: Maybe<UpgradePolicy>;
   createWebhook?: Maybe<Webhook>;
@@ -1162,6 +1183,7 @@ export type RootMutationType = {
   deleteGroupMember?: Maybe<GroupMember>;
   deleteJob?: Maybe<Job>;
   deleteNode?: Maybe<Node>;
+  deletePeer?: Maybe<WireguardPeer>;
   deletePod?: Maybe<Pod>;
   deleteRole?: Maybe<Role>;
   deleteUpgradePolicy?: Maybe<UpgradePolicy>;
@@ -1216,6 +1238,13 @@ export type RootMutationTypeCreateInviteArgs = {
 };
 
 
+export type RootMutationTypeCreatePeerArgs = {
+  email?: InputMaybe<Scalars['String']>;
+  name: Scalars['String'];
+  userId?: InputMaybe<Scalars['ID']>;
+};
+
+
 export type RootMutationTypeCreateRoleArgs = {
   attributes: RoleAttributes;
 };
@@ -1249,6 +1278,11 @@ export type RootMutationTypeDeleteJobArgs = {
 
 
 export type RootMutationTypeDeleteNodeArgs = {
+  name: Scalars['String'];
+};
+
+
+export type RootMutationTypeDeletePeerArgs = {
   name: Scalars['String'];
 };
 
@@ -1395,6 +1429,7 @@ export type RootQueryType = {
   logs?: Maybe<Array<Maybe<LogStream>>>;
   me?: Maybe<User>;
   metric?: Maybe<Array<Maybe<MetricResponse>>>;
+  myWireguardPeers?: Maybe<Array<Maybe<WireguardPeer>>>;
   namespaces?: Maybe<Array<Maybe<Namespace>>>;
   node?: Maybe<Node>;
   nodeMetric?: Maybe<NodeMetric>;
@@ -1407,6 +1442,7 @@ export type RootQueryType = {
   recipe?: Maybe<Recipe>;
   recipes?: Maybe<RecipeConnection>;
   repositories?: Maybe<RepositoryConnection>;
+  repository?: Maybe<Repository>;
   role?: Maybe<Role>;
   roles?: Maybe<RoleConnection>;
   runbook?: Maybe<Runbook>;
@@ -1419,6 +1455,8 @@ export type RootQueryType = {
   upgradePolicies?: Maybe<Array<Maybe<UpgradePolicy>>>;
   users?: Maybe<UserConnection>;
   webhooks?: Maybe<WebhookConnection>;
+  wireguardPeer?: Maybe<WireguardPeer>;
+  wireguardPeers?: Maybe<Array<Maybe<WireguardPeer>>>;
 };
 
 
@@ -1616,6 +1654,11 @@ export type RootQueryTypeRepositoriesArgs = {
 };
 
 
+export type RootQueryTypeRepositoryArgs = {
+  name: Scalars['String'];
+};
+
+
 export type RootQueryTypeRolesArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
@@ -1675,6 +1718,11 @@ export type RootQueryTypeWebhooksArgs = {
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
+};
+
+
+export type RootQueryTypeWireguardPeerArgs = {
+  name: Scalars['String'];
 };
 
 export type RootSubscriptionType = {
@@ -2079,3 +2127,24 @@ export enum WebhookType {
   Piazza = 'PIAZZA',
   Slack = 'SLACK'
 }
+
+export type WireguardPeer = {
+  __typename?: 'WireguardPeer';
+  config?: Maybe<Scalars['String']>;
+  metadata: Metadata;
+  raw: Scalars['String'];
+  spec: WireguardPeerSpec;
+  status: WireguardPeerStatus;
+  user?: Maybe<User>;
+};
+
+export type WireguardPeerSpec = {
+  __typename?: 'WireguardPeerSpec';
+  wireguardRef?: Maybe<Scalars['String']>;
+};
+
+export type WireguardPeerStatus = {
+  __typename?: 'WireguardPeerStatus';
+  conditions?: Maybe<Array<Maybe<StatusCondition>>>;
+  ready?: Maybe<Scalars['Boolean']>;
+};

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1,0 +1,1473 @@
+schema {
+  query: RootQueryType
+  mutation: RootMutationType
+  subscription: RootSubscriptionType
+}
+
+type PageInfo {
+  "When paginating backwards, are there more items?"
+  hasPreviousPage: Boolean!
+
+  "When paginating forwards, are there more items?"
+  hasNextPage: Boolean!
+
+  "When paginating backwards, the cursor to continue."
+  startCursor: String
+
+  "When paginating forwards, the cursor to continue."
+  endCursor: String
+}
+
+type RunbookAction {
+  name: String!
+  type: String!
+  configuration: ConfigurationAction
+}
+
+enum AuditAction {
+  CREATE
+  UPDATE
+  DELETE
+  APPROVE
+  CANCEL
+}
+
+type RecipeSection {
+  id: ID!
+  repository: Repository
+  recipeItems: [RecipeItem]
+  configuration: [ConfigurationItem]
+}
+
+type StatusCondition {
+  message: String!
+  reason: String!
+  status: String!
+  type: String!
+}
+
+type UserConnection {
+  pageInfo: PageInfo!
+  edges: [UserEdge]
+}
+
+type Application {
+  name: String!
+  spec: ApplicationSpec!
+  status: ApplicationStatus!
+  cost: CostAnalysis
+  license: License
+  configuration: Configuration
+}
+
+type ConfigurationAction {
+  updates: [PathUpdate]
+}
+
+type NotificationConnection {
+  pageInfo: PageInfo!
+  edges: [NotificationEdge]
+}
+
+type RecipeItem {
+  id: ID!
+  configuration: [ConfigurationItem]
+}
+
+type DashboardLabel {
+  name: String!
+  values: [String]
+}
+
+type Changelog {
+  id: ID!
+  repo: String!
+  tool: String!
+  content: String
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type RoleEdge {
+  node: Role
+  cursor: String
+}
+
+type GroupEdge {
+  node: Group
+  cursor: String
+}
+
+type InstallationEdge {
+  node: Installation
+  cursor: String
+}
+
+type WebhookEdge {
+  node: Webhook
+  cursor: String
+}
+
+type NodeUsage {
+  cpu: String
+  memory: String
+}
+
+type RepositoryEdge {
+  node: Repository
+  cursor: String
+}
+
+type OverlayUpdate {
+  path: [String]
+}
+
+enum AutoscalingTarget {
+  STATEFULSET
+  DEPLOYMENT
+}
+
+type StatusComponent {
+  group: String
+  kind: String!
+  name: String!
+  status: String!
+}
+
+input SmtpInput {
+  server: String
+  port: Int
+  password: String
+  sender: String
+  user: String
+}
+
+type StatefulSet {
+  metadata: Metadata!
+  status: StatefulSetStatus!
+  spec: StatefulSetSpec!
+  pods: [Pod]
+  raw: String!
+  events: [Event]
+}
+
+type FileContent {
+  path: String
+  content: String
+}
+
+type MetricResult {
+  timestamp: Int
+  value: String
+}
+
+type Component {
+  group: String!
+  kind: String!
+}
+
+type ConfigurationOverlaySpec {
+  name: String
+  folder: String
+  subfolder: String
+  documentation: String
+  updates: [OverlayUpdate]
+  inputType: String
+  inputValues: [String]
+}
+
+type LoadBalancerStatus {
+  ingress: [LoadBalancerIngressStatus]
+}
+
+type ContainerStatus {
+  restartCount: Int
+  ready: Boolean
+  name: String
+  image: String
+  state: ContainerState
+}
+
+input ContextAttributes {
+  buckets: [String]
+  domain: [String]
+  configuration: Map!
+}
+
+type IngressTls {
+  hosts: [String]
+}
+
+type NodeStatus {
+  allocatable: Map
+  capacity: Map
+  phase: String
+  conditions: [NodeCondition]
+}
+
+type IngressSpec {
+  rules: [IngressRule]
+  tls: [IngressTls]
+}
+
+type DeploymentStatus {
+  availableReplicas: Int
+  replicas: Int
+  readyReplicas: Int
+  unavailableReplicas: Int
+}
+
+input InviteAttributes {
+  email: String
+}
+
+input BindingAttributes {
+  id: ID
+  userId: ID
+  groupId: ID
+}
+
+input BuildAttributes {
+  repository: String!
+  type: BuildType
+  message: String
+}
+
+type DeploymentSpec {
+  replicas: Int
+  strategy: DeploymentStrategy
+}
+
+type CronJob {
+  metadata: Metadata!
+  status: CronStatus!
+  spec: CronSpec!
+  raw: String!
+  events: [Event]
+  jobs: [Job]
+}
+
+type PodDelta {
+  delta: Delta
+  payload: Pod
+}
+
+"supported kubernetes objects fetchable in runbooks"
+union KubernetesData = Deployment | StatefulSet
+
+type Smtp {
+  server: String
+  port: Int
+  password: String
+  sender: String
+  user: String
+}
+
+type ClusterInfo {
+  gitCommit: String
+  gitVersion: String
+  platform: String
+  version: String
+}
+
+type LoginInfo {
+  oidcUri: String
+}
+
+type RootSubscriptionType {
+  applicationDelta: ApplicationDelta
+  podDelta: PodDelta
+  buildDelta(buildId: ID): BuildDelta
+  commandDelta(buildId: ID!): CommandDelta
+  notificationDelta: NotificationDelta
+}
+
+type RepositoryConnection {
+  pageInfo: PageInfo!
+  edges: [RepositoryEdge]
+}
+
+type WebhookConnection {
+  pageInfo: PageInfo!
+  edges: [WebhookEdge]
+}
+
+type ConfigurationValidation {
+  type: String
+  regex: String
+  message: String
+}
+
+type InstallationConnection {
+  pageInfo: PageInfo!
+  edges: [InstallationEdge]
+}
+
+type PodCondition {
+  lastProbeTime: String
+  lastTransitionTime: String
+  message: String
+  reason: String
+  status: String
+  type: String
+}
+
+type GroupConnection {
+  pageInfo: PageInfo!
+  edges: [GroupEdge]
+}
+
+type RoleConnection {
+  pageInfo: PageInfo!
+  edges: [RoleEdge]
+}
+
+type RunbookExecution {
+  id: ID!
+  name: String!
+  namespace: String!
+  context: Map!
+  user: User
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type ConfigurationItem {
+  name: String
+  type: String
+  placeholder: String
+  documentation: String
+  default: String
+  optional: Boolean
+  condition: ConfigurationCondition
+  validation: ConfigurationValidation
+}
+
+type LogStream {
+  stream: Map
+  values: [MetricResult]
+}
+
+type ApplicationInfoItem {
+  type: String
+  name: String
+  value: String
+}
+
+type LogLabel {
+  name: String
+  value: String
+}
+
+type ManifestNetwork {
+  pluralDns: Boolean
+  subdomain: String
+}
+
+type Webhook {
+  id: ID!
+  url: String!
+  health: WebhookHealth!
+  type: WebhookType!
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type Runbook {
+  name: String!
+  spec: RunbookSpec!
+  status: RunbookStatus
+  data(context: RunbookContext): [RunbookData]
+  executions(after: String, first: Int, before: String, last: Int): RunbookExecutionConnection
+}
+
+type Repository {
+  id: ID!
+  name: String!
+  description: String
+  icon: String
+  docs: [FileContent]
+  configuration: Configuration
+  grafanaDns: String
+}
+
+type DeploymentStrategy {
+  type: String
+  rollingUpdate: RollingUpdate
+}
+
+enum Severity {
+  NONE
+  LOW
+  MEDIUM
+  HIGH
+  CRITICAL
+}
+
+type DashboardGraph {
+  name: String!
+  queries: [DashboardMetric]
+  format: String
+}
+
+type IngressPath {
+  backend: IngressBackend
+  path: String
+}
+
+type IngressRule {
+  host: String
+  http: HttpIngressRule
+}
+
+type Service {
+  metadata: Metadata!
+  status: ServiceStatus!
+  spec: ServiceSpec!
+  pods: [Pod]
+  raw: String!
+  events: [Event]
+}
+
+type License {
+  metadata: Metadata!
+  spec: LicenseSpec!
+  status: LicenseStatus
+}
+
+type Node {
+  status: NodeStatus!
+  spec: NodeSpec!
+  metadata: Metadata!
+  raw: String!
+  pods: [Pod]
+  events: [Event]
+}
+
+type Invite {
+  secureId: String!
+  email: String
+}
+
+type PodEdge {
+  node: Pod
+  cursor: String
+}
+
+type PrometheusDatasource {
+  query: String!
+  format: String
+  legend: String
+}
+
+type Recipe {
+  id: ID!
+  name: String!
+  description: String
+  provider: String
+  restricted: Boolean
+  recipeSections: [RecipeSection]
+  oidcEnabled: Boolean
+}
+
+enum BuildType {
+  DEPLOY
+  BOUNCE
+  APPROVAL
+  INSTALL
+  DESTROY
+  DEDICATED
+}
+
+type AuditEdge {
+  node: Audit
+  cursor: String
+}
+
+type KubernetesDatasource {
+  resource: String!
+  name: String!
+}
+
+type RunbookActionResponse {
+  redirectTo: String
+}
+
+type LicenseFeature {
+  name: String!
+  description: String
+}
+
+type Role {
+  id: ID!
+  name: String!
+  description: String
+  repositories: [String]
+  permissions: [Permission]
+  roleBindings: [RoleBinding]
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type CrossVersionResourceTarget {
+  apiVersion: String
+  kind: String
+  name: String
+}
+
+type PluralManifest {
+  network: ManifestNetwork
+  bucketPrefix: String
+  cluster: String
+}
+
+input RunbookContext {
+  timeseriesStart: Int
+  timeseriesStep: String
+}
+
+type ServicePort {
+  name: String
+  protocol: String
+  port: Int
+  targetPort: String
+}
+
+type Deployment {
+  metadata: Metadata!
+  status: DeploymentStatus!
+  spec: DeploymentSpec!
+  pods: [Pod]
+  raw: String!
+  events: [Event]
+}
+
+type Build {
+  id: ID!
+  repository: String!
+  type: BuildType!
+  status: Status!
+  message: String
+  completedAt: DateTime
+  sha: String
+  commands(after: String, first: Int, before: String, last: Int): CommandConnection
+  creator: User
+  approver: User
+  changelogs: [Changelog]
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type Command {
+  id: ID!
+  command: String!
+  exitCode: Int
+  stdout: String
+  completedAt: DateTime
+  build: Build
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type DashboardMetric {
+  legend: String
+  query: String
+  results: [MetricResult]
+}
+
+type NodeSpec {
+  podCidr: String
+  providerId: String
+  unschedulable: Boolean
+}
+
+type LicenseSpec {
+  secretRef: SecretKeySelector!
+}
+
+input UserAttributes {
+  name: String
+  email: String
+  password: String
+  roles: UserRoleAttributes
+}
+
+type VerticalPodAutoscalerSpec {
+  targetRef: CrossVersionResourceTarget!
+  updatePolicy: VerticalPodAutoscalerUpdatePolicy!
+}
+
+type ContainerResources {
+  cpu: String
+  memory: String
+}
+
+type CertificateStatus {
+  conditions: [StatusCondition]
+  notAfter: String
+  notBefore: String
+  renewalTime: String
+}
+
+type CertificateSpec {
+  dnsNames: [String]
+  secretName: String!
+  issuerRef: IssuerRef
+}
+
+type JobSpec {
+  backoffLimit: Int
+  parallelism: Int
+  activeDeadlineSeconds: Int
+}
+
+type RunbookStatus {
+  alerts: [RunbookAlertStatus]
+}
+
+type NamespaceStatus {
+  phase: String
+}
+
+type PodStatus {
+  message: String
+  phase: String
+  hostIp: String
+  podIp: String
+  reason: String
+  conditions: [PodCondition]
+  containerStatuses: [ContainerStatus]
+  initContainerStatuses: [ContainerStatus]
+}
+
+type GitStatus {
+  cloned: Boolean
+  output: String
+}
+
+type CronSpec {
+  schedule: String!
+  suspend: Boolean
+  concurrencyPolicy: String
+}
+
+type CostAnalysis {
+  minutes: Float
+  cpuCost: Float
+  cpuEfficiency: Float
+  efficiency: Float
+  gpuCost: Float
+  networkCost: Float
+  pvCost: Float
+  ramCost: Float
+  ramEfficiency: Float
+  totalCost: Float
+  sharedCost: Float
+}
+
+type ApplicationSpec {
+  descriptor: ApplicationDescriptor!
+  components: [Component]
+  info: [ApplicationInfoItem]
+}
+
+type AvailableFeatures {
+  vpn: Boolean
+}
+
+type WireguardPeer {
+  metadata: Metadata!
+  status: WireguardPeerStatus!
+  spec: WireguardPeerSpec!
+  config: String
+  user: User
+  raw: String!
+}
+
+type Container {
+  image: String
+  name: String
+  ports: [Port]
+  resources: Resources
+}
+
+type GroupMember {
+  id: ID!
+  user: User
+  group: Group
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type ApplicationDescriptor {
+  type: String!
+  version: String!
+  description: String
+  icons: [String]
+  links: [ApplicationLink]
+}
+
+enum Delta {
+  CREATE
+  UPDATE
+  DELETE
+}
+
+type ApplicationDelta {
+  delta: Delta
+  payload: Application
+}
+
+type Installation {
+  id: ID!
+  repository: Repository
+}
+
+type Configuration {
+  terraform: String
+  helm: String
+}
+
+type Notification {
+  id: ID!
+  title: String!
+  description: String
+  fingerprint: String!
+  status: NotificationStatus
+  labels: Map
+  annotations: Map
+  repository: String!
+  seenAt: DateTime
+  severity: Severity
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type AuditConnection {
+  pageInfo: PageInfo!
+  edges: [AuditEdge]
+}
+
+type RootMutationType {
+  createBuild(attributes: BuildAttributes!): Build
+  restartBuild(id: ID!): Build
+  cancelBuild(id: ID!): Build
+  approveBuild(id: ID!): Build
+  signIn(email: String!, password: String!): User
+  loginLink(key: String!): User
+  readNotifications: User
+  signup(inviteId: String!, attributes: UserAttributes!): User
+  oauthCallback(code: String!, redirect: String): User
+  createInvite(attributes: InviteAttributes!): Invite
+  updateUser(id: ID, attributes: UserAttributes!): User
+  markRead(type: ReadType): User
+  createGroup(attributes: GroupAttributes!): Group
+  deleteGroup(groupId: ID!): Group
+  updateGroup(groupId: ID!, attributes: GroupAttributes!): Group
+  createGroupMember(groupId: ID!, userId: ID!): GroupMember
+  deleteGroupMember(groupId: ID!, userId: ID!): GroupMember
+  createRole(attributes: RoleAttributes!): Role
+  updateRole(id: ID!, attributes: RoleAttributes!): Role
+  deleteRole(id: ID!): Role
+  deletePod(namespace: String!, name: String!): Pod
+  deleteJob(namespace: String!, name: String!): Job
+  deleteNode(name: String!): Node
+  overlayConfiguration(namespace: String!, context: Map!): Build
+  createPeer(userId: ID, email: String, name: String!): WireguardPeer
+  deletePeer(name: String!): WireguardPeer
+  installRecipe(id: ID!, context: Map!, oidc: Boolean): Build
+  installStack(name: String!, context: ContextAttributes!, oidc: Boolean): Build
+  updateSmtp(smtp: SmtpInput!): Smtp
+  updateConfiguration(repository: String!, content: String!, tool: Tool, message: String): Configuration
+  createUpgradePolicy(attributes: UpgradePolicyAttributes!): UpgradePolicy
+  deleteUpgradePolicy(id: ID!): UpgradePolicy
+  executeRunbook(namespace: String!, name: String!, input: RunbookActionInput!): RunbookActionResponse
+  createWebhook(attributes: WebhookAttributes!): Webhook
+  deleteWebhook(id: ID!): Webhook
+}
+
+type ConfigurationCondition {
+  field: String
+  value: String
+  operation: String
+}
+
+type Recommendation {
+  containerRecommendations: [ContainerRecommendation]
+}
+
+type PodConnection {
+  pageInfo: PageInfo!
+  edges: [PodEdge]
+}
+
+enum Tool {
+  HELM
+  TERRAFORM
+}
+
+type ApplicationLink {
+  url: String
+  description: String
+}
+
+type Stack {
+  id: ID!
+  name: String!
+  bundles: [Recipe]
+  sections: [RecipeSection]
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type UpgradePolicy {
+  id: ID!
+  name: String!
+  description: String
+  type: UpgradePolicyType!
+  target: String!
+  weight: Int
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type RootQueryType {
+  configuration: ConsoleConfiguration
+  externalToken: String
+  builds(after: String, first: Int, before: String, last: Int): BuildConnection
+  build(id: ID!): Build
+  buildInfo: BuildInfo
+  users(after: String, first: Int, before: String, last: Int, q: String): UserConnection
+  loginInfo(redirect: String): LoginInfo
+  me: User
+  invite(id: String!): Invite
+  groups(after: String, first: Int, before: String, last: Int, q: String): GroupConnection
+  groupMembers(after: String, first: Int, before: String, last: Int, groupId: ID!): GroupMemberConnection
+  role: Role
+  roles(after: String, first: Int, before: String, last: Int, q: String): RoleConnection
+  notifications(after: String, first: Int, before: String, last: Int, all: Boolean): NotificationConnection
+  dashboards(repo: String!): [Dashboard]
+  dashboard(repo: String!, name: String!, step: String, offset: Int, labels: [LabelInput]): Dashboard
+  metric(query: String!, offset: Int, step: String): [MetricResponse]
+  logs(query: String!, start: Long, end: Long, limit: Int!): [LogStream]
+  scalingRecommendation(kind: AutoscalingTarget!, namespace: String!, name: String!): VerticalPodAutoscaler
+  service(namespace: String!, name: String!): Service
+  clusterInfo: ClusterInfo
+  deployment(namespace: String!, name: String!): Deployment
+  statefulSet(namespace: String!, name: String!): StatefulSet
+  ingress(namespace: String!, name: String!): Ingress
+  nodes: [Node]
+  node(name: String!): Node
+  cronJob(namespace: String!, name: String!): CronJob
+  job(namespace: String!, name: String!): Job
+  certificate(namespace: String!, name: String!): Certificate
+  pod(namespace: String!, name: String!): Pod
+  pods(after: String, first: Int, before: String, last: Int, namespaces: [String]): PodConnection
+  wireguardPeers: [WireguardPeer]
+  myWireguardPeers: [WireguardPeer]
+  wireguardPeer(name: String!): WireguardPeer
+  cachedPods(namespaces: [String]): [Pod]
+  namespaces: [Namespace]
+  logFilters(namespace: String!): [LogFilter]
+  nodeMetrics: [NodeMetric]
+  nodeMetric(name: String!): NodeMetric
+  configurationOverlays(namespace: String!): [ConfigurationOverlay]
+  audits(after: String, first: Int, before: String, last: Int, repo: String): AuditConnection
+  auditMetrics: [AuditMetric]
+  installations(after: String, first: Int, before: String, last: Int): InstallationConnection
+  applications: [Application]
+  application(name: String!): Application
+  repository(name: String!): Repository
+  repositories(after: String, first: Int, before: String, last: Int, query: String!): RepositoryConnection
+  recipes(after: String, first: Int, before: String, last: Int, id: ID!): RecipeConnection
+  context: [RepositoryContext]
+  pluralContext: PluralContext
+  recipe(id: ID!): Recipe
+  stack(name: String!): Stack
+  smtp: Smtp
+  upgradePolicies: [UpgradePolicy]
+  runbook(namespace: String!, name: String!): Runbook
+  runbooks(namespace: String!, pinned: Boolean): [Runbook]
+  webhooks(after: String, first: Int, before: String, last: Int): WebhookConnection
+}
+
+type RoleBinding {
+  id: ID!
+  user: User
+  group: Group
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type IssuerRef {
+  group: String
+  kind: String
+  name: String
+}
+
+enum AuditType {
+  BUILD
+  POD
+  CONFIGURATION
+  USER
+  GROUP
+  ROLE
+  GROUP_MEMBER
+  POLICY
+}
+
+type MetricResponse {
+  metric: Map
+  values: [MetricResult]
+}
+
+enum ReadType {
+  NOTIFICATION
+  BUILD
+}
+
+type BuildEdge {
+  node: Build
+  cursor: String
+}
+
+type RecipeEdge {
+  node: Recipe
+  cursor: String
+}
+
+type RunningState {
+  startedAt: String
+}
+
+type WaitingState {
+  message: String
+  reason: String
+}
+
+"""
+The `DateTime` scalar type represents a date and time in the UTC
+timezone. The DateTime appears in a JSON response as an ISO8601 formatted
+string, including UTC timezone ("Z"). The parsed date and time string will
+be converted to UTC if there is an offset.
+"""
+scalar DateTime
+
+type GroupMemberEdge {
+  node: GroupMember
+  cursor: String
+}
+
+type RunbookDatasource {
+  name: String!
+  type: String!
+  prometheus: PrometheusDatasource
+  kubernetes: KubernetesDatasource
+}
+
+type JobReference {
+  name: String!
+  namespace: String!
+}
+
+type CommandEdge {
+  node: Command
+  cursor: String
+}
+
+type RunbookExecutionEdge {
+  node: RunbookExecution
+  cursor: String
+}
+
+type Namespace {
+  status: NamespaceStatus!
+  spec: NamespaceSpec!
+  metadata: Metadata!
+  raw: String!
+  events: [Event]
+}
+
+type PluralContext {
+  buckets: [String]
+  domains: [String]
+  configuration: Map!
+}
+
+type Port {
+  hostPort: Int
+  containerPort: Int
+  protocol: String
+}
+
+type IngressBackend {
+  serviceName: String
+  servicePort: String
+}
+
+type Pod {
+  status: PodStatus!
+  spec: PodSpec!
+  metadata: Metadata!
+  raw: String!
+  events: [Event]
+}
+
+type Event {
+  action: String
+  count: Int
+  eventTime: String
+  lastTimestamp: String
+  message: String
+  reason: String
+  type: String
+}
+
+type RunbookSpec {
+  name: String!
+  description: String
+  display: Map
+  datasources: [RunbookDatasource]
+  actions: [RunbookAction]
+}
+
+type Ingress {
+  metadata: Metadata!
+  status: ServiceStatus!
+  spec: IngressSpec!
+  raw: String!
+  events: [Event]
+}
+
+input UserRoleAttributes {
+  admin: Boolean
+}
+
+type DashboardSpec {
+  name: String
+  description: String
+  timeslices: [String]
+  labels: [DashboardLabel]
+  graphs: [DashboardGraph]
+}
+
+input UpgradePolicyAttributes {
+  name: String!
+  description: String
+  type: UpgradePolicyType!
+  target: String!
+  weight: Int
+}
+
+type AuditMetric {
+  country: String
+  count: Int
+}
+
+type LicenseStatus {
+  plan: String
+  free: Boolean
+  features: [LicenseFeature]
+  limits: Map
+  secrets: Map
+}
+
+input WebhookAttributes {
+  url: String!
+}
+
+type ApplicationStatus {
+  components: [StatusComponent]
+  conditions: [StatusCondition]
+  componentsReady: String!
+}
+
+input GroupAttributes {
+  name: String!
+  description: String
+}
+
+input RoleAttributes {
+  name: String
+  description: String
+  repositories: [String]
+  roleBindings: [BindingAttributes]
+  permissions: [Permission]
+}
+
+type Job {
+  metadata: Metadata!
+  status: JobStatus!
+  spec: JobSpec!
+  raw: String!
+  events: [Event]
+  pods: [Pod]
+}
+
+type LogFilter {
+  metadata: Metadata!
+  spec: LogFilterSpec!
+}
+
+type Metadata {
+  labels: [LabelPair]
+  annotations: [LabelPair]
+  name: String!
+  namespace: String
+}
+
+type BuildInfo {
+  all: Int
+  failed: Int
+  queued: Int
+  running: Int
+  successful: Int
+}
+
+enum Permission {
+  READ
+  CONFIGURE
+  DEPLOY
+  OPERATE
+}
+
+type RunbookExecutionConnection {
+  pageInfo: PageInfo!
+  edges: [RunbookExecutionEdge]
+}
+
+type ConsoleConfiguration {
+  gitCommit: String
+  isDemoProject: Boolean
+  isSandbox: Boolean
+  pluralLogin: Boolean
+  vpnEnabled: Boolean
+  features: AvailableFeatures
+  manifest: PluralManifest
+  gitStatus: GitStatus
+}
+
+type CommandConnection {
+  pageInfo: PageInfo!
+  edges: [CommandEdge]
+}
+
+type NodeCondition {
+  message: String
+  reason: String
+  status: String
+  type: String
+}
+
+type GroupMemberConnection {
+  pageInfo: PageInfo!
+  edges: [GroupMemberEdge]
+}
+
+type RecipeConnection {
+  pageInfo: PageInfo!
+  edges: [RecipeEdge]
+}
+
+type ContainerRecommendation {
+  name: String
+  containerName: String
+  target: ContainerResources
+  lowerBound: ContainerResources
+  upperBound: ContainerResources
+  uncappedTarget: ContainerResources
+}
+
+type BuildConnection {
+  pageInfo: PageInfo!
+  edges: [BuildEdge]
+}
+
+type VerticalPodAutoscalerUpdatePolicy {
+  updateMode: String
+}
+
+type ConfigurationOverlay {
+  metadata: Metadata!
+  spec: ConfigurationOverlaySpec!
+}
+
+enum WebhookHealth {
+  HEALTHY
+  UNHEALTHY
+}
+
+scalar Long
+
+type RollingUpdate {
+  maxSurge: Int
+  maxUnavailable: Int
+}
+
+type NotificationEdge {
+  node: Notification
+  cursor: String
+}
+
+type HttpIngressRule {
+  paths: [IngressPath]
+}
+
+type TerminatedState {
+  exitCode: Int
+  finishedAt: String
+  startedAt: String
+  message: String
+  reason: String
+}
+
+type PathUpdate {
+  path: [String]
+  valueFrom: String!
+}
+
+enum UpgradePolicyType {
+  DEPLOY
+  APPROVAL
+  IGNORE
+}
+
+type UserEdge {
+  node: User
+  cursor: String
+}
+
+enum WebhookType {
+  PIAZZA
+  SLACK
+}
+
+type Certificate {
+  metadata: Metadata!
+  status: CertificateStatus!
+  spec: CertificateSpec!
+  raw: String!
+  events: [Event]
+}
+
+type ContainerState {
+  running: RunningState
+  terminated: TerminatedState
+  waiting: WaitingState
+}
+
+input RunbookActionInput {
+  action: String!
+  context: Map!
+}
+
+type RepositoryContext {
+  repository: String!
+  context: Map
+}
+
+type Audit {
+  id: ID!
+  action: AuditAction!
+  type: AuditType!
+  repository: String
+  ip: String
+  city: String
+  country: String
+  latitude: String
+  longitude: String
+  actor: User
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+input LabelInput {
+  name: String
+  value: String
+}
+
+type Dashboard {
+  id: String!
+  spec: DashboardSpec!
+}
+
+type WireguardPeerStatus {
+  ready: Boolean
+  conditions: [StatusCondition]
+}
+
+type WireguardPeerSpec {
+  wireguardRef: String
+}
+
+type PodSpec {
+  serviceAccountName: String
+  nodeName: String
+  containers: [Container]
+  initContainers: [Container]
+}
+
+enum Status {
+  QUEUED
+  RUNNING
+  SUCCESSFUL
+  FAILED
+  CANCELLED
+  PENDING
+}
+
+type RunbookAlertStatus {
+  name: String!
+  startsAt: String
+  fingerprint: String
+  annotations: Map
+  labels: Map
+}
+
+type NamespaceSpec {
+  finalizers: [String]
+}
+
+type CronStatus {
+  active: [JobReference]
+  lastScheduleTime: String
+}
+
+type ServiceStatus {
+  loadBalancer: LoadBalancerStatus
+}
+
+type StatefulSetStatus {
+  currentReplicas: Int
+  replicas: Int
+  readyReplicas: Int
+  updatedReplicas: Int
+}
+
+type StatefulSetSpec {
+  replicas: Int
+  serviceName: String
+}
+
+type ResourceSpec {
+  cpu: String
+  memory: String
+}
+
+type JobStatus {
+  active: Int
+  completionTime: String
+  startTime: String
+  succeeded: Int
+  failed: Int
+}
+
+type LogFilterSpec {
+  name: String
+  description: String
+  query: String
+  labels: [LogLabel]
+}
+
+type NodeMetric {
+  metadata: Metadata!
+  timestamp: String
+  window: String
+  usage: NodeUsage
+}
+
+type LoadBalancerIngressStatus {
+  hostname: String
+  ip: String
+}
+
+type ServiceSpec {
+  type: String
+  clusterIp: String
+  selector: Map
+  ports: [ServicePort]
+}
+
+type VerticalPodAutoscalerStatus {
+  recommendation: Recommendation
+}
+
+type Resources {
+  limits: ResourceSpec
+  requests: ResourceSpec
+}
+
+enum NotificationStatus {
+  FIRING
+  RESOLVED
+}
+
+type UserRoles {
+  admin: Boolean
+}
+
+type User {
+  id: ID!
+  name: String!
+  email: String!
+  deletedAt: DateTime
+  profile: String
+  roles: UserRoles
+  readTimestamp: DateTime
+  buildTimestamp: DateTime
+  boundRoles: [Role]
+  jwt: String
+  unreadNotifications: Int
+  backgroundColor: String
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type LabelPair {
+  name: String
+  value: String
+}
+
+type VerticalPodAutoscaler {
+  metadata: Metadata!
+  spec: VerticalPodAutoscalerSpec!
+  status: VerticalPodAutoscalerStatus
+}
+
+type SecretKeySelector {
+  name: String!
+  key: String
+}
+
+type RunbookData {
+  name: String!
+  source: RunbookDatasource
+  kubernetes: KubernetesData
+  prometheus: [MetricResponse]
+  nodes: [Node]
+}
+
+type BuildDelta {
+  delta: Delta
+  payload: Build
+}
+
+type CommandDelta {
+  delta: Delta
+  payload: Command
+}
+
+type NotificationDelta {
+  delta: Delta
+  payload: Notification
+}
+
+type Group {
+  id: ID!
+  name: String!
+  description: String
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+scalar Map


### PR DESCRIPTION
## Summary
Similarly to what we do on the main app now, this PR uses a local version of the GraphQL schema to generate the TS types and functions. This removes the need to release the console for an API change before the frontend work can continue. It also ensures that API changes that would break the frontend can be caught and fixed in the same PR.


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.