### PR TITLE
Fix annoying redirect bug

### DIFF
--- a/assets/src/components/PluralApi.jsx
+++ b/assets/src/components/PluralApi.jsx
@@ -19,9 +19,9 @@ export function PluralApi({ children }) {
     const res = buildClient(
       PLURAL_GQL,
       PLURAL_WSS,
-      () => {
-        window.location = '/'
-      },
+      // () => {
+      //   window.location = '/'
+      // },
       () => token
     )
 


### PR DESCRIPTION
## Summary

I think a change to `buildClient` is causing us to always redirect to / on the accounts page, this should fix.

## Test Plan
local


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.