### PR TITLE
optimize cluster and service search bars

### DIFF
--- a/assets/src/components/cd/clusters/Clusters.tsx
+++ b/assets/src/components/cd/clusters/Clusters.tsx
@@ -132,7 +132,9 @@ export default function Clusters() {
     },
     {
       q: debouncedSearchString,
-      ...(statusFilter !== 'ALL' ? { status: statusFilter } : {}),
+      ...(statusFilter !== 'ALL'
+        ? { healthy: statusFilter === 'HEALTHY' }
+        : {}),
       ...(!isEmpty(searchTags)
         ? { tagQuery: { op: tagOp, tags: searchTags } }
         : {}),
@@ -210,10 +212,8 @@ export default function Clusters() {
           }}
         >
           <ClustersFilters
-            statusFilter={statusFilter}
-            setStatusFilter={setStatusFilter}
-            searchString={searchString}
-            setSearchString={setSearchString}
+            setQueryStatusFilter={setStatusFilter}
+            setQueryString={setSearchString}
             tabStateRef={tabStateRef}
             statusCounts={statusCounts}
             selectedTagKeys={selectedTagKeys}

--- a/assets/src/components/cd/services/ServicesTable.tsx
+++ b/assets/src/components/cd/services/ServicesTable.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router'
 import { useTheme } from 'styled-components'
 import type { Row } from '@tanstack/react-table'
 import isEmpty from 'lodash/isEmpty'
-import { useDebounce } from '@react-hooks-library/core'
 import {
   ServiceDeploymentStatus,
   type ServiceDeploymentsRowFragment,
@@ -36,10 +35,10 @@ export function ServicesTable({
   const navigate = useNavigate()
   const [clusterIdInternal, setClusterId] = useState<string>('')
   const clusterId = clusterIdProp ?? clusterIdInternal
-  const [searchString, setSearchString] = useState()
-  const debouncedSearchString = useDebounce(searchString, 100)
   const tabStateRef = useRef<any>(null)
-  const [statusFilter, setStatusFilter] = useState<StatusTabKey>('ALL')
+  const [queryString, setQueryString] = useState()
+  const [queryStatusFilter, setQueryStatusFilter] =
+    useState<StatusTabKey>('ALL')
 
   const {
     data,
@@ -56,9 +55,9 @@ export function ServicesTable({
       queryKey: 'serviceDeployments',
     },
     {
-      q: debouncedSearchString,
+      q: queryString,
       ...(clusterId ? { clusterId } : {}),
-      ...(statusFilter !== 'ALL' ? { status: statusFilter } : {}),
+      ...(queryStatusFilter !== 'ALL' ? { status: queryStatusFilter } : {}),
     }
   )
 
@@ -114,10 +113,8 @@ export function ServicesTable({
       }}
     >
       <ServicesFilters
-        statusFilter={statusFilter}
-        setStatusFilter={setStatusFilter}
-        searchString={searchString}
-        setSearchString={setSearchString}
+        setQueryStatusFilter={setQueryStatusFilter}
+        setQueryString={setQueryString}
         clusterId={clusterId}
         setClusterId={clusterIdProp ? undefined : setClusterId}
         tabStateRef={tabStateRef}


### PR DESCRIPTION
The search inputs/filters are pretty laggy (very noticeable on mid-lower end devices). Debouncing solves the issue of reducing network requests but doesn't prevent rerendering the whole table on every keystroke. I decoupled the input value states (what's displayed) from the query values so basically the table rendering is also debounced or deferred

The other solution to this would be memoizing the tables (and also all of the props passed to them) but that would probably require a much bigger refactor

Also fixed a bug with the cluster status filters not actually filtering