### PR TITLE
fix generated global service yaml

### DIFF
--- a/assets/src/components/cd/YamlGeneratorModal.tsx
+++ b/assets/src/components/cd/YamlGeneratorModal.tsx
@@ -345,7 +345,7 @@ function getYaml(
     defaultObj.spec.tags = tags
   }
 
-  if (distro !== '') {
+  if (distro) {
     defaultObj.spec.distro = distro
   }
 

--- a/assets/src/components/cd/YamlGeneratorModal.tsx
+++ b/assets/src/components/cd/YamlGeneratorModal.tsx
@@ -209,7 +209,9 @@ export function YamlGeneratorModal({
             {getYaml(
               name,
               tags,
-              distributionValue === 'all' ? '' : distributionValue,
+              distributionValue === 'all'
+                ? ''
+                : ClusterDistro[distributionValue],
               kind
             )}
           </Code>
@@ -321,7 +323,7 @@ function ModalIllustration({ modalStep }: { modalStep: 'configure' | 'copy' }) {
 function getYaml(
   name: string,
   tags: Record<string, string>,
-  distribution: string,
+  distro: string,
   kind: string
 ) {
   const defaultObj: any = {
@@ -336,12 +338,15 @@ function getYaml(
         name: 'my-service',
         namespace: 'infra',
       },
-      distribution,
     },
   }
 
   if (!isEmpty(tags)) {
     defaultObj.spec.tags = tags
+  }
+
+  if (distro !== '') {
+    defaultObj.spec.distro = distro
   }
 
   return stringify(defaultObj)


### PR DESCRIPTION
 [as requested by @zreigz in `cd` channel](https://plural-labs.slack.com/archives/C05SRM1JEM8/p1713194287831209)

It fixes wrong fields in the global service generated yaml

- distro instead of distribution,
- all provider names in capital letters: GENERIC,EKS,AKS,GKE,RKE,K3S
- remove distro field in case of all providers
