### PR TITLE
Better gate transition validation

### DIFF
--- a/lib/console/graphql/middleware/error_handler.ex
+++ b/lib/console/graphql/middleware/error_handler.ex
@@ -5,7 +5,7 @@ defmodule Console.Middleware.ErrorHandler do
 
   @impl true
   def call(%{errors: [_ | _] = errors} = resolution, _config) do
-    %{ resolution | errors: Enum.map(errors, &format/1) }
+    %{ resolution | errors: Enum.map(errors, &format/1) |> flatten() }
   end
   def call(res, _), do: res
 
@@ -19,4 +19,10 @@ defmodule Console.Middleware.ErrorHandler do
     Logger.error "found unknown error: #{inspect(err)}"
     "unknown error"
   end
+
+  defp flatten(vals, res \\ [])
+  defp flatten([], res), do: res
+  defp flatten([l | tail], res) when is_list(l), do: flatten(tail, res ++ l)
+  defp flatten([h | tail], res), do: flatten(tail, [h | res])
+  defp flatten(v, res), do: [v | res]
 end

--- a/lib/console/schema/pipeline_gate.ex
+++ b/lib/console/schema/pipeline_gate.ex
@@ -58,12 +58,21 @@ defmodule Console.Schema.PipelineGate do
     from(g in query, order_by: ^order)
   end
 
+  @terminal ~w(open closed)a
+
+  def valid_transition?(state, :pending) when state in @terminal, do: false
+  def valid_transition?(:pending, state) when state in @terminal, do: true
+  def valid_transition?(state, state), do: true
+  def valid_transition?(nil, _), do: true
+  def valid_transition?(_, _), do: false
+
   @valid ~w(name state type edge_id cluster_id approver_id)a
 
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, @valid)
     |> cast_embed(:spec, with: &spec_changeset/2)
+    |> validate_state()
     |> foreign_key_constraint(:edge_id)
     |> foreign_key_constraint(:approver_id)
     |> validate_format(:name, ~r/[a-z0-9][ -a-z0-9]*[a-z0-9]/, message: "Gate names must be lowercase alphanumeric, or separated by spaces or hyphens")
@@ -92,5 +101,15 @@ defmodule Console.Schema.PipelineGate do
     model
     |> cast(attrs, ~w(name namespace)a)
     |> validate_required(~w(name namespace)a)
+  end
+
+  defp validate_state(cs) do
+    current = cs.data.state
+    validate_change(cs, :state, fn _, val ->
+      case valid_transition?(current, val) do
+        true -> []
+        false -> [state: "cannot transition gate state from #{current} to #{val}"]
+      end
+    end)
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -314,6 +314,7 @@ defmodule Console.Factory do
 
   def pipeline_gate_factory do
     %Schema.PipelineGate{
+      state: :pending,
       name: sequence(:gate, & "gate-#{&1}"),
       edge: build(:pipeline_edge),
       type: :approval


### PR DESCRIPTION
## Summary

Validate that gates can only move like so:

* nil -> pending (on init)
* pending -> closed, open
* closed, open -> pending

This should block some annoying agent race conditions

## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.