### PR TITLE
fix: Data syncing issue with virtualized lists

### DIFF
--- a/assets/src/components/account/groups/GroupsList.tsx
+++ b/assets/src/components/account/groups/GroupsList.tsx
@@ -31,7 +31,10 @@ export function GroupsList({ q }: any) {
           setListRef={setListRef}
           items={edges}
           mapper={({ node: group }, { next }) => (
-            <ListItem last={!next.node}>
+            <ListItem
+              key={group.id}
+              last={!next.node}
+            >
               <Group
                 group={group}
                 q={q}

--- a/assets/src/components/account/roles/RolesList.tsx
+++ b/assets/src/components/account/roles/RolesList.tsx
@@ -33,7 +33,10 @@ export default function RolesList({ q }: any) {
           setListRef={setListRef}
           items={edges}
           mapper={({ node: role }, { next }) => (
-            <ListItem last={!next.node}>
+            <ListItem
+              key={role.id}
+              last={!next.node}
+            >
               <Role
                 role={role}
                 q={q}

--- a/assets/src/components/account/users/UsersList.tsx
+++ b/assets/src/components/account/users/UsersList.tsx
@@ -50,7 +50,10 @@ export default function UsersList() {
             setListRef={setListRef}
             items={edges}
             mapper={({ node: user }, { next }) => (
-              <ListItem last={!next.node}>
+              <ListItem
+                key={user.id}
+                last={!next.node}
+              >
                 <User user={user} />
               </ListItem>
             )}

--- a/assets/src/components/account/webhooks/WebhooksList.tsx
+++ b/assets/src/components/account/webhooks/WebhooksList.tsx
@@ -28,7 +28,12 @@ export default function WebhooksList() {
         listRef={listRef}
         setListRef={setListRef}
         items={edges}
-        mapper={({ node }) => <Webhook hook={node} />}
+        mapper={({ node }) => (
+          <Webhook
+            key={node.id}
+            hook={node}
+          />
+        )}
         loading={loading}
         loadNextPage={() =>
           pageInfo.hasNextPage &&

--- a/assets/src/components/apps/app/logs/LogContent.tsx
+++ b/assets/src/components/apps/app/logs/LogContent.tsx
@@ -106,6 +106,7 @@ export default function LogContent({
         items={lines}
         mapper={({ line, level, stream }, o) => (
           <LogLine
+            key={line.timestamp}
             line={line}
             level={level}
             open={open === o}

--- a/assets/src/components/apps/app/logs/LogLine.tsx
+++ b/assets/src/components/apps/app/logs/LogLine.tsx
@@ -60,7 +60,12 @@ export default function LogLine({
       >
         {ts(timestamp)}
         {blocks.map((json) => (
-          <Span {...textStyle(json)}>&nbsp;{json.content}</Span>
+          <Span
+            key={json.content}
+            {...textStyle(json)}
+          >
+            &nbsp;{json.content}
+          </Span>
         ))}
       </Flex>
       <Flex

--- a/assets/src/components/incidents/Incident.jsx
+++ b/assets/src/components/incidents/Incident.jsx
@@ -305,9 +305,13 @@ export function Messages({ incident, loading, fetchMore, subscribeToMore }) {
       items={[...edges, 'end']}
       mapper={(e, { next, prev }, props) =>
         e === 'end' ? (
-          <LastMessage date={prev.node.insertedAt} />
+          <LastMessage
+            key={e.node.id}
+            date={prev.node.insertedAt}
+          />
         ) : (
           <Message
+            key={e.node.id}
             message={e.node}
             next={next.node}
             prev={prev.node}
@@ -371,6 +375,7 @@ function Files({ incident, fetchMore }) {
         emptyState={<NoFiles />}
         mapper={({ node }, { node: next }) => (
           <FileEntry
+            key={node.id}
             file={node}
             next={next}
           />


### PR DESCRIPTION
Updated all `mapper` functions in `<StandardScroller>` components to have `key` props set. This fixes issue with component states getting out of sync with the underlying data.