### PR TITLE
fix: Link to PR not working when PR list is inside modal

### DIFF
--- a/assets/src/components/pr/queue/PrQueueColumns.tsx
+++ b/assets/src/components/pr/queue/PrQueueColumns.tsx
@@ -185,6 +185,10 @@ const ColLink = columnHelper.accessor(({ node }) => node?.url, {
         href={getValue()}
         target="_blank"
         rel="noopener noreferrer"
+        onClick={(e) => {
+          e.preventDefault()
+          window.open(getValue(), '_blank')
+        }}
       />
     )
   },


### PR DESCRIPTION
Fixes external link in this modal:
<img width="944" alt="Screenshot 2024-02-29 at 2 36 12 PM" src="https://github.com/pluralsh/console/assets/85062/08e7054a-aa96-40b4-80f1-9b684ad2a1b9">
