### PR TITLE
Auto-create SCM webhooks when registering connections

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -3784,6 +3784,7 @@ export type RootQueryType = {
   scalingRecommendation?: Maybe<VerticalPodAutoscaler>;
   scmConnection?: Maybe<ScmConnection>;
   scmConnections?: Maybe<ScmConnectionConnection>;
+  scmWebhooks?: Maybe<ScmWebhookConnection>;
   secret?: Maybe<Secret>;
   secrets?: Maybe<Array<Maybe<Secret>>>;
   service?: Maybe<Service>;
@@ -4313,6 +4314,14 @@ export type RootQueryTypeScmConnectionsArgs = {
 };
 
 
+export type RootQueryTypeScmWebhooksArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
 export type RootQueryTypeSecretArgs = {
   name: Scalars['String']['input'];
   namespace: Scalars['String']['input'];
@@ -4657,6 +4666,8 @@ export type ScmConnectionAttributes = {
   apiUrl?: InputMaybe<Scalars['String']['input']>;
   baseUrl?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
+  /** the owning entity in this scm provider, eg a github organization */
+  owner?: InputMaybe<Scalars['String']['input']>;
   /** a ssh private key to be used for commit signing */
   signingPrivateKey?: InputMaybe<Scalars['String']['input']>;
   token?: InputMaybe<Scalars['String']['input']>;
@@ -4680,6 +4691,31 @@ export enum ScmType {
   Github = 'GITHUB',
   Gitlab = 'GITLAB'
 }
+
+export type ScmWebhook = {
+  __typename?: 'ScmWebhook';
+  id: Scalars['ID']['output'];
+  insertedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** the name in your SCM provider for this webhook */
+  name: Scalars['String']['output'];
+  owner: Scalars['String']['output'];
+  type: ScmType;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** the url for this specific webhook */
+  url: Scalars['String']['output'];
+};
+
+export type ScmWebhookConnection = {
+  __typename?: 'ScmWebhookConnection';
+  edges?: Maybe<Array<Maybe<ScmWebhookEdge>>>;
+  pageInfo: PageInfo;
+};
+
+export type ScmWebhookEdge = {
+  __typename?: 'ScmWebhookEdge';
+  cursor?: Maybe<Scalars['String']['output']>;
+  node?: Maybe<ScmWebhook>;
+};
 
 export type ScopeAttributes = {
   api?: InputMaybe<Scalars['String']['input']>;
@@ -6245,14 +6281,14 @@ export type UnstructuredResourceQueryVariables = Exact<{
 
 export type UnstructuredResourceQuery = { __typename?: 'RootQueryType', unstructuredResource?: { __typename?: 'KubernetesUnstructured', raw?: Record<string, unknown> | null, metadata: { __typename?: 'Metadata', name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, events?: Array<{ __typename?: 'Event', action?: string | null, lastTimestamp?: string | null, count?: number | null, message?: string | null, reason?: string | null, type?: string | null } | null> | null } | null };
 
-export type AccessTokenFragment = { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api: string, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null };
+export type AccessTokenFragment = { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api?: string | null, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null };
 
 export type AccessTokenAuditFragment = { __typename?: 'AccessTokenAudit', id?: string | null, city?: string | null, count?: number | null, country?: string | null, insertedAt?: string | null, ip?: string | null, latitude?: string | null, longitude?: string | null, timestamp?: string | null, updatedAt?: string | null };
 
 export type AccessTokensQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AccessTokensQuery = { __typename?: 'RootQueryType', accessTokens?: { __typename?: 'AccessTokenConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null, hasPreviousPage: boolean, startCursor?: string | null }, edges?: Array<{ __typename?: 'AccessTokenEdge', node?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api: string, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null } | null> | null } | null };
+export type AccessTokensQuery = { __typename?: 'RootQueryType', accessTokens?: { __typename?: 'AccessTokenConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null, hasPreviousPage: boolean, startCursor?: string | null }, edges?: Array<{ __typename?: 'AccessTokenEdge', node?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api?: string | null, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null } | null> | null } | null };
 
 export type TokenAuditsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -6267,14 +6303,14 @@ export type CreateAccessTokenMutationVariables = Exact<{
 }>;
 
 
-export type CreateAccessTokenMutation = { __typename?: 'RootMutationType', createAccessToken?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api: string, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null };
+export type CreateAccessTokenMutation = { __typename?: 'RootMutationType', createAccessToken?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api?: string | null, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null };
 
 export type DeleteAccessTokenMutationVariables = Exact<{
   token: Scalars['String']['input'];
 }>;
 
 
-export type DeleteAccessTokenMutation = { __typename?: 'RootMutationType', deleteAccessToken?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api: string, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null };
+export type DeleteAccessTokenMutation = { __typename?: 'RootMutationType', deleteAccessToken?: { __typename?: 'AccessToken', id?: string | null, insertedAt?: string | null, updatedAt?: string | null, token?: string | null, scopes?: Array<{ __typename?: 'AccessTokenScope', api?: string | null, apis?: Array<string> | null, identifier?: string | null, ids?: Array<string> | null } | null> | null } | null };
 
 export type UserFragment = { __typename?: 'User', id: string, pluralId?: string | null, name: string, email: string, profile?: string | null, backgroundColor?: string | null, readTimestamp?: string | null, roles?: { __typename?: 'UserRoles', admin?: boolean | null } | null };
 

--- a/lib/console/deployments/git.ex
+++ b/lib/console/deployments/git.ex
@@ -100,18 +100,45 @@ defmodule Console.Deployments.Git do
   end
 
   @doc """
-
+  Creates an scm connection and attempts to register a webhook simultaneously for the connection
   """
   @spec create_scm_connection(map, User.t) :: connection_resp
   def create_scm_connection(attrs, %User{} = user) do
-    %ScmConnection{}
-    |> ScmConnection.changeset(attrs)
-    |> allow(user, :edit)
-    |> when_ok(:insert)
+    start_transaction()
+    |> add_operation(:conn, fn _ ->
+      %ScmConnection{}
+      |> ScmConnection.changeset(attrs)
+      |> allow(user, :edit)
+      |> when_ok(:insert)
+    end)
+    |> add_operation(:hook, fn %{conn: conn} ->
+      create_webhook_for_connection(attrs[:owner], conn)
+    end)
+    |> execute(extract: :conn)
   end
 
   @doc """
+  Uses the creds in an scm connection to create a properly configured webhook for us to use
+  """
+  @spec create_webhook_for_connection(binary, ScmConnection.t) :: webhook_resp
+  def create_webhook_for_connection(owner, %ScmConnection{} = conn) do
+    start_transaction()
+    |> add_operation(:hook, fn _ ->
+      %ScmWebhook{type: conn.type}
+      |> ScmWebhook.changeset(%{owner: owner})
+      |> Repo.insert_or_update()
+    end)
+    |> add_operation(:remote, fn %{hook: hook} ->
+      case Dispatcher.webhook(conn, hook) do
+        :ok -> {:ok, conn}
+        err -> err
+      end
+    end)
+    |> execute(extract: :hook)
+  end
 
+  @doc """
+  Updates the attributes of a scm connection
   """
   @spec update_scm_connection(map, binary, User.t) :: connection_resp
   def update_scm_connection(attrs, id, %User{} = user) do
@@ -122,7 +149,7 @@ defmodule Console.Deployments.Git do
   end
 
   @doc """
-
+  Deletes an scm connection
   """
   @spec delete_scm_connection(binary, User.t) :: connection_resp
   def delete_scm_connection(id, %User{} = user) do
@@ -132,7 +159,7 @@ defmodule Console.Deployments.Git do
   end
 
   @doc """
-
+  creates an scm webhook
   """
   @spec create_scm_webhook(map, User.t) :: webhook_resp
   def create_scm_webhook(attrs, %User{} = user) do
@@ -143,7 +170,7 @@ defmodule Console.Deployments.Git do
   end
 
   @doc """
-
+  updates an scm webhook
   """
   @spec update_scm_webhook(map, binary, User.t) :: webhook_resp
   def update_scm_webhook(attrs, id, %User{} = user) do
@@ -154,7 +181,7 @@ defmodule Console.Deployments.Git do
   end
 
   @doc """
-
+  deletes a scm webhook
   """
   @spec delete_scm_webhook(binary, User.t) :: webhook_resp
   def delete_scm_webhook(id, %User{} = user) do
@@ -164,7 +191,7 @@ defmodule Console.Deployments.Git do
   end
 
   @doc """
-
+  creates a new pr automation reference
   """
   @spec create_pr_automation(map, User.t) :: automation_resp
   def create_pr_automation(attrs, %User{} = user) do
@@ -175,7 +202,7 @@ defmodule Console.Deployments.Git do
   end
 
   @doc """
-
+  updates an existing pr automation
   """
   @spec update_pr_automation(map, binary, User.t) :: automation_resp
   def update_pr_automation(attrs, id, %User{} = user) do

--- a/lib/console/deployments/pr/impl/pass.ex
+++ b/lib/console/deployments/pr/impl/pass.ex
@@ -2,4 +2,6 @@ defmodule Console.Deployments.Pr.Impl.Pass do
   @behaviour Console.Deployments.Pr.Dispatcher
 
   def create(_pr, _branch, _ctx), do: {:ok, ""}
+
+  def webhook(_, _), do: :ok
 end

--- a/lib/console/graphql/deployments/pipeline.ex
+++ b/lib/console/graphql/deployments/pipeline.ex
@@ -144,9 +144,11 @@ defmodule Console.GraphQl.Deployments.Pipeline do
     field :state, non_null(:gate_state), description: "the current state of this gate"
     field :spec,  :gate_spec, description: "more detailed specification for complex gates"
 
-    field :job, :job,
-      description: "the kubernetes job running this gate (should only be fetched lazily as this is a heavy operation)",
-      resolve: fn gate, _, _ -> Pipelines.gate_job(gate) end
+    @desc "the kubernetes job running this gate (should only be fetched lazily as this is a heavy operation)"
+    field :job, :job do
+      resolve fn gate, _, _ -> Pipelines.gate_job(gate) end
+      middleware ErrorHandler
+    end
 
     field :cluster,  :cluster, description: "the cluster this gate can run on", resolve: dataloader(Deployments)
     field :approver, :user, description: "the last user to approve this gate", resolve: dataloader(User)

--- a/lib/console/graphql/resolvers/deployments/git.ex
+++ b/lib/console/graphql/resolvers/deployments/git.ex
@@ -6,7 +6,8 @@ defmodule Console.GraphQl.Resolvers.Deployments.Git do
     GitRepository,
     PrAutomation,
     ScmConnection,
-    PullRequest
+    PullRequest,
+    ScmWebhook
   }
 
   def resolve_scm_connection(%{id: id}, _), do: {:ok, Git.get_scm_connection(id)}
@@ -44,6 +45,11 @@ defmodule Console.GraphQl.Resolvers.Deployments.Git do
     PullRequest.ordered()
     |> maybe_search(PullRequest, args)
     |> pr_filters(args)
+    |> paginate(args)
+  end
+
+  def list_scm_webhooks(args, _) do
+    ScmWebhook.ordered()
     |> paginate(args)
   end
 

--- a/lib/console/graphql/schema/base.ex
+++ b/lib/console/graphql/schema/base.ex
@@ -21,7 +21,7 @@ defmodule Console.GraphQl.Schema.Base do
       import Absinthe.Resolution.Helpers
       import Console.GraphQl.Schema.Helpers
       import Console.GraphQl.Schema.Base
-      alias Console.Middleware.{Authenticated, AdminRequired, Rbac, Feature, ClusterAuthenticated, Scope}
+      alias Console.Middleware.{Authenticated, AdminRequired, Rbac, Feature, ClusterAuthenticated, Scope, ErrorHandler}
     end
   end
 

--- a/lib/console/schema/pipeline_gate.ex
+++ b/lib/console/schema/pipeline_gate.ex
@@ -66,6 +66,7 @@ defmodule Console.Schema.PipelineGate do
     |> cast_embed(:spec, with: &spec_changeset/2)
     |> foreign_key_constraint(:edge_id)
     |> foreign_key_constraint(:approver_id)
+    |> validate_format(:name, ~r/[a-z0-9][ -a-z0-9]*[a-z0-9]/)
     |> validate_required([:name, :state, :type])
   end
 

--- a/lib/console/schema/scm_webhook.ex
+++ b/lib/console/schema/scm_webhook.ex
@@ -4,21 +4,28 @@ defmodule Console.Schema.ScmWebhook do
   schema "scm_webhooks" do
     field :type,        Console.Schema.ScmConnection.Type
     field :hmac,        Piazza.Ecto.EncryptedString
+    field :owner,       :string
     field :external_id, :string
 
     timestamps()
   end
 
+  def url(%__MODULE__{external_id: ext_id, type: t}),
+    do: Console.url("/ext/v1/webhooks/#{t}/#{ext_id}")
+
+  def name(%__MODULE__{id: id}), do: "plrl-#{id}"
+
   def ordered(query \\ __MODULE__, order \\ [asc: :inserted_at]) do
     from(w in query, order_by: ^order)
   end
 
-  @valid ~w(type hmac external_id)a
+  @valid ~w(type hmac external_id owner)a
 
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, @valid)
     |> put_new_change(:external_id, fn -> Console.rand_alphanum(30) end)
+    |> put_new_change(:hmac, fn -> Console.rand_str(32) end)
     |> validate_required(~w(type hmac external_id)a)
   end
 end

--- a/lib/console_web/controllers/webhook_controller.ex
+++ b/lib/console_web/controllers/webhook_controller.ex
@@ -6,6 +6,10 @@ defmodule ConsoleWeb.WebhookController do
   plug ConsoleWeb.Verifier when action == :webhook
   plug ConsoleWeb.PiazzaVerifier when action == :piazza
 
+  def scm(conn, _) do
+    json(conn, %{ok: true})
+  end
+
   def webhook(conn, params) do
     bot = Users.get_bot!("console")
     with {:ok, _} <- Builds.create(params, bot),

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -31,6 +31,8 @@ defmodule ConsoleWeb.Router do
     scope "/v1", ConsoleWeb do
       get "/git/tarballs", GitController, :tarball
 
+      post "/webhooks/:type/:id", WebhookController, :scm
+
       get "/gate/:cluster/:name", GitController, :proceed
       get "/gate/:id", GitController, :proceed
       post "/gate/:cluster/:name", GitController, :proceed

--- a/priv/repo/migrations/20240209225431_add_scm_webhook_owner.exs
+++ b/priv/repo/migrations/20240209225431_add_scm_webhook_owner.exs
@@ -1,0 +1,9 @@
+defmodule Console.Repo.Migrations.AddScmWebhookOwner do
+  use Ecto.Migration
+
+  def change do
+    alter table(:scm_webhooks) do
+      add :owner, :string
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -179,6 +179,8 @@ type RootQueryType {
 
   pullRequests(after: String, first: Int, before: String, last: Int, clusterId: ID, serviceId: ID, q: String): PullRequestConnection
 
+  scmWebhooks(after: String, first: Int, before: String, last: Int): ScmWebhookConnection
+
   "exchanges a kubeconfig token for user info"
   tokenExchange(token: String!): User
 
@@ -2317,6 +2319,9 @@ input ScmConnectionAttributes {
 
   type: ScmType!
 
+  "the owning entity in this scm provider, eg a github organization"
+  owner: String
+
   username: String
 
   token: String
@@ -2685,6 +2690,24 @@ type PullRequest {
   updatedAt: DateTime
 }
 
+type ScmWebhook {
+  id: ID!
+
+  type: ScmType!
+
+  owner: String!
+
+  "the url for this specific webhook"
+  url: String!
+
+  "the name in your SCM provider for this webhook"
+  name: String!
+
+  insertedAt: DateTime
+
+  updatedAt: DateTime
+}
+
 type GitRepositoryConnection {
   pageInfo: PageInfo!
   edges: [GitRepositoryEdge]
@@ -2703,6 +2726,11 @@ type PrAutomationConnection {
 type PullRequestConnection {
   pageInfo: PageInfo!
   edges: [PullRequestEdge]
+}
+
+type ScmWebhookConnection {
+  pageInfo: PageInfo!
+  edges: [ScmWebhookEdge]
 }
 
 input CloneAttributes {
@@ -4351,6 +4379,11 @@ type RunbookExecutionEdge {
 
 type WebhookEdge {
   node: Webhook
+  cursor: String
+}
+
+type ScmWebhookEdge {
+  node: ScmWebhook
   cursor: String
 }
 

--- a/test/console/deployments/git_test.exs
+++ b/test/console/deployments/git_test.exs
@@ -95,6 +95,7 @@ defmodule Console.Deployments.GitTest do
   describe "#create_scm_connection/2" do
     test "admins can create" do
       admin = admin_user()
+      expect(Tentacat.Organizations.Hooks, :create, fn _, _, _ -> {:ok, %{"id" => "id"}, :ok} end)
 
       {:ok, conn} = Git.create_scm_connection(%{type: :github, name: "github", token: "pat-asdfa"}, admin)
 

--- a/test/console/graphql/mutations/deployments/git_mutations_test.exs
+++ b/test/console/graphql/mutations/deployments/git_mutations_test.exs
@@ -56,6 +56,7 @@ defmodule Console.GraphQl.Deployments.GitMutationsTest do
 
   describe "createScmConnection" do
     test "it will create a new scm connection" do
+      expect(Tentacat.Organizations.Hooks, :create, fn _, _, _ -> {:ok, %{"id" => "id"}, :ok} end)
       {:ok, %{data: %{"createScmConnection" => scm}}} = run_query("""
         mutation Create($attrs: ScmConnectionAttributes!) {
           createScmConnection(attributes: $attrs) {
@@ -67,6 +68,7 @@ defmodule Console.GraphQl.Deployments.GitMutationsTest do
       """, %{"attrs" => %{
         "type" => "GITHUB",
         "name" => "test",
+        "owner" => "pluralsh",
         "token" => "my-pat"
       }}, %{current_user: admin_user()})
 

--- a/test/console/graphql/queries/deployments/git_queries_test.exs
+++ b/test/console/graphql/queries/deployments/git_queries_test.exs
@@ -86,6 +86,23 @@ defmodule Console.GraphQl.Deployments.GitQueriesTest do
     end
   end
 
+  describe "scmWebhooks" do
+    test "it can list scm webhooks" do
+      hooks = insert_list(3, :scm_webhook)
+
+      {:ok, %{data: %{"scmWebhooks" => found}}} = run_query("""
+        query {
+          scmWebhooks(first: 5) {
+            edges { node { id } }
+          }
+        }
+      """, %{}, %{current_user: insert(:user)})
+
+      assert from_connection(found)
+             |> ids_equal(hooks)
+    end
+  end
+
   describe "pullRequests" do
     test "it can list pull requests" do
       user = insert(:user)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -29,6 +29,7 @@ Mimic.copy(Kube.Utils)
 Mimic.copy(Console.Deployments.Clusters)
 Mimic.copy(Phoenix.Channel.Server)
 Mimic.copy(Tentacat.Pulls)
+Mimic.copy(Tentacat.Organizations.Hooks)
 Mimic.copy(Console.Deployments.Pr.Git)
 
 ExUnit.start()


### PR DESCRIPTION
## Summary
Use the access token we've already been issued to create the webhook entry to watch for statuses.


## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.