### PR TITLE
fix: do not always redirect to CD page 

### DIFF
--- a/assets/src/components/contexts/DeploymentSettingsContext.tsx
+++ b/assets/src/components/contexts/DeploymentSettingsContext.tsx
@@ -23,6 +23,7 @@ export function DeploymentSettingsProvider({
 }) {
   const { data } = useDeploymentSettingsQuery({
     pollInterval: POLL_INTERVAL,
+    errorPolicy: 'all',
   })
 
   useCDEnabled({ redirect: false })

--- a/assets/src/components/contexts/DeploymentSettingsContext.tsx
+++ b/assets/src/components/contexts/DeploymentSettingsContext.tsx
@@ -25,7 +25,7 @@ export function DeploymentSettingsProvider({
     pollInterval: POLL_INTERVAL,
   })
 
-  useCDEnabled({ redirect: true })
+  useCDEnabled({ redirect: false })
 
   const providerValue = useMemo(
     () => data?.deploymentSettings,

--- a/assets/src/components/layout/Sidebar.tsx
+++ b/assets/src/components/layout/Sidebar.tsx
@@ -203,7 +203,7 @@ export default function Sidebar() {
       isActiveMenuItem(menuItem, pathname),
     [pathname]
   )
-  const isCDEnabled = useCDEnabled()
+  const isCDEnabled = useCDEnabled({ redirect: false })
 
   const menuItems = useMemo(
     () =>


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Looks like one of global contexts had cd check that forced user redirect to clusters view. This should fix it.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.