### PR TITLE
Add apis for managing template viewing in-ui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,25 +124,25 @@ ARG GIT_COMMIT
 
 ENV REPLACE_OS_VARS=true \
     APP_NAME=${APP_NAME} \
-    GIT_ASKPASS=/root/bin/.git-askpass \
-    SSH_ASKPASS=/root/bin/.ssh-askpass \
+    GIT_ASKPASS=/opt/app/bin/.git-askpass \
+    SSH_ASKPASS=/opt/app/bin/.ssh-askpass \
     GIT_COMMIT=${GIT_COMMIT}
 
 WORKDIR /opt/app
 
 RUN addgroup -S --gid 10001 app
 RUN adduser -u 10001 -S console -G app
-RUN chown console:app /opt/app 
+RUN chown console:app /opt/app
 
 RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh
 RUN mkdir -p /root/.plural && mkdir -p /root/.creds && mkdir /root/bin
 RUN ln -s /usr/local/bin/plural /usr/local/bin/forge
 
 # add common repos to known hosts
-COPY bin /root/bin
-RUN chmod +x /root/bin/.git-askpass && \ 
-      chmod +x /root/bin/.ssh-askpass && \
-      chmod +x /root/bin/ssh-add
+COPY bin /opt/app/bin
+RUN chmod +x /opt/app/bin/.git-askpass && \ 
+      chmod +x /opt/app/bin/.ssh-askpass && \
+      chmod +x /opt/app/bin/ssh-add
 
 ENV GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=quiet"
 

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -3718,6 +3718,8 @@ export type RootMutationType = {
   restorePostgres?: Maybe<Postgresql>;
   /** rewires this service to use the given revision id */
   rollbackService?: Maybe<ServiceDeployment>;
+  /** save the manifests in cache to be retrieved by the requesting user */
+  saveManifests?: Maybe<Scalars['Boolean']['output']>;
   /** upserts a pipeline with a given name */
   savePipeline?: Maybe<Pipeline>;
   saveServiceContext?: Maybe<ServiceContext>;
@@ -4216,6 +4218,12 @@ export type RootMutationTypeRollbackServiceArgs = {
 };
 
 
+export type RootMutationTypeSaveManifestsArgs = {
+  id: Scalars['ID']['input'];
+  manifests?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
 export type RootMutationTypeSavePipelineArgs = {
   attributes: PipelineAttributes;
   name: Scalars['String']['input'];
@@ -4451,6 +4459,8 @@ export type RootQueryType = {
   deployment?: Maybe<Deployment>;
   deploymentSettings?: Maybe<DeploymentSettings>;
   externalToken?: Maybe<Scalars['String']['output']>;
+  /** Fetches the manifests from cache once the agent has given us them, will be null otherwise */
+  fetchManifests?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   gitRepositories?: Maybe<GitRepositoryConnection>;
   gitRepository?: Maybe<GitRepository>;
   globalService?: Maybe<GlobalService>;
@@ -4512,6 +4522,8 @@ export type RootQueryType = {
   refreshTokens?: Maybe<RefreshTokenConnection>;
   repositories?: Maybe<RepositoryConnection>;
   repository?: Maybe<Repository>;
+  /** request manifests from an agent, to be returned by a future call to fetchManifests */
+  requestManifests?: Maybe<ServiceDeployment>;
   role?: Maybe<Role>;
   roles?: Maybe<RoleConnection>;
   runbook?: Maybe<Runbook>;
@@ -4763,6 +4775,11 @@ export type RootQueryTypeDeploymentArgs = {
   name: Scalars['String']['input'];
   namespace: Scalars['String']['input'];
   serviceId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type RootQueryTypeFetchManifestsArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -5138,6 +5155,11 @@ export type RootQueryTypeRepositoriesArgs = {
 
 export type RootQueryTypeRepositoryArgs = {
   name: Scalars['String']['input'];
+};
+
+
+export type RootQueryTypeRequestManifestsArgs = {
+  id: Scalars['ID']['input'];
 };
 
 

--- a/lib/console/deployments/events.ex
+++ b/lib/console/deployments/events.ex
@@ -3,6 +3,7 @@ defmodule Console.PubSub.ServiceUpdated, do: use Piazza.PubSub.Event
 defmodule Console.PubSub.ServiceDeleted, do: use Piazza.PubSub.Event
 defmodule Console.PubSub.ServiceComponentsUpdated, do: use Piazza.PubSub.Event
 defmodule Console.PubSub.ServiceHardDeleted, do: use Piazza.PubSub.Event
+defmodule Console.PubSub.ServiceManifestsRequested, do: use Piazza.PubSub.Event
 
 defmodule Console.PubSub.ClusterCreated, do: use Piazza.PubSub.Event
 defmodule Console.PubSub.ClusterUpdated, do: use Piazza.PubSub.Event

--- a/lib/console/deployments/pubsub/protocols/broadcastable.ex
+++ b/lib/console/deployments/pubsub/protocols/broadcastable.ex
@@ -23,6 +23,11 @@ defimpl Console.Deployments.PubSub.Broadcastable, for: [
     do: {"cluster:#{cluster_id}", "service.event", %{"id" => id}}
 end
 
+defimpl Console.Deployments.PubSub.Broadcastable, for: Console.PubSub.ServiceManifestsRequested do
+  def message(%{item: %{id: id, cluster_id: cluster_id}}),
+    do: {"cluster:#{cluster_id}", "service.manifests", %{"id" => id}}
+end
+
 defimpl Console.Deployments.PubSub.Broadcastable, for: [Console.PubSub.ClusterRestoreCreated] do
   def message(%{item: item}) do
     %{id: id, backup: %{cluster_id: cluster_id}} = Console.Repo.preload(item, [:backup])

--- a/lib/console/graphql/deployments/service.ex
+++ b/lib/console/graphql/deployments/service.ex
@@ -377,6 +377,15 @@ defmodule Console.GraphQl.Deployments.Service do
 
       safe_resolve &Deployments.update_service_components/2
     end
+
+    @desc "save the manifests in cache to be retrieved by the requesting user"
+    field :save_manifests, :boolean do
+      middleware ClusterAuthenticated
+      arg :id, non_null(:id)
+      arg :manifests, list_of(:string)
+
+      safe_resolve &Deployments.save_manifests/2
+    end
   end
 
   object :service_queries do
@@ -412,6 +421,22 @@ defmodule Console.GraphQl.Deployments.Service do
       arg :id, non_null(:id), description: "the id of the service component for the tree view"
 
       resolve &Deployments.tree/2
+    end
+
+    @desc "request manifests from an agent, to be returned by a future call to fetchManifests"
+    field :request_manifests, :service_deployment do
+      middleware Authenticated
+      arg :id, non_null(:id)
+
+      resolve &Deployments.request_manifests/2
+    end
+
+    @desc "Fetches the manifests from cache once the agent has given us them, will be null otherwise"
+    field :fetch_manifests, list_of(:string) do
+      middleware Authenticated
+      arg :id, non_null(:id)
+
+      resolve &Deployments.fetch_manifests/2
     end
   end
 

--- a/lib/console/graphql/resolvers/deployments/service.ex
+++ b/lib/console/graphql/resolvers/deployments/service.ex
@@ -164,6 +164,17 @@ defmodule Console.GraphQl.Resolvers.Deployments.Service do
   def tarball(svc, _, _), do: {:ok, Services.tarball(svc)}
   def docs(svc, _, _), do: Services.docs(svc)
 
+  def fetch_manifests(%{id: id}, %{context: %{current_user: user}}),
+    do: Services.fetch_manifests(id, user)
+
+  def request_manifests(%{id: id}, %{context: %{current_user: user}}),
+    do: Services.request_manifests(id, user)
+
+  def save_manifests(%{id: id, manifests: mans}, %{context: %{cluster: cluster}}) do
+    with :ok <- Services.save_manifests(mans, id, cluster),
+      do: {:ok, true}
+  end
+
   defp service_filters(query, args) do
     Enum.reduce(args, query, fn
       {:cluster_id, id}, q -> Service.for_cluster(q, id)

--- a/rel/config/console.exs
+++ b/rel/config/console.exs
@@ -78,8 +78,8 @@ end
 
 config :console,
   workspace_root: "/root",
-  git_askpass: "/root/bin/.git-askpass",
-  ssh_askpass: "/root/bin/.ssh-askpass",
+  git_askpass: "/opt/app/bin/.git-askpass",
+  ssh_askpass: "/opt/app/bin/.ssh-askpass",
   git_url: get_env("GIT_URL"),
   branch: get_env("BRANCH_NAME") || "master",
   repo_root: get_env("REPO_ROOT") || "workspace",

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -266,6 +266,12 @@ type RootQueryType {
     id: ID!
   ): ComponentTree
 
+  "request manifests from an agent, to be returned by a future call to fetchManifests"
+  requestManifests(id: ID!): ServiceDeployment
+
+  "Fetches the manifests from cache once the agent has given us them, will be null otherwise"
+  fetchManifests(id: ID!): [String]
+
   pipelines(after: String, first: Int, before: String, last: Int, q: String): PipelineConnection
 
   pipeline(id: ID!): Pipeline
@@ -617,6 +623,9 @@ type RootMutationType {
 
   "updates only the components of a given service, to be sent after deploy operator syncs"
   updateServiceComponents(id: ID!, components: [ComponentAttributes], errors: [ServiceErrorAttributes]): ServiceDeployment
+
+  "save the manifests in cache to be retrieved by the requesting user"
+  saveManifests(id: ID!, manifests: [String]): Boolean
 
   updateGate(id: ID!, attributes: GateUpdateAttributes!): PipelineGate
 

--- a/test/console/deployments/services_test.exs
+++ b/test/console/deployments/services_test.exs
@@ -1068,6 +1068,16 @@ defmodule Console.Deployments.ServicesAsyncTest do
     end
   end
 
+  describe "#request_manifests/2" do
+    test "an admin can request manifests" do
+      service = insert(:service)
+
+      {:ok, found} = Services.request_manifests(service.id, admin_user())
+
+      assert_receive {:event, %Console.PubSub.ServiceManifestsRequested{item: ^found}}
+    end
+  end
+
   describe "#tarstream/1" do
     test "it can fetch a chart for a helm service" do
       svc = insert(:service, helm: %{chart: "podinfo", version: "5.0", repository: %{name: "podinfo", namespace: "helm-charts"}})


### PR DESCRIPTION
## Summary
There's a meaningful usecase to understand the generated yaml for a service post-templating.  Think of it as being able to run `helm template` from within our ui instead of locally. Our dry run experience somewhat accomplishes this but will fail for misformatted yaml or other edge cases.

## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.