### PR TITLE
Use PENDING_APPROVAL state to control approve displays

### DIFF
--- a/assets/src/components/stacks/StackRun.tsx
+++ b/assets/src/components/stacks/StackRun.tsx
@@ -5,6 +5,8 @@ import { useTheme } from 'styled-components'
 import { useNavigate } from 'react-router'
 import { useParams } from 'react-router-dom'
 
+import { StackStatus } from 'generated/graphql'
+
 import { StackRunFragment } from '../../generated/graphql'
 
 import { getStackRunsAbsPath } from '../../routes/stacksRoutesConsts'
@@ -25,7 +27,6 @@ export default function StackRun({
     insertedAt,
     message,
     status,
-    approval,
     approvedAt,
     approver,
     git: { ref },
@@ -63,7 +64,7 @@ export default function StackRun({
         >
           {message ?? (first ? 'Initial run' : 'No message')}
         </div>
-        {approval && (
+        {stackRun.status === StackStatus.PendingApproval && approvedAt && (
           <div
             css={{
               textOverflow: 'ellipsis',
@@ -74,9 +75,7 @@ export default function StackRun({
                 : theme.colors['text-warning-light'],
             }}
           >
-            {approvedAt
-              ? `Approved ${moment(approvedAt).fromNow()} by ${approver?.name}`
-              : 'Pending approval'}
+            Approved {moment(approvedAt).fromNow()} by {approver?.name}
           </div>
         )}
         <div

--- a/assets/src/components/stacks/StackRunStatusChip.tsx
+++ b/assets/src/components/stacks/StackRunStatusChip.tsx
@@ -12,11 +12,19 @@ export const statusToSeverity = {
   [StackStatus.Cancelled]: 'neutral',
   [StackStatus.Failed]: 'danger',
   [StackStatus.Successful]: 'success',
-  [StackStatus.PendingApproval]: 'info',
+  [StackStatus.PendingApproval]: 'warning',
 } as const satisfies Record<
   StackStatus,
   ComponentProps<typeof Chip>['severity']
 >
+
+const humanize = (status) => {
+  if (status === StackStatus.PendingApproval) {
+    return 'Pending Approval'
+  }
+
+  return capitalize(status)
+}
 
 export function StackRunStatusChip({
   status,
@@ -32,7 +40,7 @@ export function StackRunStatusChip({
       severity={severity}
       {...props}
     >
-      {capitalize(status)}
+      {humanize(status)}
     </Chip>
   )
 }

--- a/assets/src/components/stacks/run/Sidecar.tsx
+++ b/assets/src/components/stacks/run/Sidecar.tsx
@@ -68,14 +68,15 @@ export default function StackRunSidecar({
       flexDirection="column"
       gap="small"
     >
-      {stackRun.approval && !stackRun.approvedAt && (
-        <Button
-          onClick={mutation}
-          loading={loading}
-        >
-          Approve Run
-        </Button>
-      )}
+      {stackRun.status === StackStatus.PendingApproval &&
+        !stackRun.approvedAt && (
+          <Button
+            onClick={mutation}
+            loading={loading}
+          >
+            Approve Run
+          </Button>
+        )}
       {terminal && (
         <Button
           secondary


### PR DESCRIPTION
At the moment it shows a lot of these prematurely, having harness set this state appropriately solves for that.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
