### PR TITLE
feat: Clusters demo page

### DIFF
--- a/assets/src/components/cd/ContinuousDeployment.tsx
+++ b/assets/src/components/cd/ContinuousDeployment.tsx
@@ -10,9 +10,8 @@ import {
   useState,
 } from 'react'
 import { Outlet, useMatch } from 'react-router-dom'
+import { useTheme } from 'styled-components'
 
-import { ResponsivePageFullWidth } from 'components/utils/layout/ResponsivePageFullWidth'
-import { LinkTabWrap } from 'components/utils/Tabs'
 import {
   ADDONS_REL_PATH,
   CD_ABS_PATH,
@@ -20,6 +19,10 @@ import {
   CLUSTERS_REL_PATH,
   SERVICES_REL_PATH,
 } from 'routes/cdRoutesConsts'
+
+import { ResponsivePageFullWidth } from 'components/utils/layout/ResponsivePageFullWidth'
+import { LinkTabWrap } from 'components/utils/Tabs'
+import { MakeInert } from 'components/utils/MakeInert'
 import LoadingIndicator from 'components/utils/LoadingIndicator'
 import BillingFeatureBlockModal from 'components/billing/BillingFeatureBlockModal'
 
@@ -65,6 +68,7 @@ const directory = [
 ] as const
 
 export default function ContinuousDeployment() {
+  const theme = useTheme()
   const [headerContent, setHeaderContent] = useState<ReactNode>()
   const [showUpgrade, setShowUpgrade] = useState(true)
 
@@ -86,38 +90,48 @@ export default function ContinuousDeployment() {
     <ResponsivePageFullWidth
       scrollable={false}
       headingContent={
-        <>
-          <TabList
-            gap="xxsmall"
-            stateRef={tabStateRef}
-            stateProps={{
-              orientation: 'horizontal',
-              selectedKey: currentTab?.path,
+        <MakeInert inert={!cdEnabled}>
+          <div
+            css={{
+              display: 'flex',
+              gap: theme.spacing.large,
+              flexGrow: 1,
+              width: '100%',
+              justifyContent: 'space-between',
             }}
           >
-            {directory.map(({ label, path }) => (
-              <LinkTabWrap
-                subTab
-                key={path}
-                textValue={label}
-                to={!cdEnabled ? '' : `${CD_ABS_PATH}/${path}`}
-                onClick={(e) => {
-                  e.preventDefault()
-                  console.log('prevented')
-                }}
-              >
-                <SubTab
+            <TabList
+              gap="xxsmall"
+              stateRef={tabStateRef}
+              stateProps={{
+                orientation: 'horizontal',
+                selectedKey: currentTab?.path,
+              }}
+            >
+              {directory.map(({ label, path }) => (
+                <LinkTabWrap
+                  subTab
                   key={path}
                   textValue={label}
-                  disabled={!cdEnabled && path !== CD_DEFAULT_REL_PATH}
+                  to={!cdEnabled ? '' : `${CD_ABS_PATH}/${path}`}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    console.log('prevented')
+                  }}
                 >
-                  {label}
-                </SubTab>
-              </LinkTabWrap>
-            ))}
-          </TabList>
-          {headerContent}
-        </>
+                  <SubTab
+                    key={path}
+                    textValue={label}
+                    disabled={!cdEnabled && path !== CD_DEFAULT_REL_PATH}
+                  >
+                    {label}
+                  </SubTab>
+                </LinkTabWrap>
+              ))}
+            </TabList>
+            {headerContent}
+          </div>
+        </MakeInert>
       }
     >
       <PluralErrorBoundary>

--- a/assets/src/components/cd/GitScaffoldTabs.tsx
+++ b/assets/src/components/cd/GitScaffoldTabs.tsx
@@ -1,0 +1,32 @@
+import { Code } from '@pluralsh/design-system'
+
+const scaffoldTabs = [
+  {
+    key: 'nodejs',
+    label: 'Node.js',
+    language: 'sh',
+    content: `plural scaffold --type nodejs --name <my-service>`,
+  },
+  {
+    key: 'rails',
+    label: 'Rails',
+    language: 'sh',
+    content: `plural scaffold --type rails --name <my-service>`,
+  },
+  {
+    key: 'springboot',
+    label: 'Spring boot',
+    language: 'sh',
+    content: `plural scaffold --type springboot --name <my-service>`,
+  },
+  {
+    key: 'django',
+    label: 'Django',
+    language: 'sh',
+    content: `plural scaffold --type django --name <my-service>`,
+  },
+]
+
+export function GitScaffoldTabs() {
+  return <Code tabs={scaffoldTabs} />
+}

--- a/assets/src/components/cd/PrepareGitStep.tsx
+++ b/assets/src/components/cd/PrepareGitStep.tsx
@@ -1,6 +1,8 @@
 import { Code } from '@pluralsh/design-system'
 import { useTheme } from 'styled-components'
 
+import { CD_QUICKSTART_LINK } from 'routes/cdRoutesConsts'
+
 import { StepBody, StepH, StepLink } from './ModalAlt'
 
 const scaffoldTabs = [
@@ -53,7 +55,7 @@ export function PrepareGitStep() {
           Need some help to Git ready? Use a plural scaffold to get started or
           read our{' '}
           <StepLink
-            href="https://docs.plural.sh/getting-started/deployments"
+            href={CD_QUICKSTART_LINK}
             target="_blank"
           >
             quick start guide

--- a/assets/src/components/cd/PrepareGitStep.tsx
+++ b/assets/src/components/cd/PrepareGitStep.tsx
@@ -1,36 +1,8 @@
-import { Code } from '@pluralsh/design-system'
 import { useTheme } from 'styled-components'
 
 import { CD_QUICKSTART_LINK } from 'routes/cdRoutesConsts'
 
 import { StepBody, StepH, StepLink } from './ModalAlt'
-
-const scaffoldTabs = [
-  {
-    key: 'nodejs',
-    label: 'Node.js',
-    language: 'sh',
-    content: `plural scaffold --type nodejs --name <my-service>`,
-  },
-  {
-    key: 'rails',
-    label: 'Rails',
-    language: 'sh',
-    content: `plural scaffold --type rails --name <my-service>`,
-  },
-  {
-    key: 'springboot',
-    label: 'Spring boot',
-    language: 'sh',
-    content: `plural scaffold --type springboot --name <my-service>`,
-  },
-  {
-    key: 'django',
-    label: 'Django',
-    language: 'sh',
-    content: `plural scaffold --type django --name <my-service>`,
-  },
-]
 
 export function PrepareGitStep() {
   const theme = useTheme()
@@ -52,8 +24,7 @@ export function PrepareGitStep() {
       >
         <StepH>Step 1. Prepare your Git repository</StepH>
         <StepBody>
-          Need some help to Git ready? Use a plural scaffold to get started or
-          read our{' '}
+          Need some help to Git ready? Read our{' '}
           <StepLink
             href={CD_QUICKSTART_LINK}
             target="_blank"
@@ -63,7 +34,6 @@ export function PrepareGitStep() {
           .
         </StepBody>
       </div>
-      <Code tabs={scaffoldTabs} />
     </div>
   )
 }

--- a/assets/src/components/cd/cluster/Cluster.tsx
+++ b/assets/src/components/cd/cluster/Cluster.tsx
@@ -116,7 +116,7 @@ export default function Cluster() {
 
   return (
     <ResponsivePageFullWidth
-      scrollable
+      scrollable={tab !== 'services' && tab !== 'pods'}
       headingContent={
         <>
           {clusterEdges && !isEmpty(clusterEdges) && (

--- a/assets/src/components/cd/clusters/Clusters.tsx
+++ b/assets/src/components/cd/clusters/Clusters.tsx
@@ -10,7 +10,7 @@ import {
   useSetBreadcrumbs,
 } from '@pluralsh/design-system'
 import { ClustersRowFragment, useClustersQuery } from 'generated/graphql'
-import { ComponentProps, useLayoutEffect, useMemo, useRef } from 'react'
+import { ComponentProps, useMemo } from 'react'
 import { isEmpty } from 'lodash'
 import LoadingIndicator from 'components/utils/LoadingIndicator'
 import { createColumnHelper } from '@tanstack/react-table'
@@ -24,29 +24,25 @@ import {
   CLUSTERS_REL_PATH,
   GLOBAL_SETTINGS_ABS_PATH,
 } from 'routes/cdRoutesConsts'
-import { roundToTwoPlaces } from 'components/cluster/utils'
-import { BasicLink } from 'components/utils/typography/BasicLink'
-
 import chroma from 'chroma-js'
 
-import { POLL_INTERVAL, useSetCDHeaderContent } from '../ContinuousDeployment'
+import { coerceSemver, nextSupportedVersion, toNiceVersion } from 'utils/semver'
+
+import { roundToTwoPlaces } from 'components/cluster/utils'
+import { BasicLink } from 'components/utils/typography/BasicLink'
 import {
   cpuFormat,
   cpuParser,
   memoryFormat,
   memoryParser,
-} from '../../../utils/kubernetes'
-import { UsageBar } from '../../cluster/nodes/UsageBar'
-import { TableText } from '../../cluster/TableElements'
-import {
-  coerceSemver,
-  nextSupportedVersion,
-  toNiceVersion,
-} from '../../../utils/semver'
+} from 'utils/kubernetes'
+import { UsageBar } from 'components/cluster/nodes/UsageBar'
+import { TableText } from 'components/cluster/TableElements'
+import { MakeInert } from 'components/utils/MakeInert'
+
+import { POLL_INTERVAL, useSetCDHeaderContent } from '../ContinuousDeployment'
 import { DeleteCluster } from '../providers/DeleteCluster'
-
 import { useCDEnabled } from '../utils/useCDEnabled'
-
 import { DEMO_CLUSTERS } from '../utils/demoData'
 
 import ClusterUpgrade from './ClusterUpgrade'
@@ -347,29 +343,6 @@ const TableWrapperSC = styled(FullHeightTableWrap)<TableWrapperSCProps>(
   })
 )
 
-function TableWrapper({
-  blurred,
-  ...props
-}: Omit<ComponentProps<typeof TableWrapperSC>, '$blurred'>) {
-  const ref = useRef<HTMLDivElement>(null)
-
-  useLayoutEffect(() => {
-    if (blurred) {
-      ref.current?.setAttribute('inert', '')
-    } else {
-      ref.current?.removeAttribute('inert')
-    }
-  }, [blurred])
-
-  return (
-    <TableWrapperSC
-      $blurred={blurred}
-      ref={ref}
-      {...props}
-    />
-  )
-}
-
 export default function Clusters() {
   const theme = useTheme()
   const navigate = useNavigate()
@@ -415,21 +388,23 @@ export default function Clusters() {
   const tableData = usingDemoData ? DEMO_CLUSTERS : data?.clusters?.edges
 
   return !isEmpty(tableData) ? (
-    <TableWrapper
-      blurred={usingDemoData && true}
-      className="shouldforward"
-    >
-      <Table
-        loose
-        data={tableData || []}
-        columns={columns}
-        reactTableOptions={reactTableOptions}
-        css={{
-          maxHeight: 'unset',
-          height: '100%',
-        }}
-      />
-    </TableWrapper>
+    <MakeInert inert={usingDemoData}>
+      <TableWrapperSC
+        $blurred={usingDemoData}
+        className="shouldforward"
+      >
+        <Table
+          loose
+          data={tableData || []}
+          columns={columns}
+          reactTableOptions={reactTableOptions}
+          css={{
+            maxHeight: 'unset',
+            height: '100%',
+          }}
+        />
+      </TableWrapperSC>
+    </MakeInert>
   ) : (
     <EmptyState message="Looks like you don't have any CD clusters yet." />
   )

--- a/assets/src/components/cd/clusters/create/ImportClusterContent.tsx
+++ b/assets/src/components/cd/clusters/create/ImportClusterContent.tsx
@@ -8,8 +8,10 @@ import {
   useState,
 } from 'react'
 
-import { StepBody, StepH, StepLink } from 'components/cd/ModalAlt'
 import { ClusterAttributes } from 'generated/graphql'
+
+import { CD_QUICKSTART_LINK } from 'routes/cdRoutesConsts'
+import { StepBody, StepH, StepLink } from 'components/cd/ModalAlt'
 
 import { NameVersionHandle } from './NameVersionHandle'
 import { ClusterTagSelection } from './ClusterTagSelection'
@@ -87,7 +89,7 @@ function ImportClusterContentPage2({ deployToken }: { deployToken: string }) {
           <StepBody>
             Need help? Consult our{' '}
             <StepLink
-              href="https://docs.plural.sh/getting-started/deployments"
+              href={CD_QUICKSTART_LINK}
               target="_blank"
             >
               quick start guide

--- a/assets/src/components/cd/scaffoldTabs.tsx
+++ b/assets/src/components/cd/scaffoldTabs.tsx
@@ -1,0 +1,32 @@
+import { Code } from '@pluralsh/design-system'
+
+const scaffoldTabs = [
+  {
+    key: 'nodejs',
+    label: 'Node.js',
+    language: 'sh',
+    content: `plural scaffold --type nodejs --name <my-service>`,
+  },
+  {
+    key: 'rails',
+    label: 'Rails',
+    language: 'sh',
+    content: `plural scaffold --type rails --name <my-service>`,
+  },
+  {
+    key: 'springboot',
+    label: 'Spring boot',
+    language: 'sh',
+    content: `plural scaffold --type springboot --name <my-service>`,
+  },
+  {
+    key: 'django',
+    label: 'Django',
+    language: 'sh',
+    content: `plural scaffold --type django --name <my-service>`,
+  },
+]
+
+export function GitScaffoldTabs() {
+  return <Code tabs={scaffoldTabs} />
+}

--- a/assets/src/components/cd/utils/demoData.ts
+++ b/assets/src/components/cd/utils/demoData.ts
@@ -6,7 +6,7 @@ export const DEMO_CLUSTERS = [
       apiDeprecations: [],
       currentVersion: '1.25.14',
       deletedAt: null,
-      handle: 'cd-demo',
+      handle: 'main-cluster',
       id: 'aaaa',
       installed: true,
       name: 'main-cluster',
@@ -64,7 +64,7 @@ export const DEMO_CLUSTERS = [
           },
         },
       ],
-      pingedAt: '2023-11-09T17:11:51.438277Z',
+      pingedAt: '3000-11-09T17:11:51.438277Z',
       protect: true,
       provider: {
         __typename: 'ClusterProvider',
@@ -174,7 +174,7 @@ export const DEMO_CLUSTERS = [
           },
         },
       ],
-      pingedAt: '2023-11-09T17:11:33.015081Z',
+      pingedAt: '3000-11-09T17:11:33.015081Z',
       protect: true,
       provider: {
         __typename: 'ClusterProvider',
@@ -282,7 +282,7 @@ export const DEMO_CLUSTERS = [
       name: 'kind-2',
       nodeMetrics: [],
       nodes: [],
-      pingedAt: '2023-11-08T20:00:33.035838Z',
+      pingedAt: '3000-11-08T20:00:33.035838Z',
       protect: false,
       provider: null,
       self: false,
@@ -291,4 +291,98 @@ export const DEMO_CLUSTERS = [
       version: null,
     },
   },
-] as const as any
+  {
+    __typename: 'ClusterEdge',
+    node: {
+      __typename: 'Cluster',
+      apiDeprecations: [],
+      currentVersion: '1.25.14',
+      deletedAt: null,
+      handle: 'cd-demo',
+      id: 'gggg',
+      installed: true,
+      name: 'main-cluster',
+      nodeMetrics: [
+        {
+          __typename: 'NodeMetric',
+          usage: {
+            __typename: 'NodeUsage',
+            cpu: '4000000000n',
+            memory: '10000000Ki',
+          },
+        },
+      ],
+      nodes: [
+        {
+          __typename: 'Node',
+          status: {
+            __typename: 'NodeStatus',
+            capacity: {
+              cpu: '2',
+              'ephemeral-storage': '47227284Ki',
+              'hugepages-1Gi': '0',
+              'hugepages-2Mi': '0',
+              memory: '8145588Ki',
+              pods: '110',
+            },
+          },
+        },
+        {
+          __typename: 'Node',
+          status: {
+            __typename: 'NodeStatus',
+            capacity: {
+              cpu: '2',
+              'ephemeral-storage': '47227284Ki',
+              'hugepages-1Gi': '0',
+              'hugepages-2Mi': '0',
+              memory: '8145588Ki',
+              pods: '110',
+            },
+          },
+        },
+        {
+          __typename: 'Node',
+          status: {
+            __typename: 'NodeStatus',
+            capacity: {
+              cpu: '2',
+              'ephemeral-storage': '47227284Ki',
+              'hugepages-1Gi': '0',
+              'hugepages-2Mi': '0',
+              memory: '8145588Ki',
+              pods: '110',
+            },
+          },
+        },
+      ],
+      pingedAt: '3000-11-09T17:11:51.438277Z',
+      protect: true,
+      provider: {
+        __typename: 'ClusterProvider',
+        cloud: 'azure',
+        id: 'hhhh',
+        name: 'azure',
+        namespace: 'bootstrap',
+        supportedVersions: ['1.28.1'],
+      },
+      self: true,
+      service: null,
+      status: {
+        __typename: 'ClusterStatus',
+        conditions: [
+          {
+            __typename: 'ClusterCondition',
+            lastTransitionTime: '2023-11-03T18:49:25Z',
+            message: null,
+            reason: null,
+            severity: null,
+            status: 'True',
+            type: 'Ready',
+          },
+        ],
+      },
+      version: '1.25.14',
+    },
+  },
+] as any[]

--- a/assets/src/components/cd/utils/demoData.ts
+++ b/assets/src/components/cd/utils/demoData.ts
@@ -1,0 +1,294 @@
+export const DEMO_CLUSTERS = [
+  {
+    __typename: 'ClusterEdge',
+    node: {
+      __typename: 'Cluster',
+      apiDeprecations: [],
+      currentVersion: '1.25.14',
+      deletedAt: null,
+      handle: 'cd-demo',
+      id: 'aaaa',
+      installed: true,
+      name: 'main-cluster',
+      nodeMetrics: [
+        {
+          __typename: 'NodeMetric',
+          usage: {
+            __typename: 'NodeUsage',
+            cpu: '4000000000n',
+            memory: '10000000Ki',
+          },
+        },
+      ],
+      nodes: [
+        {
+          __typename: 'Node',
+          status: {
+            __typename: 'NodeStatus',
+            capacity: {
+              cpu: '2',
+              'ephemeral-storage': '47227284Ki',
+              'hugepages-1Gi': '0',
+              'hugepages-2Mi': '0',
+              memory: '8145588Ki',
+              pods: '110',
+            },
+          },
+        },
+        {
+          __typename: 'Node',
+          status: {
+            __typename: 'NodeStatus',
+            capacity: {
+              cpu: '2',
+              'ephemeral-storage': '47227284Ki',
+              'hugepages-1Gi': '0',
+              'hugepages-2Mi': '0',
+              memory: '8145588Ki',
+              pods: '110',
+            },
+          },
+        },
+        {
+          __typename: 'Node',
+          status: {
+            __typename: 'NodeStatus',
+            capacity: {
+              cpu: '2',
+              'ephemeral-storage': '47227284Ki',
+              'hugepages-1Gi': '0',
+              'hugepages-2Mi': '0',
+              memory: '8145588Ki',
+              pods: '110',
+            },
+          },
+        },
+      ],
+      pingedAt: '2023-11-09T17:11:51.438277Z',
+      protect: true,
+      provider: {
+        __typename: 'ClusterProvider',
+        cloud: 'aws',
+        id: 'bbbb',
+        name: 'aws',
+        namespace: 'bootstrap',
+        supportedVersions: ['1.28.1'],
+      },
+      self: true,
+      service: null,
+      status: {
+        __typename: 'ClusterStatus',
+        conditions: [
+          {
+            __typename: 'ClusterCondition',
+            lastTransitionTime: '2023-11-03T18:49:25Z',
+            message: null,
+            reason: null,
+            severity: null,
+            status: 'True',
+            type: 'Ready',
+          },
+        ],
+      },
+      version: '1.25.14',
+    },
+  },
+  {
+    __typename: 'ClusterEdge',
+    node: {
+      __typename: 'Cluster',
+      apiDeprecations: [],
+      currentVersion: '1.27.6',
+      deletedAt: null,
+      handle: 'workload-1',
+      id: 'cccc',
+      installed: true,
+      name: 'workload-1',
+      nodeMetrics: [
+        {
+          __typename: 'NodeMetric',
+          usage: {
+            __typename: 'NodeUsage',
+            cpu: '119042082n',
+            memory: '1443792Ki',
+          },
+        },
+        {
+          __typename: 'NodeMetric',
+          usage: {
+            __typename: 'NodeUsage',
+            cpu: '157129708n',
+            memory: '1660724Ki',
+          },
+        },
+        {
+          __typename: 'NodeMetric',
+          usage: {
+            __typename: 'NodeUsage',
+            cpu: '75695848n',
+            memory: '1264740Ki',
+          },
+        },
+      ],
+      nodes: [
+        {
+          __typename: 'Node',
+          status: {
+            __typename: 'NodeStatus',
+            capacity: {
+              cpu: '2',
+              'ephemeral-storage': '47227284Ki',
+              'hugepages-1Gi': '0',
+              'hugepages-2Mi': '0',
+              memory: '8145528Ki',
+              pods: '110',
+            },
+          },
+        },
+        {
+          __typename: 'Node',
+          status: {
+            __typename: 'NodeStatus',
+            capacity: {
+              cpu: '2',
+              'ephemeral-storage': '47227284Ki',
+              'hugepages-1Gi': '0',
+              'hugepages-2Mi': '0',
+              memory: '8145536Ki',
+              pods: '110',
+            },
+          },
+        },
+        {
+          __typename: 'Node',
+          status: {
+            __typename: 'NodeStatus',
+            capacity: {
+              cpu: '2',
+              'ephemeral-storage': '47227284Ki',
+              'hugepages-1Gi': '0',
+              'hugepages-2Mi': '0',
+              memory: '8145528Ki',
+              pods: '110',
+            },
+          },
+        },
+      ],
+      pingedAt: '2023-11-09T17:11:33.015081Z',
+      protect: true,
+      provider: {
+        __typename: 'ClusterProvider',
+        cloud: 'gcp',
+        id: 'dddd',
+        name: 'gcp',
+        namespace: 'bootstrap',
+        supportedVersions: ['1.28.1'],
+      },
+      self: false,
+      service: {
+        __typename: 'ServiceDeployment',
+        id: 'eeee',
+        repository: {
+          __typename: 'GitRepository',
+          url: 'https://github.com/pluralsh/scaffolds.git',
+        },
+      },
+      status: {
+        __typename: 'ClusterStatus',
+        conditions: [
+          {
+            __typename: 'ClusterCondition',
+            lastTransitionTime: '2023-11-03T18:49:05Z',
+            message: null,
+            reason: null,
+            severity: null,
+            status: 'True',
+            type: 'Ready',
+          },
+        ],
+      },
+      version: '1.27.6',
+    },
+  },
+  {
+    __typename: 'ClusterEdge',
+    node: {
+      __typename: 'Cluster',
+      apiDeprecations: [
+        {
+          __typename: 'ApiDeprecation',
+          availableIn: null,
+          blocking: false,
+          component: {
+            __typename: 'ServiceComponent',
+            group: 'policy',
+            kind: 'PodSecurityPolicy',
+            name: 'test-psp',
+            namespace: null,
+            service: {
+              __typename: 'ServiceDeployment',
+              git: {
+                __typename: 'GitRef',
+                folder: 'test-apps/psps',
+                ref: 'cd-scaffolding',
+              },
+              repository: {
+                __typename: 'GitRepository',
+                httpsPath: 'https://github.com/pluralsh/console',
+                urlFormat: '{url}/tree/{ref}/{folder}',
+              },
+            },
+            version: 'v1beta1',
+          },
+          deprecatedIn: 'v1.21.0',
+          removedIn: 'v1.25.0',
+          replacement: null,
+        },
+        {
+          __typename: 'ApiDeprecation',
+          availableIn: null,
+          blocking: false,
+          component: {
+            __typename: 'ServiceComponent',
+            group: 'batch',
+            kind: 'CronJob',
+            name: 'legacy-cron',
+            namespace: 'cron-jobs',
+            service: {
+              __typename: 'ServiceDeployment',
+              git: {
+                __typename: 'GitRef',
+                folder: 'test-apps/crons',
+                ref: 'cd-scaffolding',
+              },
+              repository: {
+                __typename: 'GitRepository',
+                httpsPath: 'https://github.com/pluralsh/console',
+                urlFormat: '{url}/tree/{ref}/{folder}',
+              },
+            },
+            version: 'v1beta1',
+          },
+          deprecatedIn: 'v1.21.0',
+          removedIn: 'v1.25.0',
+          replacement: 'batch/v1',
+        },
+      ],
+      currentVersion: '1.23.4',
+      deletedAt: null,
+      handle: 'kind-2',
+      id: 'ffff',
+      installed: true,
+      name: 'kind-2',
+      nodeMetrics: [],
+      nodes: [],
+      pingedAt: '2023-11-08T20:00:33.035838Z',
+      protect: false,
+      provider: null,
+      self: false,
+      service: null,
+      status: null,
+      version: null,
+    },
+  },
+] as const as any

--- a/assets/src/components/cd/utils/useCDEnabled.tsx
+++ b/assets/src/components/cd/utils/useCDEnabled.tsx
@@ -4,7 +4,7 @@ export const useCDEnabled = () => {
   const login = useLogin()
 
   // TODO: Remove this debug value
-  return false
+  // return false
 
   return !!login?.configuration?.features?.cd
 }

--- a/assets/src/components/cd/utils/useCDEnabled.tsx
+++ b/assets/src/components/cd/utils/useCDEnabled.tsx
@@ -3,6 +3,8 @@ import { useLogin } from 'components/contexts'
 export const useCDEnabled = () => {
   const login = useLogin()
 
-  // TODO: Figure out proper feature flag
-  return !!login?.configuration?.features?.userManagement
+  // TODO: Remove this debug value
+  return false
+
+  return !!login?.configuration?.features?.cd
 }

--- a/assets/src/components/utils/MakeInert.tsx
+++ b/assets/src/components/utils/MakeInert.tsx
@@ -1,0 +1,28 @@
+import { mergeRefs } from 'react-merge-refs'
+import {
+  ReactElement,
+  cloneElement,
+  forwardRef,
+  useLayoutEffect,
+  useRef,
+} from 'react'
+
+export const MakeInert = forwardRef<any, any>(
+  (
+    { children, inert = false }: { children: ReactElement; inert?: boolean },
+    ref
+  ) => {
+    const innerRef = useRef<any>(null)
+    const finalRef = mergeRefs([innerRef, ref])
+
+    useLayoutEffect(() => {
+      if (inert) {
+        innerRef.current?.setAttribute('inert', '')
+      } else {
+        innerRef.current?.removeAttribute('inert')
+      }
+    }, [inert, innerRef])
+
+    return cloneElement(children, { ref: finalRef })
+  }
+)

--- a/assets/src/components/utils/layout/FullHeightTableWrap.tsx
+++ b/assets/src/components/utils/layout/FullHeightTableWrap.tsx
@@ -1,8 +1,10 @@
 import { Flex, FlexProps } from 'honorable'
+import { forwardRef } from 'react'
 
-export function FullHeightTableWrap(props: FlexProps) {
-  return (
+export const FullHeightTableWrap = forwardRef<HTMLElement, FlexProps>(
+  (props, ref) => (
     <Flex
+      ref={ref}
       direction="column"
       height="100%"
       overflow="hidden"
@@ -14,4 +16,4 @@ export function FullHeightTableWrap(props: FlexProps) {
       {...props}
     />
   )
-}
+)

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -4434,12 +4434,14 @@ export type RoleBindingFragment = { __typename?: 'RoleBinding', id: string, user
 
 export type RoleFragment = { __typename?: 'Role', id: string, name: string, description?: string | null, repositories?: Array<string | null> | null, permissions?: Array<Permission | null> | null, roleBindings?: Array<{ __typename?: 'RoleBinding', id: string, user?: { __typename?: 'User', id: string, pluralId?: string | null, name: string, email: string, profile?: string | null, backgroundColor?: string | null, readTimestamp?: string | null, roles?: { __typename?: 'UserRoles', admin?: boolean | null } | null } | null, group?: { __typename?: 'Group', id: string, name: string, description?: string | null, insertedAt?: string | null, updatedAt?: string | null } | null } | null> | null };
 
+export type AvailableFeaturesFragment = { __typename?: 'AvailableFeatures', audits?: boolean | null, cd?: boolean | null, databaseManagement?: boolean | null, userManagement?: boolean | null, vpn?: boolean | null };
+
 export type ManifestFragment = { __typename?: 'PluralManifest', cluster?: string | null, bucketPrefix?: string | null, network?: { __typename?: 'ManifestNetwork', pluralDns?: boolean | null, subdomain?: string | null } | null };
 
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MeQuery = { __typename?: 'RootQueryType', externalToken?: string | null, me?: { __typename?: 'User', unreadNotifications?: number | null, id: string, pluralId?: string | null, name: string, email: string, profile?: string | null, backgroundColor?: string | null, readTimestamp?: string | null, boundRoles?: Array<{ __typename?: 'Role', id: string, name: string, description?: string | null, repositories?: Array<string | null> | null, permissions?: Array<Permission | null> | null, roleBindings?: Array<{ __typename?: 'RoleBinding', id: string, user?: { __typename?: 'User', id: string, pluralId?: string | null, name: string, email: string, profile?: string | null, backgroundColor?: string | null, readTimestamp?: string | null, roles?: { __typename?: 'UserRoles', admin?: boolean | null } | null } | null, group?: { __typename?: 'Group', id: string, name: string, description?: string | null, insertedAt?: string | null, updatedAt?: string | null } | null } | null> | null } | null> | null, roles?: { __typename?: 'UserRoles', admin?: boolean | null } | null } | null, clusterInfo?: { __typename?: 'ClusterInfo', version?: string | null, platform?: string | null, gitCommit?: string | null } | null, configuration?: { __typename?: 'ConsoleConfiguration', vpnEnabled?: boolean | null, gitCommit?: string | null, isDemoProject?: boolean | null, isSandbox?: boolean | null, pluralLogin?: boolean | null, byok?: boolean | null, manifest?: { __typename?: 'PluralManifest', cluster?: string | null, bucketPrefix?: string | null, network?: { __typename?: 'ManifestNetwork', pluralDns?: boolean | null, subdomain?: string | null } | null } | null, gitStatus?: { __typename?: 'GitStatus', cloned?: boolean | null, output?: string | null } | null, features?: { __typename?: 'AvailableFeatures', audits?: boolean | null, databaseManagement?: boolean | null, userManagement?: boolean | null, vpn?: boolean | null } | null } | null };
+export type MeQuery = { __typename?: 'RootQueryType', externalToken?: string | null, me?: { __typename?: 'User', unreadNotifications?: number | null, id: string, pluralId?: string | null, name: string, email: string, profile?: string | null, backgroundColor?: string | null, readTimestamp?: string | null, boundRoles?: Array<{ __typename?: 'Role', id: string, name: string, description?: string | null, repositories?: Array<string | null> | null, permissions?: Array<Permission | null> | null, roleBindings?: Array<{ __typename?: 'RoleBinding', id: string, user?: { __typename?: 'User', id: string, pluralId?: string | null, name: string, email: string, profile?: string | null, backgroundColor?: string | null, readTimestamp?: string | null, roles?: { __typename?: 'UserRoles', admin?: boolean | null } | null } | null, group?: { __typename?: 'Group', id: string, name: string, description?: string | null, insertedAt?: string | null, updatedAt?: string | null } | null } | null> | null } | null> | null, roles?: { __typename?: 'UserRoles', admin?: boolean | null } | null } | null, clusterInfo?: { __typename?: 'ClusterInfo', version?: string | null, platform?: string | null, gitCommit?: string | null } | null, configuration?: { __typename?: 'ConsoleConfiguration', vpnEnabled?: boolean | null, gitCommit?: string | null, isDemoProject?: boolean | null, isSandbox?: boolean | null, pluralLogin?: boolean | null, byok?: boolean | null, manifest?: { __typename?: 'PluralManifest', cluster?: string | null, bucketPrefix?: string | null, network?: { __typename?: 'ManifestNetwork', pluralDns?: boolean | null, subdomain?: string | null } | null } | null, gitStatus?: { __typename?: 'GitStatus', cloned?: boolean | null, output?: string | null } | null, features?: { __typename?: 'AvailableFeatures', audits?: boolean | null, cd?: boolean | null, databaseManagement?: boolean | null, userManagement?: boolean | null, vpn?: boolean | null } | null } | null };
 
 export type UsersQueryVariables = Exact<{
   q?: InputMaybe<Scalars['String']['input']>;
@@ -5500,6 +5502,15 @@ export const RoleFragmentDoc = gql`
   }
 }
     ${RoleBindingFragmentDoc}`;
+export const AvailableFeaturesFragmentDoc = gql`
+    fragment AvailableFeatures on AvailableFeatures {
+  audits
+  cd
+  databaseManagement
+  userManagement
+  vpn
+}
+    `;
 export const ManifestFragmentDoc = gql`
     fragment Manifest on PluralManifest {
   network {
@@ -8421,16 +8432,14 @@ export const MeDocument = gql`
       output
     }
     features {
-      audits
-      databaseManagement
-      userManagement
-      vpn
+      ...AvailableFeatures
     }
   }
 }
     ${UserFragmentDoc}
 ${RoleFragmentDoc}
-${ManifestFragmentDoc}`;
+${ManifestFragmentDoc}
+${AvailableFeaturesFragmentDoc}`;
 
 /**
  * __useMeQuery__
@@ -8702,6 +8711,7 @@ export const namedOperations = {
     Invite: 'Invite',
     RoleBinding: 'RoleBinding',
     Role: 'Role',
+    AvailableFeatures: 'AvailableFeatures',
     Manifest: 'Manifest'
   }
 }

--- a/assets/src/graph/users.graphql
+++ b/assets/src/graph/users.graphql
@@ -36,6 +36,14 @@ fragment Role on Role {
   }
 }
 
+fragment AvailableFeatures on AvailableFeatures {
+  audits
+  cd
+  databaseManagement
+  userManagement
+  vpn
+}
+
 fragment Manifest on PluralManifest {
   network {
     pluralDns
@@ -74,10 +82,7 @@ query Me {
       output
     }
     features {
-      audits
-      databaseManagement
-      userManagement
-      vpn
+      ...AvailableFeatures
     }
   }
 }

--- a/assets/src/routes/cdRoutesConsts.tsx
+++ b/assets/src/routes/cdRoutesConsts.tsx
@@ -2,6 +2,9 @@ function encodeSlashes(str: string) {
   return str.replaceAll('/', '%2F')
 }
 
+export const CD_QUICKSTART_LINK =
+  'https://docs.plural.sh/getting-started/deployments'
+
 export const CD_REL_PATH = 'cd' as const
 export const CD_ABS_PATH = `/${CD_REL_PATH}` as const
 export const CLUSTERS_REL_PATH = 'clusters' as const


### PR DESCRIPTION
- Now shows appropriate messaging on Clusters page for when CD is disabled or no clusters exist yet, along with a disabled table fully of fake data. 
- Scaffolds messaging has been removed from git import. 
- Better scrolling behavior on certain Cluster tabs.

TODO: Add extra instructions and demo video below fake table for empty cluster list 