### PR TITLE
fix: use semver sort for cluster version

### DIFF
--- a/assets/src/components/cd/clusters/create/CreateClusterContent.tsx
+++ b/assets/src/components/cd/clusters/create/CreateClusterContent.tsx
@@ -70,8 +70,6 @@ export function CreateClusterContent({
     [clusterProviders]
   )
 
-  console.log(attributes)
-
   const provider =
     clusterProviders.find(
       (provider) => provider.id === attributes.providerId

--- a/assets/src/components/cd/clusters/create/CreateClusterContent.tsx
+++ b/assets/src/components/cd/clusters/create/CreateClusterContent.tsx
@@ -70,6 +70,8 @@ export function CreateClusterContent({
     [clusterProviders]
   )
 
+  console.log(attributes)
+
   const provider =
     clusterProviders.find(
       (provider) => provider.id === attributes.providerId

--- a/assets/src/components/cd/clusters/create/NameVersionHandle.tsx
+++ b/assets/src/components/cd/clusters/create/NameVersionHandle.tsx
@@ -5,7 +5,7 @@ import { isNonNullable } from 'utils/isNonNullable'
 import { coerce, rsort } from 'semver'
 
 import { TabularNumbers } from '../../../cluster/TableElements'
-import { toNiceVersion } from '../../../../utils/semver'
+import { toNiceVersion, trimVersion } from '../../../../utils/semver'
 
 import { isRequired } from './CreateClusterContent'
 
@@ -29,11 +29,11 @@ export function NameVersionHandle({
   const theme = useTheme()
   const filteredVersions = useMemo(
     () =>
-      rsort(
+      rsort<string>(
         (versions?.filter(isNonNullable) || []).map(
           (v) => coerce(v)?.version ?? v
         )
-      ),
+      ).map((v) => trimVersion(v)),
     [versions]
   )
 

--- a/assets/src/components/cd/clusters/create/NameVersionHandle.tsx
+++ b/assets/src/components/cd/clusters/create/NameVersionHandle.tsx
@@ -2,6 +2,7 @@ import { Input, ListBoxItem, Select } from '@pluralsh/design-system'
 import { useMemo } from 'react'
 import { useTheme } from 'styled-components'
 import { isNonNullable } from 'utils/isNonNullable'
+import { coerce, rsort } from 'semver'
 
 import { TabularNumbers } from '../../../cluster/TableElements'
 import { toNiceVersion } from '../../../../utils/semver'
@@ -27,7 +28,12 @@ export function NameVersionHandle({
 }) {
   const theme = useTheme()
   const filteredVersions = useMemo(
-    () => versions?.filter(isNonNullable) || [],
+    () =>
+      rsort(
+        (versions?.filter(isNonNullable) || []).map(
+          (v) => coerce(v)?.version ?? v
+        )
+      ),
     [versions]
   )
 

--- a/assets/src/components/cd/clusters/runtime/ExpandedColumn.tsx
+++ b/assets/src/components/cd/clusters/runtime/ExpandedColumn.tsx
@@ -10,8 +10,6 @@ export default function ExpandedColumn({
   runtimeService: RuntimeService
 }) {
   const theme = useTheme()
-
-  console.log(runtimeService)
   const versions = runtimeService?.addon?.versions || []
 
   return (

--- a/assets/src/components/cd/clusters/runtime/RuntimeServices.tsx
+++ b/assets/src/components/cd/clusters/runtime/RuntimeServices.tsx
@@ -45,11 +45,9 @@ export default function RuntimeServices({
         data={data?.cluster?.runtimeServices || []}
         columns={runtimeColumns}
         getRowCanExpand={() => true}
-        renderExpanded={({ row }) => {
-          console.log(row)
-
-          return <ExpandedColumn runtimeService={row.original} />
-        }}
+        renderExpanded={({ row }) => (
+          <ExpandedColumn runtimeService={row.original} />
+        )}
         css={{
           maxHeight: 310,
           height: '100%',

--- a/assets/src/components/cd/services/ServicesColumns.tsx
+++ b/assets/src/components/cd/services/ServicesColumns.tsx
@@ -88,6 +88,7 @@ export const ColRepo = columnHelper.accessor(({ node }) => node, {
   enableSorting: true,
   meta: { truncate: true, gridTemplate: 'minmax(180px,1fr)' },
   cell: ({ getValue }) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const theme = useTheme()
     const svc = getValue()
     const git = svc?.repository

--- a/assets/src/utils/semver.ts
+++ b/assets/src/utils/semver.ts
@@ -45,6 +45,16 @@ export function toNiceVersion(version: Nullable<string>) {
   return `${version.startsWith('v') ? '' : 'v'}${version}`
 }
 
+export function trimVersion(version: Nullable<string>): string {
+  if (!version) {
+    return ''
+  }
+
+  return version.endsWith('.0')
+    ? version.substring(0, version.length - 2)
+    : version
+}
+
 export function toProviderSupportedVersion(
   version: Nullable<string>,
   providerCloud: Nullable<string>


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Small tweak to version selector to sort versions using semver comparison by descending order (newest first).

### Before
![Zrzut ekranu 2023-11-28 164336](https://github.com/pluralsh/console/assets/2285385/7884ded0-bb97-4b9f-88ee-30d4b70f6787)
![Zrzut ekranu 2023-11-28 164356](https://github.com/pluralsh/console/assets/2285385/1153d9a3-a157-49c9-9518-3816153b9ba4)

### After
![Zrzut ekranu 2023-11-28 164328](https://github.com/pluralsh/console/assets/2285385/f973d54c-a159-4f20-b06e-b48e2669857a)
![Zrzut ekranu 2023-11-28 164346](https://github.com/pluralsh/console/assets/2285385/20bc3f03-dad0-43bb-ad20-fd5c506c9470)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.