### PR TITLE
feat: Build progress improvements

### DIFF
--- a/assets/src/components/builds/build/progress/Command.tsx
+++ b/assets/src/components/builds/build/progress/Command.tsx
@@ -26,11 +26,12 @@ export default function Command({ command, follow }) {
         <Flex
           gap="small"
           align="center"
+          grow={1}
         >
           <ArrowRightIcon size={12} />
           <span> {command.command}</span>
-          <CommandExitStatus exitCode={command.exitCode} />
         </Flex>
+        <CommandExitStatus exitCode={command.exitCode} />
         <Timer
           insertedAt={command.insertedAt}
           completedAt={command.completedAt}

--- a/assets/src/components/builds/build/progress/Command.tsx
+++ b/assets/src/components/builds/build/progress/Command.tsx
@@ -22,13 +22,18 @@ export default function Command({ command, follow }) {
         paddingHorizontal="medium"
         paddingVertical="xsmall"
         justify="space-between"
+        backgroundColor="fill-two"
+        _hover={{ backgroundColor: 'fill-two-hover' }}
       >
         <Flex
           gap="small"
           align="center"
           grow={1}
         >
-          <ArrowRightIcon size={12} />
+          <ArrowRightIcon
+            size={12}
+            paddingRight="small"
+          />
           <span> {command.command}</span>
         </Flex>
         <CommandExitStatus exitCode={command.exitCode} />

--- a/assets/src/components/builds/build/progress/CommandExitStatus.tsx
+++ b/assets/src/components/builds/build/progress/CommandExitStatus.tsx
@@ -1,5 +1,4 @@
-import { Spinner } from '@pluralsh/design-system'
-import { P } from 'honorable'
+import { CheckIcon, ErrorIcon, Spinner, Tooltip } from '@pluralsh/design-system'
 
 export default function CommandExitStatus({ exitCode }) {
   if (!exitCode && exitCode !== 0) {
@@ -7,18 +6,20 @@ export default function CommandExitStatus({ exitCode }) {
   }
 
   return exitCode === 0 ? (
-    <P
-      color="text-success"
-      whiteSpace="pre"
-    >
-      ✓ OK
-    </P>
+    <CheckIcon
+      color="icon-success"
+      size={12}
+    />
   ) : (
-    <P
-      color="text-error"
-      whiteSpace="pre"
+    <Tooltip
+      label={`Exit code: ${exitCode}`}
+      placement="bottom"
     >
-      ✗ Exit code: {exitCode}
-    </P>
+      <ErrorIcon
+        color="icon-error"
+        cursor="help"
+        size={12}
+      />
+    </Tooltip>
   )
 }

--- a/assets/src/components/builds/build/progress/CommandLog.tsx
+++ b/assets/src/components/builds/build/progress/CommandLog.tsx
@@ -28,11 +28,16 @@ function CommandLogLine({ line, number, follow }) {
       align="center"
       color="text-light"
       gap="medium"
-      paddingLeft={50}
+      paddingLeft="medium"
       ref={lineRef}
       _hover={{ backgroundColor: 'fill-one-hover' }}
     >
-      <Span color="text-xlight">{number}</Span>
+      <Span
+        color="text-xlight"
+        width={20}
+      >
+        {number}
+      </Span>
       {blocks.map((json, i) => (
         <Span
           key={i}
@@ -54,6 +59,7 @@ export default function CommandLog({ text, follow }) {
   return (
     <Flex
       direction="column"
+      paddingVertical="small"
       overflowY="auto"
     >
       {lines.map((line, i) => (


### PR DESCRIPTION
- Move exit status next to the timer, so it's always in the same place
- Use design system icons instead of text symbols, move exit status to tooltip
- Highlight command lines and add more padding to make them move visible
- Force constant width on the line number column

Before: 
<img width="933" alt="Zrzut ekranu 2024-02-5 o 14 54 21" src="https://github.com/pluralsh/console/assets/2823399/b3bd1c47-e7f8-4138-9aba-1470c7ecac48">

After: 
<img width="947" alt="Zrzut ekranu 2024-02-5 o 15 20 23" src="https://github.com/pluralsh/console/assets/2823399/1b1ca6c4-893a-4300-b16c-7ace3e4618b2">
