### PR TITLE
Implement terraform http state remote backend

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1996,6 +1996,8 @@ export type InfrastructureStack = {
   /** A type for the stack, specifies the tool to use to apply it */
   type: StackType;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** the subdirectory you want to run the stack's commands w/in */
+  workdir?: Maybe<Scalars['String']['output']>;
   writeBindings?: Maybe<Array<Maybe<PolicyBinding>>>;
 };
 
@@ -6591,6 +6593,8 @@ export type StackAttributes = {
   git: GitRefAttributes;
   /** optional k8s job configuration for the job that will apply this stack */
   jobSpec?: InputMaybe<GateJobAttributes>;
+  /** whether you want Plural to manage your terraform state for this stack */
+  manageState?: InputMaybe<Scalars['Boolean']['input']>;
   /** the name of the stack */
   name: Scalars['String']['input'];
   observableMetrics?: InputMaybe<Array<InputMaybe<ObservableMetricAttributes>>>;
@@ -6599,6 +6603,8 @@ export type StackAttributes = {
   repositoryId: Scalars['ID']['input'];
   /** A type for the stack, specifies the tool to use to apply it */
   type: StackType;
+  /** the subdirectory you want to run the stack's commands w/in */
+  workdir?: InputMaybe<Scalars['String']['input']>;
   writeBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
 };
 

--- a/lib/console.ex
+++ b/lib/console.ex
@@ -20,6 +20,7 @@ defmodule Console do
 
   @chars String.codepoints("abcdefghijklmnopqrstuvwxyz0123456789")
 
+  def authed_user("deploy-" <> _ = deploy), do: Console.Deployments.Clusters.get_by_deploy_token(deploy)
   def authed_user("console-" <> _ = access), do: Console.Services.Users.get_by_token(access)
   def authed_user(jwt) do
     case Console.Guardian.resource_from_token(jwt) do

--- a/lib/console/deployments/stacks/state.ex
+++ b/lib/console/deployments/stacks/state.ex
@@ -1,0 +1,49 @@
+defmodule Console.Deployments.Stacks.State do
+  use Console.Services.Base
+  import Console.Deployments.Policies
+  alias Console.Schema.TerraformState
+
+  def get_tf(stack_id), do: Repo.get_by(TerraformState, stack_id: stack_id)
+
+  def get_terraform_state(stack_id, actor) do
+    case get_tf(stack_id) do
+      %TerraformState{} = state -> allow(state, actor, :state)
+      nil ->
+        stack = Console.Deployments.Stacks.get_stack!(stack_id)
+        with {:ok, _} <- allow(stack, actor, :state),
+          do: {:ok, nil}
+    end
+  end
+
+  def update_terraform_state(state, stack_id, actor) do
+    case get_tf(stack_id) do
+      %TerraformState{} = state -> state
+      _ -> %TerraformState{stack_id: stack_id}
+    end
+    |> TerraformState.changeset(%{state: state})
+    |> allow(actor, :state)
+    |> when_ok(&Repo.insert_or_update/1)
+  end
+
+  def lock_terraform_state(%{"id" => id} = lock_info, stack_id, actor) do
+    case get_tf(stack_id) do
+      nil -> {:error, :not_found}
+      %TerraformState{lock: %{id: ^id}} = state -> set_lock(lock_info, state, actor)
+      %TerraformState{lock: %{id: _} = lock} -> {:error, {:locked, lock}}
+      state -> set_lock(lock_info, state, actor)
+    end
+  end
+
+  def unlock_terraform_state(stack_id, actor) do
+    get_tf(stack_id)
+    |> TerraformState.changeset(%{lock: nil})
+    |> allow(actor, :state)
+    |> when_ok(:update)
+  end
+
+  defp set_lock(lock_info, state, actor) do
+    TerraformState.changeset(state, %{lock: lock_info})
+    |> allow(actor, :state)
+    |> when_ok(:update)
+  end
+end

--- a/lib/console/graphql/deployments/stack.ex
+++ b/lib/console/graphql/deployments/stack.ex
@@ -17,6 +17,8 @@ defmodule Console.GraphQl.Deployments.Stack do
     field :job_spec,       :gate_job_attributes, description: "optional k8s job configuration for the job that will apply this stack"
     field :configuration,  non_null(:stack_configuration_attributes), description: "version/image config for the tool you're using"
     field :approval,       :boolean, description: "whether to require approval"
+    field :manage_state,   :boolean, description: "whether you want Plural to manage your terraform state for this stack"
+    field :workdir,        :string, description: "the subdirectory you want to run the stack's commands w/in"
 
     field :read_bindings,  list_of(:policy_binding_attributes)
     field :write_bindings, list_of(:policy_binding_attributes)
@@ -96,6 +98,7 @@ defmodule Console.GraphQl.Deployments.Stack do
     field :approval,            :boolean, description: "whether to require approval"
     field :deleted_at,          :datetime, description: "whether this stack was previously deleted and is pending cleanup"
     field :cancellation_reason, :string, description: "why this run was cancelled"
+    field :workdir,             :string, description: "the subdirectory you want to run the stack's commands w/in"
 
     connection field :runs, node_type: :stack_run do
       arg :pull_request_id, :id

--- a/lib/console/schema/stack.ex
+++ b/lib/console/schema/stack.ex
@@ -66,6 +66,8 @@ defmodule Console.Schema.Stack do
     field :sha,             :string
     field :last_successful, :string
     field :deleted_at,      :utc_datetime_usec
+    field :manage_state,    :boolean, default: false
+    field :workdir,         :string
 
     field :write_policy_id,  :binary_id
     field :read_policy_id,   :binary_id
@@ -127,7 +129,7 @@ defmodule Console.Schema.Stack do
 
   def stream(query \\ __MODULE__), do: ordered(query, asc: :id)
 
-  @valid ~w(name type paused status approval connection_id repository_id cluster_id)a
+  @valid ~w(name type paused workdir manage_state status approval connection_id repository_id cluster_id)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/lib/console/schema/terraform_state.ex
+++ b/lib/console/schema/terraform_state.ex
@@ -1,0 +1,33 @@
+defmodule Console.Schema.TerraformState do
+  use Piazza.Ecto.Schema
+  alias Console.Schema.Stack
+
+  schema "terraform_states" do
+    field :state, :binary
+
+    embeds_one :lock, Lock, on_replace: :update, primary_key: false do
+      field :id,        :string
+      field :operation, :string
+      field :info,      :string
+      field :who,       :string
+      field :version,   :string
+      field :created,   :string
+      field :path,      :string
+    end
+
+    belongs_to :stack, Stack
+
+    timestamps()
+  end
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, ~w(state stack_id)a)
+    |> cast_embed(:lock, with: &lock_changeset/2)
+    |> unique_constraint(:stack_id)
+  end
+
+  def lock_changeset(model, attrs) do
+    cast(model, attrs, ~w(id operation info who version created path)a)
+  end
+end

--- a/lib/console_web/controllers/stack_controller.ex
+++ b/lib/console_web/controllers/stack_controller.ex
@@ -1,0 +1,51 @@
+defmodule ConsoleWeb.StackController do
+  use ConsoleWeb, :controller
+  alias Console.Deployments.Stacks.State
+
+  plug :get_actor when action in [:get_tf_state, :update_tf_state, :lock_tf_state, :unlock_tf_state]
+
+  def get_tf_state(conn, %{"stack_id" => id}) do
+    case State.get_terraform_state(id, conn.assigns.actor) do
+      {:ok, %{state: state}} -> send_resp(conn, 200, state)
+      {:ok, nil} -> send_resp(conn, 204, "")
+      _ -> send_resp(conn, 403, "Forbidden")
+    end
+  end
+
+  def update_tf_state(conn, %{"stack_id" => id}) do
+    %{raw_body: state, actor: actor} = conn.assigns
+
+    IO.iodata_to_binary(state)
+    |> State.update_terraform_state(id, actor)
+    |> handle_resp(conn)
+  end
+
+  def lock_tf_state(conn, %{"stack_id" => id} = lock) do
+    State.lock_terraform_state(lock, id, conn.assigns.actor)
+    |> handle_resp(conn)
+  end
+
+  def unlock_tf_state(conn, %{"stack_id" => id}) do
+    State.unlock_terraform_state(id, conn.assigns.actor)
+    |> handle_resp(conn)
+  end
+
+  defp handle_resp({:error, {:locked, lock}}, conn) do
+    put_resp_header(conn, "content-type", "application/json")
+    |> send_resp(423, Poison.encode!(Map.from_struct(lock)))
+  end
+
+  defp handle_resp({:error, :forbidden}, conn), do: send_resp(conn, 403, "Forbidden")
+  defp handle_resp({:error, err}, conn), do: send_resp(conn, 400, inspect(err))
+
+  defp handle_resp({:ok, _}, conn), do: send_resp(conn, 200, "")
+
+  defp get_actor(conn, _) do
+    with {_, token} <- Plug.BasicAuth.parse_basic_auth(conn),
+         %{} = actor <- Console.authed_user(token) do
+      assign(conn, :actor, actor)
+    else
+      _ -> send_resp(conn, 403, "Forbidden") |> halt()
+    end
+  end
+end

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -28,6 +28,15 @@ defmodule ConsoleWeb.Router do
 
       scope "/v1", ConsoleWeb do
         post "/webhooks/:type/:id", WebhookController, :scm
+
+        scope "/states" do
+          scope "/terraform" do
+            get "/:stack_id", StackController, :get_tf_state
+            post "/:stack_id", StackController, :update_tf_state
+            post "/:stack_id/lock", StackController, :lock_tf_state
+            post "/:stack_id/unlock", StackController, :unlock_tf_state
+          end
+        end
       end
     end
 

--- a/priv/repo/migrations/20240526120358_add_terraform_state.exs
+++ b/priv/repo/migrations/20240526120358_add_terraform_state.exs
@@ -1,0 +1,20 @@
+defmodule Console.Repo.Migrations.AddTerraformState do
+  use Ecto.Migration
+
+  def change do
+    create table(:terraform_states, primary_key: false) do
+      add :id,       :uuid, primary_key: true
+      add :stack_id, references(:stacks, type: :uuid, on_delete: :delete_all)
+      add :state,    :binary
+      add :lock,     :map
+
+      timestamps()
+    end
+
+    alter table(:stacks) do
+      add :manage_state, :boolean, default: false
+    end
+
+    create unique_index(:terraform_states, [:stack_id])
+  end
+end

--- a/priv/repo/migrations/20240526201015_add_workdir.exs
+++ b/priv/repo/migrations/20240526201015_add_workdir.exs
@@ -1,0 +1,9 @@
+defmodule Console.Repo.Migrations.AddWorkdir do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stacks) do
+      add :workdir, :string
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -984,6 +984,12 @@ input StackAttributes {
   "whether to require approval"
   approval: Boolean
 
+  "whether you want Plural to manage your terraform state for this stack"
+  manageState: Boolean
+
+  "the subdirectory you want to run the stack's commands w\/in"
+  workdir: String
+
   readBindings: [PolicyBindingAttributes]
 
   writeBindings: [PolicyBindingAttributes]
@@ -1113,6 +1119,9 @@ type InfrastructureStack {
 
   "why this run was cancelled"
   cancellationReason: String
+
+  "the subdirectory you want to run the stack's commands w\/in"
+  workdir: String
 
   runs(after: String, first: Int, before: String, last: Int, pullRequestId: ID): StackRunConnection
 

--- a/test/console_web/controllers/stack_controller_test.exs
+++ b/test/console_web/controllers/stack_controller_test.exs
@@ -1,0 +1,129 @@
+defmodule ConsoleWeb.StackControllerTest do
+  use ConsoleWeb.ConnCase, async: true
+
+  describe "GET /ext/v1/states/terraform/:id" do
+    test "it can fetch a tf state if you have access", %{conn: conn} do
+      state = insert(:terraform_state, state: "some state")
+
+      resp =
+        conn
+        |> basic_auth(state.stack.cluster)
+        |> get("/ext/v1/states/terraform/#{state.stack.id}")
+        |> response(200)
+
+      assert resp == state.state
+    end
+
+    test "it will 204 if there's no state yet", %{conn: conn} do
+      stack = insert(:stack)
+
+      conn
+      |> basic_auth(stack.cluster)
+      |> get("/ext/v1/states/terraform/#{stack.id}")
+      |> response(204)
+    end
+
+    test "it will 403 if you don't have access", %{conn: conn} do
+      state = insert(:terraform_state, state: "some state")
+
+      conn
+      |> basic_auth(insert(:cluster))
+      |> get("/ext/v1/states/terraform/#{state.stack.id}")
+      |> response(403)
+    end
+  end
+
+  describe "POST /ext/v1/states/terraform/:id" do
+    test "it can update a tf state if you have access", %{conn: conn} do
+      state = insert(:terraform_state, state: "some state")
+
+      new_state = Jason.encode!(%{new: "state"})
+      conn
+      |> basic_auth(state.stack.cluster)
+      |> put_req_header("content-type", "application/json")
+      |> post("/ext/v1/states/terraform/#{state.stack.id}", new_state)
+      |> response(200)
+
+      assert refetch(state).state == new_state
+    end
+
+    test "it will 403 if you don't have access", %{conn: conn} do
+      state = insert(:terraform_state, state: "some state")
+
+      new_state = Jason.encode!(%{new: "state"})
+
+      conn
+      |> basic_auth(insert(:cluster))
+      |> put_req_header("content-type", "application/json")
+      |> post("/ext/v1/states/terraform/#{state.stack.id}", new_state)
+      |> response(403)
+    end
+  end
+
+  describe "POST /ext/v1/states/terraform/:id/lock" do
+    test "it can lock a tf state if not locked", %{conn: conn} do
+      state = insert(:terraform_state, state: "some state")
+
+      conn
+      |> basic_auth(state.stack.cluster)
+      |> put_req_header("content-type", "application/json")
+      |> post("/ext/v1/states/terraform/#{state.stack.id}/lock", Jason.encode!(%{
+        id: "lock-id",
+        owner: "someone@example.com"
+      }))
+      |> response(200)
+    end
+
+    test "it will 423 if a different lock exists", %{conn: conn} do
+      state = insert(:terraform_state, state: "some state", lock: %{id: "other-id", owner: "someone@example.com"})
+
+      conn
+      |> basic_auth(state.stack.cluster)
+      |> put_req_header("content-type", "application/json")
+      |> post("/ext/v1/states/terraform/#{state.stack.id}/lock", Jason.encode!(%{
+        id: "lock-id",
+        owner: "someone-else@example.com"
+      }))
+      |> response(423)
+    end
+
+    test "it will 403 if you don't have access", %{conn: conn} do
+      state = insert(:terraform_state, state: "some state")
+
+      conn
+      |> basic_auth(insert(:cluster))
+      |> put_req_header("content-type", "application/json")
+      |> post("/ext/v1/states/terraform/#{state.stack.id}/lock", Jason.encode!(%{
+        id: "lock-id",
+        owner: "someone@example.com"
+      }))
+      |> response(403)
+    end
+  end
+
+  describe "POST /ext/v1/states/terraform/:id/unlock" do
+    test "it can unlock a tf state if you have access", %{conn: conn} do
+      state = insert(:terraform_state, state: "some state", lock: %{id: "other-id", owner: "someone@example.com"})
+
+      conn
+      |> basic_auth(state.stack.cluster)
+      |> post("/ext/v1/states/terraform/#{state.stack.id}/unlock")
+      |> response(200)
+
+      assert refetch(state).lock == nil
+    end
+
+    test "it will 403 if you don't have access", %{conn: conn} do
+      state = insert(:terraform_state, state: "some state", lock: %{id: "other-id", owner: "someone@example.com"})
+
+      conn
+      |> basic_auth(insert(:cluster))
+      |> post("/ext/v1/states/terraform/#{state.stack.id}/unlock")
+      |> response(403)
+    end
+  end
+
+  defp basic_auth(conn, cluster) do
+    put_req_header(conn, "authorization", Plug.BasicAuth.encode_basic_auth("token", cluster.deploy_token))
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -590,6 +590,12 @@ defmodule Console.Factory do
     }
   end
 
+  def terraform_state_factory do
+    %Schema.TerraformState{
+      stack: build(:stack)
+    }
+  end
+
   def setup_rbac(user, repos \\ ["*"], perms) do
     role = insert(:role, repositories: repos, permissions: Map.new(perms))
     insert(:role_binding, role: role, user: user)


### PR DESCRIPTION
This along with a agent-specified `_override.tf` file will allow us to serve as a built-in state store for terraform.

## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
