### PR TITLE
Consolidated renovate setup api

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -3105,6 +3105,8 @@ export type RootMutationType = {
   savePipeline?: Maybe<Pipeline>;
   saveServiceContext?: Maybe<ServiceContext>;
   selfManage?: Maybe<ServiceDeployment>;
+  /** creates the service to enable self-hosted renovate in one pass */
+  setupRenovate?: Maybe<ServiceDeployment>;
   signIn?: Maybe<User>;
   signup?: Maybe<User>;
   updateCluster?: Maybe<Cluster>;
@@ -3546,6 +3548,12 @@ export type RootMutationTypeSaveServiceContextArgs = {
 
 export type RootMutationTypeSelfManageArgs = {
   values: Scalars['String']['input'];
+};
+
+
+export type RootMutationTypeSetupRenovateArgs = {
+  connectionId: Scalars['ID']['input'];
+  repos?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 
@@ -4164,6 +4172,7 @@ export type RootQueryTypePipelinesArgs = {
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  q?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -6245,14 +6254,14 @@ export type UnstructuredResourceQueryVariables = Exact<{
 
 export type UnstructuredResourceQuery = { __typename?: 'RootQueryType', unstructuredResource?: { __typename?: 'KubernetesUnstructured', raw?: Record<string, unknown> | null, metadata: { __typename?: 'Metadata', name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, events?: Array<{ __typename?: 'Event', action?: string | null, lastTimestamp?: string | null, count?: number | null, message?: string | null, reason?: string | null, type?: string | null } | null> | null } | null };
 
-export type AccessTokenFragment = { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api: string, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null };
+export type AccessTokenFragment = { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api?: string | null, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null };
 
 export type AccessTokenAuditFragment = { __typename?: 'AccessTokenAudit', id?: string | null, city?: string | null, count?: number | null, country?: string | null, insertedAt?: string | null, ip?: string | null, latitude?: string | null, longitude?: string | null, timestamp?: string | null, updatedAt?: string | null };
 
 export type AccessTokensQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AccessTokensQuery = { __typename?: 'RootQueryType', accessTokens?: { __typename?: 'AccessTokenConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null, hasPreviousPage: boolean, startCursor?: string | null }, edges?: Array<{ __typename?: 'AccessTokenEdge', node?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api: string, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null } | null> | null } | null };
+export type AccessTokensQuery = { __typename?: 'RootQueryType', accessTokens?: { __typename?: 'AccessTokenConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null, hasPreviousPage: boolean, startCursor?: string | null }, edges?: Array<{ __typename?: 'AccessTokenEdge', node?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api?: string | null, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null } | null> | null } | null };
 
 export type TokenAuditsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -6267,14 +6276,14 @@ export type CreateAccessTokenMutationVariables = Exact<{
 }>;
 
 
-export type CreateAccessTokenMutation = { __typename?: 'RootMutationType', createAccessToken?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api: string, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null };
+export type CreateAccessTokenMutation = { __typename?: 'RootMutationType', createAccessToken?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api?: string | null, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null };
 
 export type DeleteAccessTokenMutationVariables = Exact<{
   token: Scalars['String']['input'];
 }>;
 
 
-export type DeleteAccessTokenMutation = { __typename?: 'RootMutationType', deleteAccessToken?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api: string, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null };
+export type DeleteAccessTokenMutation = { __typename?: 'RootMutationType', deleteAccessToken?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api?: string | null, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null };
 
 export type UserFragment = { __typename?: 'User', id: string, pluralId?: string | null, name: string, email: string, profile?: string | null, backgroundColor?: string | null, readTimestamp?: string | null, roles?: { __typename?: 'UserRoles', admin?: boolean | null } | null };
 

--- a/lib/console/graphql/deployments/git.ex
+++ b/lib/console/graphql/deployments/git.ex
@@ -438,6 +438,15 @@ defmodule Console.GraphQl.Deployments.Git do
       safe_resolve &Deployments.delete_pr_automation/2
     end
 
+    @desc "creates the service to enable self-hosted renovate in one pass"
+    field :setup_renovate, :service_deployment do
+      middleware Authenticated
+      arg :connection_id, non_null(:id)
+      arg :repos, list_of(:string)
+
+      safe_resolve &Deployments.setup_renovate/2
+    end
+
     field :create_pull_request, :pull_request do
       middleware Authenticated
       arg :id,      non_null(:id), description: "the id of the PR automation instance to use"

--- a/lib/console/graphql/deployments/pipeline.ex
+++ b/lib/console/graphql/deployments/pipeline.ex
@@ -270,6 +270,7 @@ defmodule Console.GraphQl.Deployments.Pipeline do
   object :pipeline_queries do
     connection field :pipelines, node_type: :pipeline do
       middleware Authenticated
+      arg :q, :string
 
       resolve &Deployments.list_pipelines/2
     end

--- a/lib/console/graphql/resolvers/deployments/git.ex
+++ b/lib/console/graphql/resolvers/deployments/git.ex
@@ -90,6 +90,9 @@ defmodule Console.GraphQl.Resolvers.Deployments.Git do
   def create_pr(%{attributes: attrs}, %{context: %{current_user: user}}),
     do: Git.create_pull_request(attrs, user)
 
+  def setup_renovate(%{connection_id: id, repos: repos}, %{context: %{current_user: user}}),
+    do: Git.setup_renovate(id, repos, user)
+
   defp pr_filters(query, args) do
     Enum.reduce(args, query, fn
       {:cluster_id, cid}, q -> PullRequest.for_cluster(q, cid)

--- a/lib/console/schema/pipeline.ex
+++ b/lib/console/schema/pipeline.ex
@@ -23,6 +23,10 @@ defmodule Console.Schema.Pipeline do
     timestamps()
   end
 
+  def search(query \\ __MODULE__, q) do
+    from(p in query, where: ilike(p.name, ^"%#{q}%"))
+  end
+
   def for_user(query \\ __MODULE__, %User{} = user) do
     Rbac.globally_readable(query, user, fn query, id, groups ->
       from(p in query,

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -256,7 +256,7 @@ type RootQueryType {
     id: ID!
   ): ComponentTree
 
-  pipelines(after: String, first: Int, before: String, last: Int): PipelineConnection
+  pipelines(after: String, first: Int, before: String, last: Int, q: String): PipelineConnection
 
   pipeline(id: ID!): Pipeline
 
@@ -399,6 +399,9 @@ type RootMutationType {
   updatePrAutomation(id: ID!, attributes: PrAutomationAttributes!): PrAutomation
 
   deletePrAutomation(id: ID!): PrAutomation
+
+  "creates the service to enable self-hosted renovate in one pass"
+  setupRenovate(connectionId: ID!, repos: [String]): ServiceDeployment
 
   createPullRequest(
     "the id of the PR automation instance to use"

--- a/test/console/graphql/mutations/deployments/services_mutations_test.exs
+++ b/test/console/graphql/mutations/deployments/services_mutations_test.exs
@@ -576,4 +576,23 @@ defmodule Console.GraphQl.Deployments.ServicesMutationsTest do
       refute refetch(ctx)
     end
   end
+
+  describe "setupRenovate" do
+    test "it can initialize a renovate cron" do
+      insert(:git_repository, url: "https://github.com/pluralsh/scaffolds.git")
+      insert(:user, bot_name: "console", roles: %{admin: true})
+      insert(:cluster, self: true)
+      scm = insert(:scm_connection)
+
+      {:ok, %{data: %{"setupRenovate" => svc}}} = run_query("""
+        mutation Setup($id: ID!, $repos: [String]) {
+          setupRenovate(connectionId: $id, repos: $repos) {
+            id
+          }
+        }
+      """, %{"id" => scm.id, "repos" => ["some/repo"]}, %{current_user: admin_user()})
+
+      assert svc["id"]
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Should simplify the onboarding process for renovate a lot, inferring all the main inputs from either the servers config itself, or created access tokens or other db objects.

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.