### PR TITLE
Fix redirect urls for builds and configuration

### DIFF
--- a/assets/src/components/apps/app/config/ConfigurationSettings.tsx
+++ b/assets/src/components/apps/app/config/ConfigurationSettings.tsx
@@ -39,7 +39,7 @@ function organizeOverlays(overlays) {
 
 export function ConfigurationSettings({ overlays, application: { name, configuration: { helm } } }) {
   const navigate = useNavigate()
-  const onCompleted = useCallback(() => navigate('/'), [navigate])
+  const onCompleted = useCallback(() => navigate('/builds'), [navigate])
   const [ctx, setCtx] = useState({})
   const [init, setInit] = useState({})
   const [mutation, { loading }] = useMutation(EXECUTE_OVERLAY, {

--- a/assets/src/components/apps/app/runbooks/runbook/display/DisplayButton.tsx
+++ b/assets/src/components/apps/app/runbooks/runbook/display/DisplayButton.tsx
@@ -5,6 +5,8 @@ import { useContext, useState } from 'react'
 import { useMutation } from '@apollo/client'
 import { useNavigate, useParams } from 'react-router-dom'
 
+import { legacyUrl } from 'helpers/url'
+
 import { ActionPortal } from '../Runbook'
 
 import { DisplayContext } from '../RunbookDisplay'
@@ -29,7 +31,7 @@ export function DisplayButton({ attributes: { action, headline, ...rest } }) {
   const [mutation, { loading }] = useMutation(EXECUTE_RUNBOOK, {
     variables: { name: runbookName, namespace: appName, input: { context: JSON.stringify(context), action } },
     onCompleted: ({ executeRunbook: { redirectTo } }) => {
-      if (redirectTo) navigate(redirectTo)
+      if (redirectTo) navigate(legacyUrl(redirectTo))
     },
     onError: error => {
       setError(error)

--- a/assets/src/helpers/url.js
+++ b/assets/src/helpers/url.js
@@ -1,0 +1,1 @@
+export const legacyUrl = url => (url === '/' ? '/builds' : '/')


### PR DESCRIPTION
## Summary

most runbooks specify redirect url to '/' which was the builds page on legacy console but not anymore, this will autowire it and not require all runbooks to be rewritten as a result.

Also fix redirect for config overlay updates


## Test Plan
local


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.