### PR TITLE
Add a basic byok override

### DIFF
--- a/lib/console.ex
+++ b/lib/console.ex
@@ -6,8 +6,9 @@ defmodule Console do
   def provider(), do: Console.conf(:provider)
 
   def byok?() do
-    case provider() do
-      prov when prov in ~w(aws gcp azure generic)a -> false
+    case {provider(), Console.conf(:byok)} do
+      {_, true} -> true
+      {prov, _} when prov in ~w(aws gcp azure generic)a -> false
       _ -> true
     end
   end

--- a/rel/config/console.exs
+++ b/rel/config/console.exs
@@ -94,7 +94,8 @@ config :console,
   is_sandbox: !!get_env("CONSOLE_SANDBOX"),
   provider: provider,
   build_id: get_env("CONSOLE_BUILD_ID"),
-  kas_dns: get_env("KAS_DNS")
+  kas_dns: get_env("KAS_DNS"),
+  byok: get_env("CONSOLE_BYOK") == "true"
 
 if git_url && String.starts_with?(git_url, "https") do
   config :console,


### PR DESCRIPTION
## Summary
This is to improve the ux of plural up, making the console still "byok" but the console's provider registered according to its cloud.


## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.