### PR TITLE
Fix reconciliation logic for managed namespace

### DIFF
--- a/lib/console/deployments/global.ex
+++ b/lib/console/deployments/global.ex
@@ -366,7 +366,7 @@ defmodule Console.Deployments.Global do
     with {:ok, source_secrets} <- configuration(spec),
          {:ok, dest_secrets} <- Services.configuration(dest),
       do: (spec.repository_id != dest.repository_id || spec.templated != dest.templated ||
-            specs_different?(spec, dest) || contexts_different?(spec, dest) ||
+            specs_different?(spec, dest) || !contexts_equal?(spec, dest) ||
             missing_source?(source_secrets, dest_secrets))
   end
 
@@ -415,8 +415,8 @@ defmodule Console.Deployments.Global do
     Enum.any?(source, fn {k, v} -> dest[k] != v end)
   end
 
-  defp contexts_different?(%ServiceTemplate{contexts: ctxs}, svc) do
-    MapSet.new(svc.context_bindings, & &1.context_id)
+  defp contexts_equal?(%ServiceTemplate{contexts: ctxs}, svc) do
+    MapSet.new(svc.context_bindings || [], & &1.context_id)
     |> MapSet.equal?(MapSet.new(ctxs || []))
   end
 

--- a/test/console/deployments/global_test.exs
+++ b/test/console/deployments/global_test.exs
@@ -393,4 +393,22 @@ defmodule Console.Deployments.GlobalTest do
       {:error, _} = Global.delete_managed_namespace(ns.id, insert(:user))
     end
   end
+
+  describe "#diff/2" do
+    test "it returns false if targets have all the same relevant config" do
+      svc = insert(:service,
+        helm: %{chart: "test", version: "0.4.0", repository: %{name: "chart", namespace: "infra"}},
+        templated: true
+      )
+
+      template = insert(:service_template,
+        repository: svc.repository,
+        helm: %{chart: "test", version: "0.4.0", repository: %{name: "chart", namespace: "infra"}},
+        templated: true,
+        git: svc.git
+      )
+
+      refute Global.diff?(template, Console.Repo.preload(svc, [:contexts]))
+    end
+  end
 end


### PR DESCRIPTION
We were overmarking services as different because of a bool logic error

## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
