### PR TITLE
Fix service delinking for deletion protected svcs, enable backup filtering

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -4128,6 +4128,7 @@ export type RootQueryTypeClusterStatusesArgs = {
 
 export type RootQueryTypeClustersArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
+  backups?: InputMaybe<Scalars['Boolean']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
   healthy?: InputMaybe<Scalars['Boolean']['input']>;

--- a/lib/console/deployments/backups.ex
+++ b/lib/console/deployments/backups.ex
@@ -157,8 +157,12 @@ defmodule Console.Deployments.Backups do
       |> allow(user, :write)
       |> when_ok(:update)
     end)
-    |> add_operation(:svc, fn %{cluster: %{id: id}} ->
-      svc = Services.get_service_by_name!(id, "velero")
+    |> add_operation(:disable, fn %{cluster: %{id: id}} ->
+      Services.get_service_by_name!(id, "velero")
+      |> Ecto.Changeset.change(%{protect: false})
+      |> Repo.update()
+    end)
+    |> add_operation(:svc, fn %{disable: svc} ->
       Services.delete_service(svc.id, user)
     end)
     |> execute(extract: :cluster)

--- a/lib/console/graphql/deployments/cluster.ex
+++ b/lib/console/graphql/deployments/cluster.ex
@@ -513,6 +513,7 @@ defmodule Console.GraphQl.Deployments.Cluster do
       arg :healthy,   :boolean
       arg :tag,       :tag_input
       arg :tag_query, :tag_query
+      arg :backups,   :boolean
 
       resolve &Deployments.list_clusters/2
     end

--- a/lib/console/graphql/resolvers/deployments/cluster.ex
+++ b/lib/console/graphql/resolvers/deployments/cluster.ex
@@ -140,6 +140,7 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
       {:tag, %{name: n, value: v}}, q -> Cluster.with_tag(q, n, v)
       {:tag_query, tq}, q -> Cluster.with_tag_query(q, tq)
       {:healthy, h}, q -> Cluster.health(q, h)
+      {:backups, e}, q -> Cluster.with_backups(q, !!e)
       _, q -> q
     end)
   end

--- a/lib/console/schema/cluster.ex
+++ b/lib/console/schema/cluster.ex
@@ -134,6 +134,14 @@ defmodule Console.Schema.Cluster do
     from(c in query, where: ilike(c.name, ^"#{sq}%"))
   end
 
+  def with_backups(query \\ __MODULE__, enabled)
+  def with_backups(query, true) do
+    from(c in query, left_join: o in assoc(c, :object_store), where: not is_nil(o.id))
+  end
+  def with_backups(query, false) do
+    from(c in query, left_join: o in assoc(c, :object_store), where: is_nil(o.id))
+  end
+
   def ignore_ids(query \\ __MODULE__, ids) do
     from(c in query, where: c.id not in ^ids)
   end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -188,7 +188,7 @@ type RootQueryType {
 
   "a relay connection of all clusters visible to the current user"
   clusters(
-    after: String, first: Int, before: String, last: Int, q: String, healthy: Boolean, tag: TagInput, tagQuery: TagQuery
+    after: String, first: Int, before: String, last: Int, q: String, healthy: Boolean, tag: TagInput, tagQuery: TagQuery, backups: Boolean
   ): ClusterConnection
 
   "gets summary information for all healthy\/unhealthy clusters in your fleet"

--- a/test/console/deployments/backups_test.exs
+++ b/test/console/deployments/backups_test.exs
@@ -139,7 +139,7 @@ defmodule Console.Deployments.BackupsTest do
     test "it will remove backup configuration from a cluster" do
       store = insert(:object_store, s3: %{bucket: "bucket"})
       cluster = insert(:cluster, object_store: store)
-      svc = insert(:service, cluster: cluster, name: "velero")
+      svc = insert(:service, protect: true, cluster: cluster, name: "velero")
 
       {:ok, updated} = Backups.delink_backups(cluster.id, admin_user())
 


### PR DESCRIPTION

## Summary

Currently we (correctly) set deletion protection on velero services, but that also makes the delink api break.  This fixes this in one transaction.


## Test Plan
modify test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.