### PR TITLE
make serviceRef optional

### DIFF
--- a/charts/controller/crds/deployments.plural.sh_clusters.yaml
+++ b/charts/controller/crds/deployments.plural.sh_clusters.yaml
@@ -163,6 +163,10 @@ spec:
                   This has to be specified in order to adopt existing cluster.
                 example: myclusterhandle
                 type: string
+              metadata:
+                description: Metadata for the cluster
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               nodePools:
                 description: NodePools contains specs of node pools managed by this
                   cluster.

--- a/charts/controller/crds/deployments.plural.sh_globalservices.yaml
+++ b/charts/controller/crds/deployments.plural.sh_globalservices.yaml
@@ -46,6 +46,13 @@ spec:
             properties:
               distro:
                 description: Distro of kubernetes this cluster is running
+                enum:
+                - GENERIC
+                - EKS
+                - AKS
+                - GKE
+                - RKE
+                - K3S
                 type: string
               providerRef:
                 description: ProviderRef apply to clusters with this provider
@@ -135,9 +142,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-                x-kubernetes-validations:
-                - message: Service is immutable
-                  rule: self == oldSelf
               tags:
                 additionalProperties:
                   type: string
@@ -326,8 +330,6 @@ spec:
                   templated:
                     type: boolean
                 type: object
-            required:
-            - serviceRef
             type: object
           status:
             properties:

--- a/controller/api/v1alpha1/globalservice_types.go
+++ b/controller/api/v1alpha1/globalservice_types.go
@@ -35,12 +35,12 @@ type GlobalServiceSpec struct {
 
 	// Distro of kubernetes this cluster is running
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=GENERIC;EKS;AKS;GKE;RKE;K3S
 	Distro *console.ClusterDistro `json:"distro,omitempty"`
 
 	// ServiceRef to replicate across clusters
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Service is immutable"
-	ServiceRef corev1.ObjectReference `json:"serviceRef"`
+	// +kubebuilder:validation:Optional
+	ServiceRef *corev1.ObjectReference `json:"serviceRef,omitempty"`
 	// ProviderRef apply to clusters with this provider
 	// +kubebuilder:validation:Optional
 	ProviderRef *corev1.ObjectReference `json:"providerRef,omitempty"`

--- a/controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -577,6 +577,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Metadata != nil {
+		in, out := &in.Metadata, &out.Metadata
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Bindings != nil {
 		in, out := &in.Bindings, &out.Bindings
 		*out = new(Bindings)
@@ -1026,7 +1031,11 @@ func (in *GlobalServiceSpec) DeepCopyInto(out *GlobalServiceSpec) {
 		*out = new(console_client_go.ClusterDistro)
 		**out = **in
 	}
-	out.ServiceRef = in.ServiceRef
+	if in.ServiceRef != nil {
+		in, out := &in.ServiceRef, &out.ServiceRef
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	if in.ProviderRef != nil {
 		in, out := &in.ProviderRef, &out.ProviderRef
 		*out = new(v1.ObjectReference)

--- a/controller/config/crd/bases/deployments.plural.sh_clusters.yaml
+++ b/controller/config/crd/bases/deployments.plural.sh_clusters.yaml
@@ -163,6 +163,10 @@ spec:
                   This has to be specified in order to adopt existing cluster.
                 example: myclusterhandle
                 type: string
+              metadata:
+                description: Metadata for the cluster
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               nodePools:
                 description: NodePools contains specs of node pools managed by this
                   cluster.

--- a/controller/config/crd/bases/deployments.plural.sh_globalservices.yaml
+++ b/controller/config/crd/bases/deployments.plural.sh_globalservices.yaml
@@ -46,6 +46,13 @@ spec:
             properties:
               distro:
                 description: Distro of kubernetes this cluster is running
+                enum:
+                - GENERIC
+                - EKS
+                - AKS
+                - GKE
+                - RKE
+                - K3S
                 type: string
               providerRef:
                 description: ProviderRef apply to clusters with this provider
@@ -135,9 +142,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-                x-kubernetes-validations:
-                - message: Service is immutable
-                  rule: self == oldSelf
               tags:
                 additionalProperties:
                   type: string
@@ -326,8 +330,6 @@ spec:
                   templated:
                     type: boolean
                 type: object
-            required:
-            - serviceRef
             type: object
           status:
             properties:

--- a/controller/go.mod
+++ b/controller/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.1
 // Dependencies
 require (
 	github.com/Yamashou/gqlgenc v0.18.1
-	github.com/pluralsh/console-client-go v0.1.13
+	github.com/pluralsh/console-client-go v0.1.16
 	github.com/pluralsh/polly v0.1.5
 	github.com/samber/lo v1.39.0
 	github.com/spf13/pflag v1.0.5

--- a/controller/go.sum
+++ b/controller/go.sum
@@ -607,8 +607,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
-github.com/pluralsh/console-client-go v0.1.13 h1:kQfdzzQcjpclL49yDVAlxfvCVvb1SZlKtYrwuWx6rkE=
-github.com/pluralsh/console-client-go v0.1.13/go.mod h1:eyCiLA44YbXiYyJh8303jk5JdPkt9McgCo5kBjk4lKo=
+github.com/pluralsh/console-client-go v0.1.16 h1:f+d4ah3r+dAJ6hSMFsAmTlps4IsmExCzkCOwUpSYkbs=
+github.com/pluralsh/console-client-go v0.1.16/go.mod h1:eyCiLA44YbXiYyJh8303jk5JdPkt9McgCo5kBjk4lKo=
 github.com/pluralsh/polly v0.1.5 h1:ztDafEsVL3wtqcx3QkzHLkTUKdk38qfflgQxFfH1rio=
 github.com/pluralsh/polly v0.1.5/go.mod h1:Yo1/jcW+4xwhWG+ZJikZy4J4HJkMNPZ7sq5auL2c/tY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/controller/internal/client/console.go
+++ b/controller/internal/client/console.go
@@ -53,6 +53,7 @@ type ConsoleClient interface {
 	DeleteService(serviceId string) error
 	GetGlobalService(id string) (*console.GlobalServiceFragment, error)
 	CreateGlobalService(serviceID string, attributes console.GlobalServiceAttributes) (*console.GlobalServiceFragment, error)
+	CreateGlobalServiceFromTemplate(attributes console.GlobalServiceAttributes) (*console.GlobalServiceFragment, error)
 	DeleteGlobalService(id string) error
 	UpdateGlobalService(id string, attributes console.GlobalServiceAttributes) (*console.GlobalServiceFragment, error)
 	SavePipeline(name string, attrs console.PipelineAttributes) (*console.PipelineFragment, error)

--- a/controller/internal/client/globalservice.go
+++ b/controller/internal/client/globalservice.go
@@ -27,6 +27,18 @@ func (c *client) CreateGlobalService(serviceID string, attributes console.Global
 
 }
 
+func (c *client) CreateGlobalServiceFromTemplate(attributes console.GlobalServiceAttributes) (*console.GlobalServiceFragment, error) {
+	result, err := c.consoleClient.CreateGlobalServiceDeploymentFromTemplate(c.ctx, attributes)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, fmt.Errorf("new created global service %s is nil", attributes.Name)
+	}
+	return result.CreateGlobalService, nil
+
+}
+
 func (c *client) DeleteGlobalService(id string) error {
 	_, err := c.consoleClient.DeleteGlobalServiceDeployment(c.ctx, id)
 	if err != nil {

--- a/controller/internal/controller/globalservice_test.go
+++ b/controller/internal/controller/globalservice_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Global Service Controller", Ordered, func() {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
 				Spec: v1alpha1.GlobalServiceSpec{
 					Distro: lo.ToPtr(gqlclient.ClusterDistroGeneric),
-					ServiceRef: corev1.ObjectReference{
+					ServiceRef: &corev1.ObjectReference{
 						Name:      serviceName,
 						Namespace: namespace,
 					},

--- a/controller/internal/test/mocks/ConsoleClient_mock.go
+++ b/controller/internal/test/mocks/ConsoleClient_mock.go
@@ -200,6 +200,64 @@ func (_c *ConsoleClientMock_CreateGlobalService_Call) RunAndReturn(run func(stri
 	return _c
 }
 
+// CreateGlobalServiceFromTemplate provides a mock function with given fields: attributes
+func (_m *ConsoleClientMock) CreateGlobalServiceFromTemplate(attributes gqlclient.GlobalServiceAttributes) (*gqlclient.GlobalServiceFragment, error) {
+	ret := _m.Called(attributes)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateGlobalServiceFromTemplate")
+	}
+
+	var r0 *gqlclient.GlobalServiceFragment
+	var r1 error
+	if rf, ok := ret.Get(0).(func(gqlclient.GlobalServiceAttributes) (*gqlclient.GlobalServiceFragment, error)); ok {
+		return rf(attributes)
+	}
+	if rf, ok := ret.Get(0).(func(gqlclient.GlobalServiceAttributes) *gqlclient.GlobalServiceFragment); ok {
+		r0 = rf(attributes)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gqlclient.GlobalServiceFragment)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(gqlclient.GlobalServiceAttributes) error); ok {
+		r1 = rf(attributes)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ConsoleClientMock_CreateGlobalServiceFromTemplate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateGlobalServiceFromTemplate'
+type ConsoleClientMock_CreateGlobalServiceFromTemplate_Call struct {
+	*mock.Call
+}
+
+// CreateGlobalServiceFromTemplate is a helper method to define mock.On call
+//   - attributes gqlclient.GlobalServiceAttributes
+func (_e *ConsoleClientMock_Expecter) CreateGlobalServiceFromTemplate(attributes interface{}) *ConsoleClientMock_CreateGlobalServiceFromTemplate_Call {
+	return &ConsoleClientMock_CreateGlobalServiceFromTemplate_Call{Call: _e.mock.On("CreateGlobalServiceFromTemplate", attributes)}
+}
+
+func (_c *ConsoleClientMock_CreateGlobalServiceFromTemplate_Call) Run(run func(attributes gqlclient.GlobalServiceAttributes)) *ConsoleClientMock_CreateGlobalServiceFromTemplate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(gqlclient.GlobalServiceAttributes))
+	})
+	return _c
+}
+
+func (_c *ConsoleClientMock_CreateGlobalServiceFromTemplate_Call) Return(_a0 *gqlclient.GlobalServiceFragment, _a1 error) *ConsoleClientMock_CreateGlobalServiceFromTemplate_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *ConsoleClientMock_CreateGlobalServiceFromTemplate_Call) RunAndReturn(run func(gqlclient.GlobalServiceAttributes) (*gqlclient.GlobalServiceFragment, error)) *ConsoleClientMock_CreateGlobalServiceFromTemplate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateNamespace provides a mock function with given fields: ctx, attributes
 func (_m *ConsoleClientMock) CreateNamespace(ctx context.Context, attributes gqlclient.ManagedNamespaceAttributes) (*gqlclient.ManagedNamespaceFragment, error) {
 	ret := _m.Called(ctx, attributes)

--- a/plural/helm/console/crds/deployments.plural.sh_clusters.yaml
+++ b/plural/helm/console/crds/deployments.plural.sh_clusters.yaml
@@ -163,6 +163,10 @@ spec:
                   This has to be specified in order to adopt existing cluster.
                 example: myclusterhandle
                 type: string
+              metadata:
+                description: Metadata for the cluster
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               nodePools:
                 description: NodePools contains specs of node pools managed by this
                   cluster.

--- a/plural/helm/console/crds/deployments.plural.sh_globalservices.yaml
+++ b/plural/helm/console/crds/deployments.plural.sh_globalservices.yaml
@@ -46,6 +46,13 @@ spec:
             properties:
               distro:
                 description: Distro of kubernetes this cluster is running
+                enum:
+                - GENERIC
+                - EKS
+                - AKS
+                - GKE
+                - RKE
+                - K3S
                 type: string
               providerRef:
                 description: ProviderRef apply to clusters with this provider
@@ -135,9 +142,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-                x-kubernetes-validations:
-                - message: Service is immutable
-                  rule: self == oldSelf
               tags:
                 additionalProperties:
                   type: string
@@ -326,8 +330,6 @@ spec:
                   templated:
                     type: boolean
                 type: object
-            required:
-            - serviceRef
             type: object
           status:
             properties:


### PR DESCRIPTION
## Test Plan
 - Make GlobalService `spec.serviceRef` optional
 - Extend Cluster Spec for Metadata (`Metadata *runtime.RawExtension`)
```
query  GetCluster{
 cluster(handle: "lukasz") {
    handle
    metadata
  }
}

{
  "data": {
    "cluster": {
      "handle": "lukasz",
      "metadata": {
        "name": "lukasz",
        "test": "a:a b:b"
      }
    }
  }
}
```


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
