### PR TITLE
Implement the ability to trigger custom stack runs

### DIFF
--- a/assets/src/components/stacks/run/Header.tsx
+++ b/assets/src/components/stacks/run/Header.tsx
@@ -19,6 +19,7 @@ import {
   useUpdateStackRunMutation,
 } from '../../../generated/graphql'
 import {
+  STACK_RUNS_JOB_REL_PATH,
   STACK_RUNS_OUTPUT_REL_PATH,
   STACK_RUNS_PLAN_REL_PATH,
   STACK_RUNS_REPOSITORY_REL_PATH,
@@ -35,6 +36,7 @@ const DIRECTORY = [
   { path: STACK_RUNS_STATE_REL_PATH, label: 'State' },
   { path: STACK_RUNS_PLAN_REL_PATH, label: 'Plan' },
   { path: STACK_RUNS_OUTPUT_REL_PATH, label: 'Output' },
+  { path: STACK_RUNS_JOB_REL_PATH, label: 'Job' },
 ]
 
 const TERMINAL_STATES = [

--- a/assets/src/components/stacks/run/Route.tsx
+++ b/assets/src/components/stacks/run/Route.tsx
@@ -17,6 +17,19 @@ import { ResponsiveLayoutContentContainer } from '../../utils/layout/ResponsiveL
 import StackRunHeader from './Header'
 import StackRunSidecar from './Sidecar'
 
+export function getRunBreadcrumbs(stackId: string, runId: string) {
+  return [
+    ...getBreadcrumbs(stackId ?? ''),
+    {
+      label: 'runs',
+      url: `${getStacksAbsPath(stackId)}/${STACK_RUNS_REL_PATH}`,
+    },
+    ...(runId
+      ? [{ label: runId, url: getStackRunsAbsPath(stackId, runId) }]
+      : []),
+  ]
+}
+
 export default function StackRunDetail(): ReactNode {
   const { stackId, runId } = useParams()
   const theme = useTheme()
@@ -35,16 +48,7 @@ export default function StackRunDetail(): ReactNode {
 
   useSetBreadcrumbs(
     useMemo(
-      () => [
-        ...getBreadcrumbs(stackId ?? ''),
-        {
-          label: 'runs',
-          url: `${getStacksAbsPath(stackId)}/${STACK_RUNS_REL_PATH}`,
-        },
-        ...(runId
-          ? [{ label: runId, url: getStackRunsAbsPath(stackId, runId) }]
-          : []),
-      ],
+      () => getRunBreadcrumbs(stackId || '', runId || ''),
       [runId, stackId]
     )
   )

--- a/assets/src/components/stacks/run/job/RunJob.tsx
+++ b/assets/src/components/stacks/run/job/RunJob.tsx
@@ -1,0 +1,207 @@
+import {
+  AppIcon,
+  BriefcaseIcon,
+  LoopingLogo,
+  TabPanel,
+  Tooltip,
+  useSetBreadcrumbs,
+} from '@pluralsh/design-system'
+import { createContext, useContext, useMemo, useRef } from 'react'
+import {
+  Outlet,
+  useLocation,
+  useMatch,
+  useOutletContext,
+  useParams,
+} from 'react-router-dom'
+
+import {
+  JobFragment,
+  PipelineGateJobFragment,
+  useStackRunJobQuery,
+} from 'generated/graphql'
+
+import { GqlError } from 'components/utils/Alert'
+import { ResponsiveLayoutSpacer } from 'components/utils/layout/ResponsiveLayoutSpacer'
+import { ResponsiveLayoutContentContainer } from 'components/utils/layout/ResponsiveLayoutContentContainer'
+import { ResponsiveLayoutSidenavContainer } from 'components/utils/layout/ResponsiveLayoutSidenavContainer'
+import { ResponsiveLayoutPage } from 'components/utils/layout/ResponsiveLayoutPage'
+import { SideNavEntries } from 'components/layout/SideNavEntries'
+
+import { useTheme } from 'styled-components'
+
+import { Body2P, Subtitle2H1 } from 'components/utils/typography/Text'
+
+import { POLL_INTERVAL } from 'components/cd/ContinuousDeployment'
+
+import { getStackRunsAbsPath } from 'routes/stacksRoutesConsts'
+
+import { getRunBreadcrumbs } from '../Route'
+
+const getDirectory = () => [
+  { path: 'logs', label: 'Logs', enabled: true },
+  { path: 'pods', label: 'Pods', enabled: true },
+  { path: 'status', label: 'Status', enabled: true },
+  { path: 'specs', label: 'Specs', enabled: true },
+]
+
+const getStackRunJobCrumbs = ({
+  stackId,
+  runId,
+  tab,
+}: {
+  stackId: string
+  runId: string
+  tab: string
+}) => [
+  ...getRunBreadcrumbs(stackId, runId),
+  { label: 'jobs' },
+  { label: tab, url: `${getStackRunsAbsPath(stackId, runId)}/${tab}` },
+]
+
+const PodsContext =
+  createContext<Nullable<PipelineGateJobFragment['pods']>>(undefined)
+
+export const useJobPods = () => {
+  const ctx = useContext(PodsContext)
+
+  if (!ctx) {
+    throw new Error('useJobPods must be used within a PodsContext.Provider')
+  }
+
+  return useContext(PodsContext)
+}
+
+type OutletContextT = {
+  refetch: () => void
+  status: Nullable<JobFragment['status']>
+  metadata: Nullable<JobFragment['metadata']>
+  raw: Nullable<JobFragment['raw']>
+  spec: Nullable<JobFragment['spec']>
+}
+export const useRunJob = () => useOutletContext<OutletContextT>()
+
+export default function RunJob() {
+  const theme = useTheme()
+  const tabStateRef = useRef<any>(null)
+  const { stackId, runId } = useParams()
+  const { pathname } = useLocation()
+
+  const pathPrefix = `${getStackRunsAbsPath(stackId, runId)}/job`
+  const tab = useMatch(`${pathPrefix}/:tab`)?.params?.tab || ''
+
+  const directory = getDirectory().filter(({ enabled }) => enabled)
+
+  const { data, error, refetch } = useStackRunJobQuery({
+    variables: { id: runId || '' },
+    pollInterval: POLL_INTERVAL,
+  })
+
+  useSetBreadcrumbs(
+    useMemo(
+      () =>
+        getStackRunJobCrumbs({
+          runId: runId || '',
+          stackId: stackId || '',
+          tab: tab || '',
+        }),
+      [runId, stackId, tab]
+    )
+  )
+  const outletContext: OutletContextT = useMemo(
+    () => ({
+      refetch,
+      status: data?.stackRun?.job?.status,
+      metadata: data?.stackRun?.job?.metadata,
+      raw: data?.stackRun?.job?.raw,
+      spec: data?.stackRun?.job?.spec,
+    }),
+    [
+      data?.stackRun?.job?.metadata,
+      data?.stackRun?.job?.raw,
+      data?.stackRun?.job?.spec,
+      data?.stackRun?.job?.status,
+      refetch,
+    ]
+  )
+  const podsContext = useMemo(
+    () => data?.stackRun?.job?.pods || [],
+    [data?.stackRun?.job?.pods]
+  )
+  let content = <Outlet context={outletContext} />
+  const stackRun = data?.stackRun
+  const job = stackRun?.job
+  const name = job?.metadata.name
+
+  if (error) {
+    content = <GqlError error={error} />
+  } else if (!data) {
+    content = <LoopingLogo />
+  }
+
+  return (
+    <ResponsiveLayoutPage>
+      <ResponsiveLayoutSidenavContainer>
+        <div
+          css={{
+            display: 'flex',
+            alignItem: 'center',
+            gap: theme.spacing.small,
+            marginBottom: theme.spacing.xsmall,
+          }}
+        >
+          <AppIcon
+            size="xsmall"
+            icon={<BriefcaseIcon size={theme.spacing.large} />}
+          />
+          <div
+            css={{
+              minWidth: 0,
+              '&>*': {
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              },
+            }}
+          >
+            <Tooltip label={name}>
+              <Subtitle2H1
+                css={{
+                  margin: 0,
+                }}
+              >
+                {name}
+              </Subtitle2H1>
+            </Tooltip>
+            {name && (
+              <Tooltip label={name}>
+                <Body2P
+                  css={{
+                    color: theme.colors['text-light'],
+                  }}
+                >
+                  Job gate
+                </Body2P>
+              </Tooltip>
+            )}
+          </div>
+        </div>
+
+        <SideNavEntries
+          directory={directory}
+          pathname={pathname}
+          pathPrefix={pathPrefix}
+        />
+      </ResponsiveLayoutSidenavContainer>
+      <ResponsiveLayoutSpacer />
+      <TabPanel
+        as={<ResponsiveLayoutContentContainer />}
+        stateRef={tabStateRef}
+      >
+        <PodsContext.Provider value={podsContext}>
+          {content}
+        </PodsContext.Provider>
+      </TabPanel>
+    </ResponsiveLayoutPage>
+  )
+}

--- a/assets/src/components/stacks/run/job/RunJobLogs.tsx
+++ b/assets/src/components/stacks/run/job/RunJobLogs.tsx
@@ -1,0 +1,126 @@
+import { useMemo, useState } from 'react'
+import { FormField, ListBoxItem, Select } from '@pluralsh/design-system'
+import { useStackRunJobLogsQuery } from 'generated/graphql'
+import { useParams } from 'react-router-dom'
+import { useTheme } from 'styled-components'
+
+import { GqlError } from 'components/utils/Alert'
+
+import { ScrollablePage } from 'components/utils/layout/ScrollablePage'
+
+import { ContainerLogsTable } from 'components/cd/cluster/pod/logs/ContainerLogs'
+
+import {
+  SinceSecondsOptions,
+  SinceSecondsSelectOptions,
+} from 'components/cd/cluster/pod/logs/Logs'
+
+import { isNonNullable } from 'utils/isNonNullable'
+
+import { useJobPods } from './RunJob'
+
+export default function RunJobLogs() {
+  const theme = useTheme()
+  const id = useParams().runId!
+  const pods = useJobPods()
+  const containers =
+    useMemo(
+      () =>
+        pods?.flatMap(
+          (p) =>
+            p?.spec?.containers?.flatMap?.((c) => ({
+              id: `${p.metadata.name}++${p.metadata.namespace}++${c?.name}`,
+              ...c,
+            })) ?? []
+        ),
+      [pods]
+    ) || []
+
+  const [sinceSeconds, setSinceSeconds] = useState(SinceSecondsOptions.HalfHour)
+  const [selectedContainer, setSelectedContainer] = useState<string>(
+    containers?.[0]?.name || ''
+  )
+
+  const {
+    data: currentData,
+    previousData,
+    error,
+    loading,
+    refetch,
+  } = useStackRunJobLogsQuery({
+    variables: { id, container: containers?.[0]?.name || '', sinceSeconds },
+    notifyOnNetworkStatusChange: true,
+  })
+  const data = currentData || previousData
+
+  const logs = useMemo(
+    () => (data?.stackRun?.job?.logs || []).filter(isNonNullable),
+    [data?.stackRun?.job?.logs]
+  )
+
+  if (error) {
+    return <GqlError error={error} />
+  }
+
+  return (
+    <ScrollablePage
+      heading="Logs"
+      scrollable={false}
+    >
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.medium,
+          height: '100%',
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            gap: theme.spacing.large,
+            '> *': { width: '100%' },
+          }}
+        >
+          <FormField label="Container">
+            <Select
+              selectedKey={selectedContainer}
+              onSelectionChange={(key) => setSelectedContainer(key as string)}
+            >
+              {containers?.map((c) => (
+                <ListBoxItem
+                  key={c.name || ''}
+                  label={c.name || ''}
+                  textValue={c.name || ''}
+                />
+              ))}
+            </Select>
+          </FormField>
+
+          <FormField label="Logs since">
+            <Select
+              selectedKey={`${sinceSeconds}`}
+              onSelectionChange={(key) =>
+                setSinceSeconds(Number(key) as SinceSecondsOptions)
+              }
+            >
+              {SinceSecondsSelectOptions.map((opts) => (
+                <ListBoxItem
+                  key={`${opts.key}`}
+                  label={opts.label}
+                  selected={opts.key === sinceSeconds}
+                />
+              ))}
+            </Select>
+          </FormField>
+        </div>
+        <ContainerLogsTable
+          logs={logs || []}
+          loading={loading}
+          refetch={refetch}
+          container={selectedContainer}
+        />
+      </div>
+    </ScrollablePage>
+  )
+}

--- a/assets/src/components/stacks/run/job/RunJobPods.tsx
+++ b/assets/src/components/stacks/run/job/RunJobPods.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react'
+import isEmpty from 'lodash/isEmpty'
+
+import {
+  ColActions,
+  ColContainers,
+  ColCpuReservation,
+  ColImages,
+  ColMemoryReservation,
+  ColName,
+  ColNamespace,
+  ColRestarts,
+  PodWithId,
+  PodsList,
+} from 'components/cluster/pods/PodsList'
+import { FullHeightTableWrap } from 'components/utils/layout/FullHeightTableWrap'
+
+import { ScrollablePage } from 'components/utils/layout/ScrollablePage'
+
+import { useJobPods, useRunJob } from './RunJob'
+
+const columns = [
+  ColNamespace,
+  ColName,
+  ColMemoryReservation,
+  ColCpuReservation,
+  ColRestarts,
+  ColContainers,
+  ColImages,
+  ColActions,
+]
+
+export default function RunJobPods() {
+  const pods = useJobPods()
+
+  const { refetch } = useRunJob()
+
+  const podsWithId = useMemo(() => {
+    if (isEmpty(pods)) {
+      return undefined
+    }
+    const podsWithId = pods
+      ?.map(
+        (edge) =>
+          ({
+            id: `${edge?.metadata.name}++${edge?.metadata?.namespace}`,
+            ...edge,
+          }) as PodWithId
+      )
+      ?.filter((pod?: PodWithId): pod is PodWithId => !!pod) as PodWithId[]
+
+    return podsWithId || []
+  }, [pods])
+
+  return (
+    <ScrollablePage
+      scrollable={false}
+      heading="Pods"
+    >
+      <FullHeightTableWrap>
+        <PodsList
+          pods={podsWithId}
+          columns={columns}
+          refetch={refetch}
+          //   reactTableOptions={reactTableOptions}
+          css={{
+            maxHeight: 'unset',
+            height: '100%',
+          }}
+        />
+      </FullHeightTableWrap>
+    </ScrollablePage>
+  )
+}

--- a/assets/src/components/stacks/run/job/RunJobSpecs.tsx
+++ b/assets/src/components/stacks/run/job/RunJobSpecs.tsx
@@ -1,0 +1,92 @@
+import { Card, SubTab, TabList } from '@pluralsh/design-system'
+import { useTheme } from 'styled-components'
+
+import { ScrollablePage } from 'components/utils/layout/ScrollablePage'
+import { PropWideBold } from 'components/component/info/common'
+
+import { useNavigate, useParams } from 'react-router-dom'
+
+import { useLayoutEffect, useRef } from 'react'
+
+import { LinkTabWrap } from 'components/utils/Tabs'
+
+import { PIPELINES_ABS_PATH } from 'routes/cdRoutesConsts'
+
+import { RawYaml } from 'components/component/ComponentRaw'
+
+import { useRunJob } from './RunJob'
+
+const TABS = [
+  { path: '', label: 'Info', enabled: true },
+  { path: 'raw', label: 'Raw', enabled: true },
+]
+
+export default function RunJobSpecs() {
+  const theme = useTheme()
+  const navigate = useNavigate()
+  const { raw, spec } = useRunJob()
+  const { tab: tabName, jobId } = useParams()
+  const tabStateRef = useRef<any>(null)
+  const currentTab = TABS.find((tab) => tab.path === (tabName ?? ''))
+
+  useLayoutEffect(() => {
+    if (!currentTab) {
+      navigate(`${PIPELINES_ABS_PATH}/jobs/${jobId}/specs`)
+    }
+  }, [currentTab, jobId, navigate])
+  if (!currentTab) return null
+
+  return (
+    <ScrollablePage
+      heading="Specs"
+      scrollable={currentTab?.path === ''}
+      headingContent={
+        <TabList
+          stateRef={tabStateRef}
+          stateProps={{
+            orientation: 'horizontal',
+            selectedKey: currentTab?.path,
+          }}
+        >
+          {TABS.map(({ label, path }) => (
+            <LinkTabWrap
+              subTab
+              key={path}
+              textValue={label}
+              to={`${PIPELINES_ABS_PATH}/jobs/${jobId}/specs/${path}`}
+            >
+              <SubTab
+                key={path}
+                textValue={label}
+              >
+                {label}
+              </SubTab>
+            </LinkTabWrap>
+          ))}
+        </TabList>
+      }
+    >
+      {currentTab?.path === 'raw' && <RawYaml raw={raw} />}
+      {currentTab?.path === '' && (
+        <Card
+          css={{
+            display: 'flex',
+            padding: theme.spacing.xlarge,
+            gap: theme.spacing.xsmall,
+            flexDirection: 'column',
+          }}
+        >
+          <PropWideBold title="Active deadline seconds">
+            {spec?.activeDeadlineSeconds || 0}
+          </PropWideBold>
+          <PropWideBold title="Backoff limit">
+            {spec?.backoffLimit || 0}
+          </PropWideBold>
+          <PropWideBold title="Parallelism">
+            {spec?.parallelism || 0}
+          </PropWideBold>
+        </Card>
+      )}
+    </ScrollablePage>
+  )
+}

--- a/assets/src/components/stacks/run/job/RunJobStatus.tsx
+++ b/assets/src/components/stacks/run/job/RunJobStatus.tsx
@@ -1,0 +1,64 @@
+import { Card } from '@pluralsh/design-system'
+import { useTheme } from 'styled-components'
+
+import { ScrollablePage } from 'components/utils/layout/ScrollablePage'
+import { LabelPairsSection } from 'components/utils/LabelPairsSection'
+import { PropWideBold } from 'components/component/info/common'
+
+import { useRunJob } from './RunJob'
+
+export default function RunJobStatus() {
+  const theme = useTheme()
+  const { status, metadata } = useRunJob()
+
+  return (
+    <ScrollablePage heading="Status">
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.xlarge,
+        }}
+      >
+        {status?.active}
+        <Card
+          css={{
+            display: 'flex',
+            padding: theme.spacing.xlarge,
+            gap: theme.spacing.xsmall,
+            flexDirection: 'column',
+          }}
+        >
+          <PropWideBold title="Active">{status?.active || 0}</PropWideBold>
+          <PropWideBold title="Succeeded">
+            {status?.succeeded || 0}
+          </PropWideBold>
+          <PropWideBold title="Failed">{status?.failed || 0}</PropWideBold>
+          <PropWideBold title="Start time">{status?.startTime}</PropWideBold>
+          <PropWideBold title="Completion time">
+            {status?.completionTime}
+          </PropWideBold>
+        </Card>
+        <section>
+          <Card
+            css={{
+              display: 'flex',
+              padding: theme.spacing.xlarge,
+              gap: theme.spacing.large,
+              flexDirection: 'column',
+            }}
+          >
+            <LabelPairsSection
+              vals={metadata?.labels || []}
+              title="Labels"
+            />
+            <LabelPairsSection
+              vals={metadata?.annotations || []}
+              title="Annotations"
+            />
+          </Card>
+        </section>
+      </div>
+    </ScrollablePage>
+  )
+}

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -8818,7 +8818,7 @@ export type PolicyStatisticsQuery = { __typename?: 'RootQueryType', policyStatis
 
 export type StackFragment = { __typename?: 'InfrastructureStack', id?: string | null, insertedAt?: string | null, deletedAt?: string | null, name: string, type: StackType, paused?: boolean | null, approval?: boolean | null, files?: Array<{ __typename?: 'StackFile', path: string, content: string } | null> | null, configuration: { __typename?: 'StackConfiguration', image?: string | null, version: string }, repository?: { __typename?: 'GitRepository', id: string, url: string, pulledAt?: string | null } | null, git: { __typename?: 'GitRef', ref: string, folder: string }, cluster?: { __typename?: 'Cluster', id: string, name: string, self?: boolean | null, distro?: ClusterDistro | null, provider?: { __typename?: 'ClusterProvider', cloud: string } | null } | null, environment?: Array<{ __typename?: 'StackEnvironment', name: string, value: string, secret?: boolean | null } | null> | null, jobSpec?: { __typename?: 'JobGateSpec', namespace: string, raw?: string | null, annotations?: Record<string, unknown> | null, labels?: Record<string, unknown> | null, serviceAccount?: string | null, containers?: Array<{ __typename?: 'ContainerSpec', image: string, args?: Array<string | null> | null, env?: Array<{ __typename?: 'ContainerEnv', value: string, name: string } | null> | null, envFrom?: Array<{ __typename?: 'ContainerEnvFrom', secret: string, configMap: string } | null> | null } | null> | null } | null };
 
-export type StackRunFragment = { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null, job?: { __typename?: 'Job', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'JobStatus', active?: number | null, completionTime?: string | null, succeeded?: number | null, failed?: number | null, startTime?: string | null }, spec: { __typename?: 'JobSpec', backoffLimit?: number | null, parallelism?: number | null, activeDeadlineSeconds?: number | null }, pods?: Array<{ __typename?: 'Pod', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'PodStatus', phase?: string | null, podIp?: string | null, reason?: string | null, containerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, initContainerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, conditions?: Array<{ __typename?: 'PodCondition', lastProbeTime?: string | null, lastTransitionTime?: string | null, message?: string | null, reason?: string | null, status?: string | null, type?: string | null } | null> | null }, spec: { __typename?: 'PodSpec', nodeName?: string | null, serviceAccountName?: string | null, containers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null, initContainers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null } } | null> | null } | null };
+export type StackRunFragment = { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null };
 
 export type StackConfigurationFragment = { __typename?: 'StackConfiguration', version: string, image?: string | null };
 
@@ -8870,7 +8870,7 @@ export type StackRunsQueryVariables = Exact<{
 }>;
 
 
-export type StackRunsQuery = { __typename?: 'RootQueryType', infrastructureStack?: { __typename?: 'InfrastructureStack', runs?: { __typename?: 'StackRunConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null, hasPreviousPage: boolean, startCursor?: string | null }, edges?: Array<{ __typename?: 'StackRunEdge', node?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null, job?: { __typename?: 'Job', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'JobStatus', active?: number | null, completionTime?: string | null, succeeded?: number | null, failed?: number | null, startTime?: string | null }, spec: { __typename?: 'JobSpec', backoffLimit?: number | null, parallelism?: number | null, activeDeadlineSeconds?: number | null }, pods?: Array<{ __typename?: 'Pod', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'PodStatus', phase?: string | null, podIp?: string | null, reason?: string | null, containerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, initContainerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, conditions?: Array<{ __typename?: 'PodCondition', lastProbeTime?: string | null, lastTransitionTime?: string | null, message?: string | null, reason?: string | null, status?: string | null, type?: string | null } | null> | null }, spec: { __typename?: 'PodSpec', nodeName?: string | null, serviceAccountName?: string | null, containers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null, initContainers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null } } | null> | null } | null } | null } | null> | null } | null } | null };
+export type StackRunsQuery = { __typename?: 'RootQueryType', infrastructureStack?: { __typename?: 'InfrastructureStack', runs?: { __typename?: 'StackRunConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null, hasPreviousPage: boolean, startCursor?: string | null }, edges?: Array<{ __typename?: 'StackRunEdge', node?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null } | null } | null> | null } | null } | null };
 
 export type StackRunQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -8878,6 +8878,22 @@ export type StackRunQueryVariables = Exact<{
 
 
 export type StackRunQuery = { __typename?: 'RootQueryType', stackRun?: { __typename?: 'StackRun', id: string, status: StackStatus, updatedAt?: string | null, insertedAt?: string | null, type: StackType, message?: string | null, approval?: boolean | null, approvedAt?: string | null, approver?: { __typename?: 'User', id: string, pluralId?: string | null, name: string, email: string, profile?: string | null, backgroundColor?: string | null, readTimestamp?: string | null, roles?: { __typename?: 'UserRoles', admin?: boolean | null } | null, personas?: Array<{ __typename?: 'Persona', id: string, name: string, description?: string | null, bindings?: Array<{ __typename?: 'PolicyBinding', id?: string | null, user?: { __typename?: 'User', id: string, name: string, email: string } | null, group?: { __typename?: 'Group', id: string, name: string } | null } | null> | null, configuration?: { __typename?: 'PersonaConfiguration', all?: boolean | null, deployments?: { __typename?: 'PersonaDeployment', addOns?: boolean | null, clusters?: boolean | null, pipelines?: boolean | null, providers?: boolean | null, repositories?: boolean | null, services?: boolean | null } | null, home?: { __typename?: 'PersonaHome', manager?: boolean | null, security?: boolean | null } | null, sidebar?: { __typename?: 'PersonaSidebar', audits?: boolean | null, kubernetes?: boolean | null, pullRequests?: boolean | null, settings?: boolean | null, backups?: boolean | null, stacks?: boolean | null } | null } | null } | null> | null } | null, configuration: { __typename?: 'StackConfiguration', version: string, image?: string | null }, state?: { __typename?: 'StackState', id: string, plan?: string | null, state?: Array<{ __typename?: 'StackStateResource', name: string, resource: string, identifier: string, links?: Array<string | null> | null, configuration?: Record<string, unknown> | null } | null> | null } | null, repository?: { __typename?: 'GitRepository', id: string, url: string, health?: GitHealth | null, authMethod?: AuthMethod | null, editable?: boolean | null, error?: string | null, insertedAt?: string | null, pulledAt?: string | null, updatedAt?: string | null, urlFormat?: string | null, httpsPath?: string | null } | null, git: { __typename?: 'GitRef', files?: Array<string> | null, ref: string, folder: string }, output?: Array<{ __typename?: 'StackOutput', name: string, value: string, secret?: boolean | null } | null> | null, cluster?: { __typename?: 'Cluster', id: string, name: string, self?: boolean | null, distro?: ClusterDistro | null, provider?: { __typename?: 'ClusterProvider', cloud: string } | null } | null, environment?: Array<{ __typename?: 'StackEnvironment', name: string, value: string, secret?: boolean | null } | null> | null, errors?: Array<{ __typename?: 'ServiceError', source: string, message: string } | null> | null, files?: Array<{ __typename?: 'StackFile', path: string, content: string } | null> | null, jobSpec?: { __typename?: 'JobGateSpec', annotations?: Record<string, unknown> | null, labels?: Record<string, unknown> | null, namespace: string, raw?: string | null, serviceAccount?: string | null, containers?: Array<{ __typename?: 'ContainerSpec', args?: Array<string | null> | null, image: string, env?: Array<{ __typename?: 'ContainerEnv', name: string, value: string } | null> | null, envFrom?: Array<{ __typename?: 'ContainerEnvFrom', configMap: string, secret: string } | null> | null } | null> | null } | null, steps?: Array<{ __typename?: 'RunStep', id: string, name: string, insertedAt?: string | null, updatedAt?: string | null, status: StepStatus, stage: StepStage, args?: Array<string> | null, cmd: string, index: number, logs?: Array<{ __typename?: 'RunLogs', id: string, updatedAt?: string | null, insertedAt?: string | null, logs: string } | null> | null } | null> | null } | null };
+
+export type StackRunJobQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type StackRunJobQuery = { __typename?: 'RootQueryType', stackRun?: { __typename?: 'StackRun', job?: { __typename?: 'Job', raw: string, events?: Array<{ __typename?: 'Event', action?: string | null, count?: number | null, eventTime?: string | null, lastTimestamp?: string | null, message?: string | null, reason?: string | null, type?: string | null } | null> | null, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, pods?: Array<{ __typename?: 'Pod', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'PodStatus', phase?: string | null, podIp?: string | null, reason?: string | null, containerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, initContainerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, conditions?: Array<{ __typename?: 'PodCondition', lastProbeTime?: string | null, lastTransitionTime?: string | null, message?: string | null, reason?: string | null, status?: string | null, type?: string | null } | null> | null }, spec: { __typename?: 'PodSpec', nodeName?: string | null, serviceAccountName?: string | null, containers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null, initContainers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null } } | null> | null, spec: { __typename?: 'JobSpec', activeDeadlineSeconds?: number | null, backoffLimit?: number | null, parallelism?: number | null }, status: { __typename?: 'JobStatus', active?: number | null, completionTime?: string | null, failed?: number | null, startTime?: string | null, succeeded?: number | null } } | null } | null };
+
+export type StackRunJobLogsQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+  container: Scalars['String']['input'];
+  sinceSeconds: Scalars['Int']['input'];
+}>;
+
+
+export type StackRunJobLogsQuery = { __typename?: 'RootQueryType', stackRun?: { __typename?: 'StackRun', job?: { __typename?: 'Job', logs?: Array<string | null> | null } | null } | null };
 
 export type CreateStackMutationVariables = Exact<{
   attributes: StackAttributes;
@@ -8913,7 +8929,7 @@ export type KickStackMutationVariables = Exact<{
 }>;
 
 
-export type KickStackMutation = { __typename?: 'RootMutationType', kickStack?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null, job?: { __typename?: 'Job', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'JobStatus', active?: number | null, completionTime?: string | null, succeeded?: number | null, failed?: number | null, startTime?: string | null }, spec: { __typename?: 'JobSpec', backoffLimit?: number | null, parallelism?: number | null, activeDeadlineSeconds?: number | null }, pods?: Array<{ __typename?: 'Pod', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'PodStatus', phase?: string | null, podIp?: string | null, reason?: string | null, containerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, initContainerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, conditions?: Array<{ __typename?: 'PodCondition', lastProbeTime?: string | null, lastTransitionTime?: string | null, message?: string | null, reason?: string | null, status?: string | null, type?: string | null } | null> | null }, spec: { __typename?: 'PodSpec', nodeName?: string | null, serviceAccountName?: string | null, containers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null, initContainers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null } } | null> | null } | null } | null };
+export type KickStackMutation = { __typename?: 'RootMutationType', kickStack?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null } | null };
 
 export type UpdateStackRunMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -8921,21 +8937,21 @@ export type UpdateStackRunMutationVariables = Exact<{
 }>;
 
 
-export type UpdateStackRunMutation = { __typename?: 'RootMutationType', updateStackRun?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null, job?: { __typename?: 'Job', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'JobStatus', active?: number | null, completionTime?: string | null, succeeded?: number | null, failed?: number | null, startTime?: string | null }, spec: { __typename?: 'JobSpec', backoffLimit?: number | null, parallelism?: number | null, activeDeadlineSeconds?: number | null }, pods?: Array<{ __typename?: 'Pod', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'PodStatus', phase?: string | null, podIp?: string | null, reason?: string | null, containerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, initContainerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, conditions?: Array<{ __typename?: 'PodCondition', lastProbeTime?: string | null, lastTransitionTime?: string | null, message?: string | null, reason?: string | null, status?: string | null, type?: string | null } | null> | null }, spec: { __typename?: 'PodSpec', nodeName?: string | null, serviceAccountName?: string | null, containers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null, initContainers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null } } | null> | null } | null } | null };
+export type UpdateStackRunMutation = { __typename?: 'RootMutationType', updateStackRun?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null } | null };
 
 export type ApproveStackRunMutationVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type ApproveStackRunMutation = { __typename?: 'RootMutationType', approveStackRun?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null, job?: { __typename?: 'Job', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'JobStatus', active?: number | null, completionTime?: string | null, succeeded?: number | null, failed?: number | null, startTime?: string | null }, spec: { __typename?: 'JobSpec', backoffLimit?: number | null, parallelism?: number | null, activeDeadlineSeconds?: number | null }, pods?: Array<{ __typename?: 'Pod', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'PodStatus', phase?: string | null, podIp?: string | null, reason?: string | null, containerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, initContainerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, conditions?: Array<{ __typename?: 'PodCondition', lastProbeTime?: string | null, lastTransitionTime?: string | null, message?: string | null, reason?: string | null, status?: string | null, type?: string | null } | null> | null }, spec: { __typename?: 'PodSpec', nodeName?: string | null, serviceAccountName?: string | null, containers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null, initContainers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null } } | null> | null } | null } | null };
+export type ApproveStackRunMutation = { __typename?: 'RootMutationType', approveStackRun?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null } | null };
 
 export type RestartStackRunMutationVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type RestartStackRunMutation = { __typename?: 'RootMutationType', restartStackRun?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null, job?: { __typename?: 'Job', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'JobStatus', active?: number | null, completionTime?: string | null, succeeded?: number | null, failed?: number | null, startTime?: string | null }, spec: { __typename?: 'JobSpec', backoffLimit?: number | null, parallelism?: number | null, activeDeadlineSeconds?: number | null }, pods?: Array<{ __typename?: 'Pod', raw: string, metadata: { __typename?: 'Metadata', uid?: string | null, name: string, namespace?: string | null, labels?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null, annotations?: Array<{ __typename?: 'LabelPair', name?: string | null, value?: string | null } | null> | null }, status: { __typename?: 'PodStatus', phase?: string | null, podIp?: string | null, reason?: string | null, containerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, initContainerStatuses?: Array<{ __typename?: 'ContainerStatus', restartCount?: number | null, ready?: boolean | null, name?: string | null, state?: { __typename?: 'ContainerState', running?: { __typename?: 'RunningState', startedAt?: string | null } | null, terminated?: { __typename?: 'TerminatedState', exitCode?: number | null, message?: string | null, reason?: string | null } | null, waiting?: { __typename?: 'WaitingState', message?: string | null, reason?: string | null } | null } | null } | null> | null, conditions?: Array<{ __typename?: 'PodCondition', lastProbeTime?: string | null, lastTransitionTime?: string | null, message?: string | null, reason?: string | null, status?: string | null, type?: string | null } | null> | null }, spec: { __typename?: 'PodSpec', nodeName?: string | null, serviceAccountName?: string | null, containers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null, initContainers?: Array<{ __typename?: 'Container', name?: string | null, image?: string | null, ports?: Array<{ __typename?: 'Port', containerPort?: number | null, protocol?: string | null } | null> | null, resources?: { __typename?: 'Resources', limits?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null, requests?: { __typename?: 'ResourceSpec', cpu?: string | null, memory?: string | null } | null } | null } | null> | null } } | null> | null } | null } | null };
+export type RestartStackRunMutation = { __typename?: 'RootMutationType', restartStackRun?: { __typename?: 'StackRun', id: string, insertedAt?: string | null, message?: string | null, status: StackStatus, approval?: boolean | null, approvedAt?: string | null, git: { __typename?: 'GitRef', ref: string }, approver?: { __typename?: 'User', name: string, email: string } | null } | null };
 
 export type LogsDeltaSubscriptionVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -10399,6 +10415,36 @@ export const IngressFragmentDoc = gql`
 }
     ${MetadataFragmentDoc}
 ${CertificateFragmentDoc}`;
+export const JobStatusFragmentDoc = gql`
+    fragment JobStatus on JobStatus {
+  active
+  completionTime
+  succeeded
+  failed
+  startTime
+}
+    `;
+export const JobFragmentDoc = gql`
+    fragment Job on Job {
+  metadata {
+    ...Metadata
+  }
+  status {
+    ...JobStatus
+  }
+  spec {
+    backoffLimit
+    parallelism
+    activeDeadlineSeconds
+  }
+  pods {
+    ...Pod
+  }
+  raw
+}
+    ${MetadataFragmentDoc}
+${JobStatusFragmentDoc}
+${PodFragmentDoc}`;
 export const EventFragmentDoc = gql`
     fragment Event on Event {
   action
@@ -11040,36 +11086,6 @@ export const StackFragmentDoc = gql`
   }
 }
     ${ClusterTinyFragmentDoc}`;
-export const JobStatusFragmentDoc = gql`
-    fragment JobStatus on JobStatus {
-  active
-  completionTime
-  succeeded
-  failed
-  startTime
-}
-    `;
-export const JobFragmentDoc = gql`
-    fragment Job on Job {
-  metadata {
-    ...Metadata
-  }
-  status {
-    ...JobStatus
-  }
-  spec {
-    backoffLimit
-    parallelism
-    activeDeadlineSeconds
-  }
-  pods {
-    ...Pod
-  }
-  raw
-}
-    ${MetadataFragmentDoc}
-${JobStatusFragmentDoc}
-${PodFragmentDoc}`;
 export const StackRunFragmentDoc = gql`
     fragment StackRun on StackRun {
   id
@@ -11085,11 +11101,8 @@ export const StackRunFragmentDoc = gql`
     name
     email
   }
-  job {
-    ...Job
-  }
 }
-    ${JobFragmentDoc}`;
+    `;
 export const StackConfigurationFragmentDoc = gql`
     fragment StackConfiguration on StackConfiguration {
   version
@@ -17845,6 +17858,92 @@ export type StackRunQueryHookResult = ReturnType<typeof useStackRunQuery>;
 export type StackRunLazyQueryHookResult = ReturnType<typeof useStackRunLazyQuery>;
 export type StackRunSuspenseQueryHookResult = ReturnType<typeof useStackRunSuspenseQuery>;
 export type StackRunQueryResult = Apollo.QueryResult<StackRunQuery, StackRunQueryVariables>;
+export const StackRunJobDocument = gql`
+    query StackRunJob($id: ID!) {
+  stackRun(id: $id) {
+    job {
+      ...PipelineGateJob
+    }
+  }
+}
+    ${PipelineGateJobFragmentDoc}`;
+
+/**
+ * __useStackRunJobQuery__
+ *
+ * To run a query within a React component, call `useStackRunJobQuery` and pass it any options that fit your needs.
+ * When your component renders, `useStackRunJobQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useStackRunJobQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useStackRunJobQuery(baseOptions: Apollo.QueryHookOptions<StackRunJobQuery, StackRunJobQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<StackRunJobQuery, StackRunJobQueryVariables>(StackRunJobDocument, options);
+      }
+export function useStackRunJobLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StackRunJobQuery, StackRunJobQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<StackRunJobQuery, StackRunJobQueryVariables>(StackRunJobDocument, options);
+        }
+export function useStackRunJobSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<StackRunJobQuery, StackRunJobQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<StackRunJobQuery, StackRunJobQueryVariables>(StackRunJobDocument, options);
+        }
+export type StackRunJobQueryHookResult = ReturnType<typeof useStackRunJobQuery>;
+export type StackRunJobLazyQueryHookResult = ReturnType<typeof useStackRunJobLazyQuery>;
+export type StackRunJobSuspenseQueryHookResult = ReturnType<typeof useStackRunJobSuspenseQuery>;
+export type StackRunJobQueryResult = Apollo.QueryResult<StackRunJobQuery, StackRunJobQueryVariables>;
+export const StackRunJobLogsDocument = gql`
+    query StackRunJobLogs($id: ID!, $container: String!, $sinceSeconds: Int!) {
+  stackRun(id: $id) {
+    job {
+      logs(container: $container, sinceSeconds: $sinceSeconds)
+    }
+  }
+}
+    `;
+
+/**
+ * __useStackRunJobLogsQuery__
+ *
+ * To run a query within a React component, call `useStackRunJobLogsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useStackRunJobLogsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useStackRunJobLogsQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      container: // value for 'container'
+ *      sinceSeconds: // value for 'sinceSeconds'
+ *   },
+ * });
+ */
+export function useStackRunJobLogsQuery(baseOptions: Apollo.QueryHookOptions<StackRunJobLogsQuery, StackRunJobLogsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<StackRunJobLogsQuery, StackRunJobLogsQueryVariables>(StackRunJobLogsDocument, options);
+      }
+export function useStackRunJobLogsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StackRunJobLogsQuery, StackRunJobLogsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<StackRunJobLogsQuery, StackRunJobLogsQueryVariables>(StackRunJobLogsDocument, options);
+        }
+export function useStackRunJobLogsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<StackRunJobLogsQuery, StackRunJobLogsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<StackRunJobLogsQuery, StackRunJobLogsQueryVariables>(StackRunJobLogsDocument, options);
+        }
+export type StackRunJobLogsQueryHookResult = ReturnType<typeof useStackRunJobLogsQuery>;
+export type StackRunJobLogsLazyQueryHookResult = ReturnType<typeof useStackRunJobLogsLazyQuery>;
+export type StackRunJobLogsSuspenseQueryHookResult = ReturnType<typeof useStackRunJobLogsSuspenseQuery>;
+export type StackRunJobLogsQueryResult = Apollo.QueryResult<StackRunJobLogsQuery, StackRunJobLogsQueryVariables>;
 export const CreateStackDocument = gql`
     mutation CreateStack($attributes: StackAttributes!) {
   createStack(attributes: $attributes) {
@@ -18647,6 +18746,8 @@ export const namedOperations = {
     StackTiny: 'StackTiny',
     StackRuns: 'StackRuns',
     StackRun: 'StackRun',
+    StackRunJob: 'StackRunJob',
+    StackRunJobLogs: 'StackRunJobLogs',
     AccessTokens: 'AccessTokens',
     TokenAudits: 'TokenAudits',
     Me: 'Me',

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1009,6 +1009,12 @@ export type Command = {
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
+export type CommandAttributes = {
+  args?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  cmd: Scalars['String']['input'];
+  dir?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type CommandConnection = {
   __typename?: 'CommandConnection';
   edges?: Maybe<Array<Maybe<CommandEdge>>>;
@@ -1339,6 +1345,47 @@ export type CrossVersionResourceTarget = {
   apiVersion?: Maybe<Scalars['String']['output']>;
   kind?: Maybe<Scalars['String']['output']>;
   name?: Maybe<Scalars['String']['output']>;
+};
+
+export type CustomStackRun = {
+  __typename?: 'CustomStackRun';
+  /** the list of commands that will be executed */
+  commands?: Maybe<Array<Maybe<StackCommand>>>;
+  /** self-service configuration fields presented in the UI to configure how this run executes */
+  configuration?: Maybe<Array<Maybe<PrConfiguration>>>;
+  /** Documentation to explain to users what this will do */
+  documentation?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  insertedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Name of the custom stack run */
+  name: Scalars['String']['output'];
+  stack?: Maybe<InfrastructureStack>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type CustomStackRunAttributes = {
+  /** the commands for this custom run */
+  commands?: InputMaybe<Array<InputMaybe<CommandAttributes>>>;
+  /** self-service configuration which will be presented in UI before triggering */
+  configuration?: InputMaybe<Array<InputMaybe<PrConfigurationAttributes>>>;
+  /** extended documentation to explain what this will do */
+  documentation?: InputMaybe<Scalars['String']['input']>;
+  /** human readable name for this custom run */
+  name: Scalars['String']['input'];
+  /** the stack to attach it to */
+  stackId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type CustomStackRunConnection = {
+  __typename?: 'CustomStackRunConnection';
+  edges?: Maybe<Array<Maybe<CustomStackRunEdge>>>;
+  pageInfo: PageInfo;
+};
+
+export type CustomStackRunEdge = {
+  __typename?: 'CustomStackRunEdge';
+  cursor?: Maybe<Scalars['String']['output']>;
+  node?: Maybe<CustomStackRun>;
 };
 
 export type DaemonSet = {
@@ -1968,6 +2015,7 @@ export type InfrastructureStack = {
   cluster?: Maybe<Cluster>;
   /** version/image config for the tool you're using */
   configuration: StackConfiguration;
+  customStackRuns?: Maybe<CustomStackRunConnection>;
   /** the run that physically destroys the stack */
   deleteRun?: Maybe<StackRun>;
   /** whether this stack was previously deleted and is pending cleanup */
@@ -2005,6 +2053,14 @@ export type InfrastructureStack = {
   /** the subdirectory you want to run the stack's commands w/in */
   workdir?: Maybe<Scalars['String']['output']>;
   writeBindings?: Maybe<Array<Maybe<PolicyBinding>>>;
+};
+
+
+export type InfrastructureStackCustomStackRunsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -3981,6 +4037,7 @@ export type RootMutationType = {
   deleteCertificate?: Maybe<Scalars['Boolean']['output']>;
   deleteCluster?: Maybe<Cluster>;
   deleteClusterProvider?: Maybe<ClusterProvider>;
+  deleteCustomStackRun?: Maybe<CustomStackRun>;
   deleteGitRepository?: Maybe<GitRepository>;
   deleteGlobalService?: Maybe<GlobalService>;
   deleteGroup?: Maybe<Group>;
@@ -4030,6 +4087,8 @@ export type RootMutationType = {
   /** merges configuration for a service */
   mergeService?: Maybe<ServiceDeployment>;
   oauthCallback?: Maybe<User>;
+  /** Creates a custom run, with the given command list, to execute w/in the stack's environment */
+  onDemandRun?: Maybe<StackRun>;
   overlayConfiguration?: Maybe<Build>;
   /** a regular status ping to be sent by the deploy operator */
   pingCluster?: Maybe<Cluster>;
@@ -4081,6 +4140,7 @@ export type RootMutationType = {
   updateStack?: Maybe<InfrastructureStack>;
   updateStackRun?: Maybe<StackRun>;
   updateUser?: Maybe<User>;
+  upsertCustomStackRun?: Maybe<CustomStackRun>;
   upsertNotificationRouter?: Maybe<NotificationRouter>;
   upsertNotificationSink?: Maybe<NotificationSink>;
   upsertObservabilityProvider?: Maybe<ObservabilityProvider>;
@@ -4330,6 +4390,11 @@ export type RootMutationTypeDeleteClusterProviderArgs = {
 };
 
 
+export type RootMutationTypeDeleteCustomStackRunArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type RootMutationTypeDeleteGitRepositoryArgs = {
   id: Scalars['ID']['input'];
 };
@@ -4556,6 +4621,12 @@ export type RootMutationTypeMergeServiceArgs = {
 export type RootMutationTypeOauthCallbackArgs = {
   code: Scalars['String']['input'];
   redirect?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type RootMutationTypeOnDemandRunArgs = {
+  commands?: InputMaybe<Array<InputMaybe<CommandAttributes>>>;
+  stackId: Scalars['ID']['input'];
 };
 
 
@@ -4811,6 +4882,11 @@ export type RootMutationTypeUpdateStackRunArgs = {
 export type RootMutationTypeUpdateUserArgs = {
   attributes: UserAttributes;
   id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type RootMutationTypeUpsertCustomStackRunArgs = {
+  attributes: CustomStackRunAttributes;
 };
 
 
@@ -6623,6 +6699,16 @@ export type StackAttributes = {
   /** the subdirectory you want to run the stack's commands w/in */
   workdir?: InputMaybe<Scalars['String']['input']>;
   writeBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
+};
+
+export type StackCommand = {
+  __typename?: 'StackCommand';
+  /** cli args to pass */
+  args?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  /** the executable to call */
+  cmd: Scalars['String']['output'];
+  /** working directory for this command (not required) */
+  dir?: Maybe<Scalars['String']['output']>;
 };
 
 export type StackConfiguration = {

--- a/assets/src/graph/stacks.graphql
+++ b/assets/src/graph/stacks.graphql
@@ -66,9 +66,6 @@ fragment StackRun on StackRun {
     name
     email
   }
-  job {
-    ...Job
-  }
 }
 
 fragment StackConfiguration on StackConfiguration {
@@ -242,6 +239,22 @@ query StackRun($id: ID!) {
     }
     steps {
       ...RunStep
+    }
+  }
+}
+
+query StackRunJob($id: ID!) {
+  stackRun(id: $id) {
+    job {
+      ...PipelineGateJob
+    }
+  }
+}
+
+query StackRunJobLogs($id: ID!, $container: String!, $sinceSeconds: Int!) {
+  stackRun(id: $id) {
+    job {
+      logs(container: $container, sinceSeconds: $sinceSeconds)
     }
   }
 }

--- a/assets/src/routes/stacksRoutes.tsx
+++ b/assets/src/routes/stacksRoutes.tsx
@@ -1,5 +1,15 @@
 import { Navigate, Route } from 'react-router-dom'
 
+import RunJob from 'components/stacks/run/job/RunJob'
+
+import RunJobLogs from 'components/stacks/run/job/RunJobLogs'
+
+import RunJobStatus from 'components/stacks/run/job/RunJobStatus'
+
+import RunJobPods from 'components/stacks/run/job/RunJobPods'
+
+import RunJobSpecs from 'components/stacks/run/job/RunJobSpecs'
+
 import Stacks from '../components/stacks/Stacks'
 import StackRunDetail from '../components/stacks/run/Route'
 import StackRunProgress from '../components/stacks/run/progress/Progress'
@@ -28,6 +38,7 @@ import {
   STACK_OVERVIEW_REL_PATH,
   STACK_REPOSITORY_REL_PATH,
   STACK_RUNS_ABS_PATH,
+  STACK_RUNS_JOB_REL_PATH,
   STACK_RUNS_OUTPUT_REL_PATH,
   STACK_RUNS_PLAN_REL_PATH,
   STACK_RUNS_REL_PATH,
@@ -102,5 +113,36 @@ export const stacksRoutes = [
       path={STACK_RUNS_OUTPUT_REL_PATH}
       element={<StackRunOutput />}
     />
+    <Route
+      key="run-jobs"
+      path={STACK_RUNS_JOB_REL_PATH}
+      element={<RunJob />}
+    >
+      <Route
+        index
+        element={
+          <Navigate
+            replace
+            to="logs"
+          />
+        }
+      />
+      <Route
+        path="logs"
+        element={<RunJobLogs />}
+      />
+      <Route
+        path="pods"
+        element={<RunJobPods />}
+      />
+      <Route
+        path="status"
+        element={<RunJobStatus />}
+      />
+      <Route
+        path="specs/:tab?"
+        element={<RunJobSpecs />}
+      />
+    </Route>
   </Route>,
 ]

--- a/assets/src/routes/stacksRoutesConsts.tsx
+++ b/assets/src/routes/stacksRoutesConsts.tsx
@@ -24,6 +24,7 @@ export const STACK_JOB_REL_PATH = `job`
 export const STACK_RUNS_STATE_REL_PATH = 'state'
 export const STACK_RUNS_PLAN_REL_PATH = 'plan'
 export const STACK_RUNS_OUTPUT_REL_PATH = 'output'
+export const STACK_RUNS_JOB_REL_PATH = 'job'
 export const STACK_RUNS_REPOSITORY_REL_PATH = 'repository'
 
 export function getStacksAbsPath(stackId: string | null | undefined) {

--- a/lib/console/deployments/policies/rbac.ex
+++ b/lib/console/deployments/policies/rbac.ex
@@ -20,6 +20,7 @@ defmodule Console.Deployments.Policies.Rbac do
     PinnedCustomResource,
     Stack,
     StackRun,
+    CustomStackRun,
     RunStep
   }
 
@@ -74,6 +75,8 @@ defmodule Console.Deployments.Policies.Rbac do
     do: recurse(stack, user, action, & &1.cluster)
   def evaluate(%StackRun{} = run, %User{} = user, action),
     do: recurse(run, user, action, & &1.stack)
+  def evaluate(%CustomStackRun{} = run, %User{} = user, action),
+    do: recurse(run, user, action, & &1.stack)
   def evaluate(%RunStep{} = step, %User{} = user, action),
     do: recurse(step, user, action, & &1.run)
   def evaluate(%PinnedCustomResource{} = pcr, %User{} = user, action) do
@@ -111,6 +114,8 @@ defmodule Console.Deployments.Policies.Rbac do
   def preload(%Stack{} = stack),
     do: Repo.preload(stack, @stack_preloads)
   def preload(%StackRun{} = pcr),
+    do: Repo.preload(pcr, [stack: @stack_preloads])
+  def preload(%CustomStackRun{} = pcr),
     do: Repo.preload(pcr, [stack: @stack_preloads])
   def preload(%RunStep{} = pcr),
     do: Repo.preload(pcr, run: [stack: @stack_preloads])

--- a/lib/console/graphql/resolvers/deployments/stack.ex
+++ b/lib/console/graphql/resolvers/deployments/stack.ex
@@ -4,7 +4,8 @@ defmodule Console.GraphQl.Resolvers.Deployments.Stack do
   alias Console.Schema.{
     Stack,
     StackRun,
-    PullRequest
+    PullRequest,
+    CustomStackRun
   }
 
   def list_stacks(args, %{context: %{current_user: user}}) do
@@ -27,6 +28,11 @@ defmodule Console.GraphQl.Resolvers.Deployments.Stack do
   def list_prs_for_stack(stack, args, _) do
     PullRequest.for_stack(stack.id)
     |> PullRequest.ordered()
+    |> paginate(args)
+  end
+
+  def list_custom_runs(stack, args, _) do
+    CustomStackRun.for_stack(stack.id)
     |> paginate(args)
   end
 
@@ -84,6 +90,15 @@ defmodule Console.GraphQl.Resolvers.Deployments.Stack do
 
   def add_run_logs(%{step_id: id, attributes: attrs}, %{context: %{cluster: cluster}}),
     do: Stacks.add_run_logs(attrs, id, cluster)
+
+  def upsert_custom_stack_run(%{attributes: attrs}, %{context: %{current_user: user}}),
+    do: Stacks.upsert_custom_stack_run(attrs, user)
+
+  def delete_custom_stack_run(%{id: id}, %{context: %{current_user: user}}),
+    do: Stacks.delete_custom_stack_run(id, user)
+
+  def create_stack_run(%{stack_id: id, commands: commands}, %{context: %{current_user: user}}),
+    do: Stacks.create_custom_run(id, commands, user)
 
   def stack_tarball(%{id: id}, _, _), do: {:ok, Services.api_url("v1/git/stacks/tarballs?id=#{id}")}
 

--- a/lib/console/schema/custom_stack_run.ex
+++ b/lib/console/schema/custom_stack_run.ex
@@ -1,0 +1,40 @@
+defmodule Console.Schema.CustomStackRun do
+  use Piazza.Ecto.Schema
+  alias Console.Schema.{Stack, Configuration}
+
+  schema "custom_stack_runs" do
+    field :name,          :string
+    field :documentation, :string
+
+    embeds_many :commands, Command, on_replace: :delete do
+      field :cmd,  :string
+      field :args, {:array, :string}
+      field :dir,  :string
+    end
+
+    embeds_many :configuration, Configuration, on_replace: :delete
+
+    belongs_to :stack, Stack
+
+    timestamps()
+  end
+
+  def for_stack(query \\ __MODULE__, id) do
+    from(cr in query, where: cr.stack_id == ^id or is_nil(cr.stack_id))
+  end
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, ~w(name documentation stack_id)a)
+    |> cast_embed(:configuration)
+    |> cast_embed(:commands, with: &command_changeset/2)
+    |> foreign_key_constraint(:stack_id)
+    |> validate_required([:name])
+  end
+
+  def command_changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, ~w(cmd args dir)a)
+    |> validate_required([:cmd])
+  end
+end

--- a/lib/console/schema/stack_run.ex
+++ b/lib/console/schema/stack_run.ex
@@ -135,6 +135,7 @@ defmodule Console.Schema.StackRun do
     |> cast(attrs, ~w(status)a)
     |> cast_assoc(:state)
     |> cast_assoc(:errors)
+    |> cast_embed(:job_ref, with: &job_ref_changeset/2)
     |> validate_required(~w(status)a)
   end
 

--- a/priv/repo/migrations/20240528200501_add_custom_stack_runs.exs
+++ b/priv/repo/migrations/20240528200501_add_custom_stack_runs.exs
@@ -1,0 +1,20 @@
+defmodule Console.Repo.Migrations.AddCustomStackRuns do
+  use Ecto.Migration
+
+  def change do
+    create table(:custom_stack_runs, primary_key: false) do
+      add :id,            :uuid, primary_key: true
+      add :name,          :string
+      add :documentation, :string
+      add :commands,      :map
+      add :configuration, :map
+
+      add :stack_id, references(:stacks, type: :uuid, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:custom_stack_runs, [:stack_id])
+    create unique_index(:custom_stack_runs, [:stack_id, :name])
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -722,6 +722,13 @@ type RootMutationType {
 
   restartStackRun(id: ID!): StackRun
 
+  upsertCustomStackRun(attributes: CustomStackRunAttributes!): CustomStackRun
+
+  deleteCustomStackRun(id: ID!): CustomStackRun
+
+  "Creates a custom run, with the given command list, to execute w\/in the stack's environment"
+  onDemandRun(stackId: ID!, commands: [CommandAttributes]): StackRun
+
   upsertObservabilityProvider(attributes: ObservabilityProviderAttributes!): ObservabilityProvider
 
   deleteObservabilityProvider(id: ID!): ObservabilityProvider
@@ -1096,6 +1103,29 @@ input StackStateResourceAttributes {
   links: [String]
 }
 
+input CustomStackRunAttributes {
+  "human readable name for this custom run"
+  name: String!
+
+  "extended documentation to explain what this will do"
+  documentation: String
+
+  "the stack to attach it to"
+  stackId: ID
+
+  "the commands for this custom run"
+  commands: [CommandAttributes]
+
+  "self-service configuration which will be presented in UI before triggering"
+  configuration: [PrConfigurationAttributes]
+}
+
+input CommandAttributes {
+  cmd: String!
+  args: [String]
+  dir: String
+}
+
 type InfrastructureStack {
   id: ID
 
@@ -1162,6 +1192,8 @@ type InfrastructureStack {
 
   "the actor of this stack (defaults to root console user)"
   actor: User
+
+  customStackRuns(after: String, first: Int, before: String, last: Int): CustomStackRunConnection
 
   readBindings: [PolicyBinding]
 
@@ -1365,6 +1397,39 @@ type StackStateResource {
   links: [String]
 }
 
+type CustomStackRun {
+  id: ID!
+
+  "Name of the custom stack run"
+  name: String!
+
+  "Documentation to explain to users what this will do"
+  documentation: String
+
+  "the list of commands that will be executed"
+  commands: [StackCommand]
+
+  "self-service configuration fields presented in the UI to configure how this run executes"
+  configuration: [PrConfiguration]
+
+  stack: InfrastructureStack
+
+  insertedAt: DateTime
+
+  updatedAt: DateTime
+}
+
+type StackCommand {
+  "the executable to call"
+  cmd: String!
+
+  "cli args to pass"
+  args: [String]
+
+  "working directory for this command (not required)"
+  dir: String
+}
+
 type InfrastructureStackConnection {
   pageInfo: PageInfo!
   edges: [InfrastructureStackEdge]
@@ -1373,6 +1438,11 @@ type InfrastructureStackConnection {
 type StackRunConnection {
   pageInfo: PageInfo!
   edges: [StackRunEdge]
+}
+
+type CustomStackRunConnection {
+  pageInfo: PageInfo!
+  edges: [CustomStackRunEdge]
 }
 
 type RunLogsDelta {
@@ -6173,6 +6243,11 @@ type ManagedNamespaceEdge {
 
 type GlobalServiceEdge {
   node: GlobalService
+  cursor: String
+}
+
+type CustomStackRunEdge {
+  node: CustomStackRun
   cursor: String
 }
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -596,6 +596,14 @@ defmodule Console.Factory do
     }
   end
 
+  def custom_stack_run_factory do
+    %Schema.CustomStackRun{
+      stack: build(:stack),
+      name: sequence(:csr, &"csr-#{&1}"),
+      commands: [%{cmd: "echo", args: ["hello world"]}]
+    }
+  end
+
   def setup_rbac(user, repos \\ ["*"], perms) do
     role = insert(:role, repositories: repos, permissions: Map.new(perms))
     insert(:role_binding, role: role, user: user)


### PR DESCRIPTION
This can be really useful in case you need to do one-off tasks like repair terraform state or run a bash script.  The run still will occur in the exec environment of the stack, ensuring consistency w/ the terraform run itself.

Also adds a CustomStackRun schema which adds a self-service layer on top of this.

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
