### PR TITLE
fix: Infinite render on some Service Settings pages

### DIFF
--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -11,7 +11,7 @@
 !.yarn/versions
 
 # testing
-/coverage
+/src/coverage
 
 # production
 /build

--- a/assets/package.json
+++ b/assets/package.json
@@ -148,6 +148,7 @@
     "@typescript-eslint/parser": "6.15.0",
     "@vitejs/plugin-basic-ssl": "1.0.2",
     "@vitejs/plugin-react": "4.2.1",
+    "@vitest/coverage-v8": "1.2.1",
     "@vitest/ui": "1.1.0",
     "babel-plugin-styled-components": "2.1.4",
     "concurrently": "8.1.0",

--- a/assets/src/components/cd/services/deployModal/DeployServiceSettingsHelm.tsx
+++ b/assets/src/components/cd/services/deployModal/DeployServiceSettingsHelm.tsx
@@ -102,15 +102,7 @@ export function ChartForm({ charts, chart, version, setChart, setVersion }) {
         setVersion('')
       }
     }
-  }, [
-    chart,
-    charts,
-    charts.length,
-    selectedChart?.versions,
-    setChart,
-    setVersion,
-    version,
-  ])
+  }, [chart, charts, selectedChart?.versions, setChart, setVersion, version])
 
   if (isEmpty(charts)) {
     return (

--- a/assets/src/components/hooks/useUpdateState.tsx
+++ b/assets/src/components/hooks/useUpdateState.tsx
@@ -1,10 +1,12 @@
 import isEqual from 'lodash/isEqual'
 import { useCallback, useMemo, useState } from 'react'
 
+import { isSubsetEqual } from 'utils/isSubsetEqual'
+
 type IsEqualFn<T = any> = (a: T, b: T) => boolean
 type IsEqualFns<T> = Partial<Record<keyof T, IsEqualFn<T[keyof T]>>>
 
-export function useUpdateState<T extends { [key: string]: unknown }>(
+export function useUpdateState<T extends Record<string, unknown>>(
   initialState: T,
   isEqualFns?: IsEqualFns<T>
 ) {
@@ -13,6 +15,9 @@ export function useUpdateState<T extends { [key: string]: unknown }>(
 
   const update = useCallback(
     (update: Partial<T>) => {
+      if (isSubsetEqual(state, update)) {
+        return
+      }
       setState({ ...state, ...update })
     },
     [state]

--- a/assets/src/utils/isNonNullable.ts
+++ b/assets/src/utils/isNonNullable.ts
@@ -1,3 +1,8 @@
+/**
+ * Checks if value is not equal to `null` or `undefined`
+ * @param value
+ * @returns boolean
+ */
 export function isNonNullable<TValue>(
   value: TValue
 ): value is NonNullable<TValue> {

--- a/assets/src/utils/isSubsetEqual.test.ts
+++ b/assets/src/utils/isSubsetEqual.test.ts
@@ -1,0 +1,32 @@
+import { isSubsetEqual } from './isSubsetEqual'
+
+const set = {
+  a: 'a string',
+  b: false,
+  c: 123.3,
+  d: {
+    a: true,
+    b: 2,
+    c: 'another string',
+    d: false,
+  },
+}
+
+describe('Email utils', () => {
+  it('should detect valid email addresses', () => {
+    expect(isSubsetEqual({}, {})).toBeTruthy()
+    expect(isSubsetEqual(set, {})).toBeTruthy()
+    expect(isSubsetEqual(set, set)).toBeTruthy()
+    expect(isSubsetEqual(set, { a: 'a string' })).toBeTruthy()
+    expect(isSubsetEqual(set, { a: 'a different string' })).toBeFalsy()
+    expect(isSubsetEqual(set, { b: false })).toBeTruthy()
+    expect(isSubsetEqual(set, { b: true })).toBeFalsy()
+    expect(isSubsetEqual({}, set)).toBeFalsy()
+    expect(isSubsetEqual(set, { d: { a: true } })).toBeFalsy()
+    expect(
+      isSubsetEqual(set, {
+        d: { a: true, b: 2, c: 'another string', d: false },
+      })
+    ).toBeTruthy()
+  })
+})

--- a/assets/src/utils/isSubsetEqual.test.ts
+++ b/assets/src/utils/isSubsetEqual.test.ts
@@ -1,6 +1,6 @@
 import { isSubsetEqual } from './isSubsetEqual'
 
-const set:Record<string,any> = {
+const set: Record<string, any> = {
   a: 'a string',
   b: false,
   c: 123.3,

--- a/assets/src/utils/isSubsetEqual.test.ts
+++ b/assets/src/utils/isSubsetEqual.test.ts
@@ -1,6 +1,6 @@
 import { isSubsetEqual } from './isSubsetEqual'
 
-const set = {
+const set:Record<string,any> = {
   a: 'a string',
   b: false,
   c: 123.3,

--- a/assets/src/utils/isSubsetEqual.ts
+++ b/assets/src/utils/isSubsetEqual.ts
@@ -1,0 +1,21 @@
+import pick from 'lodash/pick'
+import isEqual from 'lodash/isEqual'
+
+/**
+ * Performs a deep comparison between two objects to determine if `subObject` is
+ * equivalent to a subset of `object` using only the own enumerable keys of
+ * `subset`. Essentially checks if shallow merging `subObject` into `object`
+ * would be equivalent to `object` itself.
+ *
+ * @param object Object to compare against
+ * @param subObject Object containing
+ * @returns
+ */
+export function isSubsetEqual<T extends Record<string, unknown>>(
+  object: T,
+  subObject: Partial<T>
+) {
+  const partialSet = pick(object, Object.keys(subObject))
+
+  return isEqual(partialSet, subObject)
+}

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -7144,7 +7144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/coverage-v8@npm:^1.2.1":
+"@vitest/coverage-v8@npm:1.2.1":
   version: 1.2.1
   resolution: "@vitest/coverage-v8@npm:1.2.1"
   dependencies:
@@ -9112,7 +9112,7 @@ __metadata:
     "@typescript-eslint/parser": 6.15.0
     "@vitejs/plugin-basic-ssl": 1.0.2
     "@vitejs/plugin-react": 4.2.1
-    "@vitest/coverage-v8": ^1.2.1
+    "@vitest/coverage-v8": 1.2.1
     "@vitest/ui": 1.1.0
     anser: 2.1.1
     apollo-absinthe-upload-link: 1.7.0

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -220,6 +220,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ampproject/remapping@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@ampproject/remapping@npm:2.2.1"
+  dependencies:
+    "@jridgewell/gen-mapping": ^0.3.0
+    "@jridgewell/trace-mapping": ^0.3.9
+  checksum: 03c04fd526acc64a1f4df22651186f3e5ef0a9d6d6530ce4482ec9841269cf7a11dbb8af79237c282d721c5312024ff17529cd72cc4768c11e999b58e2302079
+  languageName: node
+  linkType: hard
+
 "@apideck/better-ajv-errors@npm:^0.3.1":
   version: 0.3.6
   resolution: "@apideck/better-ajv-errors@npm:0.3.6"
@@ -1824,6 +1834,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bcoe/v8-coverage@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@bcoe/v8-coverage@npm:0.2.3"
+  checksum: 850f9305536d0f2bd13e9e0881cb5f02e4f93fad1189f7b2d4bebf694e3206924eadee1068130d43c11b750efcc9405f88a8e42ef098b6d75239c0f047de1a27
+  languageName: node
+  linkType: hard
+
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
@@ -3424,6 +3441,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@istanbuljs/schema@npm:^0.1.2":
+  version: 0.1.3
+  resolution: "@istanbuljs/schema@npm:0.1.3"
+  checksum: 5282759d961d61350f33d9118d16bcaed914ebf8061a52f4fa474b2cb08720c9c81d165e13b82f2e5a8a212cc5af482f0c6fc1ac27b9e067e5394c9a6ed186c9
+  languageName: node
+  linkType: hard
+
 "@jest/expect-utils@npm:^29.5.0":
   version: 29.5.0
   resolution: "@jest/expect-utils@npm:29.5.0"
@@ -3484,6 +3508,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/resolve-uri@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "@jridgewell/resolve-uri@npm:3.1.1"
+  checksum: f5b441fe7900eab4f9155b3b93f9800a916257f4e8563afbcd3b5a5337b55e52bd8ae6735453b1b745457d9f6cdb16d74cd6220bbdd98cf153239e13f6cbb653
+  languageName: node
+  linkType: hard
+
 "@jridgewell/set-array@npm:^1.0.0, @jridgewell/set-array@npm:^1.0.1":
   version: 1.1.2
   resolution: "@jridgewell/set-array@npm:1.1.2"
@@ -3508,10 +3539,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.15":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15":
   version: 1.4.15
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
   checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.12":
+  version: 0.3.22
+  resolution: "@jridgewell/trace-mapping@npm:0.3.22"
+  dependencies:
+    "@jridgewell/resolve-uri": ^3.1.0
+    "@jridgewell/sourcemap-codec": ^1.4.14
+  checksum: ac7dd2cfe0b479aa1b81776d40d789243131cc792dc8b6b6a028c70fcd6171958ae1a71bf67b618ffe3c0c3feead9870c095ee46a5e30319410d92976b28f498
   languageName: node
   linkType: hard
 
@@ -6586,6 +6627,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/istanbul-lib-coverage@npm:^2.0.1":
+  version: 2.0.6
+  resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
+  checksum: 3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
+  languageName: node
+  linkType: hard
+
 "@types/istanbul-lib-report@npm:*":
   version: 3.0.0
   resolution: "@types/istanbul-lib-report@npm:3.0.0"
@@ -7093,6 +7141,29 @@ __metadata:
   peerDependencies:
     vite: ^4.2.0 || ^5.0.0
   checksum: 08d227d27ff2304e395e746bd2d4b5fee40587f69d7e2fcd6beb7d91163c1f1dc26d843bc48e2ffb8f38c6b8a1b9445fb07840e3dcc841f97b56bbb8205346aa
+  languageName: node
+  linkType: hard
+
+"@vitest/coverage-v8@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@vitest/coverage-v8@npm:1.2.1"
+  dependencies:
+    "@ampproject/remapping": ^2.2.1
+    "@bcoe/v8-coverage": ^0.2.3
+    debug: ^4.3.4
+    istanbul-lib-coverage: ^3.2.2
+    istanbul-lib-report: ^3.0.1
+    istanbul-lib-source-maps: ^4.0.1
+    istanbul-reports: ^3.1.6
+    magic-string: ^0.30.5
+    magicast: ^0.3.3
+    picocolors: ^1.0.0
+    std-env: ^3.5.0
+    test-exclude: ^6.0.0
+    v8-to-istanbul: ^9.2.0
+  peerDependencies:
+    vitest: ^1.0.0
+  checksum: ec132dfd6322d733a1342142dbf1cf7a4cb059af2f612cc7d60b709c0f088f86a7f046ffb97ec71319fef2520454f045398597680305cf7ce509356958cf1862
   languageName: node
   linkType: hard
 
@@ -9041,6 +9112,7 @@ __metadata:
     "@typescript-eslint/parser": 6.15.0
     "@vitejs/plugin-basic-ssl": 1.0.2
     "@vitejs/plugin-react": 4.2.1
+    "@vitest/coverage-v8": ^1.2.1
     "@vitest/ui": 1.1.0
     anser: 2.1.1
     apollo-absinthe-upload-link: 1.7.0
@@ -12163,6 +12235,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
+  languageName: node
+  linkType: hard
+
 "html-tags@npm:^3.3.1":
   version: 3.3.1
   resolution: "html-tags@npm:3.3.1"
@@ -12990,6 +13069,45 @@ __metadata:
   version: 0.1.2
   resolution: "isstream@npm:0.1.2"
   checksum: 1eb2fe63a729f7bdd8a559ab552c69055f4f48eb5c2f03724430587c6f450783c8f1cd936c1c952d0a927925180fcc892ebd5b174236cf1065d4bd5bdb37e963
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 2367407a8d13982d8f7a859a35e7f8dd5d8f75aae4bb5484ede3a9ea1b426dc245aff28b976a2af48ee759fdd9be374ce2bd2669b644f31e76c5f46a2e29a831
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: ^3.0.0
+    make-dir: ^4.0.0
+    supports-color: ^7.1.0
+  checksum: fd17a1b879e7faf9bb1dc8f80b2a16e9f5b7b8498fe6ed580a618c34df0bfe53d2abd35bf8a0a00e628fb7405462576427c7df20bbe4148d19c14b431c974b21
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-source-maps@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "istanbul-lib-source-maps@npm:4.0.1"
+  dependencies:
+    debug: ^4.1.1
+    istanbul-lib-coverage: ^3.0.0
+    source-map: ^0.6.1
+  checksum: 21ad3df45db4b81852b662b8d4161f6446cd250c1ddc70ef96a585e2e85c26ed7cd9c2a396a71533cfb981d1a645508bc9618cae431e55d01a0628e7dec62ef2
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.1.6":
+  version: 3.1.6
+  resolution: "istanbul-reports@npm:3.1.6"
+  dependencies:
+    html-escaper: ^2.0.0
+    istanbul-lib-report: ^3.0.0
+  checksum: 44c4c0582f287f02341e9720997f9e82c071627e1e862895745d5f52ec72c9b9f38e1d12370015d2a71dcead794f34c7732aaef3fab80a24bc617a21c3d911d6
   languageName: node
   linkType: hard
 
@@ -13865,6 +13983,26 @@ __metadata:
   dependencies:
     "@jridgewell/sourcemap-codec": ^1.4.15
   checksum: da10fecff0c0a7d3faf756913ce62bd6d5e7b0402be48c3b27bfd651b90e29677e279069a63b764bcdc1b8ecdcdb898f29a5c5ec510f2323e8d62ee057a6eb18
+  languageName: node
+  linkType: hard
+
+"magicast@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "magicast@npm:0.3.3"
+  dependencies:
+    "@babel/parser": ^7.23.6
+    "@babel/types": ^7.23.6
+    source-map-js: ^1.0.2
+  checksum: de2bfca38cf4a20e598cf0e48598d183ebe2a846b80c5f4a71950b4e501f27492b3d21111a4da3dcff8aa85c2acdf3900126a8867a030a9f2fbb3c7a0a0c78bc
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: ^7.5.3
+  checksum: bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
   languageName: node
   linkType: hard
 
@@ -17199,7 +17337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.5.4, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.5.4":
+"semver@npm:7.5.4, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -18279,6 +18417,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"test-exclude@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "test-exclude@npm:6.0.0"
+  dependencies:
+    "@istanbuljs/schema": ^0.1.2
+    glob: ^7.1.4
+    minimatch: ^3.0.4
+  checksum: 3b34a3d77165a2cb82b34014b3aba93b1c4637a5011807557dc2f3da826c59975a5ccad765721c4648b39817e3472789f9b0fa98fc854c5c1c7a1e632aacdc28
+  languageName: node
+  linkType: hard
+
 "text-table@npm:^0.2.0":
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
@@ -19151,6 +19300,17 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"v8-to-istanbul@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "v8-to-istanbul@npm:9.2.0"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.12
+    "@types/istanbul-lib-coverage": ^2.0.1
+    convert-source-map: ^2.0.0
+  checksum: 31ef98c6a31b1dab6be024cf914f235408cd4c0dc56a5c744a5eea1a9e019ba279e1b6f90d695b78c3186feed391ed492380ccf095009e2eb91f3d058f0b4491
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
Service pages could get stuck in an infinite render loop when the chart version didn't match any of the versions in the selected chart. I fixed this by preventing `useUpdateState` from updating its internal state when the update would result in an equivalent state, thus preventing the `setVersion('')` call in `ChartForm` from causing re-renders that trigger that call again (and again (and again (...)).

## Labels
<!-- For breaking changes, add the `breaking-change` label.️ -->
<!-- For bug fixes, add the `bug-fix` label. -->
<!-- For new features and notable changes, add the `enhancement` label. -->


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.