### PR TITLE
feat: update cluster/services routes and fix cluster pod detail view

### DIFF
--- a/assets/src/components/cd/cluster/ClusterServices.tsx
+++ b/assets/src/components/cd/cluster/ClusterServices.tsx
@@ -122,7 +122,7 @@ export default function ClusterServices() {
             ) =>
               navigate(
                 getServiceDetailsPath({
-                  clusterName: original.node?.cluster?.name,
+                  clusterId: original.node?.cluster?.id,
                   serviceId: original.node?.id,
                 })
               )

--- a/assets/src/components/cd/services/ServiceSelector.tsx
+++ b/assets/src/components/cd/services/ServiceSelector.tsx
@@ -30,7 +30,7 @@ export default function ServiceSelector({
 
         navigate(
           `${getServiceDetailsPath({
-            clusterName: service?.cluster?.name,
+            clusterId: service?.cluster?.id,
             serviceId: service?.id,
           })}${urlSuffix}`
         )

--- a/assets/src/components/cd/services/Services.tsx
+++ b/assets/src/components/cd/services/Services.tsx
@@ -18,7 +18,7 @@ import {
 import {
   CD_BASE_PATH,
   SERVICES_PATH,
-  SERVICE_PARAM_CLUSTER,
+  SERVICE_PARAM_CLUSTER_ID,
   getServiceDetailsPath,
 } from 'routes/cdRoutesConsts'
 import { createMapperWithFallback } from 'utils/mapping'
@@ -69,7 +69,7 @@ export function AuthMethodChip({
 export default function Services() {
   const theme = useTheme()
   const navigate = useNavigate()
-  const clusterName = useParams()[SERVICE_PARAM_CLUSTER]
+  const [clusterId, setClusterId] = useState<string>('')
   const [searchString, setSearchString] = useState()
   const debouncedSearchString = useDebounce(searchString, 100)
 
@@ -80,7 +80,7 @@ export default function Services() {
     previousData,
   } = useServiceDeploymentsQuery({
     variables: {
-      ...(clusterName ? { cluster: clusterName } : {}),
+      ...(clusterId ? { clusterId } : {}),
       q: debouncedSearchString,
     },
     pollInterval: POLL_INTERVAL,
@@ -108,11 +108,10 @@ export default function Services() {
         ...CD_BASE_CRUMBS,
         {
           label: 'services',
-          ...(clusterName ? { url: `/${CD_BASE_PATH}/${SERVICES_PATH}` } : {}),
+          url: `/${CD_BASE_PATH}/${SERVICES_PATH}`,
         },
-        ...(clusterName ? [{ label: clusterName }] : []),
       ],
-      [clusterName]
+      []
     )
   )
 
@@ -157,6 +156,8 @@ export default function Services() {
         searchString={searchString}
         setSearchString={setSearchString}
         showClusterSelect
+        clusterId={clusterId}
+        setClusterId={setClusterId}
       />
       {!data ? (
         <LoadingIndicator />
@@ -175,7 +176,7 @@ export default function Services() {
             ) =>
               navigate(
                 getServiceDetailsPath({
-                  clusterName: original.node?.cluster?.name,
+                  clusterId: original.node?.cluster?.id,
                   serviceId: original.node?.id,
                 })
               )
@@ -185,7 +186,7 @@ export default function Services() {
         </FullHeightTableWrap>
       ) : (
         <div css={{ height: '100%' }}>
-          {searchString || clusterName ? (
+          {searchString || clusterId ? (
             <EmptyState message="No service deployments match your query." />
           ) : (
             <EmptyState message="Looks like you don't have any service deployments yet." />

--- a/assets/src/components/cd/services/component/ServiceComponent.tsx
+++ b/assets/src/components/cd/services/component/ServiceComponent.tsx
@@ -7,7 +7,7 @@ import { useServiceDeploymentComponentsQuery } from 'generated/graphql'
 import {
   COMPONENT_PARAM_ID,
   SERVICE_COMPONENT_PATH_MATCHER_ABS,
-  SERVICE_PARAM_CLUSTER,
+  SERVICE_PARAM_CLUSTER_ID,
   SERVICE_PARAM_ID,
   getServiceComponentPath,
 } from 'routes/cdRoutesConsts'
@@ -20,7 +20,7 @@ import { getServiceComponentsBreadcrumbs } from '../service/ServiceComponents'
 
 export const getServiceComponentBreadcrumbs = ({
   serviceId,
-  clusterName,
+  clusterId,
   componentName,
   componentId,
   ...props
@@ -28,11 +28,15 @@ export const getServiceComponentBreadcrumbs = ({
   componentName: string | null | undefined
   componentId: string | null | undefined
 }) => [
-  ...getServiceComponentsBreadcrumbs({ clusterName, serviceId, ...props }),
+  ...getServiceComponentsBreadcrumbs({
+    clusterId,
+    serviceId,
+    ...props,
+  }),
   {
     label: componentName || componentId || '',
     url: getServiceComponentPath({
-      clusterName,
+      clusterId,
       serviceId,
       componentId,
     }),
@@ -40,14 +44,14 @@ export const getServiceComponentBreadcrumbs = ({
 ]
 
 function BreadcrumbWrapper({
-  clusterName,
+  clusterId,
   serviceId,
   serviceName,
   componentId,
   componentName,
   children,
 }: {
-  clusterName: string
+  clusterId: string
   serviceId: string
   serviceName: string | undefined
   componentId: string | undefined
@@ -59,13 +63,13 @@ function BreadcrumbWrapper({
     useMemo(
       () =>
         getServiceComponentBreadcrumbs({
-          clusterName,
+          clusterId,
           serviceId,
           serviceName,
           componentId,
           componentName,
         }),
-      [clusterName, serviceId, serviceName, componentId, componentName]
+      [clusterId, serviceId, serviceName, componentId, componentName]
     )
   )
 
@@ -76,7 +80,7 @@ function BreadcrumbWrapper({
 export default function ServiceComponent() {
   const params = useParams()
   const componentId = params[COMPONENT_PARAM_ID]
-  const clusterName = params[SERVICE_PARAM_CLUSTER]!
+  const clusterId = params[SERVICE_PARAM_CLUSTER_ID]!
   const serviceId = params[SERVICE_PARAM_ID]!
 
   const { data, error } = useServiceDeploymentComponentsQuery({
@@ -94,7 +98,7 @@ export default function ServiceComponent() {
   const componentName = component?.name
 
   const breadcrumbProps = {
-    clusterName,
+    clusterId,
     serviceId,
     serviceName,
     componentId,
@@ -113,7 +117,7 @@ export default function ServiceComponent() {
       <ComponentDetails
         component={component}
         serviceComponents={components}
-        clusterName={clusterName}
+        clusterId={clusterId}
         serviceId={serviceId}
         pathMatchString={SERVICE_COMPONENT_PATH_MATCHER_ABS}
       />

--- a/assets/src/components/cd/services/service/ServiceComponents.tsx
+++ b/assets/src/components/cd/services/service/ServiceComponents.tsx
@@ -13,7 +13,7 @@ import {
 } from 'generated/graphql'
 
 import {
-  SERVICE_PARAM_CLUSTER,
+  SERVICE_PARAM_CLUSTER_ID,
   SERVICE_PARAM_ID,
   getServiceComponentPath,
   getServiceDetailsPath,
@@ -34,13 +34,13 @@ import { ServiceDeprecationsModal } from './ServiceDeprecationsModal'
 export const getServiceComponentsBreadcrumbs = ({
   serviceId,
   serviceName,
-  clusterName,
+  clusterId,
 }: Parameters<typeof getServiceDetailsBreadcrumbs>[0]) => [
-  ...getServiceDetailsBreadcrumbs({ clusterName, serviceId, serviceName }),
+  ...getServiceDetailsBreadcrumbs({ clusterId, serviceId, serviceName }),
   {
     label: 'components',
     url: `${getServiceDetailsPath({
-      clusterName,
+      clusterId,
       serviceId,
     })}/components`,
   },
@@ -49,7 +49,7 @@ export const getServiceComponentsBreadcrumbs = ({
 export default function ServiceComponents() {
   const theme = useTheme()
   const serviceId = useParams()[SERVICE_PARAM_ID]
-  const clusterName = useParams()[SERVICE_PARAM_CLUSTER]
+  const clusterId = useParams()[SERVICE_PARAM_CLUSTER_ID]
   const [showDeprecations, setShowDeprecations] = useState(false)
   const outletContext = useOutletContext<{
     service: ServiceDeploymentDetailsFragment | null | undefined
@@ -61,8 +61,12 @@ export default function ServiceComponents() {
   const serviceName = outletContext?.service?.name
   const breadcrumbs: Breadcrumb[] = useMemo(
     () =>
-      getServiceComponentsBreadcrumbs({ clusterName, serviceId, serviceName }),
-    [clusterName, serviceId, serviceName]
+      getServiceComponentsBreadcrumbs({
+        clusterId,
+        serviceId,
+        serviceName,
+      }),
+    [clusterId, serviceId, serviceName]
   )
 
   useSetBreadcrumbs(breadcrumbs)
@@ -127,7 +131,7 @@ export default function ServiceComponents() {
           setUrl={(c) =>
             c?.name && c?.kind
               ? `${getServiceComponentPath({
-                  clusterName,
+                  clusterId,
                   serviceId,
                   componentId: c.id,
                 })}`

--- a/assets/src/components/cd/services/service/ServiceDetails.tsx
+++ b/assets/src/components/cd/services/service/ServiceDetails.tsx
@@ -25,7 +25,7 @@ import {
 import { getDocsData } from 'components/apps/app/App'
 import {
   CD_BASE_PATH,
-  SERVICE_PARAM_CLUSTER,
+  SERVICE_PARAM_CLUSTER_ID,
   SERVICE_PARAM_ID,
   getServiceDetailsPath,
 } from 'routes/cdRoutesConsts'
@@ -38,25 +38,30 @@ import ServiceSelector from '../ServiceSelector'
 import { ServiceDetailsSidecar } from './ServiceDetailsSidecar'
 
 export const getServiceDetailsBreadcrumbs = ({
-  clusterName,
+  clusterId,
   serviceId,
   serviceName,
 }: {
-  clusterName: string | null | undefined
+  clusterId: string | null | undefined
   serviceId: string | null | undefined
   serviceName?: string | null | undefined
 }) => [
   ...CD_BASE_CRUMBS,
-  { label: 'services', url: `${CD_BASE_PATH}/services` },
-  ...(clusterName && serviceId
+  { label: 'clusters', url: `${CD_BASE_PATH}/clusters` },
+  ...(clusterId
     ? [
         {
-          label: clusterName,
-          url: `/${CD_BASE_PATH}/services/${clusterName}`,
+          label: clusterId,
+          url: `/${CD_BASE_PATH}/clusters/${clusterId}`,
         },
+      ]
+    : []),
+  { label: 'services', url: `${CD_BASE_PATH}/services` },
+  ...(serviceId
+    ? [
         {
           label: serviceName || serviceId,
-          url: getServiceDetailsPath({ clusterName, serviceId }),
+          url: getServiceDetailsPath({ clusterId, serviceId }),
         },
       ]
     : []),
@@ -95,9 +100,9 @@ function ServiceDetailsBase() {
   const { pathname } = useLocation()
   const params = useParams()
   const serviceId = params[SERVICE_PARAM_ID] as string
-  const clusterName = params[SERVICE_PARAM_CLUSTER] as string
+  const clusterId = params[SERVICE_PARAM_CLUSTER_ID] as string
   const pathPrefix = getServiceDetailsPath({
-    clusterName,
+    clusterId,
     serviceId,
   })
   const docPageContext = useDocPageContext()

--- a/assets/src/components/cd/services/service/ServiceDetailsSidecar.tsx
+++ b/assets/src/components/cd/services/service/ServiceDetailsSidecar.tsx
@@ -47,7 +47,14 @@ export function ServiceDetailsSidecar({
         )}
       </Prop>
       <Prop title="Git folder">{git.folder}</Prop>
-      <Prop title="Git ref">{git.ref}</Prop>
+      <Prop
+        title="Git ref"
+        css={{
+          wordBreak: 'break-word',
+        }}
+      >
+        {git.ref}
+      </Prop>
       {cluster?.name && (
         <Prop title="Cluster name">
           <InlineLink

--- a/assets/src/components/cd/services/service/ServiceSecrets.tsx
+++ b/assets/src/components/cd/services/service/ServiceSecrets.tsx
@@ -28,7 +28,7 @@ import {
 
 import {
   CD_BASE_PATH,
-  SERVICE_PARAM_CLUSTER,
+  SERVICE_PARAM_CLUSTER_ID,
   SERVICE_PARAM_ID,
 } from 'routes/cdRoutesConsts'
 
@@ -358,7 +358,7 @@ const ColActions = ({
 export default function ServiceSecrets() {
   const theme = useTheme()
   const serviceId = useParams()[SERVICE_PARAM_ID]
-  const clusterName = useParams()[SERVICE_PARAM_CLUSTER]
+  const clusterName = useParams()[SERVICE_PARAM_CLUSTER_ID]
   const outletContext = useOutletContext<{
     service: ServiceDeploymentDetailsFragment | null | undefined
   }>()
@@ -370,7 +370,11 @@ export default function ServiceSecrets() {
   const serviceName = outletContext?.service?.name
   const breadcrumbs: Breadcrumb[] = useMemo(
     () => [
-      ...getServiceDetailsBreadcrumbs({ clusterName, serviceId, serviceName }),
+      ...getServiceDetailsBreadcrumbs({
+        clusterId: clusterName,
+        serviceId,
+        serviceName,
+      }),
       {
         label: 'secrets',
         url: `${CD_BASE_PATH}/services/${serviceId}/secrets`,

--- a/assets/src/components/component/ComponentDetails.tsx
+++ b/assets/src/components/component/ComponentDetails.tsx
@@ -62,13 +62,13 @@ export type ComponentDetailsContext = {
 export function ComponentDetails({
   component,
   pathMatchString,
-  clusterName,
+  clusterId,
   serviceId,
   serviceComponents,
 }: {
   component: DetailsComponent
   pathMatchString: string
-  clusterName?: string
+  clusterId?: string
   serviceId?: string
   serviceComponents?: ComponentDetailsContext['serviceComponents']
 }) {
@@ -117,19 +117,11 @@ export function ComponentDetails({
       data,
       loading,
       refetch,
-      clusterName,
+      clusterId,
       serviceId,
       serviceComponents,
     }),
-    [
-      clusterName,
-      component,
-      data,
-      loading,
-      refetch,
-      serviceComponents,
-      serviceId,
-    ]
+    [clusterId, component, data, loading, refetch, serviceComponents, serviceId]
   )
 
   if (error) {

--- a/assets/src/components/component/info/CronJob.tsx
+++ b/assets/src/components/component/info/CronJob.tsx
@@ -108,7 +108,7 @@ export function getJobPath({
     if (job && clusterName) {
       jobPath = getServiceComponentPath({
         serviceId,
-        clusterName,
+        clusterId: clusterName,
         componentId: job.id,
       })
     }

--- a/assets/src/components/component/info/Pods.tsx
+++ b/assets/src/components/component/info/Pods.tsx
@@ -9,12 +9,18 @@ import {
   PodsList,
 } from 'components/cluster/pods/PodsList'
 import { useMemo } from 'react'
-import { useOutletContext } from 'react-router-dom'
+import { useOutletContext, useParams } from 'react-router-dom'
 import { useTheme } from 'styled-components'
+
+import {
+  SERVICE_PARAM_CLUSTER_ID,
+  getPodDetailsPath,
+} from '../../../routes/cdRoutesConsts'
 
 import { InfoSectionH2 } from './common'
 
 export default function Pods({ pods }) {
+  const clusterId = useParams()[SERVICE_PARAM_CLUSTER_ID]
   const { refetch } = useOutletContext<any>()
   const theme = useTheme()
   const columns = useMemo(
@@ -49,6 +55,11 @@ export default function Pods({ pods }) {
       <PodsList
         pods={pods}
         columns={columns}
+        {...(clusterId
+          ? {
+              linkBasePath: getPodDetailsPath({ clusterId }),
+            }
+          : {})}
       />
     </div>
   )

--- a/assets/src/routes/cdRoutes.tsx
+++ b/assets/src/routes/cdRoutes.tsx
@@ -54,7 +54,7 @@ import {
   SERVICE_BASE_PATH,
   SERVICE_COMPONENTS_PATH,
   SERVICE_COMPONENT_PATH_MATCHER_REL,
-  SERVICE_PARAM_CLUSTER,
+  SERVICE_PARAM_CLUSTER_ID,
 } from './cdRoutesConsts'
 
 export const componentRoutes = [
@@ -110,7 +110,7 @@ export const cdRoutes = [
       element={<Clusters />}
     />
     <Route
-      path={`services/:${SERVICE_PARAM_CLUSTER}?`}
+      path={`services/:${SERVICE_PARAM_CLUSTER_ID}?`}
       element={<Services />}
     />
     {/* <Route

--- a/assets/src/routes/cdRoutesConsts.tsx
+++ b/assets/src/routes/cdRoutesConsts.tsx
@@ -31,10 +31,10 @@ export const POD_BASE_PATH = getPodDetailsPath({
 })
 
 export const SERVICE_PARAM_ID = 'serviceId' as const
-export const SERVICE_PARAM_CLUSTER = 'clusterName' as const
+export const SERVICE_PARAM_CLUSTER_ID = 'clusterId' as const
 export const SERVICE_BASE_PATH = getServiceDetailsPath({
   isRelative: true,
-  clusterName: `:${SERVICE_PARAM_CLUSTER}`,
+  clusterId: `:${SERVICE_PARAM_CLUSTER_ID}`,
   serviceId: `:${SERVICE_PARAM_ID}`,
 })
 export const SERVICE_COMPONENTS_PATH = 'components'
@@ -42,7 +42,7 @@ export const SERVICE_COMPONENTS_PATH = 'components'
 export const COMPONENT_PARAM_ID = `componentId` as const
 export const SERVICE_COMPONENT_PATH_MATCHER_REL = getServiceComponentPath({
   isRelative: true,
-  clusterName: `:${SERVICE_PARAM_CLUSTER}`,
+  clusterId: `:${SERVICE_PARAM_CLUSTER_ID}`,
   serviceId: `:${SERVICE_PARAM_ID}`,
   componentId: `:${COMPONENT_PARAM_ID}`,
 })
@@ -52,19 +52,19 @@ export const GLOBAL_SETTINGS_PATH_REL = `${CD_BASE_PATH}/settings`
 export const GLOBAL_SETTINGS_PATH = `/${GLOBAL_SETTINGS_PATH_REL}`
 
 export function getServiceDetailsPath({
-  clusterName,
+  clusterId,
   serviceId,
   isRelative = false,
 }: {
-  clusterName: string | null | undefined
+  clusterId: string | null | undefined
   serviceId: string | null | undefined
   isRelative?: boolean
 }) {
   return `${
     isRelative ? '' : '/'
-  }${CD_BASE_PATH}/${SERVICES_PATH}/${encodeSlashes(
-    clusterName || ''
-  )}/${encodeSlashes(serviceId || '')}`
+  }${CD_BASE_PATH}/${CLUSTERS_PATH}/${clusterId}/${SERVICES_PATH}/${encodeSlashes(
+    serviceId || ''
+  )}`
 }
 
 export function getServiceComponentPath({


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- updated services overview to be a single view and use `clusterId` instead of `clusterName`
- service details view is now a child view of a cluster since every service belongs to a cluster
- clusters filter on services overview is now local and filters services by refetching instead of navigating to a separate view
- fixed pod details view accessible from cluster service component details view

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.