### PR TITLE
Add support for git repositories as a helm chart source.

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1819,7 +1819,10 @@ export type HelmChartVersion = {
 
 export type HelmConfigAttributes = {
   chart?: InputMaybe<Scalars['String']['input']>;
+  git?: InputMaybe<GitRefAttributes>;
   repository?: InputMaybe<NamespacedName>;
+  /** pointer to a Plural GitRepository */
+  repositoryId?: InputMaybe<Scalars['ID']['input']>;
   set?: InputMaybe<HelmValueAttributes>;
   values?: InputMaybe<Scalars['String']['input']>;
   valuesFiles?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
@@ -1856,8 +1859,12 @@ export type HelmSpec = {
   __typename?: 'HelmSpec';
   /** the name of the chart this service is using */
   chart?: Maybe<Scalars['String']['output']>;
+  /** spec of where to find the chart in git */
+  git?: Maybe<GitRef>;
   /** pointer to the flux helm repository resource used for this chart */
   repository?: Maybe<ObjectReference>;
+  /** a git repository in Plural to use as a source */
+  repositoryId?: Maybe<Scalars['ID']['output']>;
   /** a list of helm name/value pairs to precisely set individual values */
   set?: Maybe<Array<Maybe<HelmValue>>>;
   /** a helm values file to use with this service, requires auth and so is heavy to query */

--- a/lib/console/deployments/services.ex
+++ b/lib/console/deployments/services.ex
@@ -80,21 +80,27 @@ defmodule Console.Deployments.Services do
   before sending it upstream to the given client.
   """
   @spec tarstream(Service.t) :: {:ok, File.t} | Console.error
-  def tarstream(%Service{repository_id: id, helm: %Service.Helm{chart: c, values_files: [_ | _] = files} = helm} = svc) when is_binary(id) and is_binary(c) do
+  def tarstream(%Service{repository_id: id, helm: %Service.Helm{repository_id: rid, chart: c, values_files: [_ | _] = files} = helm} = svc)
+      when is_binary(id) and (is_binary(c) or is_binary(rid)) do
     with {:ok, f} <- Git.Discovery.fetch(svc),
          {:ok, contents} <- Tar.tar_stream(f),
          contents = Map.new(contents),
-         {:ok, f, _} <- Helm.Charts.artifact(svc),
-         splice <- Map.take(contents, files)
-                   |> maybe_values(helm),
-      do: Tar.splice(f, splice)
+         {:ok, chart} <- tarfile(%{svc | norevise: true}),
+         splice <- Map.take(contents, files) |> maybe_values(helm),
+      do: Tar.splice(chart, splice)
   end
+
   def tarstream(%Service{helm: %Service.Helm{values: values}} = svc) when is_binary(values) do
     with {:ok, tar} <- tarfile(svc),
       do: Tar.splice(tar, %{"values.yaml.static" => values})
   end
+
   def tarstream(%Service{} = svc), do: tarfile(svc)
 
+  defp tarfile(%Service{helm: %Service.Helm{repository_id: id, git: %{} = git}}) when is_binary(id) do
+    Git.get_repository!(id)
+    |> Git.Discovery.fetch(git)
+  end
   defp tarfile(%Service{helm: %Service.Helm{chart: c, version: v}} = svc) when is_binary(c) and is_binary(v) do
     with {:ok, f, sha} <- Helm.Charts.artifact(svc),
          {:ok, _} <- update_sha_without_revision(svc, sha),
@@ -359,6 +365,7 @@ defmodule Console.Deployments.Services do
     |> notify(:update, :ignore)
   end
 
+  defp update_sha_without_revision(%Service{norevise: true} = svc, _), do: {:ok, svc}
   defp update_sha_without_revision(%Service{revision: %Revision{sha: sha}} = svc, sha), do: {:ok, svc}
   defp update_sha_without_revision(%Service{id: id}, sha) do
     start_transaction()

--- a/lib/console/graphql/deployments/service.ex
+++ b/lib/console/graphql/deployments/service.ex
@@ -33,12 +33,14 @@ defmodule Console.GraphQl.Deployments.Service do
   end
 
   input_object :helm_config_attributes do
-    field :values,       :string
-    field :values_files, list_of(:string)
-    field :chart,        :string
-    field :version,      :string
-    field :set,          :helm_value_attributes
-    field :repository,   :namespaced_name
+    field :values,        :string
+    field :values_files,  list_of(:string)
+    field :chart,         :string
+    field :version,       :string
+    field :set,           :helm_value_attributes
+    field :repository,    :namespaced_name
+    field :git,           :git_ref_attributes
+    field :repository_id, :id, description: "pointer to a Plural GitRepository"
   end
 
   input_object :metadata_attributes do
@@ -212,14 +214,16 @@ defmodule Console.GraphQl.Deployments.Service do
   end
 
   object :helm_spec do
-    field :chart,        :string, description: "the name of the chart this service is using"
-    field :values,       :string,
+    field :chart,         :string, description: "the name of the chart this service is using"
+    field :values,        :string,
       description: "a helm values file to use with this service, requires auth and so is heavy to query",
       resolve: &Deployments.helm_values/3
-    field :repository,   :object_reference, description: "pointer to the flux helm repository resource used for this chart"
-    field :version,      :string, description: "the chart version in use currently"
-    field :set,          list_of(:helm_value), description: "a list of helm name/value pairs to precisely set individual values"
-    field :values_files, list_of(:string), description: "a list of relative paths to values files to use for helm applies"
+    field :git,           :git_ref, description: "spec of where to find the chart in git"
+    field :repository_id, :id, description: "a git repository in Plural to use as a source"
+    field :repository,    :object_reference, description: "pointer to the flux helm repository resource used for this chart"
+    field :version,       :string, description: "the chart version in use currently"
+    field :set,           list_of(:helm_value), description: "a list of helm name/value pairs to precisely set individual values"
+    field :values_files,  list_of(:string), description: "a list of relative paths to values files to use for helm applies"
   end
 
   @desc "a configuration item k/v pair"

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -2203,11 +2203,21 @@ input SyncConfigAttributes {
 
 input HelmConfigAttributes {
   values: String
+
   valuesFiles: [String]
+
   chart: String
+
   version: String
+
   set: HelmValueAttributes
+
   repository: NamespacedName
+
+  git: GitRefAttributes
+
+  "pointer to a Plural GitRepository"
+  repositoryId: ID
 }
 
 input MetadataAttributes {
@@ -2464,6 +2474,12 @@ type HelmSpec {
 
   "a helm values file to use with this service, requires auth and so is heavy to query"
   values: String
+
+  "spec of where to find the chart in git"
+  git: GitRef
+
+  "a git repository in Plural to use as a source"
+  repositoryId: ID
 
   "pointer to the flux helm repository resource used for this chart"
   repository: ObjectReference


### PR DESCRIPTION
This would enable a user to specify a git repo for the chart and another git repo for the values.

## Test Plan
existing tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
