### PR TITLE
feat: Allow specifying display name for pinned CRDs

### DIFF
--- a/assets/src/components/kubernetes/Cluster.tsx
+++ b/assets/src/components/kubernetes/Cluster.tsx
@@ -2,6 +2,8 @@ import { createContext, useContext, useEffect, useMemo } from 'react'
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { isEmpty } from 'lodash'
 
+import { useTheme } from 'styled-components'
+
 import {
   KubernetesClusterFragment,
   Maybe,
@@ -12,6 +14,8 @@ import { mapExistingNodes } from '../../utils/graphql'
 import { getWorkloadsAbsPath } from '../../routes/kubernetesRoutesConsts'
 import { useNamespacesQuery } from '../../generated/graphql-kubernetes'
 import { KubernetesClient } from '../../helpers/kubernetes.client'
+import LoadingIndicator from '../utils/LoadingIndicator'
+import { GqlError } from '../utils/Alert'
 
 type ClusterContextT = {
   clusters: KubernetesClusterFragment[]
@@ -75,11 +79,12 @@ export const useNamespaces = () => {
 }
 
 export default function Cluster() {
+  const theme = useTheme()
   const { clusterId } = useParams()
   const { search } = useLocation()
   const navigate = useNavigate()
 
-  const { data, refetch } = useKubernetesClustersQuery({
+  const { data, error, refetch } = useKubernetesClustersQuery({
     pollInterval: 120_000,
     fetchPolicy: 'cache-and-network',
   })
@@ -121,6 +126,18 @@ export default function Cluster() {
       }
     }
   }, [clusters, navigate, search, clusterId])
+
+  if (error)
+    return (
+      <div css={{ padding: theme.spacing.large }}>
+        <GqlError
+          header="Cannot load clusters"
+          error={error}
+        />
+      </div>
+    )
+
+  if (!cluster) return <LoadingIndicator />
 
   return (
     <ClusterContext.Provider value={context}>

--- a/assets/src/components/kubernetes/Cluster.tsx
+++ b/assets/src/components/kubernetes/Cluster.tsx
@@ -61,11 +61,13 @@ export const usePinnedResources = (): Maybe<PinnedCustomResourceFragment>[] => {
 }
 
 export const useIsPinnedResource = (
-  kind: string,
-  version: string,
-  group: string
+  kind: string | null | undefined,
+  version: string | null | undefined,
+  group: string | null | undefined
 ) => {
   const pinnedResources = usePinnedResources()
+
+  if (!kind || !version || !group) return false
 
   return !!pinnedResources.find(
     (pr) => pr?.group === group && pr?.version === version && pr?.kind === kind

--- a/assets/src/components/kubernetes/Navigation.tsx
+++ b/assets/src/components/kubernetes/Navigation.tsx
@@ -52,7 +52,6 @@ export default function Navigation() {
   const { pathname, search } = useLocation()
   const { clusterId = '' } = useParams()
   const clusters = useClusters()
-  const cluster = useCluster()
   const [params, setParams] = useSearchParams()
   const [headerContent, setHeaderContent] = useState<ReactNode>()
   const pathPrefix = getKubernetesAbsPath(clusterId)
@@ -75,8 +74,6 @@ export default function Navigation() {
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataSelect, pathname])
-
-  if (!cluster) return <LoadingIndicator />
 
   return (
     <ResponsiveLayoutPage>

--- a/assets/src/components/kubernetes/Navigation.tsx
+++ b/assets/src/components/kubernetes/Navigation.tsx
@@ -23,10 +23,9 @@ import { ResponsiveLayoutPage } from '../utils/layout/ResponsiveLayoutPage'
 import { ResponsiveLayoutSidenavContainer } from '../utils/layout/ResponsiveLayoutSidenavContainer'
 import { Directory, SideNavEntries } from '../layout/SideNavEntries'
 import { ClusterSelect } from '../cd/addOns/ClusterSelect'
-import LoadingIndicator from '../utils/LoadingIndicator'
 import { PageHeaderContext } from '../cd/ContinuousDeployment'
 
-import { useCluster, useClusters } from './Cluster'
+import { useClusters } from './Cluster'
 import {
   DataSelect,
   DataSelectInputs,

--- a/assets/src/components/kubernetes/customresources/PinCustomResourceDefinition.tsx
+++ b/assets/src/components/kubernetes/customresources/PinCustomResourceDefinition.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+import { IconFrame, PushPinIcon } from '@pluralsh/design-system'
+
+import { useIsPinnedResource } from '../Cluster'
+
+import { Types_CustomResourceDefinition as CustomResourceDefinitionT } from '../../../generated/graphql-kubernetes'
+
+import PinCustomResourceDefinitionModal from './PinCustomResourceDefinitionModal'
+
+export default function PinCustomResourceDefinition({
+  crd,
+}: {
+  crd: CustomResourceDefinitionT
+}) {
+  const [open, setOpen] = useState(false)
+  const isPinned = useIsPinnedResource(crd.names.kind, crd.version, crd.group)
+
+  if (isPinned) return null
+
+  return (
+    crd?.objectMeta?.name &&
+    crd?.group &&
+    crd?.version &&
+    crd?.names?.kind &&
+    crd?.scope && (
+      <div onClick={(e) => e.stopPropagation()}>
+        <IconFrame
+          icon={<PushPinIcon />}
+          textValue="Pin Custom Resource Definition"
+          tooltip
+          size="medium"
+          clickable
+          onClick={() => setOpen(true)}
+        />
+        {open && (
+          <PinCustomResourceDefinitionModal
+            name={crd.objectMeta.name}
+            group={crd.group}
+            version={crd.version}
+            kind={crd.names.kind}
+            namespaced={crd.scope?.toLowerCase() === 'namespaced'}
+            onClose={() => setOpen(false)}
+          />
+        )}
+      </div>
+    )
+  )
+}

--- a/assets/src/components/kubernetes/customresources/PinCustomResourceDefinitionModal.tsx
+++ b/assets/src/components/kubernetes/customresources/PinCustomResourceDefinitionModal.tsx
@@ -1,0 +1,92 @@
+import React, { Dispatch, useState } from 'react'
+import { Button, Modal, ValidatedInput } from '@pluralsh/design-system'
+import isEmpty from 'lodash/isEmpty'
+import { usePinCustomResourceMutation } from 'generated/graphql'
+import { useTheme } from 'styled-components'
+import { useParams } from 'react-router-dom'
+
+import { GqlError } from '../../utils/Alert'
+import { useRefetch } from '../Cluster'
+
+export default function PinCustomResourceDefinitionModal({
+  name,
+  group,
+  version,
+  kind,
+  namespaced,
+  onClose,
+}: {
+  name: string
+  group: string
+  version: string
+  kind: string
+  namespaced: boolean
+  onClose?: Nullable<Dispatch<void>>
+}) {
+  const theme = useTheme()
+  const { clusterId } = useParams()
+  const refetch = useRefetch()
+  const [displayName, setDisplayName] = useState(kind)
+
+  const [mutation, { error, loading }] = usePinCustomResourceMutation({
+    variables: {
+      attributes: {
+        name,
+        group,
+        version,
+        kind,
+        namespaced,
+        clusterId,
+        displayName,
+      },
+    },
+    onCompleted: () => refetch?.(),
+  })
+
+  return (
+    <Modal
+      header="Pin Custom Resource Definition"
+      open
+      onClose={onClose ? () => onClose() : undefined}
+      actions={
+        <>
+          <Button
+            secondary
+            onClick={() => onClose?.()}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={isEmpty(displayName)}
+            onClick={() => mutation()}
+            loading={loading}
+            marginLeft="medium"
+          >
+            Create
+          </Button>
+        </>
+      }
+    >
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.medium,
+        }}
+      >
+        {error && (
+          <GqlError
+            header="Sorry, something went wrong"
+            error={error}
+          />
+        )}
+        <ValidatedInput
+          value={displayName}
+          onChange={({ target: { value } }) => setDisplayName(value)}
+          label="Display name"
+        />
+      </div>
+    </Modal>
+  )
+}

--- a/assets/src/components/kubernetes/customresources/PinnedCustomResourceDefinitions.tsx
+++ b/assets/src/components/kubernetes/customresources/PinnedCustomResourceDefinitions.tsx
@@ -1,0 +1,107 @@
+import styled from 'styled-components'
+import {
+  CloseIcon,
+  SubTab,
+  TabList,
+  Toast,
+  Tooltip,
+} from '@pluralsh/design-system'
+import React, { useRef, useState } from 'react'
+import { ApolloError } from 'apollo-boost'
+
+import { LinkTabWrap } from '../../utils/Tabs'
+import {
+  KubernetesClusterFragment,
+  PinnedCustomResourceFragment,
+  useUnpinCustomResourceMutation,
+} from '../../../generated/graphql'
+import { Maybe } from '../../../generated/graphql-kubernetes'
+import { useRefetch } from '../Cluster'
+import { getResourceDetailsAbsPath } from '../../../routes/kubernetesRoutesConsts'
+import { Kind } from '../common/types'
+
+const DeleteIcon = styled(CloseIcon)(({ theme }) => ({
+  marginLeft: theme.spacing.xxsmall,
+  padding: theme.spacing.xxsmall,
+  opacity: 0,
+  '&:hover': {
+    color: theme.colors['icon-danger'],
+  },
+}))
+
+const LinkContainer = styled(LinkTabWrap)(() => ({
+  [`:hover ${DeleteIcon}`]: { opacity: 1 },
+}))
+
+export default function PinnedCustomResourceDefinitions({
+  cluster,
+  pinnedResources,
+}: {
+  cluster?: KubernetesClusterFragment
+  pinnedResources: Maybe<PinnedCustomResourceFragment>[]
+}) {
+  const refetchClusters = useRefetch()
+  const tabStateRef = useRef<any>(null)
+  const [error, setError] = useState<ApolloError>()
+  const [mutation] = useUnpinCustomResourceMutation({
+    onCompleted: () => refetchClusters?.(),
+    onError: (error) => {
+      setError(error)
+      setTimeout(() => setError(undefined), 3000)
+    },
+  })
+
+  return (
+    <TabList
+      scrollable
+      gap="xxsmall"
+      stateRef={tabStateRef}
+      stateProps={{ orientation: 'horizontal', selectedKey: '' }}
+      paddingBottom="xxsmall"
+    >
+      <>
+        {pinnedResources
+          .filter((pr): pr is PinnedCustomResourceFragment => !!pr)
+          .map(({ id, name, displayName }) => (
+            <LinkContainer
+              subTab
+              key={name}
+              textValue={name}
+              to={getResourceDetailsAbsPath(
+                cluster?.id,
+                Kind.CustomResourceDefinition,
+                name
+              )}
+            >
+              <SubTab
+                key={name}
+                textValue={name}
+                css={{ display: 'flex' }}
+              >
+                {displayName}
+                <Tooltip label="Unpin custom resource">
+                  <DeleteIcon
+                    size={12}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      mutation({ variables: { id } })
+                    }}
+                  />
+                </Tooltip>
+              </SubTab>
+            </LinkContainer>
+          ))}
+        {error && (
+          <Toast
+            heading="Error unpinning resource"
+            severity="danger"
+            margin="large"
+            marginRight="xxxxlarge"
+          >
+            {error.message}
+          </Toast>
+        )}
+      </>
+    </TabList>
+  )
+}


### PR DESCRIPTION
- Allow specifying display name for pinned CRDs
  - It can be done in a simple modal
  - CRD kind is used as default value
- Organize code in separate files
- Add error handling for Kubernetes clusters query
- Fix issue with broken links on Chrome

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
<img width="970" alt="Zrzut ekranu 2024-04-19 o 11 56 04" src="https://github.com/pluralsh/console/assets/2823399/a97233bb-4301-420c-96f7-6401e173e4ed">


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
