### PR TITLE
feat: allow overriding CLI version used by console via helm config

### DIFF
--- a/plural/helm/console/Chart.yaml
+++ b/plural/helm/console/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: console
 description: A chart for plural console
-appVersion: 0.5.4
+appVersion: 0.5.5
 version: 0.7.80
 dependencies:
   - name: test-base

--- a/plural/helm/console/templates/deployment.yaml
+++ b/plural/helm/console/templates/deployment.yaml
@@ -35,6 +35,15 @@ spec:
         image: {{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}
         imagePullPolicy: IfNotPresent
         command: [ "/bin/sh", "-c", "until nc -zv plural-console 5432 -w1; do echo 'waiting for db'; sleep 1; done" ]
+      {{ if .Values.cliContainer.enabled }}
+      - name: cli-override
+        image: {{ .Values.cliContainer.image.repository }}:{{ .Values.cliContainer.image.tag }}
+        imagePullPolicy: IfNotPresent
+        command: [ "/bin/sh", "-c", "cp /go/bin/plural /shared/plural"]
+        volumeMounts:
+          - name: cli-override
+            mountPath: /shared
+      {{- end }}
       containers:
       - name: console
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -54,6 +63,11 @@ spec:
         {{ end }}
         - name: console-conf
           mountPath: "/root/.plural"
+        {{ if .Values.cliContainer.enabled }}
+        - name: cli-override
+          mountPath: /usr/local/bin/plural
+          subPath: plural
+        {{- end }}
         ports:
         - name: http
           containerPort: {{ .Values.service.port }}
@@ -93,3 +107,7 @@ spec:
       - name: console-conf
         secret:
           secretName: console-conf
+      {{ if .Values.cliContainer.enabled }}
+      - name: cli-override
+        emptyDir: {}
+      {{- end }}

--- a/plural/helm/console/values.yaml
+++ b/plural/helm/console/values.yaml
@@ -14,6 +14,12 @@ initContainer:
     repository: gcr.io/pluralsh/library/busybox
     tag: 1.35.0
 
+cliContainer:
+  enabled: false
+  image:
+    repository: ghcr.io/pluralsh/plural-cli
+    tag: latest
+
 serviceAccount:
   create: true
   annotations: {}


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
This change allows us to easily swap baked-in CLI in the console with a custom CLI from our docker image pushed by every PR.

To replace CLI with a new version simply add to the `values.yaml`:
```yaml
console:
  cliContainer:
    enabled: true
    image:
      tag: pr-455
```

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Manually with a console link on our cd-demo cluster.

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.