### PR TITLE
Add pinned custom resources api

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -623,6 +623,8 @@ export type Cluster = {
   objectStore?: Maybe<ObjectStore>;
   /** last time the deploy operator pinged this cluster */
   pingedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** custom resources with dedicated views for this cluster */
+  pinnedCustomResources?: Maybe<Array<Maybe<PinnedCustomResource>>>;
   /** lists OPA constraints registered in this cluster */
   policyConstraints?: Maybe<PolicyConstraintConnection>;
   /** pr automations that are relevant to managing this cluster */
@@ -2645,6 +2647,27 @@ export type PersonaSidebarAttributes = {
   stacks?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+/** A reference to a custom resource you want to be displayed in the k8s dashboard */
+export type PinnedCustomResource = {
+  __typename?: 'PinnedCustomResource';
+  cluster?: Maybe<Cluster>;
+  displayName: Scalars['String']['output'];
+  group: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  kind: Scalars['String']['output'];
+  namespaced?: Maybe<Scalars['Boolean']['output']>;
+  version: Scalars['String']['output'];
+};
+
+export type PinnedCustomResourceAttributes = {
+  clusterId?: InputMaybe<Scalars['ID']['input']>;
+  displayName: Scalars['String']['input'];
+  group: Scalars['String']['input'];
+  kind: Scalars['String']['input'];
+  namespaced?: InputMaybe<Scalars['Boolean']['input']>;
+  version: Scalars['String']['input'];
+};
+
 /** a release pipeline, composed of multiple stages each with potentially multiple services */
 export type Pipeline = {
   __typename?: 'Pipeline';
@@ -3644,6 +3667,7 @@ export type RootMutationType = {
   createObjectStore?: Maybe<ObjectStore>;
   createPeer?: Maybe<WireguardPeer>;
   createPersona?: Maybe<Persona>;
+  createPinnedCustomResource?: Maybe<PinnedCustomResource>;
   /** creates a new pipeline context and binds it to the beginning stage */
   createPipelineContext?: Maybe<PipelineContext>;
   createPrAutomation?: Maybe<PrAutomation>;
@@ -3675,6 +3699,7 @@ export type RootMutationType = {
   deleteObjectStore?: Maybe<ObjectStore>;
   deletePeer?: Maybe<Scalars['Boolean']['output']>;
   deletePersona?: Maybe<Persona>;
+  deletePinnedCustomResource?: Maybe<PinnedCustomResource>;
   deletePipeline?: Maybe<Pipeline>;
   deletePod?: Maybe<Pod>;
   deletePrAutomation?: Maybe<PrAutomation>;
@@ -3873,6 +3898,11 @@ export type RootMutationTypeCreatePersonaArgs = {
 };
 
 
+export type RootMutationTypeCreatePinnedCustomResourceArgs = {
+  attributes: PinnedCustomResourceAttributes;
+};
+
+
 export type RootMutationTypeCreatePipelineContextArgs = {
   attributes: PipelineContextAttributes;
   pipelineId: Scalars['ID']['input'];
@@ -4026,6 +4056,11 @@ export type RootMutationTypeDeletePeerArgs = {
 
 
 export type RootMutationTypeDeletePersonaArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type RootMutationTypeDeletePinnedCustomResourceArgs = {
   id: Scalars['ID']['input'];
 };
 

--- a/lib/console/deployments/clusters.ex
+++ b/lib/console/deployments/clusters.ex
@@ -19,7 +19,8 @@ defmodule Console.Deployments.Clusters do
     ClusterRevision,
     ProviderCredential,
     RuntimeService,
-    AgentMigration
+    AgentMigration,
+    PinnedCustomResource
   }
   alias Console.Deployments.Compatibilities
   require Logger
@@ -33,6 +34,7 @@ defmodule Console.Deployments.Clusters do
   @type cluster_provider_resp :: {:ok, ClusterProvider.t} | Console.error
   @type credential_resp :: {:ok, ProviderCredential.t} | Console.error
   @type runtime_service_resp :: {:ok, RuntimeService.t} | Console.error
+  @type pinned_resp :: {:ok, PinnedCustomResource.t} | Console.error
 
   def find!(identifier) do
     case Uniq.UUID.parse(identifier) do
@@ -711,6 +713,27 @@ defmodule Console.Deployments.Clusters do
 
       _ -> {:ok, 0}
     end
+  end
+
+  @doc """
+  Creates a new pinned custom resource, can be cluster or global scoped
+  """
+  @spec create_pinned_custom_resource(map, User.t) :: pinned_resp
+  def create_pinned_custom_resource(attrs, %User{} = user) do
+    %PinnedCustomResource{}
+    |> PinnedCustomResource.changeset(attrs)
+    |> allow(user, :write)
+    |> when_ok(:insert)
+  end
+
+  @doc """
+  Creates a new pinned custom resource, can be cluster or global scoped
+  """
+  @spec delete_pinned_custom_resource(binary, User.t) :: pinned_resp
+  def delete_pinned_custom_resource(id, %User{} = user) do
+    Repo.get!(PinnedCustomResource, id)
+    |> allow(user, :write)
+    |> when_ok(:delete)
   end
 
   def kas_url() do

--- a/lib/console/graphql/resolvers/deployments/cluster.ex
+++ b/lib/console/graphql/resolvers/deployments/cluster.ex
@@ -5,7 +5,8 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
     User,
     Cluster,
     ClusterProvider,
-    ClusterRevision
+    ClusterRevision,
+    PinnedCustomResource
   }
 
   def resolve_cluster(_, %{context: %{cluster: cluster}}), do: {:ok, cluster}
@@ -81,6 +82,13 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
 
   def list_node_metrics(cluster, _, _), do: Clusters.node_metrics(cluster)
 
+  def list_pinned_custom_resources(cluster, _, _) do
+    PinnedCustomResource.for_cluster(cluster.id)
+    |> PinnedCustomResource.ordered()
+    |> Console.Repo.all()
+    |> ok()
+  end
+
   def runtime_services(cluster, _, _), do: {:ok, Clusters.runtime_services(cluster)}
 
   def deploy_token(%{deploy_token: token} = cluster, _, %{context: %{current_user: user}}) do
@@ -131,6 +139,12 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
 
   def create_agent_migration(%{attributes: attrs}, %{context: %{current_user: user}}),
     do: Clusters.create_agent_migration(attrs, user)
+
+  def create_pinned_custom_resource(%{attributes: attrs}, %{context: %{current_user: user}}),
+    do: Clusters.create_pinned_custom_resource(attrs, user)
+
+  def delete_pinned_custom_resource(%{id: id}, %{context: %{current_user: user}}),
+    do: Clusters.delete_pinned_custom_resource(id, user)
 
   def ping(%{attributes: attrs}, %{context: %{cluster: cluster}}),
     do: Clusters.ping(attrs, cluster)

--- a/lib/console/schema/pinned_custom_resource.ex
+++ b/lib/console/schema/pinned_custom_resource.ex
@@ -1,0 +1,33 @@
+defmodule Console.Schema.PinnedCustomResource do
+  use Piazza.Ecto.Schema
+  alias Console.Schema.{Cluster}
+
+  schema "pinned_custom_resources" do
+    field :kind,         :string
+    field :group,        :string
+    field :version,      :string
+    field :display_name, :string
+    field :namespaced,   :boolean
+
+    belongs_to :cluster, Cluster
+
+    timestamps()
+  end
+
+  def for_cluster(query \\ __MODULE__, cluster_id) do
+    from(pc in query, where: pc.cluster_id == ^cluster_id or is_nil(pc.cluster_id))
+  end
+
+  def ordered(query \\ __MODULE__, order \\ [asc: :display_name]) do
+    from(pc in query, order_by: ^order)
+  end
+
+  @valid ~w(kind group version display_name namespaced)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, [:cluster_id | @valid])
+    |> foreign_key_constraint(:cluster_id)
+    |> validate_required(@valid)
+  end
+end

--- a/priv/repo/migrations/20240328143552_add_pinned_custom_resources.exs
+++ b/priv/repo/migrations/20240328143552_add_pinned_custom_resources.exs
@@ -1,0 +1,19 @@
+defmodule Console.Repo.Migrations.AddPinnedCustomResources do
+  use Ecto.Migration
+
+  def change do
+    create table(:pinned_custom_resources, primary_key: false) do
+      add :id,           :uuid, primary_key: true
+      add :kind,         :string
+      add :group,        :string
+      add :version,      :string
+      add :display_name, :string
+      add :namespaced,   :boolean
+      add :cluster_id,   references(:clusters, type: :uuid, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:pinned_custom_resources, [:cluster_id])
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -508,6 +508,10 @@ type RootMutationType {
 
   createAgentMigration(attributes: AgentMigrationAttributes!): AgentMigration
 
+  createPinnedCustomResource(attributes: PinnedCustomResourceAttributes!): PinnedCustomResource
+
+  deletePinnedCustomResource(id: ID!): PinnedCustomResource
+
   createServiceDeployment(
     clusterId: ID
 
@@ -2442,6 +2446,15 @@ input AgentMigrationAttributes {
   configuration: Json
 }
 
+input PinnedCustomResourceAttributes {
+  displayName: String!
+  group: String!
+  version: String!
+  kind: String!
+  namespaced: Boolean
+  clusterId: ID
+}
+
 input TagInput {
   name: String!
   value: String!
@@ -2594,6 +2607,9 @@ type Cluster {
 
   "list the cached node metrics for a cluster, can also be stale up to 5m"
   nodeMetrics: [NodeMetric]
+
+  "custom resources with dedicated views for this cluster"
+  pinnedCustomResources: [PinnedCustomResource]
 
   "the status of the cluster as seen from the CAPI operator, since some clusters can be provisioned without CAPI, this can be null"
   status: ClusterStatus
@@ -2885,6 +2901,17 @@ type Tag {
 type ClusterStatusInfo {
   healthy: Boolean
   count: Int
+}
+
+"A reference to a custom resource you want to be displayed in the k8s dashboard"
+type PinnedCustomResource {
+  id: ID!
+  displayName: String!
+  group: String!
+  version: String!
+  kind: String!
+  namespaced: Boolean
+  cluster: Cluster
 }
 
 type ClusterConnection {

--- a/test/console/graphql/queries/deployments/cluster_queries_test.exs
+++ b/test/console/graphql/queries/deployments/cluster_queries_test.exs
@@ -305,6 +305,22 @@ defmodule Console.GraphQl.Deployments.ClusterQueriesTest do
       assert from_connection(found["policyConstraints"])
              |> ids_equal(constraints)
     end
+
+    test "it can fetch pinned custom resources for a cluster" do
+      cluster = insert(:cluster)
+      first = insert_list(2, :pinned_custom_resource, cluster: cluster)
+      second = insert_list(3, :pinned_custom_resource, cluster_id: nil, cluster: nil)
+
+      {:ok, %{data: %{"cluster" => found}}} = run_query("""
+        query Cluster($id: ID!) {
+          cluster(id: $id) {
+            pinnedCustomResources { id }
+          }
+        }
+      """, %{"id" => cluster.id}, %{current_user: admin_user()})
+
+      assert ids_equal(found["pinnedCustomResources"], first ++ second)
+    end
   end
 
   describe "runtimeService" do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -500,6 +500,17 @@ defmodule Console.Factory do
     }
   end
 
+  def pinned_custom_resource_factory do
+    %Schema.PinnedCustomResource{
+      kind: "ConstraintTemplate",
+      group: "gatekeeper.sh",
+      version: "v1beta1",
+      namespaced: false,
+      display_name: "Constraint Templates",
+      cluster: build(:cluster)
+    }
+  end
+
   def setup_rbac(user, repos \\ ["*"], perms) do
     role = insert(:role, repositories: repos, permissions: Map.new(perms))
     insert(:role_binding, role: role, user: user)


### PR DESCRIPTION
## Summary
Useful for customizing the dashboard CRD view, can be pinned globally or by cluster

## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] I have added relevant labels to this PR to help with categorization for release notes.