### PR TITLE
fix(controller): existence checks now return error instead of false

### DIFF
--- a/controller/internal/client/cluster.go
+++ b/controller/internal/client/cluster.go
@@ -2,9 +2,10 @@ package client
 
 import (
 	console "github.com/pluralsh/console-client-go"
-	internalerror "github.com/pluralsh/console/controller/internal/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	internalerror "github.com/pluralsh/console/controller/internal/errors"
 )
 
 func (c *client) CreateCluster(attrs console.ClusterAttributes) (*console.ClusterFragment, error) {
@@ -94,16 +95,17 @@ func (c *client) DeleteCluster(id string) (*console.ClusterFragment, error) {
 	return response.DeleteCluster, nil
 }
 
-func (c *client) IsClusterExisting(id *string) bool {
+func (c *client) IsClusterExisting(id *string) (bool, error) {
 	cluster, err := c.GetCluster(id)
-	if cluster != nil {
-		return true
-	}
 	if errors.IsNotFound(err) {
-		return false
+		return false, nil
 	}
 
-	return err == nil
+	if err != nil {
+		return false, err
+	}
+
+	return cluster != nil, nil
 }
 
 func (c *client) IsClusterDeleting(id *string) bool {

--- a/controller/internal/client/console.go
+++ b/controller/internal/client/console.go
@@ -40,14 +40,14 @@ type ConsoleClient interface {
 	UpdateCluster(id string, attrs console.ClusterUpdateAttributes) (*console.ClusterFragment, error)
 	ListClusters() (*console.ListClusters, error)
 	DeleteCluster(id string) (*console.ClusterFragment, error)
-	IsClusterExisting(id *string) bool
+	IsClusterExisting(id *string) (bool, error)
 	IsClusterDeleting(id *string) bool
 	CreateProvider(ctx context.Context, attributes console.ClusterProviderAttributes) (*console.ClusterProviderFragment, error)
 	GetProvider(ctx context.Context, id string) (*console.ClusterProviderFragment, error)
 	GetProviderByCloud(ctx context.Context, cloud v1alpha1.CloudProvider) (*console.ClusterProviderFragment, error)
 	UpdateProvider(ctx context.Context, id string, attributes console.ClusterProviderUpdateAttributes) (*console.ClusterProviderFragment, error)
 	DeleteProvider(ctx context.Context, id string) error
-	IsProviderExists(ctx context.Context, id string) bool
+	IsProviderExists(ctx context.Context, id string) (bool, error)
 	IsProviderDeleting(ctx context.Context, id string) bool
 	UpdateService(serviceId string, attributes console.ServiceUpdateAttributes) error
 	DeleteService(serviceId string) error
@@ -60,7 +60,7 @@ type ConsoleClient interface {
 	DeletePipeline(id string) (*console.PipelineFragment, error)
 	GetPipeline(id string) (*console.PipelineFragment, error)
 	ListPipelines() (*console.GetPipelines, error)
-	IsPipelineExisting(id string) bool
+	IsPipelineExisting(id string) (bool, error)
 	GetUser(email string) (*console.UserFragment, error)
 	GetGroup(name string) (*console.GroupFragment, error)
 	CreateScmConnection(ctx context.Context, attributes console.ScmConnectionAttributes) (*console.ScmConnectionFragment, error)
@@ -73,14 +73,14 @@ type ConsoleClient interface {
 	GetClusterRestore(ctx context.Context, id string) (*console.ClusterRestoreFragment, error)
 	UpdateClusterRestore(ctx context.Context, id string, attrs console.RestoreAttributes) (*console.ClusterRestoreFragment, error)
 	CreateClusterRestore(ctx context.Context, backupId string) (*console.ClusterRestoreFragment, error)
-	IsClusterRestoreExisting(ctx context.Context, id string) bool
+	IsClusterRestoreExisting(ctx context.Context, id string) (bool, error)
 	CreatePrAutomation(ctx context.Context, attributes console.PrAutomationAttributes) (*console.PrAutomationFragment, error)
 	UpdatePrAutomation(ctx context.Context, id string, attributes console.PrAutomationAttributes) (*console.PrAutomationFragment, error)
 	DeletePrAutomation(ctx context.Context, id string) error
 	GetPrAutomation(ctx context.Context, id string) (*console.PrAutomationFragment, error)
 	GetPrAutomationByName(ctx context.Context, name string) (*console.PrAutomationFragment, error)
-	IsPrAutomationExists(ctx context.Context, id string) bool
-	IsPrAutomationExistsByName(ctx context.Context, name string) bool
+	IsPrAutomationExists(ctx context.Context, id string) (bool, error)
+	IsPrAutomationExistsByName(ctx context.Context, name string) (bool, error)
 	GetServiceContext(name string) (*console.ServiceContextFragment, error)
 	GetPipelineContext(ctx context.Context, id string) (*console.PipelineContextFragment, error)
 	CreatePipelineContext(ctx context.Context, pipelineID string, attributes console.PipelineContextAttributes) (*console.CreatePipelineContext, error)

--- a/controller/internal/client/console.go
+++ b/controller/internal/client/console.go
@@ -68,7 +68,7 @@ type ConsoleClient interface {
 	DeleteScmConnection(ctx context.Context, id string) error
 	GetScmConnection(ctx context.Context, id string) (*console.ScmConnectionFragment, error)
 	GetScmConnectionByName(ctx context.Context, name string) (*console.ScmConnectionFragment, error)
-	IsScmConnectionExists(ctx context.Context, name string) bool
+	IsScmConnectionExists(ctx context.Context, name string) (bool, error)
 	GetClusterBackup(clusterId, namespace, name *string) (*console.ClusterBackupFragment, error)
 	GetClusterRestore(ctx context.Context, id string) (*console.ClusterRestoreFragment, error)
 	UpdateClusterRestore(ctx context.Context, id string, attrs console.RestoreAttributes) (*console.ClusterRestoreFragment, error)

--- a/controller/internal/client/pipeline.go
+++ b/controller/internal/client/pipeline.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	console "github.com/pluralsh/console-client-go"
-	internalerror "github.com/pluralsh/console/controller/internal/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	internalerror "github.com/pluralsh/console/controller/internal/errors"
 )
 
 func (c *client) SavePipeline(name string, attrs console.PipelineAttributes) (*console.PipelineFragment, error) {
@@ -49,16 +50,17 @@ func (c *client) DeletePipeline(id string) (*console.PipelineFragment, error) {
 	return response.DeletePipeline, nil
 }
 
-func (c *client) IsPipelineExisting(id string) bool {
+func (c *client) IsPipelineExisting(id string) (bool, error) {
 	pipeline, err := c.GetPipeline(id)
-	if pipeline != nil {
-		return true
-	}
 	if errors.IsNotFound(err) {
-		return false
+		return false, nil
 	}
 
-	return err == nil
+	if err != nil {
+		return false, err
+	}
+
+	return pipeline != nil, nil
 }
 
 func (c *client) GetPipelineContext(ctx context.Context, id string) (*console.PipelineContextFragment, error) {

--- a/controller/internal/client/prautomation.go
+++ b/controller/internal/client/prautomation.go
@@ -58,24 +58,30 @@ func (c *client) GetPrAutomationByName(ctx context.Context, name string) (*conso
 	return response.PrAutomation, err
 }
 
-func (c *client) IsPrAutomationExists(ctx context.Context, id string) bool {
-	_, err := c.GetPrAutomation(ctx, id)
+func (c *client) IsPrAutomationExists(ctx context.Context, id string) (bool, error) {
+	automation, err := c.GetPrAutomation(ctx, id)
 	if errors.IsNotFound(err) {
-		return false
+		return false, nil
 	}
 
-	// We are assuming that if there is an error, and it is not ErrorNotFound then resource does not exist.
-	return err == nil
+	if err != nil {
+		return false, err
+	}
+
+	return automation != nil, err
 }
 
-func (c *client) IsPrAutomationExistsByName(ctx context.Context, name string) bool {
-	_, err := c.GetPrAutomationByName(ctx, name)
+func (c *client) IsPrAutomationExistsByName(ctx context.Context, name string) (bool, error) {
+	automation, err := c.GetPrAutomationByName(ctx, name)
 	if errors.IsNotFound(err) {
-		return false
+		return false, nil
 	}
 
-	// We are assuming that if there is an error, and it is not ErrorNotFound then resource does not exist.
-	return err == nil
+	if err != nil {
+		return false, err
+	}
+
+	return automation != nil, err
 }
 
 func (c *client) CreatePullRequest(ctx context.Context, prAutomationID string, branch *string, context *string) (*console.CreatePullRequest, error) {

--- a/controller/internal/client/provider.go
+++ b/controller/internal/client/provider.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	gqlclient "github.com/pluralsh/console-client-go"
-	"github.com/pluralsh/console/controller/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/pluralsh/console/controller/api/v1alpha1"
 )
 
 func (c *client) CreateProvider(ctx context.Context, attributes gqlclient.ClusterProviderAttributes) (*gqlclient.ClusterProviderFragment, error) {
@@ -62,14 +63,17 @@ func (c *client) DeleteProvider(ctx context.Context, id string) error {
 	return err
 }
 
-func (c *client) IsProviderExists(ctx context.Context, id string) bool {
-	_, err := c.GetProvider(ctx, id)
+func (c *client) IsProviderExists(ctx context.Context, id string) (bool, error) {
+	provider, err := c.GetProvider(ctx, id)
 	if errors.IsNotFound(err) {
-		return false
+		return false, nil
 	}
 
-	// We are assuming that if there is an error, and it is not ErrorNotFound then provider does not exist.
-	return err == nil
+	if err != nil {
+		return false, err
+	}
+
+	return provider != nil, nil
 }
 
 func (c *client) IsProviderDeleting(ctx context.Context, id string) bool {

--- a/controller/internal/client/restore.go
+++ b/controller/internal/client/restore.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	console "github.com/pluralsh/console-client-go"
-	internalerror "github.com/pluralsh/console/controller/internal/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	internalerror "github.com/pluralsh/console/controller/internal/errors"
 )
 
 func (c *client) GetClusterRestore(ctx context.Context, id string) (*console.ClusterRestoreFragment, error) {
@@ -42,14 +43,15 @@ func (c *client) CreateClusterRestore(ctx context.Context, backupId string) (*co
 	return restore.CreateClusterRestore, nil
 }
 
-func (c *client) IsClusterRestoreExisting(ctx context.Context, id string) bool {
+func (c *client) IsClusterRestoreExisting(ctx context.Context, id string) (bool, error) {
 	restore, err := c.GetClusterRestore(ctx, id)
-	if restore != nil {
-		return true
-	}
 	if errors.IsNotFound(err) {
-		return false
+		return false, nil
 	}
 
-	return err == nil
+	if err != nil {
+		return false, err
+	}
+
+	return restore != nil, nil
 }

--- a/controller/internal/client/scmconnection.go
+++ b/controller/internal/client/scmconnection.go
@@ -59,7 +59,7 @@ func (c *client) GetScmConnectionByName(ctx context.Context, name string) (*gqlc
 }
 
 func (c *client) IsScmConnectionExists(ctx context.Context, name string) (bool, error) {
-	_, err := c.GetScmConnectionByName(ctx, name)
+	scm, err := c.GetScmConnectionByName(ctx, name)
 	if errors.IsNotFound(err) {
 		return false, nil
 	}
@@ -68,5 +68,5 @@ func (c *client) IsScmConnectionExists(ctx context.Context, name string) (bool, 
 		return false, err
 	}
 
-	return true, nil
+	return scm != nil, nil
 }

--- a/controller/internal/client/scmconnection.go
+++ b/controller/internal/client/scmconnection.go
@@ -58,12 +58,15 @@ func (c *client) GetScmConnectionByName(ctx context.Context, name string) (*gqlc
 	return response.ScmConnection, err
 }
 
-func (c *client) IsScmConnectionExists(ctx context.Context, name string) bool {
+func (c *client) IsScmConnectionExists(ctx context.Context, name string) (bool, error) {
 	_, err := c.GetScmConnectionByName(ctx, name)
 	if errors.IsNotFound(err) {
-		return false
+		return false, nil
 	}
 
-	// We are assuming that if there is an error, and it is not ErrorNotFound then resource does not exist.
-	return err == nil
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/controller/internal/controller/cluster_controller_test.go
+++ b/controller/internal/controller/cluster_controller_test.go
@@ -7,10 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gqlclient "github.com/pluralsh/console-client-go"
-	"github.com/pluralsh/console/controller/api/v1alpha1"
-	"github.com/pluralsh/console/controller/internal/controller"
-	common "github.com/pluralsh/console/controller/internal/test/common"
-	"github.com/pluralsh/console/controller/internal/test/mocks"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
@@ -20,6 +16,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/pluralsh/console/controller/api/v1alpha1"
+	"github.com/pluralsh/console/controller/internal/controller"
+	common "github.com/pluralsh/console/controller/internal/test/common"
+	"github.com/pluralsh/console/controller/internal/test/mocks"
 )
 
 func sanitizeClusterStatus(status v1alpha1.ClusterStatus) v1alpha1.ClusterStatus {
@@ -148,7 +149,7 @@ var _ = Describe("Cluster Controller", Ordered, func() {
 		It("should successfully reconcile AWS cluster", func() {
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("GetClusterByHandle", mock.AnythingOfType("*string")).Return(nil, errors.NewNotFound(schema.GroupResource{}, awsClusterName))
-			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(false)
+			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(false, nil)
 			fakeConsoleClient.On("CreateCluster", mock.Anything).Return(&gqlclient.ClusterFragment{ID: awsClusterConsoleID}, nil)
 
 			controllerReconciler := &controller.ClusterReconciler{
@@ -191,7 +192,7 @@ var _ = Describe("Cluster Controller", Ordered, func() {
 			})).To(Succeed())
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
-			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(true)
+			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(true, nil)
 			fakeConsoleClient.On("UpdateCluster", mock.AnythingOfType("string"), mock.Anything).Return(
 				&gqlclient.ClusterFragment{ID: awsClusterConsoleID, CurrentVersion: lo.ToPtr("1.25.6")}, nil)
 
@@ -237,7 +238,7 @@ var _ = Describe("Cluster Controller", Ordered, func() {
 			})).To(Succeed())
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
-			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(true)
+			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(true, nil)
 			fakeConsoleClient.On("UpdateCluster", mock.AnythingOfType("string"), mock.Anything).Return(
 				&gqlclient.ClusterFragment{ID: awsClusterConsoleID, CurrentVersion: lo.ToPtr("1.25.6")}, nil)
 
@@ -277,7 +278,7 @@ var _ = Describe("Cluster Controller", Ordered, func() {
 		It("should successfully reconcile BYOK cluster", func() {
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("GetClusterByHandle", mock.AnythingOfType("*string")).Return(nil, errors.NewNotFound(schema.GroupResource{}, byokClusterName))
-			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(false)
+			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(false, nil)
 			fakeConsoleClient.On("CreateCluster", mock.Anything).Return(&gqlclient.ClusterFragment{ID: byokClusterConsoleID}, nil)
 
 			controllerReconciler := &controller.ClusterReconciler{
@@ -320,7 +321,7 @@ var _ = Describe("Cluster Controller", Ordered, func() {
 			})).To(Succeed())
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
-			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(true)
+			fakeConsoleClient.On("IsClusterExisting", mock.AnythingOfType("*string")).Return(true, nil)
 			fakeConsoleClient.On("UpdateCluster", mock.AnythingOfType("string"), mock.Anything).Return(
 				&gqlclient.ClusterFragment{ID: byokClusterConsoleID, CurrentVersion: lo.ToPtr("1.25.6")}, nil)
 

--- a/controller/internal/controller/clusterrestore_controller.go
+++ b/controller/internal/controller/clusterrestore_controller.go
@@ -21,15 +21,16 @@ import (
 	"fmt"
 
 	console "github.com/pluralsh/console-client-go"
-	"github.com/pluralsh/console/controller/api/v1alpha1"
-	consoleclient "github.com/pluralsh/console/controller/internal/client"
-	"github.com/pluralsh/console/controller/internal/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/pluralsh/console/controller/api/v1alpha1"
+	consoleclient "github.com/pluralsh/console/controller/internal/client"
+	"github.com/pluralsh/console/controller/internal/utils"
 )
 
 // ClusterRestoreReconciler reconciles a ClusterRestore object
@@ -98,8 +99,11 @@ func (r *ClusterRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func (r *ClusterRestoreReconciler) sync(ctx context.Context, restore *v1alpha1.ClusterRestore) (*console.ClusterRestoreFragment, error) {
-	exists := r.ConsoleClient.IsClusterRestoreExisting(ctx, restore.Status.GetID())
 	logger := log.FromContext(ctx)
+	exists, err := r.ConsoleClient.IsClusterRestoreExisting(ctx, restore.Status.GetID())
+	if err != nil {
+		return nil, err
+	}
 
 	if exists {
 		logger.V(9).Info(fmt.Sprintf("No changes detected for %s cluster", restore.Name))

--- a/controller/internal/controller/clusterrestore_controller_test.go
+++ b/controller/internal/controller/clusterrestore_controller_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Cluster Restore Controller", Ordered, func() {
 		It("should successfully reconcile cluster restore", func() {
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("GetClusterRestore", mock.Anything, mock.AnythingOfType("string")).Return(nil, errors.NewNotFound(schema.GroupResource{}, restoreName))
-			fakeConsoleClient.On("IsClusterRestoreExisting", mock.Anything, mock.AnythingOfType("string")).Return(false)
+			fakeConsoleClient.On("IsClusterRestoreExisting", mock.Anything, mock.AnythingOfType("string")).Return(false, nil)
 			fakeConsoleClient.On("CreateClusterRestore", mock.Anything, restoreBackupID).Return(&gqlclient.ClusterRestoreFragment{ID: restoreConsoleID, Status: gqlclient.RestoreStatusSuccessful}, nil)
 
 			controllerReconciler := &controller.ClusterRestoreReconciler{

--- a/controller/internal/controller/pipeline_controller_test.go
+++ b/controller/internal/controller/pipeline_controller_test.go
@@ -225,7 +225,7 @@ var _ = Describe("Pipeline Controller", Ordered, func() {
 
 		It("should successfully reconcile pipeline", func() {
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
-			fakeConsoleClient.On("IsPipelineExisting", mock.AnythingOfType("string")).Return(false)
+			fakeConsoleClient.On("IsPipelineExisting", mock.AnythingOfType("string")).Return(false, nil)
 			fakeConsoleClient.On("SavePipeline", mock.AnythingOfType("string"), mock.Anything).Return(&gqlclient.PipelineFragment{ID: pipelineConsoleID}, nil)
 
 			controllerReconciler := &controller.PipelineReconciler{
@@ -261,7 +261,7 @@ var _ = Describe("Pipeline Controller", Ordered, func() {
 			})).To(Succeed())
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
-			fakeConsoleClient.On("IsPipelineExisting", mock.AnythingOfType("string")).Return(false)
+			fakeConsoleClient.On("IsPipelineExisting", mock.AnythingOfType("string")).Return(false, nil)
 			fakeConsoleClient.On("SavePipeline", mock.AnythingOfType("string"), mock.Anything).Return(&gqlclient.PipelineFragment{ID: pipelineConsoleID}, nil)
 
 			controllerReconciler := &controller.PipelineReconciler{

--- a/controller/internal/controller/prautomation_controller_test.go
+++ b/controller/internal/controller/prautomation_controller_test.go
@@ -87,7 +87,7 @@ var _ = Describe("PR Automation Controller", func() {
 
 				It("should successfully reconcile", func() {
 					fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
-					fakeConsoleClient.On("IsPrAutomationExistsByName", mock.Anything, prAutomationName).Return(false)
+					fakeConsoleClient.On("IsPrAutomationExistsByName", mock.Anything, prAutomationName).Return(false, nil)
 					fakeConsoleClient.On("CreatePrAutomation", mock.Anything, mock.Anything).Return(&gqlclient.PrAutomationFragment{
 						ID:   prAutomationConsoleID,
 						Name: prAutomationName,
@@ -147,7 +147,7 @@ var _ = Describe("PR Automation Controller", func() {
 
 				It("should error with scm connection not found", func() {
 					fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
-					fakeConsoleClient.On("IsPrAutomationExistsByName", mock.Anything, prAutomationName).Return(false)
+					fakeConsoleClient.On("IsPrAutomationExistsByName", mock.Anything, prAutomationName).Return(false, nil)
 					fakeConsoleClient.On("CreatePrAutomation", mock.Anything, mock.Anything).Return(&gqlclient.PrAutomationFragment{
 						ID:   prAutomationConsoleID,
 						Name: prAutomationName,
@@ -223,7 +223,7 @@ var _ = Describe("PR Automation Controller", func() {
 
 				It("should successfully reconcile", func() {
 					fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
-					fakeConsoleClient.On("IsPrAutomationExistsByName", mock.Anything, prAutomationName).Return(false)
+					fakeConsoleClient.On("IsPrAutomationExistsByName", mock.Anything, prAutomationName).Return(false, nil)
 					fakeConsoleClient.On("CreatePrAutomation", mock.Anything, mock.Anything).Return(&gqlclient.PrAutomationFragment{
 						ID:   prAutomationConsoleID,
 						Name: prAutomationName,
@@ -302,7 +302,7 @@ var _ = Describe("PR Automation Controller", func() {
 
 				It("should error with cluster not found", func() {
 					fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
-					fakeConsoleClient.On("IsPrAutomationExistsByName", mock.Anything, prAutomationName).Return(false)
+					fakeConsoleClient.On("IsPrAutomationExistsByName", mock.Anything, prAutomationName).Return(false, nil)
 					fakeConsoleClient.On("CreatePrAutomation", mock.Anything, mock.Anything).Return(&gqlclient.PrAutomationFragment{
 						ID:   prAutomationConsoleID,
 						Name: prAutomationName,

--- a/controller/internal/controller/provider_controller_test.go
+++ b/controller/internal/controller/provider_controller_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Provider Controller", Ordered, func() {
 		It("should successfully reconcile provider", func() {
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("GetProviderByCloud", mock.Anything, v1alpha1.GCP).Return(nil, errors.NewNotFound(schema.GroupResource{}, providerName))
-			fakeConsoleClient.On("IsProviderExists", mock.Anything, mock.AnythingOfType("string")).Return(false)
+			fakeConsoleClient.On("IsProviderExists", mock.Anything, mock.AnythingOfType("string")).Return(false, nil)
 			fakeConsoleClient.On("CreateProvider", mock.Anything, mock.Anything).Return(&gqlclient.ClusterProviderFragment{
 				ID:        providerConsoleID,
 				Name:      providerName,

--- a/controller/internal/test/mocks/ConsoleClient_mock.go
+++ b/controller/internal/test/mocks/ConsoleClient_mock.go
@@ -2726,7 +2726,7 @@ func (_c *ConsoleClientMock_IsClusterDeleting_Call) RunAndReturn(run func(*strin
 }
 
 // IsClusterExisting provides a mock function with given fields: id
-func (_m *ConsoleClientMock) IsClusterExisting(id *string) bool {
+func (_m *ConsoleClientMock) IsClusterExisting(id *string) (bool, error) {
 	ret := _m.Called(id)
 
 	if len(ret) == 0 {
@@ -2734,13 +2734,23 @@ func (_m *ConsoleClientMock) IsClusterExisting(id *string) bool {
 	}
 
 	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*string) (bool, error)); ok {
+		return rf(id)
+	}
 	if rf, ok := ret.Get(0).(func(*string) bool); ok {
 		r0 = rf(id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(*string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ConsoleClientMock_IsClusterExisting_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsClusterExisting'
@@ -2761,18 +2771,18 @@ func (_c *ConsoleClientMock_IsClusterExisting_Call) Run(run func(id *string)) *C
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsClusterExisting_Call) Return(_a0 bool) *ConsoleClientMock_IsClusterExisting_Call {
-	_c.Call.Return(_a0)
+func (_c *ConsoleClientMock_IsClusterExisting_Call) Return(_a0 bool, _a1 error) *ConsoleClientMock_IsClusterExisting_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsClusterExisting_Call) RunAndReturn(run func(*string) bool) *ConsoleClientMock_IsClusterExisting_Call {
+func (_c *ConsoleClientMock_IsClusterExisting_Call) RunAndReturn(run func(*string) (bool, error)) *ConsoleClientMock_IsClusterExisting_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IsClusterRestoreExisting provides a mock function with given fields: ctx, id
-func (_m *ConsoleClientMock) IsClusterRestoreExisting(ctx context.Context, id string) bool {
+func (_m *ConsoleClientMock) IsClusterRestoreExisting(ctx context.Context, id string) (bool, error) {
 	ret := _m.Called(ctx, id)
 
 	if len(ret) == 0 {
@@ -2780,13 +2790,23 @@ func (_m *ConsoleClientMock) IsClusterRestoreExisting(ctx context.Context, id st
 	}
 
 	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, id)
+	}
 	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
 		r0 = rf(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ConsoleClientMock_IsClusterRestoreExisting_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsClusterRestoreExisting'
@@ -2808,18 +2828,18 @@ func (_c *ConsoleClientMock_IsClusterRestoreExisting_Call) Run(run func(ctx cont
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsClusterRestoreExisting_Call) Return(_a0 bool) *ConsoleClientMock_IsClusterRestoreExisting_Call {
-	_c.Call.Return(_a0)
+func (_c *ConsoleClientMock_IsClusterRestoreExisting_Call) Return(_a0 bool, _a1 error) *ConsoleClientMock_IsClusterRestoreExisting_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsClusterRestoreExisting_Call) RunAndReturn(run func(context.Context, string) bool) *ConsoleClientMock_IsClusterRestoreExisting_Call {
+func (_c *ConsoleClientMock_IsClusterRestoreExisting_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *ConsoleClientMock_IsClusterRestoreExisting_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IsPipelineExisting provides a mock function with given fields: id
-func (_m *ConsoleClientMock) IsPipelineExisting(id string) bool {
+func (_m *ConsoleClientMock) IsPipelineExisting(id string) (bool, error) {
 	ret := _m.Called(id)
 
 	if len(ret) == 0 {
@@ -2827,13 +2847,23 @@ func (_m *ConsoleClientMock) IsPipelineExisting(id string) bool {
 	}
 
 	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (bool, error)); ok {
+		return rf(id)
+	}
 	if rf, ok := ret.Get(0).(func(string) bool); ok {
 		r0 = rf(id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ConsoleClientMock_IsPipelineExisting_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPipelineExisting'
@@ -2854,18 +2884,18 @@ func (_c *ConsoleClientMock_IsPipelineExisting_Call) Run(run func(id string)) *C
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsPipelineExisting_Call) Return(_a0 bool) *ConsoleClientMock_IsPipelineExisting_Call {
-	_c.Call.Return(_a0)
+func (_c *ConsoleClientMock_IsPipelineExisting_Call) Return(_a0 bool, _a1 error) *ConsoleClientMock_IsPipelineExisting_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsPipelineExisting_Call) RunAndReturn(run func(string) bool) *ConsoleClientMock_IsPipelineExisting_Call {
+func (_c *ConsoleClientMock_IsPipelineExisting_Call) RunAndReturn(run func(string) (bool, error)) *ConsoleClientMock_IsPipelineExisting_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IsPrAutomationExists provides a mock function with given fields: ctx, id
-func (_m *ConsoleClientMock) IsPrAutomationExists(ctx context.Context, id string) bool {
+func (_m *ConsoleClientMock) IsPrAutomationExists(ctx context.Context, id string) (bool, error) {
 	ret := _m.Called(ctx, id)
 
 	if len(ret) == 0 {
@@ -2873,13 +2903,23 @@ func (_m *ConsoleClientMock) IsPrAutomationExists(ctx context.Context, id string
 	}
 
 	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, id)
+	}
 	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
 		r0 = rf(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ConsoleClientMock_IsPrAutomationExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPrAutomationExists'
@@ -2901,18 +2941,18 @@ func (_c *ConsoleClientMock_IsPrAutomationExists_Call) Run(run func(ctx context.
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsPrAutomationExists_Call) Return(_a0 bool) *ConsoleClientMock_IsPrAutomationExists_Call {
-	_c.Call.Return(_a0)
+func (_c *ConsoleClientMock_IsPrAutomationExists_Call) Return(_a0 bool, _a1 error) *ConsoleClientMock_IsPrAutomationExists_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsPrAutomationExists_Call) RunAndReturn(run func(context.Context, string) bool) *ConsoleClientMock_IsPrAutomationExists_Call {
+func (_c *ConsoleClientMock_IsPrAutomationExists_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *ConsoleClientMock_IsPrAutomationExists_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IsPrAutomationExistsByName provides a mock function with given fields: ctx, name
-func (_m *ConsoleClientMock) IsPrAutomationExistsByName(ctx context.Context, name string) bool {
+func (_m *ConsoleClientMock) IsPrAutomationExistsByName(ctx context.Context, name string) (bool, error) {
 	ret := _m.Called(ctx, name)
 
 	if len(ret) == 0 {
@@ -2920,13 +2960,23 @@ func (_m *ConsoleClientMock) IsPrAutomationExistsByName(ctx context.Context, nam
 	}
 
 	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, name)
+	}
 	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
 		r0 = rf(ctx, name)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ConsoleClientMock_IsPrAutomationExistsByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsPrAutomationExistsByName'
@@ -2948,12 +2998,12 @@ func (_c *ConsoleClientMock_IsPrAutomationExistsByName_Call) Run(run func(ctx co
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsPrAutomationExistsByName_Call) Return(_a0 bool) *ConsoleClientMock_IsPrAutomationExistsByName_Call {
-	_c.Call.Return(_a0)
+func (_c *ConsoleClientMock_IsPrAutomationExistsByName_Call) Return(_a0 bool, _a1 error) *ConsoleClientMock_IsPrAutomationExistsByName_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsPrAutomationExistsByName_Call) RunAndReturn(run func(context.Context, string) bool) *ConsoleClientMock_IsPrAutomationExistsByName_Call {
+func (_c *ConsoleClientMock_IsPrAutomationExistsByName_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *ConsoleClientMock_IsPrAutomationExistsByName_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -3006,7 +3056,7 @@ func (_c *ConsoleClientMock_IsProviderDeleting_Call) RunAndReturn(run func(conte
 }
 
 // IsProviderExists provides a mock function with given fields: ctx, id
-func (_m *ConsoleClientMock) IsProviderExists(ctx context.Context, id string) bool {
+func (_m *ConsoleClientMock) IsProviderExists(ctx context.Context, id string) (bool, error) {
 	ret := _m.Called(ctx, id)
 
 	if len(ret) == 0 {
@@ -3014,13 +3064,23 @@ func (_m *ConsoleClientMock) IsProviderExists(ctx context.Context, id string) bo
 	}
 
 	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, id)
+	}
 	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
 		r0 = rf(ctx, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ConsoleClientMock_IsProviderExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsProviderExists'
@@ -3042,18 +3102,18 @@ func (_c *ConsoleClientMock_IsProviderExists_Call) Run(run func(ctx context.Cont
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsProviderExists_Call) Return(_a0 bool) *ConsoleClientMock_IsProviderExists_Call {
-	_c.Call.Return(_a0)
+func (_c *ConsoleClientMock_IsProviderExists_Call) Return(_a0 bool, _a1 error) *ConsoleClientMock_IsProviderExists_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsProviderExists_Call) RunAndReturn(run func(context.Context, string) bool) *ConsoleClientMock_IsProviderExists_Call {
+func (_c *ConsoleClientMock_IsProviderExists_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *ConsoleClientMock_IsProviderExists_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IsScmConnectionExists provides a mock function with given fields: ctx, name
-func (_m *ConsoleClientMock) IsScmConnectionExists(ctx context.Context, name string) bool {
+func (_m *ConsoleClientMock) IsScmConnectionExists(ctx context.Context, name string) (bool, error) {
 	ret := _m.Called(ctx, name)
 
 	if len(ret) == 0 {
@@ -3061,13 +3121,23 @@ func (_m *ConsoleClientMock) IsScmConnectionExists(ctx context.Context, name str
 	}
 
 	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, name)
+	}
 	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
 		r0 = rf(ctx, name)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // ConsoleClientMock_IsScmConnectionExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsScmConnectionExists'
@@ -3089,12 +3159,12 @@ func (_c *ConsoleClientMock_IsScmConnectionExists_Call) Run(run func(ctx context
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsScmConnectionExists_Call) Return(_a0 bool) *ConsoleClientMock_IsScmConnectionExists_Call {
-	_c.Call.Return(_a0)
+func (_c *ConsoleClientMock_IsScmConnectionExists_Call) Return(_a0 bool, _a1 error) *ConsoleClientMock_IsScmConnectionExists_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsScmConnectionExists_Call) RunAndReturn(run func(context.Context, string) bool) *ConsoleClientMock_IsScmConnectionExists_Call {
+func (_c *ConsoleClientMock_IsScmConnectionExists_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *ConsoleClientMock_IsScmConnectionExists_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Some controllers assumed that when there is an error different than not found it means that the resource does not exist. It was not always the case, i.e. on network error or timeout.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
