### PR TITLE
Fix error handling for query cast errors

### DIFF
--- a/lib/console/graphql/exceptions/protocol.ex
+++ b/lib/console/graphql/exceptions/protocol.ex
@@ -13,5 +13,9 @@ defimpl Console.GraphQl.Exception, for: Ecto.NoResultsError do
 end
 
 defimpl Console.GraphQl.Exception, for: Ecto.CastError do
-  def error(_), do: {400, "invalid input"}
+  def error(_), do: {400, "could not find resource"}
+end
+
+defimpl Console.GraphQl.Exception, for: Ecto.Query.CastError do
+  def error(_), do: {404, "could not find resource"}
 end

--- a/lib/console/graphql/middleware/safe_resolution.ex
+++ b/lib/console/graphql/middleware/safe_resolution.ex
@@ -29,9 +29,11 @@ defmodule Console.Middleware.SafeResolution do
     Resolution.call(resolution, resolver)
   rescue
     exception ->
-      {_, msg} = Console.GraphQl.Exception.error(exception)
-      error = Exception.format(:error, exception, __STACKTRACE__)
-      Logger.error(error)
+      {code, msg} = Console.GraphQl.Exception.error(exception)
+      if code >= 500 do
+        error = Exception.format(:error, exception, __STACKTRACE__)
+        Logger.error(error)
+      end
       Resolution.put_result(resolution, {:error, msg})
   end
 end


### PR DESCRIPTION
Looks like the k8s controller likes to feed the api lots of empty strings, which we're currently throwing 400-like errors for because they can't be cast as guids.  Treat them like not-founds instead.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
