### PR TITLE
Don't autoreconcile eks semvers

### DIFF
--- a/test/console/deployments/clusters_test.exs
+++ b/test/console/deployments/clusters_test.exs
@@ -336,24 +336,24 @@ defmodule Console.Deployments.ClustersTest do
 
       {:ok, cluster} = Clusters.create_cluster(%{
         name: "test",
-        version: "1.25",
-        current_version: "1.25",
+        version: "1.25.0",
+        current_version: "1.25.0",
         provider_id: provider.id,
         node_pools: [
           %{name: "pool", min_size: 1, max_size: 5, instance_type: "t5.large"}
         ]
       }, user)
 
-      assert cluster.current_version == "1.25"
+      assert cluster.current_version == "1.25.0"
 
       {:ok, cluster} = Clusters.update_cluster(%{
-        version: "1.26",
+        version: "1.26.0",
         node_pools: [
           %{name: "pool", min_size: 2, max_size: 5, instance_type: "t5.large"}
         ]
       }, cluster.id, user)
 
-      assert cluster.version == "1.26"
+      assert cluster.version == "1.26.0"
 
       {:error, _} = Clusters.update_cluster(%{
         version: "1.26.5",

--- a/test/console/graphql/mutations/deployment_mutations_test.exs
+++ b/test/console/graphql/mutations/deployment_mutations_test.exs
@@ -133,7 +133,7 @@ defmodule Console.GraphQl.DeploymentMutationsTest do
 
   describe "pingCluster" do
     test "it can mark a cluster as pinged" do
-      cluster = insert(:cluster, version: "1.24")
+      cluster = insert(:cluster, version: "1.24.1")
 
       {:ok, %{data: %{"pingCluster" => pinged}}} = run_query("""
         mutation Ping($ping: ClusterPing!) {
@@ -145,11 +145,11 @@ defmodule Console.GraphQl.DeploymentMutationsTest do
             currentVersion
           }
         }
-      """, %{"ping" => %{"currentVersion" => "1.25"}}, %{cluster: cluster})
+      """, %{"ping" => %{"currentVersion" => "1.24.2"}}, %{cluster: cluster})
 
       assert pinged["id"] == cluster.id
-      assert pinged["currentVersion"] == "1.25"
-      assert pinged["version"] == "1.25"
+      assert pinged["currentVersion"] == "1.24.2"
+      assert pinged["version"] == "1.24.2"
       assert pinged["pingedAt"]
       assert pinged["installed"]
     end


### PR DESCRIPTION
## Summary
This can mess with the terraform provider in weird ways, will keep the api from auto-reconciling it (but will likely also need a frontent change to also respect that this is the new api behavior)


## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.