### PR TITLE
Fix stack state persistence bug

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -7068,7 +7068,7 @@ export type ViolationStatistic = {
   /** the total number of policy constraints */
   count?: Maybe<Scalars['Int']['output']>;
   /** the value of this field being aggregated */
-  value: Scalars['String']['output'];
+  value?: Maybe<Scalars['String']['output']>;
   /** the total number of violations found */
   violations?: Maybe<Scalars['Int']['output']>;
 };

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1984,6 +1984,8 @@ export type InfrastructureStack = {
   observableMetrics?: Maybe<Array<Maybe<ObservableMetric>>>;
   /** the most recent output for this stack */
   output?: Maybe<Array<Maybe<StackOutput>>>;
+  /** whether the stack is actively tracking changes in git */
+  paused?: Maybe<Scalars['Boolean']['output']>;
   pullRequests?: Maybe<PullRequestConnection>;
   readBindings?: Maybe<Array<Maybe<PolicyBinding>>>;
   /** the git repository you're sourcing IaC from */
@@ -6612,6 +6614,8 @@ export type StackRun = {
   insertedAt?: Maybe<Scalars['DateTime']['output']>;
   /** optional k8s job configuration for the job that will apply this stack */
   jobSpec?: Maybe<JobGateSpec>;
+  /** the commit message */
+  message?: Maybe<Scalars['String']['output']>;
   /** the most recent output for this stack */
   output?: Maybe<Array<Maybe<StackOutput>>>;
   /** the git repository you're sourcing IaC from */

--- a/lib/console/deployments/cron.ex
+++ b/lib/console/deployments/cron.ex
@@ -239,6 +239,7 @@ defmodule Console.Deployments.Cron do
 
   defp stack_stream() do
     Stack.stream()
+    |> Stack.unpaused()
     |> Repo.stream(method: :keyset)
     |> Stream.concat(
       PullRequest.stack()

--- a/lib/console/deployments/git/cache.ex
+++ b/lib/console/deployments/git/cache.ex
@@ -65,7 +65,20 @@ defmodule Console.Deployments.Git.Cache do
     end
   end
 
-  def changes(%__MODULE__{git: g}, sha1, sha2, folder), do: file_changes(g, sha1, sha2, folder)
+  def changes(%__MODULE__{git: g} = c, sha1, sha2, folder) do
+    case file_changes(g, sha1, sha2, folder) do
+      {:ok, [_ | _] = changes} -> add_msgs(c, changes, sha2)
+      {:ok, :pass} -> add_msgs(c, :pass, sha1)
+      pass -> pass
+    end
+  end
+
+  defp add_msgs(%__MODULE__{git: g}, changes, sha) do
+    case msg(g, sha) do
+      {:ok, msg} -> {:ok, changes, msg}
+      _ -> {:ok, changes, ""}
+    end
+  end
 
   defp new_line(cache, repo, sha, path, filter) do
     with {:ok, _} <- git(repo, "checkout", [sha]),

--- a/lib/console/deployments/git/cmd.ex
+++ b/lib/console/deployments/git/cmd.ex
@@ -68,6 +68,7 @@ defmodule Console.Deployments.Git.Cmd do
   end
 
   def msg(%GitRepository{} = repo), do: git(repo, "--no-pager", ["log", "-n", "1", "--format=%B"])
+  def msg(%GitRepository{} = repo, sha), do: git(repo, "--no-pager", ["log", "-n", "1", "--format=%B", sha])
 
   def clone(%GitRepository{dir: dir} = git) when is_binary(dir) do
     with {:ok, _} = res <- git(git, "clone", ["--filter=blob:none", url(git), git.dir]),

--- a/lib/console/deployments/stacks.ex
+++ b/lib/console/deployments/stacks.ex
@@ -201,8 +201,8 @@ defmodule Console.Deployments.Stacks do
     case Discovery.sha(repo, git.ref) do
       {:ok, ^sha} -> {:error, "no new commit in repo"}
       {:ok, new_sha} ->
-        with {:ok, new_sha} <- new_changes(repo, git, sha, new_sha),
-          do: create_run(stack, new_sha)
+        with {:ok, new_sha, msg} <- new_changes(repo, git, sha, new_sha),
+          do: create_run(stack, new_sha, %{message: msg})
       err -> err
     end
   end
@@ -212,10 +212,10 @@ defmodule Console.Deployments.Stacks do
     case Discovery.sha(repo, ref) do
       {:ok, ^sha} -> {:error, "no new commit in repo for branch #{ref}"}
       {:ok, new_sha} ->
-        with {:ok, new_sha} <- new_changes(repo, stack.git, sha, new_sha) do
+        with {:ok, new_sha, msg} <- new_changes(repo, stack.git, sha, new_sha) do
           start_transaction()
           |> add_operation(:run, fn _ ->
-            create_run(stack, new_sha, %{pull_request_id: pr.id, dry_run: true})
+            create_run(stack, new_sha, %{pull_request_id: pr.id, message: msg, dry_run: true})
           end)
           |> add_operation(:pr, fn _ ->
             Ecto.Changeset.change(pr, %{ref: new_sha})
@@ -231,8 +231,7 @@ defmodule Console.Deployments.Stacks do
 
   defp new_changes(repo, %{folder: folder}, sha1, sha2) do
     case Discovery.changes(repo, sha1, sha2, folder) do
-      {:ok, [_ | _]} -> {:ok, sha2}
-      {:ok, :pass} -> {:ok, sha2}
+      {:ok, _, msg} -> {:ok, sha2, msg}
       _ -> {:error, "no changes within #{folder}"}
     end
   end

--- a/lib/console/graphql/deployments/policy.ex
+++ b/lib/console/graphql/deployments/policy.ex
@@ -43,9 +43,11 @@ defmodule Console.GraphQl.Deployments.Policy do
     field :violation_count, :integer
     field :enforcement,     :constraint_enforcement
 
-    field :object, :kubernetes_unstructured,
-      description: "Fetches the live constraint object from K8s, this is an expensive query and should not be done in list endpoints",
-      resolve: &Deployments.fetch_constraint/3
+    @desc "Fetches the live constraint object from K8s, this is an expensive query and should not be done in list endpoints"
+    field :object, :kubernetes_unstructured do
+      middleware ErrorHandler
+      resolve &Deployments.fetch_constraint/3
+    end
 
     field :ref, :constraint_ref, description: "pointer to the kubernetes resource itself"
 
@@ -62,7 +64,7 @@ defmodule Console.GraphQl.Deployments.Policy do
 
   @desc "A summary of statistics for violations w/in a specific column"
   object :violation_statistic do
-    field :value,      non_null(:string), description: "the value of this field being aggregated"
+    field :value,      :string, description: "the value of this field being aggregated"
     field :violations, :integer, description: "the total number of violations found"
     field :count,      :integer, description: "the total number of policy constraints"
   end

--- a/lib/console/graphql/deployments/stack.ex
+++ b/lib/console/graphql/deployments/stack.ex
@@ -82,6 +82,7 @@ defmodule Console.GraphQl.Deployments.Stack do
     field :name,                non_null(:string), description: "the name of the stack"
     field :type,                non_null(:stack_type), description: "A type for the stack, specifies the tool to use to apply it"
     field :git,                 non_null(:git_ref), description: "reference w/in the repository where the IaC lives"
+    field :paused,              :boolean, description: "whether the stack is actively tracking changes in git"
     field :job_spec,            :job_gate_spec, description: "optional k8s job configuration for the job that will apply this stack"
     field :configuration,       non_null(:stack_configuration), description: "version/image config for the tool you're using"
     field :approval,            :boolean, description: "whether to require approval"
@@ -127,6 +128,7 @@ defmodule Console.GraphQl.Deployments.Stack do
     field :job_spec,       :job_gate_spec, description: "optional k8s job configuration for the job that will apply this stack"
     field :configuration,  non_null(:stack_configuration), description: "version/image config for the tool you're using"
     field :approval,       :boolean, description: "whether to require approval"
+    field :message,        :string, description: "the commit message"
     field :approved_at,    :datetime, description: "when this run was approved"
 
     field :tarball, non_null(:string), resolve: &Deployments.stack_tarball/3, description: "https url to fetch the latest tarball of stack IaC"

--- a/lib/console/graphql/resolvers/deployments/policy.ex
+++ b/lib/console/graphql/resolvers/deployments/policy.ex
@@ -50,7 +50,7 @@ defmodule Console.GraphQl.Resolvers.Deployments.Policy do
   end
 
   def fetch_constraint(%{ref: %{name: name, kind: kind}, cluster_id: cluster_id}, _, _) do
-    path = Kube.Client.Base.path("constraints.gatekeeper.sh", "v1beta1", kind, nil, name)
+    path = Kube.Client.Base.path("constraints.gatekeeper.sh", "v1beta1", String.downcase(kind), nil, name)
     with %Cluster{} = cluster <- Clusters.get_cluster(cluster_id),
          _ <- save_kubeconfig(cluster),
          {:ok, res} <- Kube.Client.raw(path),

--- a/lib/console/schema/stack.ex
+++ b/lib/console/schema/stack.ex
@@ -39,6 +39,7 @@ defmodule Console.Schema.Stack do
     field :name,            :string
     field :type,            Type
     field :status,          Status
+    field :paused,          :boolean, default: false
     field :approval,        :boolean
     field :sha,             :string
     field :last_successful, :string
@@ -88,13 +89,17 @@ defmodule Console.Schema.Stack do
     end)
   end
 
+  def unpaused(query \\ __MODULE__) do
+    from(s in query, where: not s.paused or is_nil(s.paused))
+  end
+
   def ordered(query \\ __MODULE__, order \\ [asc: :name]) do
     from(s in query, order_by: ^order)
   end
 
   def stream(query \\ __MODULE__), do: ordered(query, asc: :id)
 
-  @valid ~w(name type status approval connection_id repository_id cluster_id)a
+  @valid ~w(name type paused status approval connection_id repository_id cluster_id)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/lib/console/schema/stack_run.ex
+++ b/lib/console/schema/stack_run.ex
@@ -22,6 +22,7 @@ defmodule Console.Schema.StackRun do
     field :approval,    :boolean, default: true
     field :dry_run,     :boolean, default: false
     field :approved_at, :utc_datetime_usec
+    field :message,     :binary
 
     field :cancellation_reason, :string
 
@@ -100,7 +101,7 @@ defmodule Console.Schema.StackRun do
     from(r in query, order_by: ^order)
   end
 
-  @valid ~w(type status approval dry_run repository_id pull_request_id cluster_id stack_id)a
+  @valid ~w(type status message approval dry_run repository_id pull_request_id cluster_id stack_id)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/lib/console/schema/stack_state.ex
+++ b/lib/console/schema/stack_state.ex
@@ -24,6 +24,8 @@ defmodule Console.Schema.StackState do
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, @valid)
+    |> unique_constraint(:run_id)
+    |> unique_constraint(:stack_id)
     |> cast_embed(:state, with: &state_changeset/2)
   end
 

--- a/priv/repo/migrations/20240506193611_add_run_message.exs
+++ b/priv/repo/migrations/20240506193611_add_run_message.exs
@@ -1,0 +1,13 @@
+defmodule Console.Repo.Migrations.AddRunMessage do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stack_runs) do
+      add :message, :binary
+    end
+
+    alter table(:stacks) do
+      add :paused, :boolean, default: false
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1570,7 +1570,7 @@ type ConstraintRef {
 "A summary of statistics for violations w\/in a specific column"
 type ViolationStatistic {
   "the value of this field being aggregated"
-  value: String!
+  value: String
 
   "the total number of violations found"
   violations: Int

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1063,6 +1063,9 @@ type InfrastructureStack {
   "reference w\/in the repository where the IaC lives"
   git: GitRef!
 
+  "whether the stack is actively tracking changes in git"
+  paused: Boolean
+
   "optional k8s job configuration for the job that will apply this stack"
   jobSpec: JobGateSpec
 
@@ -1140,6 +1143,9 @@ type StackRun {
 
   "whether to require approval"
   approval: Boolean
+
+  "the commit message"
+  message: String
 
   "when this run was approved"
   approvedAt: DateTime

--- a/test/console/deployments/cron_test.exs
+++ b/test/console/deployments/cron_test.exs
@@ -208,7 +208,7 @@ defmodule Console.Deployments.CronTest do
         git: %{ref: "main", folder: "terraform"}
       )
       expect(Console.Deployments.Git.Discovery, :sha, fn _, _ -> {:ok, "new-sha"} end)
-      expect(Console.Deployments.Git.Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"]} end)
+      expect(Console.Deployments.Git.Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"], "a commit message"} end)
 
       Cron.poll_stacks()
 

--- a/test/console/deployments/pubsub/recurse_test.exs
+++ b/test/console/deployments/pubsub/recurse_test.exs
@@ -363,7 +363,7 @@ defmodule Console.Deployments.PubSub.RecurseTest do
     test "it will poll the stack" do
       stack = insert(:stack, git: %{folder: "terraform", ref: "main"})
       expect(Discovery, :sha, fn _, _ -> {:ok, "new-sha"} end)
-      expect(Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"]} end)
+      expect(Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"], "a commit message"} end)
 
       event = %PubSub.StackCreated{item: stack}
       {:ok, run} = Recurse.handle_event(event)
@@ -380,7 +380,7 @@ defmodule Console.Deployments.PubSub.RecurseTest do
     test "it will poll the stack" do
       stack = insert(:stack, git: %{folder: "terraform", ref: "main"})
       expect(Discovery, :sha, fn _, _ -> {:ok, "new-sha"} end)
-      expect(Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"]} end)
+      expect(Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"], "a commit message"} end)
 
       event = %PubSub.StackUpdated{item: stack}
       {:ok, run} = Recurse.handle_event(event)

--- a/test/console/deployments/stacks_test.exs
+++ b/test/console/deployments/stacks_test.exs
@@ -363,6 +363,7 @@ defmodule Console.Deployments.StacksTest do
 
       {:ok, completed} = Stacks.complete_stack_run(%{
         status: :successful,
+        state: %{plan: "some plan"},
         output: [%{name: "some-output", value: "val"}]
       }, run.id, user)
 
@@ -379,6 +380,13 @@ defmodule Console.Deployments.StacksTest do
       assert output.value == "val"
 
       assert_receive {:event, %PubSub.StackRunCompleted{item: ^completed}}
+
+      # can still complete when completed
+      {:ok, _} = Stacks.complete_stack_run(%{
+        status: :successful,
+        state: %{plan: "some plan"},
+        output: [%{name: "some-output", value: "val"}]
+      }, run.id, user)
     end
 
     test "clusters can complete runs" do

--- a/test/console/deployments/stacks_test.exs
+++ b/test/console/deployments/stacks_test.exs
@@ -149,12 +149,13 @@ defmodule Console.Deployments.StacksTest do
         git: %{ref: "main", folder: "terraform"}
       )
       expect(Discovery, :sha, fn _, _ -> {:ok, "new-sha"} end)
-      expect(Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"]} end)
+      expect(Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"], "a commit message"} end)
 
       {:ok, run} = Stacks.poll(stack)
 
       assert run.stack_id == stack.id
       assert run.status == :queued
+      assert run.message == "a commit message"
       assert run.cluster_id == stack.cluster_id
       assert run.repository_id == stack.repository_id
       assert run.git.ref == "new-sha"
@@ -188,7 +189,7 @@ defmodule Console.Deployments.StacksTest do
       )
       pr = insert(:pull_request, stack: stack)
       expect(Discovery, :sha, fn _, _ -> {:ok, "new-sha"} end)
-      expect(Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"]} end)
+      expect(Discovery, :changes, fn _, _, _, _ -> {:ok, ["terraform/main.tf"], "a commit message"} end)
 
       {:ok, run} = Stacks.poll(pr)
 
@@ -196,6 +197,7 @@ defmodule Console.Deployments.StacksTest do
       assert run.pull_request_id == pr.id
       assert run.status == :queued
       assert run.dry_run
+      assert run.message == "a commit message"
       assert run.cluster_id == stack.cluster_id
       assert run.repository_id == stack.repository_id
       assert run.git.ref == "new-sha"
@@ -469,6 +471,7 @@ defmodule Console.Deployments.StacksSyncTest do
 
       assert run.status == :queued
       refute run.dry_run
+      assert run.message
       assert run.stack_id == stack.id
       refute run.git.ref == stack.git.ref
     end


### PR DESCRIPTION
We were keeping the run id when adding state to the owning stack (not just the run) which led to a unique constraint violation

## Test Plan
unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
