### PR TITLE
fix service component pod links

### DIFF
--- a/assets/src/components/cd/pipelines/job/PipelineJobPods.tsx
+++ b/assets/src/components/cd/pipelines/job/PipelineJobPods.tsx
@@ -65,6 +65,7 @@ export default function PipelineJobLogs() {
         <PodsList
           pods={podsWithId}
           clusterId={clusterId}
+          linkToK8sDashboard
           columns={columns}
           refetch={refetch}
           //   reactTableOptions={reactTableOptions}

--- a/assets/src/components/cluster/pods/PodsList.tsx
+++ b/assets/src/components/cluster/pods/PodsList.tsx
@@ -311,6 +311,7 @@ type PodListProps = Omit<ComponentProps<typeof Table>, 'data'> & {
   refetch: Nullable<() => void>
   applications?: Maybe<Maybe<Application>[]>
   columns: any[]
+  linkToK8sDashboard?: boolean
   linkBasePath?: string
   clusterId?: string | null
   serviceId?: string | null
@@ -349,6 +350,7 @@ export const PodsList = memo(
     columns,
     clusterId,
     serviceId,
+    linkToK8sDashboard = false,
     linkBasePath = `/pods`,
     refetch,
     reactTableOptions: reactTableOptionsProp,
@@ -425,7 +427,7 @@ export const PodsList = memo(
           {...props}
           onRowClick={(_e, { original }: Row<PodTableRow>) =>
             navigate(
-              clusterId
+              clusterId && linkToK8sDashboard
                 ? `${getKubernetesAbsPath(clusterId)}/pods/${
                     original.namespace
                   }/${original.name}`

--- a/assets/src/components/component/info/Pods.tsx
+++ b/assets/src/components/component/info/Pods.tsx
@@ -11,7 +11,12 @@ import {
 import { useOutletContext, useParams } from 'react-router-dom'
 import { useTheme } from 'styled-components'
 
-import { SERVICE_PARAM_CLUSTER_ID } from '../../../routes/cdRoutesConsts'
+import {
+  SERVICE_PARAM_CLUSTER_ID,
+  getServicePodDetailsPath,
+} from '../../../routes/cdRoutesConsts'
+
+import { ComponentDetailsContext } from '../ComponentDetails'
 
 import { InfoSectionH2 } from './common'
 
@@ -32,8 +37,13 @@ const columns = [
 
 export default function Pods({ pods }) {
   const clusterId = useParams()[SERVICE_PARAM_CLUSTER_ID]
-  const { refetch, ...rest } = useOutletContext<any>()
+  const { refetch, component, ...rest } =
+    useOutletContext<ComponentDetailsContext>()
   const theme = useTheme()
+
+  const linkToK8sDashboard =
+    component.kind.toLowerCase() === 'job' ||
+    component.kind.toLowerCase() === 'cronjob'
 
   return (
     <div
@@ -49,9 +59,18 @@ export default function Pods({ pods }) {
       <PodsList
         pods={pods}
         columns={columns}
+        linkToK8sDashboard={linkToK8sDashboard}
         clusterId={clusterId}
         serviceId={rest?.serviceId}
         refetch={refetch}
+        {...(clusterId && rest?.serviceId
+          ? {
+              linkBasePath: getServicePodDetailsPath({
+                serviceId: rest?.serviceId,
+                clusterId,
+              }),
+            }
+          : {})}
       />
     </div>
   )

--- a/assets/src/components/stacks/run/job/RunJobPods.tsx
+++ b/assets/src/components/stacks/run/job/RunJobPods.tsx
@@ -64,6 +64,7 @@ export default function RunJobPods() {
         <PodsList
           pods={podsWithId}
           clusterId={clusterId}
+          linkToK8sDashboard
           columns={columns}
           refetch={refetch}
           // reactTableOptions={reactTableOptions}


### PR DESCRIPTION
all component pod lists were linking to the K8s dashboard, now only job and cron job lists will

(logic stays the same for pipeline and stack job tables, flag was just added to reflect the change to PodsList component)