### PR TITLE
fix: Console Pod Logs broken if not in a plural application

### DIFF
--- a/assets/src/components/apps/app/logs/LogContent.tsx
+++ b/assets/src/components/apps/app/logs/LogContent.tsx
@@ -70,7 +70,7 @@ export default function LogContent({
   listRef,
   setListRef,
   logs,
-  name,
+  namespace,
   loading,
   fetchMore,
   onScroll,
@@ -102,7 +102,7 @@ export default function LogContent({
         listRef={listRef}
         setListRef={setListRef}
         setLoader={setLoader}
-        refreshKey={`${name}:${search}`}
+        refreshKey={`${namespace}:${search}`}
         items={lines}
         mapper={({ line, level, stream }, o) => (
           <LogLine

--- a/assets/src/components/apps/app/logs/LogsCard.tsx
+++ b/assets/src/components/apps/app/logs/LogsCard.tsx
@@ -12,7 +12,7 @@ const POLL_INTERVAL = 10 * 1000
 const LIMIT = 1000
 
 export function LogsCard({
-  application: { name },
+  namespace,
   query,
   addLabel,
   fullscreen = false,
@@ -51,7 +51,7 @@ export function LogsCard({
           <LogContent
             listRef={listRef}
             setListRef={setListRef}
-            name={name}
+            namespace={namespace}
             logs={data.logs}
             setLoader={setLoader}
             search={query}

--- a/assets/src/components/apps/app/logs/LogsFullScreen.tsx
+++ b/assets/src/components/apps/app/logs/LogsFullScreen.tsx
@@ -14,7 +14,7 @@ import { LogsCard } from './LogsCard'
 import LogsFilters from './LogsFilters'
 
 export default function LogsFullScreen({
-  application,
+  namespace,
   query,
   search,
   setSearch,
@@ -90,7 +90,7 @@ export default function LogsFullScreen({
             removeLabel={removeLabel}
           />
           <LogsCard
-            application={application}
+            namespace={namespace}
             query={query}
             addLabel={addLabel}
             height="100%"

--- a/assets/src/components/cluster/pods/Pod.tsx
+++ b/assets/src/components/cluster/pods/Pod.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react'
-import { Outlet, useParams } from 'react-router-dom'
-import { TabPanel, useBreadcrumbs } from '@pluralsh/design-system'
+import { useMemo, useRef } from 'react'
+import { Outlet, useMatch, useParams } from 'react-router-dom'
+import { TabPanel, useSetBreadcrumbs } from '@pluralsh/design-system'
 import { useTheme } from 'styled-components'
 
 import { ResponsiveLayoutSidecarContainer } from 'components/utils/layout/ResponsiveLayoutSidecarContainer'
@@ -17,19 +17,23 @@ export default function Node() {
   const tabStateRef = useRef<any>()
   const theme = useTheme()
   const { name, namespace } = useParams()
-  const { setBreadcrumbs } = useBreadcrumbs()
+  const { tab } = useMatch('/pods/:namespace/:name/:tab')?.params || {}
 
-  // TODO: Investigate whether these links could more specific,
-  // based on where they navigated from, perhaps the `namespace` crumb
-  // could navigate to the Pods view already filtered for that namespace
-  useEffect(() => {
-    if (name && namespace) {
-      setBreadcrumbs([
-        { label: 'pods', url: '/pods' }, // Add filter param here later maybe?
-        { label: name, url: name },
-      ])
-    }
-  }, [name, namespace, setBreadcrumbs])
+  const breadcrumbs = useMemo(
+    () => [
+      { label: 'pods', url: '/pods' },
+      ...(namespace ? [{ label: namespace, url: `/pods/${namespace}` }] : []),
+      ...(namespace && name
+        ? [{ label: name, url: `/pods/${namespace}/${name}` }]
+        : []),
+      ...(tab && namespace && name
+        ? [{ label: tab, url: `/pods/${namespace}/${name}/${tab}` }]
+        : []),
+    ],
+    [name, namespace, tab]
+  )
+
+  useSetBreadcrumbs(breadcrumbs)
 
   return (
     <ResponsiveLayoutPage>

--- a/assets/src/components/cluster/pods/PodInfo.tsx
+++ b/assets/src/components/cluster/pods/PodInfo.tsx
@@ -13,6 +13,8 @@ import { POD_INFO_Q } from '../queries'
 import { SubTitle } from '../nodes/SubTitle'
 import { ContainersList } from '../containers/ContainersList'
 
+import { useNamespaceIsApp } from '../../hooks/useNamespaceIsApp'
+
 import PodMetadata from './PodMetadata'
 import PodConditions from './PodConditions'
 
@@ -27,14 +29,30 @@ export const statusesToRecord = (statuses?: Maybe<Maybe<ContainerStatus>[]>) =>
     {} as Record<string, Maybe<ContainerStatus>>
   )
 
-function getLogUrl({ name, namespace }) {
-  return `/apps/${namespace}/logs?${asQuery({ pod: name })}`
+function useGetLogUrl({
+  name,
+  namespace,
+}: {
+  name?: string
+  namespace?: string
+}) {
+  const isApp = useNamespaceIsApp(namespace)
+
+  if (!namespace) {
+    return null
+  }
+
+  return isApp
+    ? `/apps/${namespace}/logs${name ? `?${asQuery({ pod: name })}` : ''}`
+    : name
+    ? `/pods/${namespace}/${name}/logs`
+    : null
 }
 
 function ViewLogsButton({ metadata }: any) {
-  if (!metadata) return null
+  const url = useGetLogUrl(metadata)
 
-  const url = getLogUrl(metadata)
+  if (!url) return null
 
   return (
     <Button

--- a/assets/src/components/cluster/pods/PodLogs.tsx
+++ b/assets/src/components/cluster/pods/PodLogs.tsx
@@ -1,0 +1,12 @@
+import { LogsBase } from 'components/apps/app/logs/Logs'
+import { useParams } from 'react-router-dom'
+
+export default function PodLogs() {
+  const { namespace } = useParams()
+
+  if (!namespace) {
+    return null
+  }
+
+  return <LogsBase namespace={namespace} />
+}

--- a/assets/src/components/cluster/pods/PodSideNav.tsx
+++ b/assets/src/components/cluster/pods/PodSideNav.tsx
@@ -1,19 +1,33 @@
 import { Tab, TabList } from '@pluralsh/design-system'
-import { useMatch } from 'react-router-dom'
-
+import { useMatch, useParams } from 'react-router-dom'
 import { LinkTabWrap } from 'components/utils/Tabs'
+import { useMemo } from 'react'
 
-const DIRECTORY = [
-  { path: '', label: 'Info' },
-  { path: 'events', label: 'Events' },
-  { path: 'raw', label: 'Raw' },
-]
+import { useNamespaceIsApp } from '../../hooks/useNamespaceIsApp'
+
+const useGetDirectory = (namespace = '') => {
+  const namespaceIsApp = useNamespaceIsApp(namespace)
+
+  return useMemo(() => {
+    const showLogs = !namespaceIsApp
+
+    return [
+      { path: '', label: 'Info' },
+      { path: 'events', label: 'Events' },
+      { path: 'raw', label: 'Raw' },
+      ...(showLogs ? [{ path: 'logs', label: 'Logs' }] : []),
+    ]
+  }, [namespaceIsApp])
+}
 
 function NodesTabList({ tabStateRef }: any) {
+  const { namespace } = useParams()
+
   const subpath =
     useMatch('/pods/:namespace/:name/:subpath')?.params?.subpath || ''
+  const directory = useGetDirectory(namespace)
 
-  const currentTab = DIRECTORY.find(({ path }) => path === subpath)
+  const currentTab = directory.find(({ path }) => path === subpath)
 
   return (
     <TabList
@@ -23,7 +37,7 @@ function NodesTabList({ tabStateRef }: any) {
         selectedKey: currentTab?.path,
       }}
     >
-      {DIRECTORY.map(({ label, path }) => (
+      {directory.map(({ label, path }) => (
         <LinkTabWrap
           key={path}
           textValue={label}

--- a/assets/src/components/cluster/pods/PodsList.tsx
+++ b/assets/src/components/cluster/pods/PodsList.tsx
@@ -214,6 +214,7 @@ export const ColImages = columnHelper.accessor((row) => row?.images || [], {
 
     return images.map((image) => (
       <Tooltip
+        key={image}
         label={image}
         placement="left-start"
       >

--- a/assets/src/components/hooks/useNamespaceIsApp.tsx
+++ b/assets/src/components/hooks/useNamespaceIsApp.tsx
@@ -1,0 +1,13 @@
+import { useContext, useMemo } from 'react'
+import { InstallationContext } from 'components/Installations'
+
+export const useNamespaceIsApp = (namespace = '') => {
+  const { applications } = useContext<any>(InstallationContext) as {
+    applications?: { name?: string }[]
+  }
+
+  return useMemo(
+    () => !!(namespace && applications?.some((app) => app?.name === namespace)),
+    [applications, namespace]
+  )
+}

--- a/assets/src/components/layout/AppNav.tsx
+++ b/assets/src/components/layout/AppNav.tsx
@@ -201,6 +201,7 @@ export function StatusPanel({ statuses, open, onClose }) {
         </StatusPanelTopContainer>
         {apps.map((app, i) => (
           <AppStatusWrap
+            key={app?.name}
             onClick={() => {
               onClose()
               navigate(`/apps/${app.name}`)

--- a/assets/src/routes/clusterRoutes.tsx
+++ b/assets/src/routes/clusterRoutes.tsx
@@ -6,6 +6,7 @@ import Pod from 'components/cluster/pods/Pod'
 import PodInfo from 'components/cluster/pods/PodInfo'
 import PodEvents from 'components/cluster/pods/PodEvents'
 import PodRaw from 'components/cluster/pods/PodRaw'
+import PodLogs from 'components/cluster/pods/PodLogs'
 import Node from 'components/cluster/nodes/Node'
 import Nodes from 'components/cluster/nodes/Nodes'
 import NodeEvents from 'components/cluster/nodes/NodeEvents'
@@ -39,6 +40,10 @@ export const clusterRoutes = [
     <Route
       path="raw"
       element={<PodRaw />}
+    />
+    <Route
+      path="logs"
+      element={<PodLogs />}
     />
   </Route>,
 


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->
Created a new 'Logs' tab for Pods pages that have no associated apps. Pods without an associated apps will have the 'View logs' button direct to this tab while pods with apps will still be linked to the App page's logs tab.

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203951917789151