### PR TITLE
fix: Inconsistent scrolling behavior on CD pages

### DIFF
--- a/assets/src/components/cd/ContinuousDeployment.tsx
+++ b/assets/src/components/cd/ContinuousDeployment.tsx
@@ -87,7 +87,7 @@ const directory = [
 export default function ContinuousDeployment() {
   const theme = useTheme()
   const [headerContent, setHeaderContent] = useState<ReactNode>()
-  const [scrollable, setScrollable] = useState(true)
+  const [scrollable, setScrollable] = useState(false)
   const cdContext = useMemo(
     () => ({
       setHeaderContent,


### PR DESCRIPTION
The wrong intial scroll behavior was set for CD pages, such that scrolling is wrong until the user navigates to `cd/clusters`