### PR TITLE
add create scm webhook button

### DIFF
--- a/assets/src/components/pr/scm/CreateScmConnectionWebhook.tsx
+++ b/assets/src/components/pr/scm/CreateScmConnectionWebhook.tsx
@@ -20,7 +20,7 @@ import { Body1P } from 'components/utils/typography/Text'
 import { SCM_WEBHOOKS_Q_VARS } from './ScmWebhooks'
 import { scmTypeToLabel } from './PrScmConnectionsColumns'
 
-export function CreateScmWebhookModalBase({
+export function CreateScmConectionWebhookModalBase({
   connection,
   open,
   onClose,
@@ -123,7 +123,7 @@ export function CreateScmWebhookModalBase({
             gap: theme.spacing.medium,
           }}
         >
-          <ScmWebhookForm
+          <ScmConnectionWebhookForm
             {...{
               type: 'create',
               connection,
@@ -139,12 +139,12 @@ export function CreateScmWebhookModalBase({
   )
 }
 
-export function CreateScmWebhookModal(
-  props: ComponentProps<typeof CreateScmWebhookModalBase>
+export function CreateScmConnectionWebhookModal(
+  props: ComponentProps<typeof CreateScmConectionWebhookModalBase>
 ) {
   return (
     <ModalMountTransition open={props.open}>
-      <CreateScmWebhookModalBase {...props} />
+      <CreateScmConectionWebhookModalBase {...props} />
     </ModalMountTransition>
   )
 }
@@ -153,7 +153,7 @@ type ScmWebhookVars = {
   owner: string
 }
 
-export function ScmWebhookForm({
+export function ScmConnectionWebhookForm({
   connection,
   formState,
   updateFormState,

--- a/assets/src/components/pr/scm/EditScmConnection.tsx
+++ b/assets/src/components/pr/scm/EditScmConnection.tsx
@@ -1,12 +1,5 @@
 import { type ComponentProps, useCallback } from 'react'
-import {
-  Accordion,
-  Button,
-  FormField,
-  ListBoxItem,
-  Modal,
-  Select,
-} from '@pluralsh/design-system'
+import { Accordion, Button, FormField, Modal } from '@pluralsh/design-system'
 import Input2 from '@pluralsh/design-system/dist/components/Input2'
 import { useTheme } from 'styled-components'
 import pick from 'lodash/pick'
@@ -14,7 +7,6 @@ import pick from 'lodash/pick'
 import {
   ScmConnectionAttributes,
   ScmConnectionFragment,
-  ScmType,
   useUpdateScmConnectionMutation,
 } from 'generated/graphql'
 
@@ -25,7 +17,7 @@ import { GqlError } from 'components/utils/Alert'
 
 import { ApolloError } from '@apollo/client'
 
-import { scmTypeToIcon, scmTypeToLabel } from './PrScmConnectionsColumns'
+import GitProviderSelect from './GitProviderSelect'
 
 function EditScmConnectionModalBase({
   open,
@@ -144,27 +136,10 @@ export function ScmConnectionForm({
         gap: theme.spacing.medium,
       }}
     >
-      <FormField
-        label="Provider type"
-        required
-      >
-        <Select
-          selectedKey={formState.type}
-          leftContent={
-            !formState.type ? undefined : scmTypeToIcon[formState.type || '']
-          }
-          label="Select provider type"
-          onSelectionChange={(key) => updateFormState({ type: key as ScmType })}
-        >
-          {[ScmType.Github, ScmType.Gitlab].map((type) => (
-            <ListBoxItem
-              key={type}
-              leftContent={scmTypeToIcon[type]}
-              label={scmTypeToLabel[type]}
-            />
-          ))}
-        </Select>
-      </FormField>
+      <GitProviderSelect
+        selectedKey={formState.type}
+        updateSelectedKey={(type) => updateFormState({ type })}
+      />
       <FormField
         label="Name"
         required

--- a/assets/src/components/pr/scm/GitProviderSelect.tsx
+++ b/assets/src/components/pr/scm/GitProviderSelect.tsx
@@ -1,0 +1,38 @@
+import { FormField, ListBoxItem, Select } from '@pluralsh/design-system'
+import { ScmType } from 'generated/graphql'
+
+import { scmTypeToIcon, scmTypeToLabel } from './PrScmConnectionsColumns'
+
+function GitProviderSelect({
+  selectedKey,
+  updateSelectedKey,
+}: {
+  selectedKey: ScmType | undefined
+  updateSelectedKey: (key: ScmType | undefined) => void
+}) {
+  return (
+    <FormField
+      label="Provider type"
+      required
+    >
+      <Select
+        selectedKey={selectedKey}
+        leftContent={
+          !selectedKey ? undefined : scmTypeToIcon[selectedKey || '']
+        }
+        label="Select provider type"
+        onSelectionChange={(key) => updateSelectedKey(key as ScmType)}
+      >
+        {[ScmType.Github, ScmType.Gitlab].map((type) => (
+          <ListBoxItem
+            key={type}
+            leftContent={scmTypeToIcon[type]}
+            label={scmTypeToLabel[type]}
+          />
+        ))}
+      </Select>
+    </FormField>
+  )
+}
+
+export default GitProviderSelect

--- a/assets/src/components/pr/scm/PrScmConnectionsColumns.tsx
+++ b/assets/src/components/pr/scm/PrScmConnectionsColumns.tsx
@@ -26,7 +26,7 @@ import { StackedText } from 'components/utils/table/StackedText'
 import { MoreMenu } from 'components/utils/MoreMenu'
 
 import { EditScmConnectionModal } from './EditScmConnection'
-import { CreateScmWebhookModal } from './CreateScmWebhook'
+import { CreateScmConnectionWebhookModal } from './CreateScmConnectionWebhook'
 
 enum MenuItemKey {
   Edit = 'edit',
@@ -207,7 +207,7 @@ export const ColActions = columnHelper.display({
           />
         </MoreMenu>
         {/* Modals */}
-        <CreateScmWebhookModal
+        <CreateScmConnectionWebhookModal
           connection={scmConnection}
           open={menuKey === MenuItemKey.CreateWebhook}
           onClose={() => setMenuKey('')}

--- a/assets/src/components/pr/scm/ScmWebhooks.tsx
+++ b/assets/src/components/pr/scm/ScmWebhooks.tsx
@@ -9,11 +9,15 @@ import { extendConnection } from 'utils/graphql'
 import { FullHeightTableWrap } from 'components/utils/layout/FullHeightTableWrap'
 import { useSlicePolling } from 'components/utils/tableFetchHelpers'
 import { GqlError } from 'components/utils/Alert'
-import { POLL_INTERVAL } from 'components/cd/ContinuousDeployment'
+import {
+  POLL_INTERVAL,
+  useSetPageHeaderContent,
+} from 'components/cd/ContinuousDeployment'
 
 import { PR_BASE_CRUMBS, PR_SCM_WEBHOOKS_ABS_PATH } from 'routes/prRoutesConsts'
 
 import { columns } from './ScmWebhooksColumns'
+import { CreateScmWebhook } from './CreateScmWebhook'
 
 export const REACT_VIRTUAL_OPTIONS: ComponentProps<
   typeof Table
@@ -82,6 +86,17 @@ export default function ScmWebhooks() {
         extendConnection(prev, fetchMoreResult.scmWebhooks, 'scmWebhooks'),
     })
   }, [fetchMore, pageInfo?.endCursor])
+
+  useSetPageHeaderContent(
+    <div
+      css={{
+        display: 'flex',
+        gap: theme.spacing.small,
+      }}
+    >
+      <CreateScmWebhook refetch={refetch} />
+    </div>
+  )
 
   if (error) {
     return <GqlError error={error} />

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -7017,6 +7017,13 @@ export type CreateScmWebhookMutationVariables = Exact<{
 
 export type CreateScmWebhookMutation = { __typename?: 'RootMutationType', createScmWebhook?: { __typename?: 'ScmWebhook', id: string, name: string, owner: string, type: ScmType, url: string, insertedAt?: string | null, updatedAt?: string | null } | null };
 
+export type CreateScmWebhookPointerMutationVariables = Exact<{
+  attributes: ScmWebhookAttributes;
+}>;
+
+
+export type CreateScmWebhookPointerMutation = { __typename?: 'RootMutationType', createScmWebhookPointer?: { __typename?: 'ScmWebhook', id: string, name: string, owner: string, type: ScmType, url: string, insertedAt?: string | null, updatedAt?: string | null } | null };
+
 export type ObjectStoreFragment = { __typename?: 'ObjectStore', id: string, name: string, insertedAt?: string | null, updatedAt?: string | null, s3?: { __typename?: 'S3Store', bucket: string, region?: string | null, endpoint?: string | null, accessKeyId: string } | null, azure?: { __typename?: 'AzureStore', container: string, storageAccount: string, resourceGroup: string, subscriptionId: string, clientId: string, tenantId: string } | null, gcs?: { __typename?: 'GcsStore', bucket: string } | null };
 
 export type ClustersObjectStoresFragment = { __typename?: 'Cluster', handle?: string | null, protect?: boolean | null, deletedAt?: string | null, version?: string | null, currentVersion?: string | null, id: string, name: string, self?: boolean | null, distro?: ClusterDistro | null, objectStore?: { __typename?: 'ObjectStore', id: string, name: string, insertedAt?: string | null, updatedAt?: string | null, s3?: { __typename?: 'S3Store', bucket: string, region?: string | null, endpoint?: string | null, accessKeyId: string } | null, azure?: { __typename?: 'AzureStore', container: string, storageAccount: string, resourceGroup: string, subscriptionId: string, clientId: string, tenantId: string } | null, gcs?: { __typename?: 'GcsStore', bucket: string } | null } | null, provider?: { __typename?: 'ClusterProvider', cloud: string } | null };
@@ -10748,6 +10755,39 @@ export function useCreateScmWebhookMutation(baseOptions?: Apollo.MutationHookOpt
 export type CreateScmWebhookMutationHookResult = ReturnType<typeof useCreateScmWebhookMutation>;
 export type CreateScmWebhookMutationResult = Apollo.MutationResult<CreateScmWebhookMutation>;
 export type CreateScmWebhookMutationOptions = Apollo.BaseMutationOptions<CreateScmWebhookMutation, CreateScmWebhookMutationVariables>;
+export const CreateScmWebhookPointerDocument = gql`
+    mutation CreateScmWebhookPointer($attributes: ScmWebhookAttributes!) {
+  createScmWebhookPointer(attributes: $attributes) {
+    ...ScmWebhook
+  }
+}
+    ${ScmWebhookFragmentDoc}`;
+export type CreateScmWebhookPointerMutationFn = Apollo.MutationFunction<CreateScmWebhookPointerMutation, CreateScmWebhookPointerMutationVariables>;
+
+/**
+ * __useCreateScmWebhookPointerMutation__
+ *
+ * To run a mutation, you first call `useCreateScmWebhookPointerMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateScmWebhookPointerMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createScmWebhookPointerMutation, { data, loading, error }] = useCreateScmWebhookPointerMutation({
+ *   variables: {
+ *      attributes: // value for 'attributes'
+ *   },
+ * });
+ */
+export function useCreateScmWebhookPointerMutation(baseOptions?: Apollo.MutationHookOptions<CreateScmWebhookPointerMutation, CreateScmWebhookPointerMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateScmWebhookPointerMutation, CreateScmWebhookPointerMutationVariables>(CreateScmWebhookPointerDocument, options);
+      }
+export type CreateScmWebhookPointerMutationHookResult = ReturnType<typeof useCreateScmWebhookPointerMutation>;
+export type CreateScmWebhookPointerMutationResult = Apollo.MutationResult<CreateScmWebhookPointerMutation>;
+export type CreateScmWebhookPointerMutationOptions = Apollo.BaseMutationOptions<CreateScmWebhookPointerMutation, CreateScmWebhookPointerMutationVariables>;
 export const ObjectStoresDocument = gql`
     query ObjectStores($after: String, $first: Int = 100, $before: String, $last: Int) {
   objectStores(after: $after, first: $first, before: $before, last: $last) {
@@ -16269,6 +16309,7 @@ export const namedOperations = {
     DeleteScmConnection: 'DeleteScmConnection',
     SetupRenovate: 'SetupRenovate',
     CreateScmWebhook: 'CreateScmWebhook',
+    CreateScmWebhookPointer: 'CreateScmWebhookPointer',
     CreateObjectStore: 'CreateObjectStore',
     UpdateObjectStore: 'UpdateObjectStore',
     DeleteObjectStore: 'DeleteObjectStore',

--- a/assets/src/graph/automation.graphql
+++ b/assets/src/graph/automation.graphql
@@ -159,3 +159,9 @@ mutation CreateScmWebhook($connectionId: ID!, $owner: String!) {
     ...ScmWebhook
   }
 }
+
+mutation CreateScmWebhookPointer($attributes: ScmWebhookAttributes!) {
+  createScmWebhookPointer(attributes: $attributes) {
+    ...ScmWebhook
+  }
+}


### PR DESCRIPTION
Adds a create webhook button to the Smc Webhooks page. this button opens a modal

![image](https://github.com/pluralsh/console/assets/38671115/300e7c77-e412-4760-9c7b-de52caf0d89b)

After the user creates it the modal shows the url and the secret,

I didn't test the changed state because i didn't know if I could create a new webhook, but since this is a time sensitive issue, i wanted to submit for review asap
