### PR TITLE
added logic for nested data to slice polling

### DIFF
--- a/assets/src/components/account/groups/GroupsList.tsx
+++ b/assets/src/components/account/groups/GroupsList.tsx
@@ -26,7 +26,7 @@ export function GroupsList({ q }: any) {
     useFetchPaginatedData(
       {
         queryHook: useGroupsQuery,
-        queryKey: 'groups',
+        keyPath: ['groups'],
         pageSize: GROUPS_QUERY_PAGE_SIZE,
       },
       { q }

--- a/assets/src/components/account/users/UsersList.tsx
+++ b/assets/src/components/account/users/UsersList.tsx
@@ -22,7 +22,7 @@ export default function UsersList() {
 
   const { data, loading, error, pageInfo, fetchNextPage, setVirtualSlice } =
     useFetchPaginatedData(
-      { queryHook: useUsersQuery, queryKey: 'users' },
+      { queryHook: useUsersQuery, keyPath: ['users'] },
       { q }
     )
 

--- a/assets/src/components/backups/cluster/backups/Backups.tsx
+++ b/assets/src/components/backups/cluster/backups/Backups.tsx
@@ -68,7 +68,7 @@ export default function Backups() {
     {
       queryHook: useClusterBackupsQuery,
       pageSize: QUERY_PAGE_SIZE,
-      queryKey: 'clusterBackups',
+      keyPath: ['clusterBackups'],
     },
     {
       clusterId,

--- a/assets/src/components/backups/cluster/restores/Restores.tsx
+++ b/assets/src/components/backups/cluster/restores/Restores.tsx
@@ -155,7 +155,7 @@ export default function Restores() {
     {
       queryHook: useClusterRestoresQuery,
       pageSize: QUERY_PAGE_SIZE,
-      queryKey: 'clusterRestores',
+      keyPath: ['clusterRestores'],
     },
     {
       clusterId,

--- a/assets/src/components/backups/clusters/Clusters.tsx
+++ b/assets/src/components/backups/clusters/Clusters.tsx
@@ -59,7 +59,7 @@ export default function Clusters() {
     {
       queryHook: useClustersObjectStoresQuery,
       pageSize: QUERY_PAGE_SIZE,
-      queryKey: 'clusters',
+      keyPath: ['clusters'],
     },
     {
       backups: true,

--- a/assets/src/components/backups/objectstores/ObjectStores.tsx
+++ b/assets/src/components/backups/objectstores/ObjectStores.tsx
@@ -58,7 +58,7 @@ export default function ObjectStores() {
   } = useFetchPaginatedData({
     queryHook: useObjectStoresQuery,
     pageSize: QUERY_PAGE_SIZE,
-    queryKey: 'objectStores',
+    keyPath: ['objectStores'],
   })
 
   const objectStores = data?.objectStores

--- a/assets/src/components/cd/clusters/Clusters.tsx
+++ b/assets/src/components/cd/clusters/Clusters.tsx
@@ -131,7 +131,7 @@ export default function Clusters() {
     {
       queryHook: useClustersQuery,
       pageSize: CLUSTERS_QUERY_PAGE_SIZE,
-      queryKey: 'clusters',
+      keyPath: ['clusters'],
     },
     {
       q: debouncedSearchString,

--- a/assets/src/components/cd/globalServices/GlobalServiceDetailTable.tsx
+++ b/assets/src/components/cd/globalServices/GlobalServiceDetailTable.tsx
@@ -13,24 +13,22 @@ import { GqlError } from 'components/utils/Alert'
 
 import { ApolloError } from '@apollo/client'
 
+import { ComponentProps } from 'react'
+
 import { SERVICES_REACT_VIRTUAL_OPTIONS, columns } from '../services/Services'
 
 export function GlobalServiceDetailTable({
   error,
   data,
-  fetchNextPage,
-  loading,
+  ...props
 }: {
   error?: ApolloError
   data?: GetServiceDataQuery
-  fetchNextPage: () => void
-  loading: boolean
-}) {
+} & Omit<ComponentProps<typeof Table>, 'data' | 'columns'>) {
   const navigate = useNavigate()
 
   const globalService = data?.globalService
   const services = globalService?.services?.edges
-  const pageInfo = globalService?.services?.pageInfo
 
   if (error) {
     return <GqlError error={error} />
@@ -60,14 +58,12 @@ export function GlobalServiceDetailTable({
             })
           )
         }
-        hasNextPage={pageInfo?.hasNextPage}
-        fetchNextPage={fetchNextPage}
-        isFetchingNextPage={loading}
         reactTableOptions={{ meta: { refetch: () => undefined } }}
         reactVirtualOptions={SERVICES_REACT_VIRTUAL_OPTIONS}
         emptyStateProps={{
           message: 'Looks like this service does not exist.',
         }}
+        {...props}
       />
     </FullHeightTableWrap>
   )

--- a/assets/src/components/cd/globalServices/GlobalServicesTable.tsx
+++ b/assets/src/components/cd/globalServices/GlobalServicesTable.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useEffect, useMemo } from 'react'
+import { ComponentProps, memo, useEffect, useMemo } from 'react'
 import { Table } from '@pluralsh/design-system'
 import { useNavigate } from 'react-router'
 import { useTheme } from 'styled-components'
@@ -23,7 +23,7 @@ import {
   columns,
 } from './GlobalService'
 
-export function GlobalServicesTable({
+function GlobalServicesTableComponent({
   setRefetch,
 }: {
   setRefetch?: (refetch: () => () => void) => void
@@ -44,7 +44,7 @@ export function GlobalServicesTable({
     {
       queryHook: useGlobalServicesQuery,
       pageSize: GLOBAL_SERVICES_QUERY_PAGE_SIZE,
-      queryKey: 'globalServices',
+      keyPath: ['globalServices'],
     },
     { projectId }
   )
@@ -116,3 +116,5 @@ export function GlobalServicesTable({
     </div>
   )
 }
+
+export const GlobalServicesTable = memo(GlobalServicesTableComponent)

--- a/assets/src/components/cd/namespaces/NamespacesDetailTable.tsx
+++ b/assets/src/components/cd/namespaces/NamespacesDetailTable.tsx
@@ -13,22 +13,20 @@ import { GqlError } from 'components/utils/Alert'
 
 import { ApolloError } from '@apollo/client'
 
+import { ComponentProps } from 'react'
+
 import { SERVICES_REACT_VIRTUAL_OPTIONS, columns } from '../services/Services'
 
 export function NamespacesDetailTable({
   error,
   data,
-  fetchNextPage,
-  loading,
+  ...props
 }: {
   error?: ApolloError
   data?: GetManagedNamespaceQuery
-  fetchNextPage: () => void
-  loading: boolean
-}) {
+} & Omit<ComponentProps<typeof Table>, 'data' | 'columns'>) {
   const navigate = useNavigate()
   const services = data?.managedNamespace?.services?.edges
-  const pageInfo = data?.managedNamespace?.services?.pageInfo
 
   if (error) {
     return <GqlError error={error} />
@@ -58,11 +56,9 @@ export function NamespacesDetailTable({
             })
           )
         }
-        hasNextPage={pageInfo?.hasNextPage}
-        fetchNextPage={fetchNextPage}
-        isFetchingNextPage={loading}
         reactTableOptions={{ meta: { refetch: () => undefined } }}
         reactVirtualOptions={SERVICES_REACT_VIRTUAL_OPTIONS}
+        {...props}
       />
     </FullHeightTableWrap>
   )

--- a/assets/src/components/cd/namespaces/NamespacesTable.tsx
+++ b/assets/src/components/cd/namespaces/NamespacesTable.tsx
@@ -38,7 +38,7 @@ export function NamespacesTable() {
     {
       queryHook: useManagedNamespacesQuery,
       pageSize: NAMESPACES_QUERY_PAGE_SIZE,
-      queryKey: 'managedNamespaces',
+      keyPath: ['managedNamespaces'],
     },
     { projectId }
   )

--- a/assets/src/components/cd/pipelines/Pipelines.tsx
+++ b/assets/src/components/cd/pipelines/Pipelines.tsx
@@ -48,7 +48,7 @@ export default function PipelineList() {
       {
         queryHook: usePipelinesQuery,
         pageSize: QUERY_PAGE_SIZE,
-        queryKey: 'pipelines',
+        keyPath: ['pipelines'],
       },
       {
         q: debouncedSearchString,

--- a/assets/src/components/cd/services/ServicesTable.tsx
+++ b/assets/src/components/cd/services/ServicesTable.tsx
@@ -1,4 +1,11 @@
-import { ComponentProps, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ComponentProps,
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { EmptyState, TabPanel, Table } from '@pluralsh/design-system'
 import { useNavigate } from 'react-router'
 import { useTheme } from 'styled-components'
@@ -26,7 +33,7 @@ import {
   columns,
 } from './Services'
 
-export function ServicesTable({
+function ServicesTableComponent({
   setRefetch,
   clusterId: clusterIdProp,
 }: {
@@ -55,7 +62,7 @@ export function ServicesTable({
     {
       queryHook: useServiceDeploymentsQuery,
       pageSize: SERVICES_QUERY_PAGE_SIZE,
-      queryKey: 'serviceDeployments',
+      keyPath: ['serviceDeployments'],
     },
     {
       q: queryString,
@@ -172,3 +179,5 @@ export function ServicesTable({
     </div>
   )
 }
+
+export const ServicesTable = memo(ServicesTableComponent)

--- a/assets/src/components/home/clusteroverview/ClusterOverviewCard.tsx
+++ b/assets/src/components/home/clusteroverview/ClusterOverviewCard.tsx
@@ -33,7 +33,7 @@ export function ClusterOverviewCard() {
     {
       queryHook: useClustersQuery,
       pageSize: CLUSTERS_QUERY_PAGE_SIZE,
-      queryKey: 'clusters',
+      keyPath: ['clusters'],
     },
     {
       projectId,

--- a/assets/src/components/home/deployments/DeploymentsCard.tsx
+++ b/assets/src/components/home/deployments/DeploymentsCard.tsx
@@ -32,7 +32,7 @@ export function DeploymentsCard() {
     {
       queryHook: useServiceDeploymentsQuery,
       pageSize: SERVICES_QUERY_PAGE_SIZE,
-      queryKey: 'serviceDeployments',
+      keyPath: ['serviceDeployments'],
     },
     {
       status: ServiceDeploymentStatus.Failed,

--- a/assets/src/components/home/managerview/violations/ConstraintViolationsCard.tsx
+++ b/assets/src/components/home/managerview/violations/ConstraintViolationsCard.tsx
@@ -33,7 +33,7 @@ export function ConstraintViolationsCard() {
   } = useFetchPaginatedData({
     queryHook: usePolicyConstraintsQuery,
     pageSize: POLICIES_QUERY_PAGE_SIZE,
-    queryKey: 'policyConstraints',
+    keyPath: ['policyConstraints'],
   })
 
   const { data: chartData, error: chartError } = usePolicyStatisticsQuery({

--- a/assets/src/components/home/pullrequests/PrCard.tsx
+++ b/assets/src/components/home/pullrequests/PrCard.tsx
@@ -21,7 +21,7 @@ export function PrCard() {
     {
       queryHook: usePullRequestsQuery,
       pageSize: PR_QUERY_PAGE_SIZE,
-      queryKey: 'pullRequests',
+      keyPath: ['pullRequests'],
     },
     {
       open: true,

--- a/assets/src/components/notifications/routers/NotificationRouters.tsx
+++ b/assets/src/components/notifications/routers/NotificationRouters.tsx
@@ -76,7 +76,7 @@ export default function NotificationRouters() {
     queryHook: useNotificationRoutersQuery,
     pageSize: QUERY_PAGE_SIZE,
     errorPolicy: 'all',
-    queryKey: 'notificationRouters',
+    keyPath: ['notificationRouters'],
   })
 
   useSetPageHeaderContent(useMemo(() => <CreateRouterButton />, []))

--- a/assets/src/components/notifications/sinks/NotificationSinks.tsx
+++ b/assets/src/components/notifications/sinks/NotificationSinks.tsx
@@ -56,7 +56,7 @@ export default function AutomationPr() {
   } = useFetchPaginatedData({
     queryHook: useNotificationSinksQuery,
     pageSize: QUERY_PAGE_SIZE,
-    queryKey: 'notificationSinks',
+    keyPath: ['notificationSinks'],
   })
 
   useSetPageHeaderContent(useMemo(() => <CreateSinkButton />, []))

--- a/assets/src/components/policies/Policies.tsx
+++ b/assets/src/components/policies/Policies.tsx
@@ -54,7 +54,7 @@ export function Policies() {
       {
         queryHook: usePolicyConstraintsQuery,
         pageSize: POLICIES_QUERY_PAGE_SIZE,
-        queryKey: 'policyConstraints',
+        keyPath: ['policyConstraints'],
       },
       policyQFilters
     )

--- a/assets/src/components/pr/automations/PrAutomations.tsx
+++ b/assets/src/components/pr/automations/PrAutomations.tsx
@@ -54,7 +54,7 @@ export default function AutomationPr() {
   } = useFetchPaginatedData({
     queryHook: usePrAutomationsQuery,
     pageSize: QUERY_PAGE_SIZE,
-    queryKey: 'prAutomations',
+    keyPath: ['prAutomations'],
   })
 
   useSetPageHeaderContent(

--- a/assets/src/components/pr/queue/PrQueue.tsx
+++ b/assets/src/components/pr/queue/PrQueue.tsx
@@ -63,7 +63,7 @@ export default function OutstandingPrs() {
     {
       queryHook: usePullRequestsQuery,
       pageSize: PR_QUERY_PAGE_SIZE,
-      queryKey: 'pullRequests',
+      keyPath: ['pullRequests'],
     },
     {
       q: debouncedSearchString,

--- a/assets/src/components/pr/scm/PrScmConnections.tsx
+++ b/assets/src/components/pr/scm/PrScmConnections.tsx
@@ -48,7 +48,7 @@ export default function ScmConnections() {
   } = useFetchPaginatedData({
     queryHook: useScmConnectionsQuery,
     pageSize: PR_QUERY_PAGE_SIZE,
-    queryKey: 'scmConnections',
+    keyPath: ['scmConnections'],
   })
 
   useSetPageHeaderContent(

--- a/assets/src/components/pr/scm/ScmWebhooks.tsx
+++ b/assets/src/components/pr/scm/ScmWebhooks.tsx
@@ -51,7 +51,7 @@ export default function ScmWebhooks() {
   } = useFetchPaginatedData({
     queryHook: useScmWebhooksQuery,
     pageSize: SCM_WEBHOOKS_Q_VARS.first,
-    queryKey: 'scmWebhooks',
+    keyPath: ['scmWebhooks'],
   })
 
   useSetPageHeaderContent(

--- a/assets/src/components/stacks/Stacks.tsx
+++ b/assets/src/components/stacks/Stacks.tsx
@@ -91,7 +91,7 @@ export default function Stacks() {
       {
         queryHook: useStacksQuery,
         pageSize: QUERY_PAGE_SIZE,
-        queryKey: 'infrastructureStacks',
+        keyPath: ['infrastructureStacks'],
       },
       {
         q: debouncedSearchString,

--- a/assets/src/utils/graphql.ts
+++ b/assets/src/utils/graphql.ts
@@ -45,6 +45,31 @@ export function extendConnection<
 }
 
 /**
+ *
+ */
+export function updateNestedConnection<TData>(
+  keyPath: string[],
+  fullQuery: TData,
+  newConnection: any
+): TData {
+  if (keyPath.length < 2) return newConnection
+
+  const res = { ...fullQuery }
+  let cur = res
+
+  for (let i = 0; i < keyPath.length - 2; i++) {
+    const key = keyPath[i]
+
+    if (!cur[key]) cur[key] = {}
+    cur = cur[key]
+  }
+
+  cur[keyPath[keyPath.length - 2]] = newConnection
+
+  return res
+}
+
+/**
  * Update a connection where incoming values overwrite previous existing values
  */
 export function updateConnection<


### PR DESCRIPTION
added polling to global services and managed namespace services tables

they originally weren't able to use the same logic for polling as other tables because the paginated data isn't at the top level for these queries (e.g. it's under `{globalService: {services: {paginatedData} }` as opposed to most other tables which are just `{keyName: {paginatedData} }`). made an attempt to generalize this case on top of the existing logic. seems to be working now, though we might want to clean this up at some point