### PR TITLE
Fix cron next run at inference

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1170,6 +1170,7 @@ export enum ConfigurationType {
   Bool = 'BOOL',
   Bucket = 'BUCKET',
   Domain = 'DOMAIN',
+  Enum = 'ENUM',
   File = 'FILE',
   Function = 'FUNCTION',
   Int = 'INT',
@@ -3583,6 +3584,7 @@ export type PrConfigurationAttributes = {
   optional?: InputMaybe<Scalars['Boolean']['input']>;
   placeholder?: InputMaybe<Scalars['String']['input']>;
   type: ConfigurationType;
+  values?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 /** declaritive spec for whether a config item is relevant given prior config */

--- a/lib/console/cron/job.ex
+++ b/lib/console/cron/job.ex
@@ -11,11 +11,11 @@ defmodule Console.Cron.Job do
 
   def due?(%__MODULE__{next_run_at: at}), do: Timex.before?(at, Timex.now())
 
-  def exec(%__MODULE__{crontab: tab, next_run_at: at, job: {m, f, a}} = job) do
+  def exec(%__MODULE__{crontab: tab, job: {m, f, a}} = job) do
     Task.async(fn ->
       apply(m, f, a)
     end)
-    %{job | next_run_at: Scheduler.get_next_run_date!(tab, at)}
+    %{job | next_run_at: Scheduler.get_next_run_date!(tab)}
   end
 
   defp convert("@daily"), do: "0 0 * * *"

--- a/lib/console/deployments/settings.ex
+++ b/lib/console/deployments/settings.ex
@@ -105,7 +105,7 @@ defmodule Console.Deployments.Settings do
 
   def default_project!(), do: Repo.get_by(Project, default: true)
 
-  def add_project_id(%{project_id: id} = attrs) when is_binary(id), do: attrs
+  def add_project_id(%{project_id: id} = attrs) when is_binary(id) and byte_size(id) > 0, do: attrs
   def add_project_id(attrs) do
     proj = default_project!()
     Map.put(attrs, :project_id, proj.id)

--- a/lib/console/graphql/deployments/git.ex
+++ b/lib/console/graphql/deployments/git.ex
@@ -70,6 +70,7 @@ defmodule Console.GraphQl.Deployments.Git do
     field :placeholder,   :string
     field :optional,      :boolean
     field :condition,     :condition_attributes
+    field :values,        list_of(:string)
   end
 
   @desc "attributes for declaratively specifying whether a config item is relevant given prior config"

--- a/lib/console/schema/embeds.ex
+++ b/lib/console/schema/embeds.ex
@@ -44,7 +44,8 @@ defmodule Console.Schema.Configuration do
     bucket: 4,
     file: 5,
     function: 6,
-    password: 7
+    password: 7,
+    enum: 8
 
   defmodule Condition do
     use Piazza.Ecto.Schema
@@ -74,13 +75,14 @@ defmodule Console.Schema.Configuration do
     field :longform,      :string
     field :placeholder,   :string
     field :optional,      :boolean
+    field :values,        {:array, :string}
 
     embeds_one :condition, Condition
   end
 
   def changeset(model, attrs \\ %{}) do
     model
-    |> cast(attrs, ~w(type name default documentation longform placeholder optional)a)
+    |> cast(attrs, ~w(type name default values documentation longform placeholder optional)a)
     |> cast_embed(:condition)
     |> validate_required([:type, :name])
   end

--- a/lib/console/schema/stack.ex
+++ b/lib/console/schema/stack.ex
@@ -163,7 +163,7 @@ defmodule Console.Schema.Stack do
     |> unique_constraint(:name)
     |> put_new_change(:write_policy_id, &Ecto.UUID.generate/0)
     |> put_new_change(:read_policy_id, &Ecto.UUID.generate/0)
-    |> validate_required(~w(name type status)a)
+    |> validate_required(~w(name type status project_id)a)
   end
 
   def update_changeset(changeset) do

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -3941,6 +3941,7 @@ enum ConfigurationType {
   FILE
   FUNCTION
   PASSWORD
+  ENUM
 }
 
 enum Operation {
@@ -4056,6 +4057,7 @@ input PrConfigurationAttributes {
   placeholder: String
   optional: Boolean
   condition: ConditionAttributes
+  values: [String]
 }
 
 "attributes for declaratively specifying whether a config item is relevant given prior config"

--- a/test/console/deployments/stacks_test.exs
+++ b/test/console/deployments/stacks_test.exs
@@ -17,6 +17,7 @@ defmodule Console.Deployments.StacksTest do
         approval: true,
         repository_id: repo.id,
         cluster_id: cluster.id,
+        project_id: nil,
         git: %{ref: "main", folder: "terraform"},
       }, admin_user())
 


### PR DESCRIPTION
Using the previous next run at to benchmark the next one has a possibility to off-by-one it seems, try to just always use current time.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
