### PR TITLE
Add support for toggling templating on a service, and azure resource group config

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 24.3.4.14
+erlang 24.3.4.16
 elixir 1.12.3

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ For Mac Machines, if unable to download Erlang via `asdf` (this is very common, 
 
 ```sh
 brew install erlang@24
-cp -r /opt/homebrew/opt/erlang@24/lib/erlang ~/.asdf/installs/erlang/24.3.4.14 # this exact version will drift a lot, as long as its erlang 24 it's good
-asdf reshim erlang 24.3.4.14
+cp -r /opt/homebrew/opt/erlang@24/lib/erlang ~/.asdf/installs/erlang/24.3.4.16 # this exact version will drift a lot, as long as its erlang 24 it's good
+asdf reshim erlang 24.3.4.16
 ```
 
 You can also use the make target in our root Makefile to automate this, eg:

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -379,6 +379,7 @@ export type AzureStore = {
   __typename?: 'AzureStore';
   clientId: Scalars['String']['output'];
   container: Scalars['String']['output'];
+  resourceGroup: Scalars['String']['output'];
   storageAccount: Scalars['String']['output'];
   subscriptionId: Scalars['String']['output'];
   tenantId: Scalars['String']['output'];
@@ -388,6 +389,7 @@ export type AzureStoreAttributes = {
   clientId: Scalars['String']['input'];
   clientSecret: Scalars['String']['input'];
   container: Scalars['String']['input'];
+  resourceGroup: Scalars['String']['input'];
   storageAccount: Scalars['String']['input'];
   subscriptionId: Scalars['String']['input'];
   tenantId: Scalars['String']['input'];
@@ -1459,13 +1461,13 @@ export type GcpSettingsAttributes = {
 export type GcsStore = {
   __typename?: 'GcsStore';
   bucket: Scalars['String']['output'];
-  region: Scalars['String']['output'];
+  region?: Maybe<Scalars['String']['output']>;
 };
 
 export type GcsStoreAttributes = {
   applicationCredentials: Scalars['String']['input'];
   bucket: Scalars['String']['input'];
-  region: Scalars['String']['input'];
+  region?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type GitAttributes = {
@@ -3219,6 +3221,7 @@ export type RootMutationType = {
   installAddOn?: Maybe<ServiceDeployment>;
   installRecipe?: Maybe<Build>;
   installStack?: Maybe<Build>;
+  kickService?: Maybe<ServiceDeployment>;
   loginLink?: Maybe<User>;
   markRead?: Maybe<User>;
   /** merges configuration for a service */
@@ -3611,6 +3614,13 @@ export type RootMutationTypeInstallStackArgs = {
   context: ContextAttributes;
   name: Scalars['String']['input'];
   oidc?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type RootMutationTypeKickServiceArgs = {
+  cluster?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  serviceId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 
@@ -5076,6 +5086,8 @@ export type ServiceDeployment = {
   syncConfig?: Maybe<SyncConfig>;
   /** https url to fetch the latest tarball of kubernetes manifests */
   tarball?: Maybe<Scalars['String']['output']>;
+  /** if you should apply liquid templating to raw yaml files, defaults to true */
+  templated?: Maybe<Scalars['Boolean']['output']>;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
   /** semver of this service */
   version: Scalars['String']['output'];
@@ -5107,6 +5119,8 @@ export type ServiceDeploymentAttributes = {
   readBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
   repositoryId?: InputMaybe<Scalars['ID']['input']>;
   syncConfig?: InputMaybe<SyncConfigAttributes>;
+  /** if you should apply liquid templating to raw yaml files, defaults to true */
+  templated?: InputMaybe<Scalars['Boolean']['input']>;
   version?: InputMaybe<Scalars['String']['input']>;
   writeBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
 };
@@ -5187,6 +5201,8 @@ export type ServiceUpdateAttributes = {
   kustomize?: InputMaybe<KustomizeAttributes>;
   protect?: InputMaybe<Scalars['Boolean']['input']>;
   readBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
+  /** if you should apply liquid templating to raw yaml files, defaults to true */
+  templated?: InputMaybe<Scalars['Boolean']['input']>;
   version?: InputMaybe<Scalars['String']['input']>;
   writeBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
 };

--- a/lib/console/deployments/git/agent.ex
+++ b/lib/console/deployments/git/agent.ex
@@ -29,6 +29,8 @@ defmodule Console.Deployments.Git.Agent do
 
   def addons(pid), do: GenServer.call(pid, :addons, 30_000)
 
+  def kick(pid), do: send(pid, :pull)
+
   def start(%GitRepository{} = repo) do
     GenServer.start(__MODULE__, repo, name: via(repo))
   end

--- a/lib/console/graphql/configuration.ex
+++ b/lib/console/graphql/configuration.ex
@@ -71,6 +71,7 @@ defmodule Console.GraphQl.Configuration do
 
     field :external_token, :string do
       middleware Authenticated
+      middleware AdminRequired
       middleware Sandboxed
       resolve &Plural.resolve_external_token/2
     end

--- a/lib/console/graphql/deployments/backup.ex
+++ b/lib/console/graphql/deployments/backup.ex
@@ -32,7 +32,7 @@ defmodule Console.GraphQl.Deployments.Backup do
 
   input_object :gcs_store_attributes do
     field :bucket, non_null(:string)
-    field :region, non_null(:string)
+    field :region, :string
     field :application_credentials, non_null(:string)
   end
 
@@ -40,6 +40,7 @@ defmodule Console.GraphQl.Deployments.Backup do
     field :storage_account, non_null(:string)
     field :container,       non_null(:string)
     field :subscription_id, non_null(:string)
+    field :resource_group,  non_null(:string)
     field :tenant_id,       non_null(:string)
     field :client_id,       non_null(:string)
     field :client_secret,   non_null(:string)
@@ -91,13 +92,14 @@ defmodule Console.GraphQl.Deployments.Backup do
 
   object :gcs_store do
     field :bucket, non_null(:string)
-    field :region, non_null(:string)
+    field :region, :string
   end
 
   object :azure_store do
     field :storage_account, non_null(:string)
     field :container,       non_null(:string)
     field :subscription_id, non_null(:string)
+    field :resource_group,  non_null(:string)
     field :tenant_id,       non_null(:string)
     field :client_id,       non_null(:string)
   end

--- a/lib/console/graphql/deployments/service.ex
+++ b/lib/console/graphql/deployments/service.ex
@@ -17,6 +17,7 @@ defmodule Console.GraphQl.Deployments.Service do
     field :repository_id,    :id
     field :dry_run,          :boolean
     field :interval,         :string
+    field :templated,        :boolean, description: "if you should apply liquid templating to raw yaml files, defaults to true"
     field :git,              :git_ref_attributes
     field :helm,             :helm_config_attributes
     field :kustomize,        :kustomize_attributes
@@ -54,6 +55,7 @@ defmodule Console.GraphQl.Deployments.Service do
     field :protect,          :boolean
     field :dry_run,          :boolean
     field :interval,         :string
+    field :templated,        :boolean, description: "if you should apply liquid templating to raw yaml files, defaults to true"
     field :git,              :git_ref_attributes
     field :helm,             :helm_config_attributes
     field :configuration,    list_of(:config_attributes)
@@ -139,6 +141,7 @@ defmodule Console.GraphQl.Deployments.Service do
       svc, _, _ -> {:ok, svc.helm}
     end
     field :promotion,        :service_promotion, description: "how you'd like to perform a canary promotion"
+    field :templated,        :boolean, description: "if you should apply liquid templating to raw yaml files, defaults to true"
     field :protect,          :boolean, description: "if true, deletion of this service is not allowed"
     field :sha,              :string, description: "latest git sha we pulled from"
     field :tarball,          :string, resolve: &Deployments.tarball/3, description: "https url to fetch the latest tarball of kubernetes manifests"
@@ -496,6 +499,15 @@ defmodule Console.GraphQl.Deployments.Service do
       arg :attributes, non_null(:service_clone_attributes)
 
       safe_resolve &Deployments.clone_service/2
+    end
+
+    field :kick_service, :service_deployment do
+      middleware Authenticated
+      arg :service_id, :id
+      arg :cluster,    :string, description: "the handle of the cluster for this service"
+      arg :name,       :string
+
+      resolve &Deployments.kick_service/2
     end
 
     field :self_manage, :service_deployment do

--- a/lib/console/graphql/kubernetes.ex
+++ b/lib/console/graphql/kubernetes.ex
@@ -159,6 +159,7 @@ defmodule Console.GraphQl.Kubernetes do
 
     field :nodes, list_of(:node) do
       middleware Authenticated
+      middleware AdminRequired
 
       safe_resolve &Kubernetes.list_nodes/2
     end
@@ -238,6 +239,7 @@ defmodule Console.GraphQl.Kubernetes do
 
     field :cached_pods, list_of(:pod) do
       middleware Authenticated
+      middleware AdminRequired
       arg :namespaces, list_of(:string)
 
       safe_resolve &Kubernetes.list_cached_pods/2
@@ -253,7 +255,7 @@ defmodule Console.GraphQl.Kubernetes do
     field :log_filters, list_of(:log_filter) do
       middleware Authenticated
       arg :namespace, non_null(:string)
-      middleware Rbac, perm: :read, arg: :namespace
+      middleware Rbac, perm: :operate, arg: :namespace
 
       safe_resolve &Kubernetes.list_log_filters/2
     end

--- a/lib/console/graphql/kubernetes/config.ex
+++ b/lib/console/graphql/kubernetes/config.ex
@@ -35,6 +35,7 @@ defmodule Console.GraphQl.Kubernetes.Config do
 
     field :config_maps, list_of(:config_map) do
       middleware Authenticated
+      middleware Rbac, perm: :operate, arg: :namespace
       arg :namespace, non_null(:string)
 
       safe_resolve &Kubernetes.list_config_maps/2

--- a/lib/console/graphql/middleware/cd_authed.ex
+++ b/lib/console/graphql/middleware/cd_authed.ex
@@ -26,8 +26,7 @@ defmodule Console.Middleware.CdAuthenticated do
     end
   end
 
-  def call(res, opts) do
-    perm = Keyword.get(opts, :perm) || :read
-    Console.Middleware.Rbac.call(res, perm: perm, arg: :namespace)
+  def call(res, _opts) do
+    Console.Middleware.Rbac.call(res, perm: :operate, arg: :namespace)
   end
 end

--- a/lib/console/graphql/resolvers/deployments/service.ex
+++ b/lib/console/graphql/resolvers/deployments/service.ex
@@ -132,6 +132,14 @@ defmodule Console.GraphQl.Resolvers.Deployments.Service do
   def rollback(%{id: id, revision_id: rev}, %{context: %{current_user: user}}),
     do: Services.rollback(rev, id, user)
 
+  def kick_service(%{cluster: c, name: n} = args, %{context: %{current_user: user}})
+    when is_binary(c) and is_binary(n) do
+    svc = fetch_service(args)
+    Services.kick(svc.id, user)
+  end
+  def kick_service(%{id: id}, %{context: %{current_user: user}}),
+    do: Services.kick(id, user)
+
   def update_service_components(%{id: id} = args, %{context: %{cluster: cluster}}),
     do: Services.update_components(Map.take(args, [:errors, :components]), id, cluster)
 

--- a/lib/console/schema/object_store.ex
+++ b/lib/console/schema/object_store.ex
@@ -21,6 +21,7 @@ defmodule Console.Schema.ObjectStore do
 
     embeds_one :azure, Azure, on_replace: :update do
       field :storage_account, :string
+      field :resource_group,  :string
       field :container,       :string
       field :subscription_id, :string
       field :tenant_id,       :string
@@ -71,7 +72,7 @@ defmodule Console.Schema.ObjectStore do
 
   def azure_changeset(model, attrs) do
     model
-    |> cast(attrs, ~w(container storage_account subscription_id tenant_id client_id client_secret)a)
-    |> validate_required(~w(container storage_account subscription_id tenant_id client_id client_secret)a)
+    |> cast(attrs, ~w(container storage_account resource_group subscription_id tenant_id client_id client_secret)a)
+    |> validate_required(~w(container storage_account resource_group subscription_id tenant_id client_id client_secret)a)
   end
 end

--- a/lib/console/schema/service.ex
+++ b/lib/console/schema/service.ex
@@ -79,6 +79,7 @@ defmodule Console.Schema.Service do
     field :version,          :string
     field :promotion,        Promotion
     field :proceed,          :boolean, default: false
+    field :templated,        :boolean, default: false
     field :sha,              :string
     field :namespace,        :string
     field :docs_path,        :string
@@ -202,7 +203,7 @@ defmodule Console.Schema.Service do
   def docs_path(%__MODULE__{docs_path: p}) when is_binary(p), do: p
   def docs_path(%__MODULE__{git: %{folder: p}}), do: Path.join(p, "docs")
 
-  @valid ~w(name protect interval docs_path component_status dry_run interval status version sha cluster_id repository_id namespace owner_id message)a
+  @valid ~w(name protect interval docs_path component_status templated dry_run interval status version sha cluster_id repository_id namespace owner_id message)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/priv/repo/migrations/20240216001533_add_services_templated.exs
+++ b/priv/repo/migrations/20240216001533_add_services_templated.exs
@@ -1,0 +1,9 @@
+defmodule Console.Repo.Migrations.AddServicesTemplated do
+  use Ecto.Migration
+
+  def change do
+    alter table(:services) do
+      add :templated, :boolean, default: true, null: false
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -516,6 +516,15 @@ type RootMutationType {
     attributes: ServiceCloneAttributes!
   ): ServiceDeployment
 
+  kickService(
+    serviceId: ID
+
+    "the handle of the cluster for this service"
+    cluster: String
+
+    name: String
+  ): ServiceDeployment
+
   selfManage(values: String!): ServiceDeployment
 
   "marks a service as being able to proceed to the next stage of a canary rollout"
@@ -744,7 +753,7 @@ input S3StoreAttributes {
 
 input GcsStoreAttributes {
   bucket: String!
-  region: String!
+  region: String
   applicationCredentials: String!
 }
 
@@ -752,6 +761,7 @@ input AzureStoreAttributes {
   storageAccount: String!
   container: String!
   subscriptionId: String!
+  resourceGroup: String!
   tenantId: String!
   clientId: String!
   clientSecret: String!
@@ -794,13 +804,14 @@ type S3Store {
 
 type GcsStore {
   bucket: String!
-  region: String!
+  region: String
 }
 
 type AzureStore {
   storageAccount: String!
   container: String!
   subscriptionId: String!
+  resourceGroup: String!
   tenantId: String!
   clientId: String!
 }
@@ -1233,20 +1244,38 @@ enum ServicePromotion {
 
 input ServiceDeploymentAttributes {
   name: String!
+
   namespace: String!
+
   version: String
+
   docsPath: String
+
   syncConfig: SyncConfigAttributes
+
   protect: Boolean
+
   repositoryId: ID
+
   dryRun: Boolean
+
   interval: String
+
+  "if you should apply liquid templating to raw yaml files, defaults to true"
+  templated: Boolean
+
   git: GitRefAttributes
+
   helm: HelmConfigAttributes
+
   kustomize: KustomizeAttributes
+
   configuration: [ConfigAttributes]
+
   readBindings: [PolicyBindingAttributes]
+
   writeBindings: [PolicyBindingAttributes]
+
   contextBindings: [ContextBindingAttributes]
 }
 
@@ -1278,15 +1307,28 @@ input HelmValueAttributes {
 
 input ServiceUpdateAttributes {
   version: String
+
   protect: Boolean
+
   dryRun: Boolean
+
   interval: String
+
+  "if you should apply liquid templating to raw yaml files, defaults to true"
+  templated: Boolean
+
   git: GitRefAttributes
+
   helm: HelmConfigAttributes
+
   configuration: [ConfigAttributes]
+
   kustomize: KustomizeAttributes
+
   readBindings: [PolicyBindingAttributes]
+
   writeBindings: [PolicyBindingAttributes]
+
   contextBindings: [ContextBindingAttributes]
 }
 
@@ -1389,6 +1431,9 @@ type ServiceDeployment {
 
   "how you'd like to perform a canary promotion"
   promotion: ServicePromotion
+
+  "if you should apply liquid templating to raw yaml files, defaults to true"
+  templated: Boolean
 
   "if true, deletion of this service is not allowed"
   protect: Boolean

--- a/test/console/graphql/queries/kubernetes_queries_test.exs
+++ b/test/console/graphql/queries/kubernetes_queries_test.exs
@@ -8,7 +8,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "statefulSet" do
     test "it can fetch statefulsets by namespace/name" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:ok, stateful_set("namespace", "name")} end)
 
@@ -36,7 +36,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
 
     test "it won't choke on errors" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:error, {:http_error, 404, "an error"}} end)
 
@@ -61,7 +61,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "deployment" do
     test "it can fetch deployments by namespace/name" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:ok, deployment("namespace", "name")} end)
 
@@ -91,7 +91,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "service" do
     test "it can fetch services by namespace/name" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:ok, service("namespace", "name")} end)
 
@@ -118,7 +118,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "ingress" do
     test "it can fetch ingresses by namespace/name" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:ok, ingress("namespace", "name")} end)
 
@@ -164,7 +164,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
             spec { providerId }
           }
         }
-      """, %{}, %{current_user: insert(:user)})
+      """, %{}, %{current_user: admin_user()})
 
       assert node["metadata"]["name"]
       assert node["status"]["allocatable"]["cpu"]
@@ -204,7 +204,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "cronJob" do
     test "it can read a cron job" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:ok, cron("cron")} end)
 
@@ -229,7 +229,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "job" do
     test "it can read a job" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:ok, job("job")} end)
 
@@ -253,7 +253,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "certificate" do
     test "it can read a certificate crd" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:ok, certificate("certificate")} end)
 
@@ -279,7 +279,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "pod" do
     test "it can query an individual pod" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:ok, pod("name")} end)
 
@@ -300,7 +300,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
 
     test "it can query logs for a pod" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, 2, fn
         %{path: "/api/v1/namespaces/name/pods/name/log"} -> {:ok, "some logs\nreturned"}
@@ -358,7 +358,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
   describe "logfilters" do
     test "it can query logfilters" do
       user = insert(:user)
-      role = insert(:role, repositories: ["*"], permissions: %{read: true})
+      role = insert(:role, repositories: ["*"], permissions: %{operate: true})
       insert(:role_binding, role: role, user: user)
       expect(Kazan, :run, fn _ -> {:ok, %{items: [logfilter("name")]}} end)
 
@@ -568,7 +568,6 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
 
   describe "configMaps" do
     test "users can list config maps" do
-      user = insert(:user)
       expect(Kazan, :run, fn _ -> {:ok, %{items: [config_map("name")]}} end)
 
       {:ok, %{data: %{"configMaps" => [conf]}}} = run_query("""
@@ -578,7 +577,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
             data
           }
         }
-      """, %{"name" => "name"}, %{current_user: user})
+      """, %{"name" => "name"}, %{current_user: admin_user()})
 
       assert conf["metadata"]["name"] == "name"
       assert conf["data"]["some"] == "config"

--- a/test/console/graphql/queries/user_queries_test.exs
+++ b/test/console/graphql/queries/user_queries_test.exs
@@ -154,13 +154,20 @@ defmodule Console.GraphQl.UserQueriesTest do
       expect(HTTPoison, :post, fn _, _, _ ->
         {:ok, %{body: Poison.encode!(%{data: %{externalToken: "external-token"}})}}
       end)
-      user = insert(:user)
 
       {:ok, %{data: %{"externalToken" => token}}} = run_query("""
         query { externalToken }
-      """, %{}, %{current_user: user})
+      """, %{}, %{current_user: admin_user()})
 
       assert token == "external-token"
+    end
+
+    test "non-admins cannot fetch external tokens" do
+      user = insert(:user)
+
+      {:ok, %{errors: [_ | _]}} = run_query("""
+        query { externalToken }
+      """, %{}, %{current_user: user})
     end
   end
 


### PR DESCRIPTION
## Summary
Need the latter for velero setup.  Also realized service secret fetching is very effectively cacheable, so doing that.


## Test Plan
regression

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.