### PR TITLE
Implement api-level service dependencies

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -6072,6 +6072,21 @@ export type ServiceContextAttributes = {
   secrets?: InputMaybe<Array<InputMaybe<ConfigAttributes>>>;
 };
 
+/** A dependency of a service, the service will not actualize until all dependencies are ready */
+export type ServiceDependency = {
+  __typename?: 'ServiceDependency';
+  id: Scalars['ID']['output'];
+  insertedAt?: Maybe<Scalars['DateTime']['output']>;
+  name: Scalars['String']['output'];
+  status?: Maybe<ServiceDeploymentStatus>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+/** A named depedency of a service, will prevent applying any manifests until the dependency has become ready */
+export type ServiceDependencyAttributes = {
+  name: Scalars['String']['input'];
+};
+
 /** a reference to a service deployed from a git repo into a cluster */
 export type ServiceDeployment = {
   __typename?: 'ServiceDeployment';
@@ -6087,6 +6102,8 @@ export type ServiceDeployment = {
   contexts?: Maybe<Array<Maybe<ServiceContext>>>;
   /** the time this service was scheduled for deletion */
   deletedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** the dependencies of this service, actualization will not happen until all are HEALTHY */
+  dependencies?: Maybe<Array<Maybe<ServiceDependency>>>;
   /** fetches the /docs directory within this services git tree.  This is a heavy operation and should NOT be used in list queries */
   docs?: Maybe<Array<Maybe<GitFile>>>;
   /** whether this service should not actively reconcile state and instead simply report pending changes */
@@ -6169,6 +6186,7 @@ export type ServiceDeploymentRevisionsArgs = {
 export type ServiceDeploymentAttributes = {
   configuration?: InputMaybe<Array<InputMaybe<ConfigAttributes>>>;
   contextBindings?: InputMaybe<Array<InputMaybe<ContextBindingAttributes>>>;
+  dependencies?: InputMaybe<Array<InputMaybe<ServiceDependencyAttributes>>>;
   docsPath?: InputMaybe<Scalars['String']['input']>;
   dryRun?: InputMaybe<Scalars['Boolean']['input']>;
   git?: InputMaybe<GitRefAttributes>;
@@ -6304,6 +6322,7 @@ export type ServiceTemplateAttributes = {
 export type ServiceUpdateAttributes = {
   configuration?: InputMaybe<Array<InputMaybe<ConfigAttributes>>>;
   contextBindings?: InputMaybe<Array<InputMaybe<ContextBindingAttributes>>>;
+  dependencies?: InputMaybe<Array<InputMaybe<ServiceDependencyAttributes>>>;
   dryRun?: InputMaybe<Scalars['Boolean']['input']>;
   git?: InputMaybe<GitRefAttributes>;
   helm?: InputMaybe<HelmConfigAttributes>;

--- a/lib/console/schema/service.ex
+++ b/lib/console/schema/service.ex
@@ -16,7 +16,8 @@ defmodule Console.Schema.Service do
     Metadata,
     StageService,
     ServiceContextBinding,
-    NamespaceInstance
+    NamespaceInstance,
+    ServiceDependency
   }
 
   defenum Promotion, ignore: 0, proceed: 1, rollback: 2
@@ -128,6 +129,7 @@ defmodule Console.Schema.Service do
     has_many :errors, ServiceError, on_replace: :delete
     has_many :components, ServiceComponent, on_replace: :delete
     has_many :context_bindings, ServiceContextBinding, on_replace: :delete
+    has_many :dependencies, ServiceDependency, on_replace: :delete
     has_many :api_deprecations, through: [:components, :api_deprecations]
     has_many :contexts, through: [:context_bindings, :context]
     has_many :stage_services, StageService
@@ -240,6 +242,7 @@ defmodule Console.Schema.Service do
     |> cast_assoc(:read_bindings)
     |> cast_assoc(:write_bindings)
     |> cast_assoc(:context_bindings)
+    |> cast_assoc(:dependencies)
     |> foreign_key_constraint(:cluster_id)
     |> foreign_key_constraint(:owner_id)
     |> foreign_key_constraint(:repository_id)

--- a/lib/console/schema/service_dependency.ex
+++ b/lib/console/schema/service_dependency.ex
@@ -1,0 +1,33 @@
+defmodule Console.Schema.ServiceDependency do
+  use Piazza.Ecto.Schema
+  alias Console.Schema.Service
+
+  schema "service_dependencies" do
+    field :name,   :string
+    field :status, Service.Status
+
+    belongs_to :service, Service
+
+    timestamps()
+  end
+
+  def for_cluster(query \\ __MODULE__, cluster_id) do
+    from(d in query,
+      join: s in assoc(d, :service),
+      where: s.cluster_id == ^cluster_id
+    )
+  end
+
+  def for_name(query \\ __MODULE__, name) do
+    from(d in query, where: d.name == ^name)
+  end
+
+  @valid ~w(name status service_id)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> foreign_key_constraint(:service_id)
+    |> validate_required([:name])
+  end
+end

--- a/lib/console_web/controllers/git_controller.ex
+++ b/lib/console_web/controllers/git_controller.ex
@@ -41,6 +41,7 @@ defmodule ConsoleWeb.GitController do
     with %Cluster{} = cluster <- ConsoleWeb.Plugs.Token.get_cluster(conn),
          {:ok, svc} <- Services.authorized(service_id, cluster),
          svc <- Console.Repo.preload(svc, [:revision]),
+         {{:ok, svc}, _} <- {Services.dependencies_ready(svc), svc},
          {{:ok, f}, _} <- {Services.tarstream(svc), svc} do
       chunk_send_tar(conn, f)
     else

--- a/priv/repo/migrations/20240423154912_add_service_dependencies.exs
+++ b/priv/repo/migrations/20240423154912_add_service_dependencies.exs
@@ -1,0 +1,16 @@
+defmodule Console.Repo.Migrations.AddServiceDependencies do
+  use Ecto.Migration
+
+  def change do
+    create table(:service_dependencies, primary_key: false) do
+      add :id,         :uuid, primary_key: true
+      add :name,       :string
+      add :status,     :integer
+      add :service_id, references(:services, type: :uuid, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:service_dependencies, [:name])
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -2227,6 +2227,8 @@ input ServiceDeploymentAttributes {
 
   configuration: [ConfigAttributes]
 
+  dependencies: [ServiceDependencyAttributes]
+
   readBindings: [PolicyBindingAttributes]
 
   writeBindings: [PolicyBindingAttributes]
@@ -2282,6 +2284,8 @@ input ServiceUpdateAttributes {
   configuration: [ConfigAttributes]
 
   kustomize: KustomizeAttributes
+
+  dependencies: [ServiceDependencyAttributes]
 
   readBindings: [PolicyBindingAttributes]
 
@@ -2339,6 +2343,11 @@ input ServiceContextAttributes {
 "a binding from a service to a service context"
 input ContextBindingAttributes {
   contextId: String!
+}
+
+"A named depedency of a service, will prevent applying any manifests until the dependency has become ready"
+input ServiceDependencyAttributes {
+  name: String!
 }
 
 input KustomizeAttributes {
@@ -2445,6 +2454,9 @@ type ServiceDeployment {
 
   "bound contexts for this service"
   contexts: [ServiceContext]
+
+  "the dependencies of this service, actualization will not happen until all are HEALTHY"
+  dependencies: [ServiceDependency]
 
   "a relay connection of all revisions of this service, these are periodically pruned up to a history limit"
   revisions(after: String, first: Int, before: String, last: Int): RevisionConnection
@@ -2642,6 +2654,15 @@ type ServiceContext {
   name: String!
   configuration: Map
   secrets: [ServiceConfiguration]
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+"A dependency of a service, the service will not actualize until all dependencies are ready"
+type ServiceDependency {
+  id: ID!
+  status: ServiceDeploymentStatus
+  name: String!
   insertedAt: DateTime
   updatedAt: DateTime
 }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -563,6 +563,13 @@ defmodule Console.Factory do
     }
   end
 
+  def service_dependency_factory do
+    %Schema.ServiceDependency{
+      name: sequence(:svc_dep, & "service-#{&1}"),
+      service: build(:service)
+    }
+  end
+
   def setup_rbac(user, repos \\ ["*"], perms) do
     role = insert(:role, repositories: repos, permissions: Map.new(perms))
     insert(:role_binding, role: role, user: user)


### PR DESCRIPTION
Our current mechanism is only enforced by the operator, which is not easily compatible with global services and other subsystems.  This will be able to globally enforce dependencies.  The general flow is:

* declare a service dependency (within the same cluster and by name, so it can anticipate a service spawned by global services, etc)
* manifest rendering will error until all dependencies are ready, preventing service actualization
* when the dependency becomes ready, it marks all associations with a ready state to enable manifest rendering

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
