### PR TITLE
fix: UI/UX layout issues

### DIFF
--- a/assets/src/components/apps/app/components/ComponentList.tsx
+++ b/assets/src/components/apps/app/components/ComponentList.tsx
@@ -18,7 +18,9 @@ export function ComponentList<C extends Component>({
   const theme = useTheme()
   const filteredComponents = useMemo(
     () =>
-      components?.filter((comp) => selectedKinds.has(comp?.kind)).sort(compareComponents),
+      components
+        ?.filter((comp) => selectedKinds.has(comp?.kind))
+        .sort(compareComponents),
     [components, selectedKinds]
   )
 

--- a/assets/src/components/apps/app/components/ComponentList.tsx
+++ b/assets/src/components/apps/app/components/ComponentList.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { useTheme } from 'styled-components'
 
 import ComponentCard, { type Component } from './ComponentCard'
-import { orderBy } from './Components'
+import { compareComponents } from './Components'
 
 export function ComponentList<C extends Component>({
   components,
@@ -18,7 +18,7 @@ export function ComponentList<C extends Component>({
   const theme = useTheme()
   const filteredComponents = useMemo(
     () =>
-      components?.filter((comp) => selectedKinds.has(comp?.kind)).sort(orderBy),
+      components?.filter((comp) => selectedKinds.has(comp?.kind)).sort(compareComponents),
     [components, selectedKinds]
   )
 

--- a/assets/src/components/apps/app/components/Components.tsx
+++ b/assets/src/components/apps/app/components/Components.tsx
@@ -46,7 +46,6 @@ const FilterTrigger = styled(SelectButton)<{ $width?: number }>(
 )
 
 const KIND_ORDER = [
-  'service',
   'deployment',
   'statefulset',
   'daemonset',

--- a/assets/src/components/apps/app/components/Components.tsx
+++ b/assets/src/components/apps/app/components/Components.tsx
@@ -53,6 +53,7 @@ const KIND_ORDER = [
   'ingress',
   'cronjob',
   'job',
+  'service',
   'certificate',
   'secret',
   'configmap',

--- a/assets/src/components/apps/app/components/Components.tsx
+++ b/assets/src/components/apps/app/components/Components.tsx
@@ -45,25 +45,49 @@ const FilterTrigger = styled(SelectButton)<{ $width?: number }>(
   })
 )
 
-const ORDER = {
-  deployment: 1,
-  statefulset: 2,
-  certificate: 3,
-  ingress: 4,
-  cronjob: 5,
-  service: 6,
-  job: 7,
+const KIND_ORDER = [
+  'service',
+  'deployment',
+  'statefulset',
+  'daemonset',
+  'ingress',
+  'cronjob',
+  'job',
+  'certificate',
+  'secret',
+  'configmap',
+] as const satisfies string[]
+
+const getKindIdx = (kind: Nullable<string>) => {
+  const i = KIND_ORDER.findIndex((k) => k === kind?.toLowerCase())
+
+  return i === -1 ? Number.MAX_VALUE : i
 }
 
-const kindInd = (kind) => ORDER[kind.toLowerCase()] || 7
-
-export function orderBy(
-  { kind: k1, name: n1 }: any,
-  { kind: k2, name: n2 }: any
+export function compareComponentKinds(
+  k1: Nullable<string>,
+  k2: Nullable<string>
 ) {
-  if (k1 === k2) return n1 > n2 ? 1 : n1 === n2 ? 0 : -1
+  if (k1 === k2) return 0
 
-  return kindInd(k1) - kindInd(k2)
+  const k1Idx = getKindIdx(k1)
+  const k2Idx = getKindIdx(k2)
+
+  if (k1Idx === k2Idx) return (k1 || '')?.localeCompare(k2 || '')
+
+  return k1Idx - k2Idx
+}
+
+export function compareComponents<
+  T extends { kind?: Nullable<string>; name?: Nullable<string> },
+>({ kind: k1, name: n1 }: T, { kind: k2, name: n2 }: T) {
+  const kindCompare = compareComponentKinds(k1, k2)
+
+  if (kindCompare !== 0) {
+    return kindCompare
+  }
+
+  return (n1 || '')?.localeCompare(n2 || '')
 }
 
 export function useComponentKindSelect(
@@ -114,7 +138,7 @@ function getUniqueKinds(
 
       return kinds
     }, new Set<string>([])) || []
-  ).sort()
+  ).sort(compareComponentKinds)
 }
 
 function ComponentKindSelect({

--- a/assets/src/components/cd/services/service/ServiceDetailsSidecar.tsx
+++ b/assets/src/components/cd/services/service/ServiceDetailsSidecar.tsx
@@ -40,13 +40,18 @@ export function ServiceDetailsSidecar({
   const { id, name, status, cluster, git, helm } = serviceDeployment
 
   return (
-    <>
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.small,
+      }}
+    >
       <div
         style={{
           display: 'flex',
-          alignItems: 'center',
-          alignContent: 'center',
-          margin: theme.spacing.small,
+          flexDirection: 'column',
+          gap: theme.spacing.small,
         }}
       >
         <ServiceKick id={id} />
@@ -120,6 +125,6 @@ export function ServiceDetailsSidecar({
           </SidecarItem>
         )}
       </Sidecar>
-    </>
+    </div>
   )
 }

--- a/assets/src/components/cd/services/service/ServiceKick.tsx
+++ b/assets/src/components/cd/services/service/ServiceKick.tsx
@@ -28,7 +28,7 @@ export default function ServiceKick({ id }) {
           onClick={mutation}
           loading={loading}
         >
-          Resync Service
+          Resync service
         </Button>
       </Tooltip>
     </div>

--- a/assets/src/components/cd/services/service/ServiceKick.tsx
+++ b/assets/src/components/cd/services/service/ServiceKick.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@pluralsh/design-system'
+import { Button, Tooltip } from '@pluralsh/design-system'
 import { GqlError } from 'components/utils/Alert'
 import { useKickServiceMutation } from 'generated/graphql'
 import { useTheme } from 'styled-components'
@@ -23,12 +23,14 @@ export default function ServiceKick({ id }) {
           error={error}
         />
       )}
-      <Button
-        onClick={mutation}
-        loading={loading}
-      >
-        Resync Service
-      </Button>
+      <Tooltip label="Use this to sync this service now instead of in the next poll interval">
+        <Button
+          onClick={mutation}
+          loading={loading}
+        >
+          Resync Service
+        </Button>
+      </Tooltip>
     </div>
   )
 }

--- a/assets/src/components/component/info/Service.tsx
+++ b/assets/src/components/component/info/Service.tsx
@@ -59,13 +59,9 @@ export default function Service() {
             {ports.map(({ name, protocol, port, targetPort }, i) => (
               <PropWideBold
                 key={i}
-                gap="small"
                 title={name || '-'}
               >
-                <span>{protocol}</span>
-                <span>
-                  {port} {'->'} {targetPort}
-                </span>
+                {protocol} {port} → {targetPort}
               </PropWideBold>
             ))}
           </>


### PR DESCRIPTION
<!--- Hello Plural contributor! It's great to have you on board! -->

## Summary
- New sort order for components
  -   'deployment', 'statefulset', 'daemonset', 'ingress', 'cronjob',  'job',  'service', 'certificate',  'secret', 'configmap', then alphabetical
- Fix margins on `Resync Service` button
- Update formatting for port ranges

#### Before
<img width="936" alt="01-01" src="https://github.com/pluralsh/console/assets/85062/987f3504-64ed-45d6-960a-19664fd88cbd">


#### After
<img width="936" alt="01-02" src="https://github.com/pluralsh/console/assets/85062/9cde755f-993e-4161-9046-3dc759576292">

---

#### Before
<img width="936" alt="02-01" src="https://github.com/pluralsh/console/assets/85062/98562e95-78b7-4664-8a9a-28893d4c4354">


#### After
<img width="936" alt="02-02" src="https://github.com/pluralsh/console/assets/85062/f27adc6f-5ca2-4f72-8bd2-39e1384ca823">

---

#### Before
<img width="467" alt="Screenshot 2024-03-14 at 8 45 30 AM" src="https://github.com/pluralsh/console/assets/85062/396e9d02-04be-475b-8100-489cdeb24e26">

#### After
<img width="467" alt="Screenshot 2024-03-14 at 8 45 39 AM" src="https://github.com/pluralsh/console/assets/85062/dceb9c72-d5bd-4b27-becd-cb6e5b6a0593">


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.