### PR TITLE
fix: Sink search not working when editing notification router

### DIFF
--- a/assets/src/components/notifications/routers/CreateNotificationRouterModal.tsx
+++ b/assets/src/components/notifications/routers/CreateNotificationRouterModal.tsx
@@ -34,7 +34,7 @@ export function CreateNotificationRouterModal({
         To create a new notification router, you can set up a router in your
         configuration files.{' '}
         <InlineLink
-          href="https://docs.plural.sh/" /* TODO_KLINK: Add more specific link */
+          href="https://docs.plural.sh/" /* TODO: Add more specific link */
           target="_blank"
           rel="noreferrer"
         >

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -7340,6 +7340,7 @@ export type DeleteNotificationSinkMutationVariables = Exact<{
 export type DeleteNotificationSinkMutation = { __typename?: 'RootMutationType', deleteNotificationSink?: { __typename?: 'NotificationSink', id: string, name: string, type: SinkType, insertedAt?: string | null, updatedAt?: string | null, configuration: { __typename?: 'SinkConfiguration', id: string, slack?: { __typename?: 'UrlSinkConfiguration', url: string } | null, teams?: { __typename?: 'UrlSinkConfiguration', url: string } | null } } | null };
 
 export type NotificationSinksQueryVariables = Exact<{
+  q?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
   after?: InputMaybe<Scalars['String']['input']>;
 }>;
@@ -14432,8 +14433,8 @@ export type DeleteNotificationSinkMutationHookResult = ReturnType<typeof useDele
 export type DeleteNotificationSinkMutationResult = Apollo.MutationResult<DeleteNotificationSinkMutation>;
 export type DeleteNotificationSinkMutationOptions = Apollo.BaseMutationOptions<DeleteNotificationSinkMutation, DeleteNotificationSinkMutationVariables>;
 export const NotificationSinksDocument = gql`
-    query NotificationSinks($first: Int = 100, $after: String) {
-  notificationSinks(first: $first, after: $after) {
+    query NotificationSinks($q: String, $first: Int = 100, $after: String) {
+  notificationSinks(q: $q, first: $first, after: $after) {
     pageInfo {
       ...PageInfo
     }
@@ -14459,6 +14460,7 @@ ${NotificationSinkFragmentDoc}`;
  * @example
  * const { data, loading, error } = useNotificationSinksQuery({
  *   variables: {
+ *      q: // value for 'q'
  *      first: // value for 'first'
  *      after: // value for 'after'
  *   },

--- a/assets/src/graph/notifications.graphql
+++ b/assets/src/graph/notifications.graphql
@@ -91,8 +91,8 @@ mutation DeleteNotificationSink($id: ID!) {
   }
 }
 
-query NotificationSinks($first: Int = 100, $after: String) {
-  notificationSinks(first: $first, after: $after) {
+query NotificationSinks($q: String, $first: Int = 100, $after: String) {
+  notificationSinks(q: $q, first: $first, after: $after) {
     pageInfo {
       ...PageInfo
     }


### PR DESCRIPTION
**_Note:_** Still need docs link for Create Notification Router modal (currently links to root of docs.plural.sh)

## Summary
- Fix typeahead search in Sink combobox not working
- Remove some unneeded dev code

<img width="632" alt="Screenshot 2024-03-09 at 8 38 21 AM" src="https://github.com/pluralsh/console/assets/85062/8214ce9c-dbb7-4042-9e81-a4ba1af1487c">


## Checklist
- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added relevant labels to this PR to help with categorization for release notes.