### PR TITLE
Allow tenant headers to be injected into grafana stack clients

### DIFF
--- a/lib/console/services/plural.ex
+++ b/lib/console/services/plural.ex
@@ -5,7 +5,6 @@ defmodule Console.Services.Plural do
   alias Console.Utils
   alias Console.Services.{Builds}
   alias Console.Plural.{Repositories, Users, Recipe, Installation, OIDCProvider, Manifest, Context, Accounts}
-  alias Console.Commands
   alias Kube.Application
   use Nebulex.Caching
 

--- a/lib/loki/client.ex
+++ b/lib/loki/client.ex
@@ -1,4 +1,5 @@
 defmodule Loki.Client do
+  import Prometheus.Client, only: [headers: 0]
   alias Loki.{Response, Data, Result, Value}
 
   def host(), do: Application.get_env(:console, :loki)
@@ -8,7 +9,7 @@ defmodule Loki.Client do
 
     host()
     |> Path.join("/loki/api/v1/query_range?#{query}")
-    |> HTTPoison.get()
+    |> HTTPoison.get(headers())
     |> case do
       {:ok, %{body: body, status_code: 200}} ->
         {:ok, body

--- a/lib/prometheus/client.ex
+++ b/lib/prometheus/client.ex
@@ -14,7 +14,7 @@ defmodule Prometheus.Client do
         {"start", DateTime.to_iso8601(start)},
         {"step", step}
       ]},
-      @headers
+      headers(@headers)
     )
     |> case do
       {:ok, %{body: body, status_code: 200}} ->
@@ -43,5 +43,12 @@ defmodule Prometheus.Client do
         String.replace(str, "$#{key}", value)
       _, str -> str
     end)
+  end
+
+  def headers(base \\ []) do
+    case Console.conf(:grafana_tenant) do
+      nil -> base
+      tenant -> [{"X-Scope-OrgID", tenant} | base]
+    end
   end
 end

--- a/plural/helm/console/Chart.yaml
+++ b/plural/helm/console/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.4.18
 description: A chart for plural console
 name: console
-version: 0.7.66
+version: 0.7.67
 dependencies:
 - name: test-base
   repository: https://pluralsh.github.io/module-library

--- a/plural/helm/console/values.yaml.tpl
+++ b/plural/helm/console/values.yaml.tpl
@@ -25,11 +25,17 @@ consoleIdentityId: {{ importValue "Terraform" "console_msi_id" }}
 consoleIdentityClientId: {{ importValue "Terraform" "console_msi_client_id" }}
 {{ end }}
 
-{{- if or (eq .Provider "azure") .Configuration.loki }}
+{{- if or (eq .Provider "azure") .Configuration.loki .Configuration.mimir }}
 extraEnv:
 {{- if .Configuration.loki }}
 - name: LOKI_HOST
-  value: http://loki-loki-distributed-gateway.loki
+  value: http://loki-loki-distributed-gateway.{{ namespace "loki" }}
+{{- end }}
+{{- if .Configuration.mimir }}
+- name: PROMETHEUS_HOST
+  value: http://mimir-nginx.{{ namespace "mimir" }}/prometheus
+- name: GRAFANA_TENANT
+  value: {{ .Cluster }}
 {{- end }}
 {{ if eq .Provider "azure" }}
 - name: ARM_USE_MSI

--- a/rel/config/config.exs
+++ b/rel/config/config.exs
@@ -32,4 +32,8 @@ if get_env("LOKI_HOST") do
   config :console, :loki, get_env("LOKI_HOST")
 end
 
+if get_env("GRAFANA_TENANT") do
+  config :console, :grafana_tenant, get_env("GRAFANA_TENANT")
+end
+
 config :elixir, :ansi_enabled, true

--- a/test/console/graphql/queries/observability_queries_test.exs
+++ b/test/console/graphql/queries/observability_queries_test.exs
@@ -126,7 +126,7 @@ defmodule Console.GraphQl.ObservabilityQueriesTest do
 
   describe "logs" do
     test "it can fetch logs for a loki query" do
-      expect(HTTPoison, :get, fn _ ->
+      expect(HTTPoison, :get, fn _, _ ->
         {:ok, %HTTPoison.Response{status_code: 200, body: Poison.encode!(%{data: %{result: [
             %{stream: %{"var" => "val"}, values: [["1", "hello"]]},
             %{stream: %{"var" => "val2"}, values: [["1", "world"]]}

--- a/test/console_web/controllers/log_controller_test.exs
+++ b/test/console_web/controllers/log_controller_test.exs
@@ -5,7 +5,7 @@ defmodule ConsoleWeb.LogControllerTest do
   describe "#download/2" do
     test "it will download logs for a permitted user", %{conn: conn} do
       admin = insert(:user, roles: %{admin: true})
-      expect(HTTPoison, :get, 2, fn url ->
+      expect(HTTPoison, :get, 2, fn url, _ ->
         URI.parse(url)
         |> Map.get(:query)
         |> URI.decode_query()


### PR DESCRIPTION
## Summary
Allows console to be compatible w/ trace shield clusters. Can work on multitenancy later.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.