### PR TITLE
fix group mutation false errors

### DIFF
--- a/assets/src/components/account/groups/GroupCreate.tsx
+++ b/assets/src/components/account/groups/GroupCreate.tsx
@@ -11,6 +11,8 @@ import { useTheme } from 'styled-components'
 import { appendConnection, updateCache } from '../../../utils/graphql'
 import { GqlError } from '../../utils/Alert'
 
+import { GROUPS_QUERY_PAGE_SIZE } from './Groups'
+
 export default function GroupCreate({ q }: { q: string }) {
   const theme = useTheme()
   const { availableFeatures } = useContext(SubscriptionContext)
@@ -32,7 +34,7 @@ export default function GroupCreate({ q }: { q: string }) {
     update: (cache, { data }) =>
       updateCache(cache, {
         query: GroupsDocument,
-        variables: { q },
+        variables: { q, first: GROUPS_QUERY_PAGE_SIZE },
         update: (prev) => appendConnection(prev, data?.createGroup, 'groups'),
       }),
   })

--- a/assets/src/components/account/groups/Groups.tsx
+++ b/assets/src/components/account/groups/Groups.tsx
@@ -12,6 +12,8 @@ import { GroupsList } from './GroupsList'
 import GroupCreate from './GroupCreate'
 import GroupSearchHeader from './GroupsSearchHeader'
 
+export const GROUPS_QUERY_PAGE_SIZE = 100
+
 export function Groups() {
   const theme = useTheme()
   const [q, setQ] = useState('')

--- a/assets/src/components/account/groups/GroupsColumns.tsx
+++ b/assets/src/components/account/groups/GroupsColumns.tsx
@@ -20,6 +20,7 @@ import { removeConnection, updateCache } from 'utils/graphql'
 
 import { EditGroupAttributes, EditGroupMembers } from './GroupEdit'
 import GroupView from './GroupView'
+import { GROUPS_QUERY_PAGE_SIZE } from './Groups'
 
 const columnHelper = createColumnHelper<Group>()
 const ColGroupInfo = columnHelper.accessor((group) => group, {
@@ -54,7 +55,10 @@ const ColEditableActions = columnHelper.accessor((group) => group, {
       update: (cache, { data }) =>
         updateCache(cache, {
           query: GroupsDocument,
-          variables: { q: table.options.meta?.q },
+          variables: {
+            q: table.options.meta?.q,
+            first: GROUPS_QUERY_PAGE_SIZE,
+          },
           update: (prev) => removeConnection(prev, data?.deleteGroup, 'groups'),
         }),
     })

--- a/assets/src/components/account/groups/GroupsList.tsx
+++ b/assets/src/components/account/groups/GroupsList.tsx
@@ -16,6 +16,7 @@ import { Permissions, hasRbac } from '../misc'
 
 import GroupCreate from './GroupCreate'
 import { groupsColsEditable, groupsColsView } from './GroupsColumns'
+import { GROUPS_QUERY_PAGE_SIZE } from './Groups'
 
 export function GroupsList({ q }: any) {
   const { me } = useContext(LoginContext)
@@ -23,7 +24,11 @@ export function GroupsList({ q }: any) {
 
   const { data, loading, error, pageInfo, fetchNextPage, setVirtualSlice } =
     useFetchPaginatedData(
-      { queryHook: useGroupsQuery, queryKey: 'groups' },
+      {
+        queryHook: useGroupsQuery,
+        queryKey: 'groups',
+        pageSize: GROUPS_QUERY_PAGE_SIZE,
+      },
       { q }
     )
 

--- a/assets/src/components/cd/utils/useFetchPaginatedData.tsx
+++ b/assets/src/components/cd/utils/useFetchPaginatedData.tsx
@@ -10,7 +10,7 @@ import {
   QueryResult,
 } from '@apollo/client'
 
-const DEFAULT_PAGE_SIZE = 100
+export const DEFAULT_PAGE_SIZE = 100
 
 type GenericQueryHook<TQueryType, TVariables extends OperationVariables> = (
   baseOptions: QueryHookOptions<TQueryType, TVariables>
@@ -44,7 +44,7 @@ export function useFetchPaginatedData<
   const queryResult = options.queryHook({
     variables: {
       ...variables,
-      first: options.pageSize,
+      first: options.pageSize ?? DEFAULT_PAGE_SIZE,
     },
     errorPolicy: options.errorPolicy,
     fetchPolicy: 'cache-and-network',


### PR DESCRIPTION
apollo was throwing errors when trying to update the cache after creating or deleting new groups. recent update added a page size variable to the groups query so needed to fix the cache lookup to reflect that