### PR TITLE
use multiline input for smc connection private key

### DIFF
--- a/assets/src/components/pr/scm/EditScmConnection.tsx
+++ b/assets/src/components/pr/scm/EditScmConnection.tsx
@@ -1,5 +1,11 @@
 import { type ComponentProps, useCallback } from 'react'
-import { Accordion, Button, FormField, Modal } from '@pluralsh/design-system'
+import {
+  Accordion,
+  Button,
+  FormField,
+  Input,
+  Modal,
+} from '@pluralsh/design-system'
 import Input2 from '@pluralsh/design-system/dist/components/Input2'
 import { useTheme } from 'styled-components'
 import pick from 'lodash/pick'
@@ -186,12 +192,12 @@ export function ScmConnectionForm({
             />
           </FormField>
           <FormField label="Signing private key">
-            <InputRevealer
-              defaultRevealed={false}
+            <Input
               value={formState.signingPrivateKey ?? ''}
               onChange={(e) =>
                 updateFormState({ signingPrivateKey: e.target.value })
               }
+              multiline
             />
           </FormField>
         </div>


### PR DESCRIPTION
Switched from `InputRevealer` component to `Input` component in order to use it's `multiline` feature. We lost the hide/show feature though.

I also checked and it does keep the new lines in the text.

![image](https://github.com/pluralsh/console/assets/38671115/2ba6c921-e9e2-4fdf-81d9-114f33d83073)
![image](https://github.com/pluralsh/console/assets/38671115/8e9ae7e4-81c6-4c83-a232-962d94049e56)

