### PR TITLE
Add conjunctive tag queries

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -944,6 +944,11 @@ export type ConfigurationValidation = {
   type?: Maybe<Scalars['String']['output']>;
 };
 
+export enum Conjunction {
+  And = 'AND',
+  Or = 'OR'
+}
+
 export type ConsoleConfiguration = {
   __typename?: 'ConsoleConfiguration';
   byok?: Maybe<Scalars['Boolean']['output']>;
@@ -3537,6 +3542,7 @@ export type RootQueryTypeClustersArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
   q?: InputMaybe<Scalars['String']['input']>;
   tag?: InputMaybe<TagInput>;
+  tagQuery?: InputMaybe<TagQuery>;
 };
 
 
@@ -4621,6 +4627,11 @@ export type TagEdge = {
 export type TagInput = {
   name: Scalars['String']['input'];
   value: Scalars['String']['input'];
+};
+
+export type TagQuery = {
+  op: Conjunction;
+  tags?: InputMaybe<Array<InputMaybe<TagInput>>>;
 };
 
 /** a kubernetes node taint */

--- a/lib/console/graphql/deployments/cluster.ex
+++ b/lib/console/graphql/deployments/cluster.ex
@@ -5,6 +5,10 @@ defmodule Console.GraphQl.Deployments.Cluster do
   alias Console.GraphQl.Resolvers.{Deployments}
 
   ecto_enum :cluster_distro, Cluster.Distro
+  enum :conjunction do
+    value :and
+    value :or
+  end
 
   input_object :cluster_attributes do
     field :name,           non_null(:string)
@@ -156,6 +160,11 @@ defmodule Console.GraphQl.Deployments.Cluster do
   input_object :tag_input do
     field :name,  non_null(:string)
     field :value, non_null(:string)
+  end
+
+  input_object :tag_query do
+    field :op,   non_null(:conjunction)
+    field :tags, list_of(:tag_input)
   end
 
   @desc "a CAPI provider for a cluster, cloud is inferred from name if not provided manually"
@@ -497,9 +506,10 @@ defmodule Console.GraphQl.Deployments.Cluster do
     @desc "a relay connection of all clusters visible to the current user"
     connection field :clusters, node_type: :cluster do
       middleware Authenticated
-      arg :q,       :string
-      arg :healthy, :boolean
-      arg :tag,     :tag_input
+      arg :q,         :string
+      arg :healthy,   :boolean
+      arg :tag,       :tag_input
+      arg :tag_query, :tag_query
 
       resolve &Deployments.list_clusters/2
     end

--- a/lib/console/graphql/resolvers/deployments/cluster.ex
+++ b/lib/console/graphql/resolvers/deployments/cluster.ex
@@ -138,6 +138,7 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
   defp cluster_filters(query, args) do
     Enum.reduce(args, query, fn
       {:tag, %{name: n, value: v}}, q -> Cluster.with_tag(q, n, v)
+      {:tag_query, tq}, q -> Cluster.with_tag_query(q, tq)
       {:healthy, h}, q -> Cluster.health(q, h)
       _, q -> q
     end)

--- a/lib/console/schema/cluster.ex
+++ b/lib/console/schema/cluster.ex
@@ -218,6 +218,15 @@ defmodule Console.Schema.Cluster do
     )
   end
 
+  def with_tag_query(query \\ __MODULE__, tq) do
+    tags = Tag.for_query(tq)
+    from(c in query,
+      join: t in subquery(tags),
+        on: t.cluster_id == c.id,
+      distinct: true
+    )
+  end
+
   def for_tags(query \\ __MODULE__, tags) do
     Enum.reduce(tags, query, fn %{name: n, value: v}, q -> with_tag(q, n, v) end)
   end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -183,7 +183,9 @@ type RootQueryType {
   tokenExchange(token: String!): User
 
   "a relay connection of all clusters visible to the current user"
-  clusters(after: String, first: Int, before: String, last: Int, q: String, healthy: Boolean, tag: TagInput): ClusterConnection
+  clusters(
+    after: String, first: Int, before: String, last: Int, q: String, healthy: Boolean, tag: TagInput, tagQuery: TagQuery
+  ): ClusterConnection
 
   "gets summary information for all healthy\/unhealthy clusters in your fleet"
   clusterStatuses(q: String, tag: TagInput): [ClusterStatusInfo]
@@ -1424,6 +1426,11 @@ enum ClusterDistro {
   K3S
 }
 
+enum Conjunction {
+  AND
+  OR
+}
+
 input ClusterAttributes {
   name: String!
 
@@ -1602,6 +1609,11 @@ input AgentMigrationAttributes {
 input TagInput {
   name: String!
   value: String!
+}
+
+input TagQuery {
+  op: Conjunction!
+  tags: [TagInput]
 }
 
 "a CAPI provider for a cluster, cloud is inferred from name if not provided manually"


### PR DESCRIPTION
## Summary
Allows users to multiselect tag pairs, then chose if they want to and or or them.


## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.