### PR TITLE
Fallback to global settings for stack job spec

### DIFF
--- a/lib/console/cache.ex
+++ b/lib/console/cache.ex
@@ -3,6 +3,16 @@ defmodule Console.Cache do
     otp_app: :console,
     adapter: Nebulex.Adapters.Partitioned,
     primary_storage_adapter: Nebulex.Adapters.Local
+
+  def process_cache(key, fun) do
+    case Process.get(key, :miss) do
+      :miss ->
+        val = fun.()
+        Process.put(key, val)
+        val
+      val -> val
+    end
+  end
 end
 
 defmodule Console.ReplicatedCache do

--- a/lib/console/deployments/settings.ex
+++ b/lib/console/deployments/settings.ex
@@ -18,6 +18,12 @@ defmodule Console.Deployments.Settings do
   @preloads ~w(read_bindings write_bindings git_bindings create_bindings deployer_repository artifact_repository)a
 
   @doc """
+  same as `fetch/0` but caches in the process dict
+  """
+  @spec cached() :: DeploymentSettings.t | nil
+  def cached(), do: Console.Cache.process_cache(:settings, &fetch/0)
+
+  @doc """
   Fetches and caches the global deployment settings object, preloads also fetched along the way
   """
   @spec fetch() :: DeploymentSettings.t | nil

--- a/lib/console/graphql/deployments/stack.ex
+++ b/lib/console/graphql/deployments/stack.ex
@@ -187,7 +187,9 @@ defmodule Console.GraphQl.Deployments.Stack do
     field :status,         non_null(:stack_status), description: "The status of this run"
     field :type,           non_null(:stack_type), description: "A type for the stack, specifies the tool to use to apply it"
     field :git,            non_null(:git_ref), description: "reference w/in the repository where the IaC lives"
-    field :job_spec,       :job_gate_spec, description: "optional k8s job configuration for the job that will apply this stack"
+    field :job_spec,       :job_gate_spec,
+      description: "optional k8s job configuration for the job that will apply this stack",
+      resolve: &Deployments.job_spec/3
     field :configuration,  non_null(:stack_configuration), description: "version/image config for the tool you're using"
     field :approval,       :boolean, description: "whether to require approval"
     field :message,        :string, description: "the commit message"

--- a/test/console/graphql/queries/deployments/stack_queries_test.exs
+++ b/test/console/graphql/queries/deployments/stack_queries_test.exs
@@ -82,7 +82,12 @@ defmodule Console.GraphQl.Deployments.StackQueriesTest do
       {:ok, %{data: %{"clusterStackRuns" => found}}} = run_query("""
         query {
           clusterStackRuns(first: 5) {
-            edges { node { id } }
+            edges {
+              node {
+                id
+                jobSpec { namespace serviceAccount }
+              }
+            }
           }
         }
       """, %{}, %{cluster: cluster})


### PR DESCRIPTION
If we can't find a valid job spec, we should try to return the global settings job spec.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
