### PR TITLE
fix: Fix cluster reconciler error handling

### DIFF
--- a/controller/config/samples/cluster_azure.yaml
+++ b/controller/config/samples/cluster_azure.yaml
@@ -1,32 +1,33 @@
 apiVersion: deployments.plural.sh/v1alpha1
 kind: Provider
 metadata:
-  name: gcp
+  name: azure
 spec:
-  cloud: gcp
-  name: gcp
+  cloud: azure
+  name: azure
 ---
 apiVersion: deployments.plural.sh/v1alpha1
 kind: Cluster
 metadata:
-  name: gcp
+  name: azure
   namespace: default
 spec:
-  handle: gcp
-  version: "1.25.14"
+  handle: azure
+  version: "1.25.11"
   providerRef:
-    name: gcp
+    name: azure
     namespace: default
-  cloud: gcp
+  cloud: azure
   protect: false
   cloudSettings:
-    gcp:
-      project: pluralsh-test-384515
-      network: testgcp
-      region: europe-central2
+    azure:
+      location: eastus
+      network: azure-vnet
+      resourceGroup: azure-rg
+      subscriptionId: "" # Required
   nodePools:
-    - name: test
-      instanceType: e2-standard-2
+    - name: pool1
+      instanceType: Standard_D2as_v5
       minSize: 1
       maxSize: 3
   tags:

--- a/controller/config/samples/cluster_gcp.yaml
+++ b/controller/config/samples/cluster_gcp.yaml
@@ -1,0 +1,31 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: Provider
+metadata:
+  name: gcp
+spec:
+  cloud: gcp
+  name: gcp
+---
+apiVersion: deployments.plural.sh/v1alpha1
+kind: Cluster
+metadata:
+  name: gcp1
+  namespace: default
+spec:
+  handle: gcp1
+  version: '1.25.14'
+  providerRef:
+    name: gcp
+    namespace: default
+  cloud: gcp
+  protect: false
+  cloudSettings:
+    gcp:
+      project: pluralsh-test-384515
+      network: testgcp
+      region: europe-central2
+  nodePools:
+    - name: test
+      instanceType: e2-standard-2
+      minSize: 1
+      maxSize: 3

--- a/controller/internal/client/cluster.go
+++ b/controller/internal/client/cluster.go
@@ -95,12 +95,14 @@ func (c *client) DeleteCluster(id string) (*console.ClusterFragment, error) {
 }
 
 func (c *client) IsClusterExisting(id *string) bool {
-	_, err := c.GetCluster(id)
+	cluster, err := c.GetCluster(id)
+	if cluster != nil {
+		return true
+	}
 	if errors.IsNotFound(err) {
 		return false
 	}
 
-	// We are assuming that if there is an error, and it is not ErrorNotFound then provider does not exist.
 	return err == nil
 }
 


### PR DESCRIPTION
When errors appeared before assigning readonly status but after resource creation in Console, then in second reconcile loop resource was marked as readonly. Now this will no longer happen.