### PR TITLE
Add schemas for personas

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -2322,6 +2322,7 @@ export type PersonaConnection = {
 export type PersonaDeployment = {
   __typename?: 'PersonaDeployment';
   addOns?: Maybe<Scalars['Boolean']['output']>;
+  clusters?: Maybe<Scalars['Boolean']['output']>;
   deployments?: Maybe<Scalars['Boolean']['output']>;
   pipelines?: Maybe<Scalars['Boolean']['output']>;
   providers?: Maybe<Scalars['Boolean']['output']>;
@@ -2330,6 +2331,7 @@ export type PersonaDeployment = {
 
 export type PersonaDeploymentAttributes = {
   addOns?: InputMaybe<Scalars['Boolean']['input']>;
+  clusters?: InputMaybe<Scalars['Boolean']['input']>;
   deployments?: InputMaybe<Scalars['Boolean']['input']>;
   pipelines?: InputMaybe<Scalars['Boolean']['input']>;
   providers?: InputMaybe<Scalars['Boolean']['input']>;
@@ -2347,12 +2349,14 @@ export type PersonaSidebar = {
   audits?: Maybe<Scalars['Boolean']['output']>;
   kubernetes?: Maybe<Scalars['Boolean']['output']>;
   pullRequests?: Maybe<Scalars['Boolean']['output']>;
+  settings?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type PersonaSidebarAttributes = {
   audits?: InputMaybe<Scalars['Boolean']['input']>;
   kubernetes?: InputMaybe<Scalars['Boolean']['input']>;
   pullRequests?: InputMaybe<Scalars['Boolean']['input']>;
+  settings?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** a release pipeline, composed of multiple stages each with potentially multiple services */

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -2271,6 +2271,90 @@ export enum Permission {
   Read = 'READ'
 }
 
+export type Persona = {
+  __typename?: 'Persona';
+  /** the group bindings for this persona */
+  bindings?: Maybe<Array<Maybe<PolicyBinding>>>;
+  /** the ui configuration for this persona (additive across personas) */
+  configuration?: Maybe<PersonaConfiguration>;
+  /** longform description of this persona */
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  insertedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** the name for this persona */
+  name: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type PersonaAttributes = {
+  bindings?: InputMaybe<Array<InputMaybe<BindingAttributes>>>;
+  configuration?: InputMaybe<PersonaConfigurationAttributes>;
+  /** longform description of this persona */
+  description?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type PersonaConfiguration = {
+  __typename?: 'PersonaConfiguration';
+  /** enable full ui for this persona */
+  all?: Maybe<Scalars['Boolean']['output']>;
+  /** enable individual parts of the deployments views */
+  deployments?: Maybe<PersonaDeployment>;
+  /** enable individual aspects of the sidebar */
+  sidebar?: Maybe<PersonaSidebar>;
+};
+
+export type PersonaConfigurationAttributes = {
+  /** enable full ui for this persona */
+  all?: InputMaybe<Scalars['Boolean']['input']>;
+  /** enable individual parts of the deployments views */
+  deployments?: InputMaybe<PersonaDeploymentAttributes>;
+  /** enable individual aspects of the sidebar */
+  sidebar?: InputMaybe<PersonaSidebarAttributes>;
+};
+
+export type PersonaConnection = {
+  __typename?: 'PersonaConnection';
+  edges?: Maybe<Array<Maybe<PersonaEdge>>>;
+  pageInfo: PageInfo;
+};
+
+export type PersonaDeployment = {
+  __typename?: 'PersonaDeployment';
+  addOns?: Maybe<Scalars['Boolean']['output']>;
+  deployments?: Maybe<Scalars['Boolean']['output']>;
+  pipelines?: Maybe<Scalars['Boolean']['output']>;
+  providers?: Maybe<Scalars['Boolean']['output']>;
+  services?: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type PersonaDeploymentAttributes = {
+  addOns?: InputMaybe<Scalars['Boolean']['input']>;
+  deployments?: InputMaybe<Scalars['Boolean']['input']>;
+  pipelines?: InputMaybe<Scalars['Boolean']['input']>;
+  providers?: InputMaybe<Scalars['Boolean']['input']>;
+  services?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type PersonaEdge = {
+  __typename?: 'PersonaEdge';
+  cursor?: Maybe<Scalars['String']['output']>;
+  node?: Maybe<Persona>;
+};
+
+export type PersonaSidebar = {
+  __typename?: 'PersonaSidebar';
+  audits?: Maybe<Scalars['Boolean']['output']>;
+  kubernetes?: Maybe<Scalars['Boolean']['output']>;
+  pullRequests?: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type PersonaSidebarAttributes = {
+  audits?: InputMaybe<Scalars['Boolean']['input']>;
+  kubernetes?: InputMaybe<Scalars['Boolean']['input']>;
+  pullRequests?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
 /** a release pipeline, composed of multiple stages each with potentially multiple services */
 export type Pipeline = {
   __typename?: 'Pipeline';
@@ -3172,6 +3256,7 @@ export type RootMutationType = {
   createInvite?: Maybe<Invite>;
   createObjectStore?: Maybe<ObjectStore>;
   createPeer?: Maybe<WireguardPeer>;
+  createPersona?: Maybe<Persona>;
   /** creates a new pipeline context and binds it to the beginning stage */
   createPipelineContext?: Maybe<PipelineContext>;
   createPrAutomation?: Maybe<PrAutomation>;
@@ -3199,6 +3284,7 @@ export type RootMutationType = {
   deleteNode?: Maybe<Node>;
   deleteObjectStore?: Maybe<ObjectStore>;
   deletePeer?: Maybe<Scalars['Boolean']['output']>;
+  deletePersona?: Maybe<Persona>;
   deletePipeline?: Maybe<Pipeline>;
   deletePod?: Maybe<Pod>;
   deletePrAutomation?: Maybe<PrAutomation>;
@@ -3259,6 +3345,7 @@ export type RootMutationType = {
   updateGlobalService?: Maybe<GlobalService>;
   updateGroup?: Maybe<Group>;
   updateObjectStore?: Maybe<ObjectStore>;
+  updatePersona?: Maybe<Persona>;
   updatePrAutomation?: Maybe<PrAutomation>;
   /** a reusable mutation for updating rbac settings on core services */
   updateRbac?: Maybe<Scalars['Boolean']['output']>;
@@ -3376,6 +3463,11 @@ export type RootMutationTypeCreatePeerArgs = {
   email?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
   userId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type RootMutationTypeCreatePersonaArgs = {
+  attributes: PersonaAttributes;
 };
 
 
@@ -3513,6 +3605,11 @@ export type RootMutationTypeDeleteObjectStoreArgs = {
 
 export type RootMutationTypeDeletePeerArgs = {
   name: Scalars['String']['input'];
+};
+
+
+export type RootMutationTypeDeletePersonaArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -3802,6 +3899,12 @@ export type RootMutationTypeUpdateObjectStoreArgs = {
 };
 
 
+export type RootMutationTypeUpdatePersonaArgs = {
+  attributes: PersonaAttributes;
+  id: Scalars['ID']['input'];
+};
+
+
 export type RootMutationTypeUpdatePrAutomationArgs = {
   attributes: PrAutomationAttributes;
   id: Scalars['ID']['input'];
@@ -3940,6 +4043,8 @@ export type RootQueryType = {
   objectStores?: Maybe<ObjectStoreConnection>;
   pagedClusterGates?: Maybe<PipelineGateConnection>;
   pagedClusterServices?: Maybe<ServiceDeploymentConnection>;
+  persona?: Maybe<Persona>;
+  personas?: Maybe<PersonaConnection>;
   pipeline?: Maybe<Pipeline>;
   pipelineContext?: Maybe<PipelineContext>;
   pipelineGate?: Maybe<PipelineGate>;
@@ -4354,6 +4459,19 @@ export type RootQueryTypePagedClusterGatesArgs = {
 
 
 export type RootQueryTypePagedClusterServicesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type RootQueryTypePersonaArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type RootQueryTypePersonasArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -5463,6 +5581,7 @@ export type User = {
   insertedAt?: Maybe<Scalars['DateTime']['output']>;
   jwt?: Maybe<Scalars['String']['output']>;
   name: Scalars['String']['output'];
+  personas?: Maybe<Array<Maybe<Persona>>>;
   pluralId?: Maybe<Scalars['String']['output']>;
   profile?: Maybe<Scalars['String']['output']>;
   readTimestamp?: Maybe<Scalars['DateTime']['output']>;

--- a/controller/api/v1alpha1/prautomation_types.go
+++ b/controller/api/v1alpha1/prautomation_types.go
@@ -337,6 +337,10 @@ type Condition struct {
 }
 
 func (in *Condition) Attributes() *console.ConditionAttributes {
+	if in == nil {
+		return nil
+	}
+
 	return &console.ConditionAttributes{
 		Operation: in.Operation,
 		Field:     in.Field,

--- a/lib/console/deployments/services.ex
+++ b/lib/console/deployments/services.ex
@@ -69,7 +69,7 @@ defmodule Console.Deployments.Services do
   defp tarfile(%Service{} = svc), do: Git.Discovery.fetch(svc)
 
   defp maybe_values(files, %Service.Helm{values: vals}) when is_binary(vals),
-    do: Map.put(files, "values.yaml.liquid", vals)
+    do: Map.merge(files, %{"values.yaml.liquid" => vals, "values.yaml.static" => vals})
   defp maybe_values(files, _), do: files
 
   def referenced?(id) do

--- a/lib/console/graphql/users.ex
+++ b/lib/console/graphql/users.ex
@@ -76,6 +76,7 @@ defmodule Console.GraphQl.Users do
   end
 
   input_object :persona_deployment_attributes do
+    field :clusters,    :boolean
     field :deployments, :boolean
     field :services,    :boolean
     field :pipelines,   :boolean
@@ -87,6 +88,7 @@ defmodule Console.GraphQl.Users do
     field :audits,        :boolean
     field :kubernetes,    :boolean
     field :pull_requests, :boolean
+    field :settings,      :boolean
   end
 
   object :user do
@@ -242,6 +244,7 @@ defmodule Console.GraphQl.Users do
   end
 
   object :persona_deployment do
+    field :clusters,    :boolean
     field :deployments, :boolean
     field :services,    :boolean
     field :pipelines,   :boolean
@@ -253,6 +256,7 @@ defmodule Console.GraphQl.Users do
     field :audits,        :boolean
     field :kubernetes,    :boolean
     field :pull_requests, :boolean
+    field :settings,      :boolean
   end
 
   connection node_type: :user

--- a/lib/console/schema/persona.ex
+++ b/lib/console/schema/persona.ex
@@ -8,11 +8,11 @@ defmodule Console.Schema.Persona do
     embedded_schema do
       field :all, :boolean
       embeds_one :deployments, Deployments, on_replace: :update do
-        boolean_fields [:deployments, :services, :pipelines, :providers, :add_ons]
+        boolean_fields [:clusters, :deployments, :services, :pipelines, :providers, :add_ons]
       end
 
       embeds_one :sidebar, Sidebar, on_replace: :update do
-        boolean_fields [:all, :kubernetes, :audits, :pull_requests]
+        boolean_fields [:all, :kubernetes, :audits, :pull_requests, :settings]
       end
     end
 

--- a/lib/console/schema/persona.ex
+++ b/lib/console/schema/persona.ex
@@ -1,0 +1,77 @@
+defmodule Console.Schema.Persona do
+  use Piazza.Ecto.Schema
+  alias Console.Schema.{PolicyBinding, User}
+
+  defmodule Configuration do
+    use Piazza.Ecto.Schema
+
+    embedded_schema do
+      field :all, :boolean
+      embeds_one :deployments, Deployments, on_replace: :update do
+        boolean_fields [:deployments, :services, :pipelines, :providers, :add_ons]
+      end
+
+      embeds_one :sidebar, Sidebar, on_replace: :update do
+        boolean_fields [:all, :kubernetes, :audits, :pull_requests]
+      end
+    end
+
+    def changeset(model, attrs) do
+      model
+      |> cast(attrs, [:all])
+      |> cast_embed(:deployments, with: &deployments_cs/2)
+      |> cast_embed(:sidebar, with: &sidebar_cs/2)
+    end
+
+    defp deployments_cs(model, attrs) do
+      model
+      |> cast(attrs, deployments_fields())
+    end
+
+    defp sidebar_cs(model, attrs) do
+      model
+      |> cast(attrs, sidebar_fields())
+    end
+
+    defp deployments_fields(), do: __MODULE__.Deployments.__schema__(:fields) -- [:id]
+    defp sidebar_fields(), do: __MODULE__.Sidebar.__schema__(:fields) -- [:id]
+  end
+
+  schema "personas" do
+    field :name,        :string
+    field :description, :string
+    field :bindings_id, :binary_id
+
+    embeds_one :configuration, Configuration, on_replace: :update
+
+    has_many :bindings, PolicyBinding,
+      on_replace: :delete,
+      foreign_key: :policy_id,
+      references: :bindings_id
+
+    timestamps()
+  end
+
+  def ordered(query \\ __MODULE__, order \\ [asc: :name]) do
+    from(p in query, order_by: ^order)
+  end
+
+  def for_user(query \\ __MODULE__, %User{id: user_id} = user) do
+    %{groups: groups} = Console.Repo.preload(user, [:groups])
+    group_ids = Enum.map(groups, & &1.id)
+    from(p in query,
+      left_join: b in assoc(p, :bindings),
+      where: b.user_id == ^user_id or b.group_id in ^group_ids,
+      distinct: true
+    )
+  end
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, ~w(name description)a)
+    |> cast_embed(:configuration)
+    |> cast_assoc(:bindings)
+    |> put_new_change(:bindings_id, &Ecto.UUID.generate/0)
+    |> validate_required(~w(name)a)
+  end
+end

--- a/priv/repo/migrations/20240217015346_add_personas.exs
+++ b/priv/repo/migrations/20240217015346_add_personas.exs
@@ -1,0 +1,17 @@
+defmodule Console.Repo.Migrations.AddPersonas do
+  use Ecto.Migration
+
+  def change do
+    create table(:personas, primary_key: false) do
+      add :id,            :uuid, primary_key: true
+      add :name,          :string
+      add :description,   :string
+      add :bindings_id,   :uuid
+      add :configuration, :map
+
+      timestamps()
+    end
+
+    create unique_index(:personas, [:name])
+  end
+end

--- a/priv/repo/seeds/06_personas.exs
+++ b/priv/repo/seeds/06_personas.exs
@@ -1,0 +1,21 @@
+import Botanist
+
+alias Console.Services.Users
+
+seed do
+  config = fn fields -> Map.new(fields, & {&1, true}) end
+  {:ok, _} = Users.create_persona(%{
+    name: "platform",
+    description: "Platform engineer persona with access to all features",
+    configuration: %{all: true}
+  })
+
+  {:ok, _} = Users.create_persona(%{
+    name: "developer",
+    description: "Developer persona with access to features relevant to microservice deployment",
+    configuration: %{
+      deployments: config.(~w(clusters services pipelines)a),
+      sidebar: config.(~w(kubernetes pull_requests)a)
+    }
+  })
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -4183,6 +4183,7 @@ input PersonaConfigurationAttributes {
 }
 
 input PersonaDeploymentAttributes {
+  clusters: Boolean
   deployments: Boolean
   services: Boolean
   pipelines: Boolean
@@ -4194,6 +4195,7 @@ input PersonaSidebarAttributes {
   audits: Boolean
   kubernetes: Boolean
   pullRequests: Boolean
+  settings: Boolean
 }
 
 type User {
@@ -4341,6 +4343,7 @@ type PersonaConfiguration {
 }
 
 type PersonaDeployment {
+  clusters: Boolean
   deployments: Boolean
   services: Boolean
   pipelines: Boolean
@@ -4352,6 +4355,7 @@ type PersonaSidebar {
   audits: Boolean
   kubernetes: Boolean
   pullRequests: Boolean
+  settings: Boolean
 }
 
 type UserConnection {

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -45,6 +45,10 @@ type RootQueryType {
 
   accessToken(id: ID!): AccessToken
 
+  persona(id: ID!): Persona
+
+  personas(after: String, first: Int, before: String, last: Int): PersonaConnection
+
   dashboards(repo: String!): [Dashboard]
 
   dashboard(repo: String!, name: String!, step: String, offset: Int, labels: [LabelInput]): Dashboard
@@ -357,6 +361,12 @@ type RootMutationType {
   createServiceAccountToken(id: ID!, scopes: [ScopeAttributes]): AccessToken
 
   deleteAccessToken(token: String!): AccessToken
+
+  createPersona(attributes: PersonaAttributes!): Persona
+
+  updatePersona(id: ID!, attributes: PersonaAttributes!): Persona
+
+  deletePersona(id: ID!): Persona
 
   deleteCertificate(name: String!, namespace: String!): Boolean
 
@@ -4150,6 +4160,42 @@ input BindingAttributes {
   groupId: ID
 }
 
+input PersonaAttributes {
+  name: String
+
+  "longform description of this persona"
+  description: String
+
+  configuration: PersonaConfigurationAttributes
+
+  bindings: [BindingAttributes]
+}
+
+input PersonaConfigurationAttributes {
+  "enable full ui for this persona"
+  all: Boolean
+
+  "enable individual parts of the deployments views"
+  deployments: PersonaDeploymentAttributes
+
+  "enable individual aspects of the sidebar"
+  sidebar: PersonaSidebarAttributes
+}
+
+input PersonaDeploymentAttributes {
+  deployments: Boolean
+  services: Boolean
+  pipelines: Boolean
+  providers: Boolean
+  addOns: Boolean
+}
+
+input PersonaSidebarAttributes {
+  audits: Boolean
+  kubernetes: Boolean
+  pullRequests: Boolean
+}
+
 type User {
   id: ID!
   name: String!
@@ -4162,6 +4208,7 @@ type User {
   buildTimestamp: DateTime
   assumeBindings: [PolicyBinding]
   groups: [Group]
+  personas: [Persona]
   boundRoles: [Role]
   jwt: String
   unreadNotifications: Int
@@ -4262,6 +4309,51 @@ type AccessTokenAudit {
   updatedAt: DateTime
 }
 
+type Persona {
+  id: ID!
+
+  "the name for this persona"
+  name: String!
+
+  "longform description of this persona"
+  description: String
+
+  "the ui configuration for this persona (additive across personas)"
+  configuration: PersonaConfiguration
+
+  "the group bindings for this persona"
+  bindings: [PolicyBinding]
+
+  insertedAt: DateTime
+
+  updatedAt: DateTime
+}
+
+type PersonaConfiguration {
+  "enable full ui for this persona"
+  all: Boolean
+
+  "enable individual parts of the deployments views"
+  deployments: PersonaDeployment
+
+  "enable individual aspects of the sidebar"
+  sidebar: PersonaSidebar
+}
+
+type PersonaDeployment {
+  deployments: Boolean
+  services: Boolean
+  pipelines: Boolean
+  providers: Boolean
+  addOns: Boolean
+}
+
+type PersonaSidebar {
+  audits: Boolean
+  kubernetes: Boolean
+  pullRequests: Boolean
+}
+
 type UserConnection {
   pageInfo: PageInfo!
   edges: [UserEdge]
@@ -4295,6 +4387,11 @@ type AccessTokenConnection {
 type AccessTokenAuditConnection {
   pageInfo: PageInfo!
   edges: [AccessTokenAuditEdge]
+}
+
+type PersonaConnection {
+  pageInfo: PageInfo!
+  edges: [PersonaEdge]
 }
 
 type NotificationDelta {
@@ -4484,6 +4581,11 @@ type CommandEdge {
 
 type BuildEdge {
   node: Build
+  cursor: String
+}
+
+type PersonaEdge {
+  node: Persona
   cursor: String
 }
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -413,6 +413,17 @@ defmodule Console.Factory do
     }
   end
 
+  def persona_factory do
+    %Schema.Persona{
+      name: sequence(:persona, & "persona-#{&1}"),
+      bindings_id: Ecto.UUID.generate(),
+      configuration: %{
+        deployments: %{deployments: true},
+        sidebar: %{kubernetes: true}
+      }
+    }
+  end
+
   def setup_rbac(user, repos \\ ["*"], perms) do
     role = insert(:role, repositories: repos, permissions: Map.new(perms))
     insert(:role_binding, role: role, user: user)


### PR DESCRIPTION
## Summary
Defines core graphql schemas for user personas. These will allow us to reconfigure the ui in an orderly way at scale for teams that want to hide specific functionality as needed.


## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.