### PR TITLE
feat: Sync admin state in console logins

### DIFF
--- a/lib/console/services/users.ex
+++ b/lib/console/services/users.ex
@@ -79,6 +79,7 @@ defmodule Console.Services.Users do
 
   @spec bootstrap_user(map) :: user_resp
   def bootstrap_user(%{"email" => email} = attrs) do
+    attrs = token_attrs(attrs)
     start_transaction()
     |> add_operation(:user, fn _ ->
       case get_user_by_email(email) do
@@ -89,6 +90,10 @@ defmodule Console.Services.Users do
     |> hydrate_groups(attrs)
     |> execute(extract: :user)
   end
+
+  defp token_attrs(%{"admin" => true} = attrs), do: Map.put(attrs, "roles", %{"admin" => true})
+  defp token_attrs(%{"admin" => false} = attrs), do: Map.put(attrs, "roles", %{"admin" => false})
+  defp token_attrs(attrs), do: attrs
 
   def temporary_token(%User{} = user) do
     with {:ok, token, _} <- Console.Guardian.encode_and_sign(user, %{}, ttl: {1, :hour}) do

--- a/test/console/services/users_test.exs
+++ b/test/console/services/users_test.exs
@@ -55,6 +55,7 @@ defmodule Console.Services.UsersTest do
         "name" => "Some User",
         "profile" => "https://some.image.com",
         "groups" => ["general"],
+        "admin" => true,
         "plural_id" => "abcdef-123456789-ghijkl"
       })
 
@@ -62,6 +63,7 @@ defmodule Console.Services.UsersTest do
       assert user.email == "someone@example.com"
       assert user.profile == "https://some.image.com"
       assert user.plural_id == "abcdef-123456789-ghijkl"
+      assert user.roles.admin
 
       group = Users.get_group_by_name("general")
       assert group.description == "synced from Plural"


### PR DESCRIPTION
## Summary

Sync admin state from id tokens on console logins.  Users keep tripping up on this so just auto-sync it for now.  If requested, we can killswitch this functionality.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.