### PR TITLE
fix: set missing image tag for migration

### DIFF
--- a/plural/helm/console/Chart.yaml
+++ b/plural/helm/console/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.4.18
 description: A chart for plural console
 name: console
-version: 0.7.65
+version: 0.7.66
 dependencies:
 - name: test-base
   repository: https://pluralsh.github.io/module-library

--- a/plural/helm/console/templates/deployment.yaml
+++ b/plural/helm/console/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.shutdownDelay }}
       initContainers:
       - name: wait-for-pg
-        image: gcr.io/pluralsh/library/busybox:1.35.0
+        image: {{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}
         imagePullPolicy: IfNotPresent
         command: [ "/bin/sh", "-c", "until nc -zv plural-console 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:

--- a/plural/helm/console/templates/migration.yaml
+++ b/plural/helm/console/templates/migration.yaml
@@ -14,12 +14,12 @@ spec:
       {{- end }}
       initContainers:
       - name: wait-for-pg
-        image: gcr.io/pluralsh/busybox:latest
+        image: {{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}
         imagePullPolicy: IfNotPresent
         command: [ "/bin/sh", "-c", "until nc -zv plural-console 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
       containers:
       - name: migrator
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command: ["/opt/app/bin/console",  "migrate"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:

--- a/plural/helm/console/values.yaml
+++ b/plural/helm/console/values.yaml
@@ -9,6 +9,11 @@ image:
   tag: ~
   imagePullPolicy: IfNotPresent
 
+initContainer:
+  image:
+    repository: gcr.io/pluralsh/library/busybox
+    tag: 1.35.0
+
 serviceAccount:
   create: true
   annotations: {}


### PR DESCRIPTION
## Summary
The last PR to set the default image tag wasn't set on the migration container. This adds that back as well as templating in the init container image.

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.