### PR TITLE
feat: Hide installer steps for already installed apps

### DIFF
--- a/assets/src/components/repos/installer/Installer.tsx
+++ b/assets/src/components/repos/installer/Installer.tsx
@@ -98,7 +98,13 @@ export function Installer({ setOpen, setConfirmClose, setVisible }) {
   const onSelect = useCallback(
     (selectedApplications) => {
       const build = async () => {
-        const steps = await buildSteps(client, selectedApplications)
+        const steps = await buildSteps(
+          client,
+          selectedApplications,
+          new Set<string>(
+            installedApplications.map((repository) => repository.name)
+          )
+        )
 
         setSteps(steps)
       }
@@ -112,7 +118,7 @@ export function Installer({ setOpen, setConfirmClose, setVisible }) {
           onResetRef?.current?.onReset()
         })
     },
-    [client]
+    [client, installedApplications]
   )
 
   useEffect(

--- a/assets/src/components/repos/installer/helpers.tsx
+++ b/assets/src/components/repos/installer/helpers.tsx
@@ -1,3 +1,4 @@
+import { ApolloClient, FetchResult } from '@apollo/client'
 import {
   AppsIcon,
   InstallIcon,
@@ -5,10 +6,10 @@ import {
   WizardPicker,
   WizardStepConfig,
 } from '@pluralsh/design-system'
-import { ApolloClient, FetchResult } from '@apollo/client'
 import React from 'react'
 
 import {
+  Installation,
   Recipe,
   RecipeSection,
   RepositoryContext,
@@ -61,7 +62,8 @@ const toDependencySteps = (
 
 const buildSteps = async (
   client: ApolloClient<unknown>,
-  selectedApplications: Array<WizardStepConfig>
+  selectedApplications: Array<WizardStepConfig>,
+  installedApplications: Set<string>
 ) => {
   const dependencyMap = new Map<
     string,
@@ -88,9 +90,13 @@ const buildSteps = async (
       variables: { id: recipeBase?.id },
     })
 
-    const sections = recipe.recipe.recipeSections!.filter(
-      (section) => section!.repository!.name !== app.label
-    )
+    const sections = recipe.recipe
+      .recipeSections!.filter(
+        (section) => section!.repository!.name !== app.label
+      )
+      .filter(
+        (section) => !installedApplications.has(section!.repository!.name)
+      )
 
     sections.forEach((section) => {
       if (

--- a/assets/src/components/repos/installer/helpers.tsx
+++ b/assets/src/components/repos/installer/helpers.tsx
@@ -9,7 +9,6 @@ import {
 import React from 'react'
 
 import {
-  Installation,
   Recipe,
   RecipeSection,
   RepositoryContext,

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -2026,6 +2026,7 @@ export type UpgradePolicy = {
   id: Scalars['ID'];
   insertedAt?: Maybe<Scalars['DateTime']>;
   name: Scalars['String'];
+  repositories?: Maybe<Array<Maybe<Scalars['String']>>>;
   target: Scalars['String'];
   type: UpgradePolicyType;
   updatedAt?: Maybe<Scalars['DateTime']>;
@@ -2035,6 +2036,7 @@ export type UpgradePolicy = {
 export type UpgradePolicyAttributes = {
   description?: InputMaybe<Scalars['String']>;
   name: Scalars['String'];
+  repositories?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   target: Scalars['String'];
   type: UpgradePolicyType;
   weight?: InputMaybe<Scalars['Int']>;

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -840,6 +840,7 @@ type UpgradePolicy {
   id: ID!
   name: String!
   description: String
+  repositories: [String]
   type: UpgradePolicyType!
   target: String!
   weight: Int
@@ -1073,8 +1074,9 @@ type DashboardSpec {
 input UpgradePolicyAttributes {
   name: String!
   description: String
-  type: UpgradePolicyType!
   target: String!
+  type: UpgradePolicyType!
+  repositories: [String]
   weight: Int
 }
 


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
When building dependency steps already installed apps will not be visible.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally by installing few apps via dev console.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.