### PR TITLE
feat: use nginx sidecar to allow exposing grpc agent server on a subpath

### DIFF
--- a/plural/helm/kas/Chart.yaml
+++ b/plural/helm/kas/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kas
 description: k8s agent server
-version: 0.0.6
+version: 0.1.0
 appVersion: "0.0.1"
 dependencies:
   - name: redis

--- a/plural/helm/kas/templates/configmap.yaml
+++ b/plural/helm/kas/templates/configmap.yaml
@@ -31,3 +31,33 @@ data:
         address: ":{{ .Values.service.privateApiPort }}"
         authentication_secret_file: "/etc/kas/.privateapi_secret"
     plural_url: "https://{{ .Values.consoleUrl }}/gql"
+  nginx.conf: |
+    pid /tmp/nginx.pid;
+    events {}
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path       /tmp/proxy_temp_path;
+      fastcgi_temp_path     /tmp/fastcgi_temp;
+      uwsgi_temp_path       /tmp/uwsgi_temp;
+      scgi_temp_path        /tmp/scgi_temp;
+
+      map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+      }
+
+      upstream websocket {
+        server "{{ .Values.agent.backend }}";
+      }
+
+      server {
+        listen {{ .Values.agent.proxy.port }};
+        location "{{ .Values.agent.path }}" {
+          proxy_pass http://{{ .Values.agent.backend }};
+          proxy_http_version 1.1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "Upgrade";
+          proxy_set_header Host $host;
+        }
+      }
+    }

--- a/plural/helm/kas/templates/deployment.yaml
+++ b/plural/helm/kas/templates/deployment.yaml
@@ -83,6 +83,17 @@ spec:
           - name: etc-kas
             mountPath: /etc/kas
             readOnly: true
+        - name: nginx
+          image: {{ .Values.agent.proxy.image.repository }}:{{ .Values.agent.proxy.image.tag }}
+          imagePullPolicy: {{ .Values.agent.proxy.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          ports:
+          - containerPort: {{ .Values.agent.proxy.port }}
+          volumeMounts:
+          - name: nginx-conf
+            mountPath: /etc/nginx
+            readOnly: true
       terminationGracePeriodSeconds: 300
       volumes:
       {{ if .Values.global.additionalVolumes }}
@@ -106,6 +117,15 @@ spec:
                 items:
                   - key: redis-password
                     path: redis_server_secret
+      - name: nginx-conf
+        projected:
+          defaultMode: 0440
+          sources:
+          - configMap:
+              name: {{ template "kas.configMapName" . }}
+              items:
+              - key: nginx.conf
+                path: nginx.conf
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/plural/helm/kas/templates/ingress.yaml
+++ b/plural/helm/kas/templates/ingress.yaml
@@ -28,6 +28,13 @@ spec:
                 name: {{ include "kas.serviceName" . }}
                 port:
                   number: {{ .Values.service.externalPort }}
+          - path: {{ .Values.agent.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "kas.serviceName" . }}
+                port:
+                  number: {{ .Values.agent.proxy.port }}
   {{ if .Values.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/plural/helm/kas/templates/service.yaml
+++ b/plural/helm/kas/templates/service.yaml
@@ -19,6 +19,10 @@ spec:
       targetPort: {{ .Values.service.kubernetesApiPort }}
       protocol: TCP
       name: tcp-{{ include "kas.name" . }}-k8s-api
+    - port: {{ .Values.agent.proxy.port }}
+      targetPort: {{ .Values.agent.proxy.port }}
+      protocol: TCP
+      name: tcp-{{ include "kas.name" . }}-nginx
   {{- if .Values.metrics.enabled }}
     - port: {{ .Values.service.observabilityPort }}
       targetPort: {{ .Values.service.observabilityPort }}

--- a/plural/helm/kas/values.yaml
+++ b/plural/helm/kas/values.yaml
@@ -86,6 +86,16 @@ secrets:
   privateapi: ""
   redis: ""
 
+agent:
+  path: /ext/kas
+  backend: localhost:8150
+  proxy:
+    image:
+      repository: docker.io/nginx
+      tag: stable-alpine3.17-slim
+      pullPolicy: IfNotPresent
+    port: 8180
+
 ingress:
   enabled: true
   ingressClass: nginx


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Added simple nginx sidecar container to rewrite websocket traffic on a subpath to kas agent server.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally with kind

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
