### PR TITLE
Fix thrashing of templated global services

### DIFF
--- a/lib/console/schema/group.ex
+++ b/lib/console/schema/group.ex
@@ -13,7 +13,7 @@ defmodule Console.Schema.Group do
   end
 
   def search(query \\ __MODULE__, name) do
-    from(g in query, where: like(g.name, ^"#{name}%"))
+    from(g in query, where: ilike(g.name, ^"%#{name}%"))
   end
 
   def global(query \\ __MODULE__) do


### PR DESCRIPTION
Noticed this happened with a recent change to the global services business logic.  This fix should resolve plus added tests to catch the regression in the future

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
