### PR TITLE
fix: PR status chip colors

### DIFF
--- a/assets/src/components/pr/queue/PrQueueColumns.tsx
+++ b/assets/src/components/pr/queue/PrQueueColumns.tsx
@@ -87,11 +87,11 @@ const ColStatus = columnHelper.accessor(({ node }) => node?.status, {
     const severity: ComponentProps<typeof Chip>['severity'] = useMemo(() => {
       switch (status) {
         case PrStatus.Open:
-          return 'success'
+          return 'warning'
         case PrStatus.Closed:
           return 'danger'
         case PrStatus.Merged:
-          return 'info'
+          return 'success'
       }
     }, [status])
 


### PR DESCRIPTION
## Summary
OPEN → 'warning' (yellow)
MERGED → 'success' (green)
CLOSED → 'danger' (red)

https://linear.app/pluralsh/issue/ENG-1883/pr-status-color-map-is-off