### PR TITLE
feat: Add dry-run for Helm values

### DIFF
--- a/assets/src/components/cd/services/service/ServiceHelm.tsx
+++ b/assets/src/components/cd/services/service/ServiceHelm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Button, usePrevious } from '@pluralsh/design-system'
 import { useTheme } from 'styled-components'
@@ -78,6 +78,14 @@ export default function ServiceHelm() {
     },
   })
 
+  // TODO: Replace with API call
+  const [dryRunLoading, setDryRunLoading] = useState(false)
+  const dryRun = useCallback(() => {
+    setDryRunLoading(true)
+    setTimeout(() => setDryRunLoading(false), 1000)
+    // TODO: Open modal
+  }, [setDryRunLoading])
+
   if (!service) {
     navigate(`${CD_ABS_PATH}/${SERVICES_REL_PATH}`)
 
@@ -148,6 +156,18 @@ export default function ServiceHelm() {
             disabled={!hasUpdates && !errors}
           >
             Save
+          </Button>
+          <Button
+            secondary
+            type="button"
+            loading={dryRunLoading}
+            disabled={!hasUpdates && !errors}
+            onClick={(e) => {
+              e.preventDefault()
+              dryRun()
+            }}
+          >
+            Dry run
           </Button>
           <Button
             secondary

--- a/assets/src/components/cd/services/service/ServiceHelm.tsx
+++ b/assets/src/components/cd/services/service/ServiceHelm.tsx
@@ -24,7 +24,10 @@ import { useUpdateState } from 'components/hooks/useUpdateState'
 
 import { ServiceSettingsHelmValues } from '../deployModal/DeployServiceSettingsHelmValues'
 
+import { ModalMountTransition } from '../../../utils/ModalMountTransition'
+
 import { useServiceContext } from './ServiceDetails'
+import { ServiceHelmDryRunModal } from './ServiceHelmDryRunModal'
 
 export default function ServiceHelm() {
   const theme = useTheme()
@@ -79,12 +82,15 @@ export default function ServiceHelm() {
   })
 
   // TODO: Replace with API call
+  const [open, setOpen] = useState(false)
   const [dryRunLoading, setDryRunLoading] = useState(false)
   const dryRun = useCallback(() => {
     setDryRunLoading(true)
-    setTimeout(() => setDryRunLoading(false), 1000)
-    // TODO: Open modal
-  }, [setDryRunLoading])
+    setTimeout(() => {
+      setDryRunLoading(false)
+      setOpen(true)
+    }, 1000)
+  }, [setDryRunLoading, setOpen])
 
   if (!service) {
     navigate(`${CD_ABS_PATH}/${SERVICES_REL_PATH}`)
@@ -169,6 +175,14 @@ export default function ServiceHelm() {
           >
             Dry run
           </Button>
+          <ModalMountTransition open={open}>
+            <ServiceHelmDryRunModal
+              open={open}
+              onClose={() => {
+                setOpen(false)
+              }}
+            />
+          </ModalMountTransition>
           <Button
             secondary
             type="button"

--- a/assets/src/components/cd/services/service/ServiceHelmDryRunModal.tsx
+++ b/assets/src/components/cd/services/service/ServiceHelmDryRunModal.tsx
@@ -1,0 +1,46 @@
+import { Button, Modal } from '@pluralsh/design-system'
+import { useTheme } from 'styled-components'
+
+export function ServiceHelmDryRunModal({
+  open,
+  onClose,
+}: {
+  open: boolean
+  onClose: () => void
+}) {
+  const theme = useTheme()
+
+  return (
+    <Modal
+      portal
+      header="Dry run output"
+      open={open}
+      onClose={onClose}
+      size="large"
+      actions={
+        <div css={{ display: 'flex', gap: theme.spacing.medium }}>
+          <Button
+            type="button"
+            secondary
+            onClick={(e) => {
+              e.preventDefault()
+              onClose()
+            }}
+          >
+            Close
+          </Button>
+          <Button
+            type="submit"
+            // disabled={disabled}
+            // loading={loading}
+            primary
+          >
+            Save
+          </Button>
+        </div>
+      }
+    >
+      output
+    </Modal>
+  )
+}


### PR DESCRIPTION
<img width="942" alt="Zrzut ekranu 2024-01-10 o 12 27 38" src="https://github.com/pluralsh/console/assets/2823399/9e0d4896-5532-4c8f-ab00-1f9d17c6ac22">

- Dry run button is always visible but enabled only if state has changed (i.e. if user has modified values). It is the same logic as for the save button.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206028699790091