### PR TITLE
Make bootstrap_user robust to duplicate groups

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres:latest
+    image: postgres:14
     restart: always
     ports:
     - 5432:5432

--- a/lib/console/services/users.ex
+++ b/lib/console/services/users.ex
@@ -112,7 +112,8 @@ defmodule Console.Services.Users do
   end
 
   defp hydrate_groups(transaction, %{"groups" => [_ | _] = groups}) do
-    Enum.reduce(groups, transaction, fn group, xaction ->
+    Enum.uniq(groups)
+    |> Enum.reduce(transaction, fn group, xaction ->
       xaction
       |> add_operation({:group, group}, fn _ ->
         case get_group_by_name(group) do

--- a/test/console/services/users_test.exs
+++ b/test/console/services/users_test.exs
@@ -71,6 +71,28 @@ defmodule Console.Services.UsersTest do
       assert Users.get_group_member(group.id, user.id)
     end
 
+    test "it is robust to duplicate group names" do
+      {:ok, user} = Users.bootstrap_user(%{
+        "email" => "someone@example.com",
+        "name" => "Some User",
+        "profile" => "https://some.image.com",
+        "groups" => ["general", "general"],
+        "admin" => true,
+        "plural_id" => "abcdef-123456789-ghijkl"
+      })
+
+      assert user.name == "Some User"
+      assert user.email == "someone@example.com"
+      assert user.profile == "https://some.image.com"
+      assert user.plural_id == "abcdef-123456789-ghijkl"
+      assert user.roles.admin
+
+      group = Users.get_group_by_name("general")
+      assert group.description == "synced from Plural"
+
+      assert Users.get_group_member(group.id, user.id)
+    end
+
     test "If the user already exists, they will be returned" do
       user = insert(:user)
 


### PR DESCRIPTION
## Summary
This used to be able to happen (should be fixed in plural core) due to account transfers.  There are still some users out there with dupe groups so should make console handle it explicitly.


## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.