### PR TITLE
fix: handle delete resource error better

### DIFF
--- a/assets/src/components/kubernetes/Cluster.tsx
+++ b/assets/src/components/kubernetes/Cluster.tsx
@@ -4,6 +4,8 @@ import { isEmpty } from 'lodash'
 
 import { useTheme } from 'styled-components'
 
+import { EmptyState } from '@pluralsh/design-system'
+
 import {
   KubernetesClusterFragment,
   Maybe,
@@ -86,7 +88,7 @@ export default function Cluster() {
   const { search } = useLocation()
   const navigate = useNavigate()
 
-  const { data, error, refetch } = useKubernetesClustersQuery({
+  const { data, error, refetch, loading } = useKubernetesClustersQuery({
     pollInterval: 120_000,
     fetchPolicy: 'cache-and-network',
   })
@@ -139,7 +141,9 @@ export default function Cluster() {
       </div>
     )
 
-  if (!cluster) return <LoadingIndicator />
+  if (loading) return <LoadingIndicator />
+
+  if (!cluster) return <EmptyState message="No clusters found." />
 
   return (
     <ClusterContext.Provider value={context}>


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Properly display delete error response in the delete resource dialog
- Improve k8s dashboard zerostate handling when there are no clusters

![image](https://github.com/pluralsh/console/assets/2285385/89943a74-622c-4cde-9c70-3b25beb67b00)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
