### PR TITLE
Proper draining of attached global services on non-delete actions

### DIFF
--- a/lib/console/schema/global_service.ex
+++ b/lib/console/schema/global_service.ex
@@ -24,6 +24,15 @@ defmodule Console.Schema.GlobalService do
     timestamps()
   end
 
+  def service_ids(query \\ __MODULE__, id) do
+    from(g in query,
+      join: s in Service,
+        on: s.owner_id == g.id,
+      where: g.id == ^id,
+      select: s.id
+    )
+  end
+
   def ordered(query \\ __MODULE__, order \\ [asc: :name]) do
     from(g in query, order_by: ^order)
   end

--- a/lib/console/schema/service.ex
+++ b/lib/console/schema/service.ex
@@ -214,6 +214,10 @@ defmodule Console.Schema.Service do
     from(s in query, where: s.owner_id == ^owner_id)
   end
 
+  def globalized(query \\ __MODULE__) do
+    from(s in query, where: not is_nil(s.owner_id))
+  end
+
   def for_namespace(query \\ __MODULE__, ns_id) do
     from(s in query,
       join: ni in assoc(s, :namespace_instance),


### PR DESCRIPTION
We did this well when the global service was deleted but not on cluster tag changes or on global service spec changes.  This solves for both.

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
