### PR TITLE
fix: add clusterid param back to service table query

### DIFF
--- a/assets/src/components/cd/services/ServicesTable.tsx
+++ b/assets/src/components/cd/services/ServicesTable.tsx
@@ -57,6 +57,7 @@ export function ServicesTable({
     },
     {
       q: debouncedSearchString,
+      ...(clusterId ? { clusterId } : {}),
       ...(statusFilter !== 'ALL' ? { status: statusFilter } : {}),
     }
   )


### PR DESCRIPTION
The param was left out by mistake during a recent refactor