### PR TITLE
feat: hide state/plan/output tabs if data is not available

### DIFF
--- a/assets/src/components/stacks/run/Header.tsx
+++ b/assets/src/components/stacks/run/Header.tsx
@@ -11,6 +11,8 @@ import {
   TabList,
 } from '@pluralsh/design-system'
 
+import { isEmpty } from 'lodash'
+
 import {
   StackRun,
   StackStatus,
@@ -33,9 +35,21 @@ import { TRUNCATE } from '../../utils/truncate'
 const DIRECTORY = [
   { path: '', label: 'Progress' },
   { path: STACK_RUNS_REPOSITORY_REL_PATH, label: 'Repository' },
-  { path: STACK_RUNS_STATE_REL_PATH, label: 'State' },
-  { path: STACK_RUNS_PLAN_REL_PATH, label: 'Plan' },
-  { path: STACK_RUNS_OUTPUT_REL_PATH, label: 'Output' },
+  {
+    path: STACK_RUNS_STATE_REL_PATH,
+    label: 'State',
+    condition: (s: StackRun) => !isEmpty(s.state?.state),
+  },
+  {
+    path: STACK_RUNS_PLAN_REL_PATH,
+    label: 'Plan',
+    condition: (s: StackRun) => !isEmpty(s.state?.plan),
+  },
+  {
+    path: STACK_RUNS_OUTPUT_REL_PATH,
+    label: 'Output',
+    condition: (s: StackRun) => !isEmpty(s.output),
+  },
   { path: STACK_RUNS_JOB_REL_PATH, label: 'Job' },
 ]
 
@@ -88,7 +102,7 @@ export default function StackRunHeader({
           refetch={refetch}
         />
       </div>
-      <StackRunNav />
+      <StackRunNav stackRun={stackRun} />
     </div>
   )
 }
@@ -225,7 +239,7 @@ function StackRunHeaderButtons({ stackRun, refetch }): ReactNode {
   )
 }
 
-function StackRunNav(): ReactNode {
+function StackRunNav({ stackRun }: { stackRun: StackRun }): ReactNode {
   const { pathname } = useLocation()
   const tabStateRef = useRef<any>(null)
   const currentTab = useMemo(
@@ -245,21 +259,23 @@ function StackRunNav(): ReactNode {
         selectedKey: currentTab?.path,
       }}
     >
-      {DIRECTORY.map(({ label, path }) => (
-        <LinkTabWrap
-          subTab
-          key={path}
-          textValue={label}
-          to={path}
-        >
-          <SubTab
+      {DIRECTORY.filter((d) => d.condition?.(stackRun) ?? true).map(
+        ({ label, path }) => (
+          <LinkTabWrap
+            subTab
             key={path}
             textValue={label}
+            to={path}
           >
-            {label}
-          </SubTab>
-        </LinkTabWrap>
-      ))}
+            <SubTab
+              key={path}
+              textValue={label}
+            >
+              {label}
+            </SubTab>
+          </LinkTabWrap>
+        )
+      )}
     </TabList>
   )
 }


### PR DESCRIPTION
A small change to hide some stack run tabs in case data is not available. Some tf/ansible versions might never have a proper state/output available.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
