### PR TITLE
Check if an add-on is blocking for next not current k8s version

### DIFF
--- a/lib/console/deployments/compatibilities/schema.ex
+++ b/lib/console/deployments/compatibilities/schema.ex
@@ -12,12 +12,13 @@ defmodule Console.Deployments.Compatibilities.Version do
 
   defstruct [:version, :kube, :requirements, :incompatibilities]
 
-  def blocking?(%__MODULE__{kube: kube_vsns}, kube_version) do
+  def blocking?(%__MODULE__{kube: kube_vsns}, kube_version, inc \\ 1) do
     with {:ok, %{major: maj, minor: min}} <- Version.parse(clean_version(kube_version)) do
-      kube_vsns = Enum.map(kube_vsns, &clean_version/1)
-      Enum.all?(kube_vsns, fn kube ->
+      minor = min + inc
+      Enum.map(kube_vsns, &clean_version/1)
+      |> Enum.all?(fn kube ->
         case Version.parse(kube) do
-          {:ok, %{major: ^maj, minor: ^min}} -> false
+          {:ok, %{major: ^maj, minor: ^minor}} -> false
           _ -> true
         end
       end)

--- a/test/console/graphql/queries/deployments/cluster_queries_test.exs
+++ b/test/console/graphql/queries/deployments/cluster_queries_test.exs
@@ -195,7 +195,7 @@ defmodule Console.GraphQl.Deployments.ClusterQueriesTest do
               addonVersion {
                 version
                 kube
-                blocking(kubeVersion: "1.26")
+                blocking(kubeVersion: "1.25")
               }
             }
           }
@@ -221,7 +221,7 @@ defmodule Console.GraphQl.Deployments.ClusterQueriesTest do
               addonVersion {
                 version
                 kube
-                blocking(kubeVersion: "1.25")
+                blocking(kubeVersion: "1.24")
               }
             }
           }


### PR DESCRIPTION
## Summary
we actually determine blocking for the current k8s vsn not the next one (which is more relevant for upgrades)

## Test Plan
units


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.