### PR TITLE
Prune unfound runtime services

### DIFF
--- a/test/console/deployments/clusters_test.exs
+++ b/test/console/deployments/clusters_test.exs
@@ -898,6 +898,18 @@ defmodule Console.Deployments.ClustersTest do
       assert runtime.service_id == svc.id
     end
 
+    test "it can prune uneeded runtime services" do
+      cluster = insert(:cluster)
+      prune = insert(:runtime_service, name: "pruned", cluster: cluster)
+
+      {:ok, 1} = Clusters.create_runtime_services([
+        %{name: "ingress-nginx", version: "1.8.1"},
+        %{name: "bogus", version: "2.0.0"}
+      ], nil, cluster)
+
+      refute refetch(prune)
+    end
+
     test "it can create with goofy semvers" do
       cluster = insert(:cluster)
 


### PR DESCRIPTION
We were not actually dropping runtime services when they were no longer found.  This logic will strip them out appropriately.

## Test Plan
unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
