### PR TITLE
Remove rewrite ingress by default

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -3,7 +3,7 @@ name: console
 description: >-
   deploys the plural console and additional dependencies, for use in bring-your-own-kube setups
 appVersion: 0.9.9
-version: 0.3.11
+version: 0.3.12
 dependencies:
   - name: kas
     version: 0.1.0

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      {{ if .Values.console.securityContext }}
+      securityContext:
+      {{ toYaml .Values.console.securityContext | nindent 8 }}
+      {{ end }}
       terminationGracePeriodSeconds: {{ .Values.shutdownDelay }}
       {{ if .Values.cliContainer.enabled }}
       initContainers:
@@ -45,6 +49,10 @@ spec:
       {{- end }}
       containers:
       - name: console
+        {{ if .Values.console.containerSecurityContext }}
+        securityContext:
+        {{- toYaml .Values.console.containerSecurityContext | nindent 10 }}
+        {{ end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.imagePullPolicy }}
         envFrom:
@@ -87,19 +95,19 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
       volumes:
       {{ if .Values.cliContainer.enabled }}
       - name: cli-override
         emptyDir: {}
-      {{- end }}
+      {{ end }}
       {{- if or .Values.secrets.identity .Values.secrets.key }}
       - name: console-conf
         secret:

--- a/charts/console/templates/migration.yaml
+++ b/charts/console/templates/migration.yaml
@@ -13,8 +13,16 @@ spec:
       imagePullSecrets:
       {{- toYaml . | nindent 6 }}
       {{- end }}
+      {{ if .Values.migrator.securityContext }}
+      securityContext:
+      {{- toYaml .Values.migrator.securityContext | nindent 8 }}
+      {{ end }}
       containers:
       - name: migrator
+        {{ if .Values.migrator.containerSecurityContext }}
+        securityContext:
+        {{- toYaml .Values.migrator.containerSecurityContext | nindent 10 }}
+        {{ end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command: ["/opt/app/bin/console",  "migrate"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -25,5 +33,19 @@ spec:
             name: console-migration-env
         env:
         {{ include "console.env" . | nindent 8 }}
+        volumeMounts:
+        - mountPath: /opt/app/var
+          name: scratch
       restartPolicy: Never
+      {{ with .Values.migrator.nodeSelector}}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{ with .Values.migrator.tolerations}}
+      tolerations:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      volumes:
+      - name: scratch
+        emptyDir: {}
   backoffLimit: 5

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -15,6 +15,10 @@ homeDir: /root
 podLabels: {}
 podAnnotations: {}
 
+migrator: {}
+
+console: {}
+
 secrets:
   cluster_name: test
   jwt: REPLACEME

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -85,7 +85,7 @@ ingress:
     enabled: true
 
   rewrite:
-    enabled: true
+    enabled: false
     annotations:
       konghq.com/rewrite: /$2
       nginx.ingress.kubernetes.io/use-regex: "true"

--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: controller
 description: deploys the deployment operator for plural cd
 appVersion: 0.9.9
-version: 0.0.36
+version: 0.0.37
 type: application

--- a/charts/controller/templates/deployment.yaml
+++ b/charts/controller/templates/deployment.yaml
@@ -83,12 +83,24 @@ spec:
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
       imagePullSecrets: {{ .Values.imagePullSecrets | default list | toJson }}
+      {{ if  .Values.securityContext}}
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+      {{ toYaml .Values.securityContext | nindent 8 }}
+      {{ end }}
       serviceAccountName: {{ include "controller.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{ if .Values.global.additionalVolumes }}
       volumes:
       {{ toYaml .Values.global.additionalVolumes | nindent 6 }}

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -4,11 +4,18 @@ global:
 
 disableAdditionalVolumes: false
 
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
 consoleUrl: ~
 fullnameOverride: console-operator
+
 tokenSecretRef:
   name: console-auth-token
   key: access-token
+
 controllerManager:
   podLabels: {}
   podAnnotations: {}


### PR DESCRIPTION
The new sidecar nginx rewrite should take precedence, and can now deprecate the old rewrite ingress solution.

## Test Plan
tested on boot-aws


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
