### PR TITLE
Allow repository to be parameterized in pr automations

### DIFF
--- a/assets/src/components/pr/automations/CreatePrModal.tsx
+++ b/assets/src/components/pr/automations/CreatePrModal.tsx
@@ -68,6 +68,7 @@ function CreatePrModalBase({
     )
   )
   const [branch, setBranch] = useState<string>('')
+  const [identifier, setIdentifier] = useState<string>(prAutomation.identifier)
   const [successPr, setSuccessPr] = useState<PullRequestFragment>()
 
   const theme = useTheme()
@@ -105,6 +106,7 @@ function CreatePrModalBase({
               variables: {
                 id: prAutomation.id,
                 branch,
+                identifier,
                 context: JSON.stringify(
                   Object.fromEntries(
                     filteredConfig.map((cfg) => [cfg.name, cfg.value])
@@ -259,6 +261,16 @@ function CreatePrModalBase({
               >
                 {configJson || ''}
               </Code>
+            </FormField>
+            <FormField
+              label="Repository"
+              required
+              name="repository"
+            >
+              <Input2
+                value={identifier}
+                onChange={(e) => setIdentifier(e.target.value)}
+              />
             </FormField>
             <FormField
               label="Branch"

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -3787,6 +3787,8 @@ export type PromotionCriteria = {
   __typename?: 'PromotionCriteria';
   id: Scalars['ID']['output'];
   insertedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** overrides the repository slug for the referenced pr automation */
+  repository?: Maybe<Scalars['String']['output']>;
   /** whether you want to copy any configuration values from the source service */
   secrets?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** the source service in a prior stage to promote settings from */
@@ -3802,6 +3804,8 @@ export type PromotionCriteriaAttributes = {
   name?: InputMaybe<Scalars['String']['input']>;
   /** the id of a pr automation to update this service */
   prAutomationId?: InputMaybe<Scalars['ID']['input']>;
+  /** overrides the repository slug for the referenced pr automation */
+  repository?: InputMaybe<Scalars['String']['input']>;
   /** the secrets to copy over in a promotion */
   secrets?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** the id of the service to promote from */
@@ -4491,6 +4495,7 @@ export type RootMutationTypeCreatePullRequestArgs = {
   branch?: InputMaybe<Scalars['String']['input']>;
   context?: InputMaybe<Scalars['Json']['input']>;
   id: Scalars['ID']['input'];
+  identifier?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -8463,6 +8468,7 @@ export type PullRequestFragment = { __typename?: 'PullRequest', id: string, titl
 export type CreatePullRequestMutationVariables = Exact<{
   id: Scalars['ID']['input'];
   branch: Scalars['String']['input'];
+  identifier?: InputMaybe<Scalars['String']['input']>;
   context: Scalars['Json']['input'];
 }>;
 
@@ -15333,8 +15339,13 @@ export type DeleteClusterProviderMutationHookResult = ReturnType<typeof useDelet
 export type DeleteClusterProviderMutationResult = Apollo.MutationResult<DeleteClusterProviderMutation>;
 export type DeleteClusterProviderMutationOptions = Apollo.BaseMutationOptions<DeleteClusterProviderMutation, DeleteClusterProviderMutationVariables>;
 export const CreatePullRequestDocument = gql`
-    mutation CreatePullRequest($id: ID!, $branch: String!, $context: Json!) {
-  createPullRequest(id: $id, branch: $branch, context: $context) {
+    mutation CreatePullRequest($id: ID!, $branch: String!, $identifier: String, $context: Json!) {
+  createPullRequest(
+    id: $id
+    branch: $branch
+    identifier: $identifier
+    context: $context
+  ) {
     ...PullRequest
   }
 }
@@ -15356,6 +15367,7 @@ export type CreatePullRequestMutationFn = Apollo.MutationFunction<CreatePullRequ
  *   variables: {
  *      id: // value for 'id'
  *      branch: // value for 'branch'
+ *      identifier: // value for 'identifier'
  *      context: // value for 'context'
  *   },
  * });

--- a/assets/src/graph/cdPrs.graphql
+++ b/assets/src/graph/cdPrs.graphql
@@ -18,8 +18,18 @@ fragment PullRequest on PullRequest {
   updatedAt
 }
 
-mutation CreatePullRequest($id: ID!, $branch: String!, $context: Json!) {
-  createPullRequest(id: $id, branch: $branch, context: $context) {
+mutation CreatePullRequest(
+  $id: ID!
+  $branch: String!
+  $identifier: String
+  $context: Json!
+) {
+  createPullRequest(
+    id: $id
+    branch: $branch
+    identifier: $identifier
+    context: $context
+  ) {
     ...PullRequest
   }
 }

--- a/lib/console/deployments/pipelines.ex
+++ b/lib/console/deployments/pipelines.ex
@@ -156,7 +156,8 @@ defmodule Console.Deployments.Pipelines do
       add_operation(xact, {:pull, svc.id}, fn _ ->
         branch = "plrl-svc/#{service.name}/pipeline-#{stage.pipeline.name}-#{String.slice(service.id, 0..4)}-#{String.slice(ctx.id, 0..4)}"
         context = build_pr_context(ctx.context, svc, stage)
-        Git.create_pull_request(%{service_id: service.id}, context, svc.criteria.pr_automation_id, branch, bot)
+        %{pr_automation_id: id, repository: repo} = svc.criteria
+        Git.create_pull_request(%{service_id: service.id}, context, id, branch, repo, bot)
       end)
       |> add_operation({:ptr, svc.id}, fn res ->
         pr = Map.get(res, {:pull, svc.id})

--- a/lib/console/graphql/deployments/git.ex
+++ b/lib/console/graphql/deployments/git.ex
@@ -553,9 +553,10 @@ defmodule Console.GraphQl.Deployments.Git do
 
     field :create_pull_request, :pull_request do
       middleware Authenticated
-      arg :id,      non_null(:id), description: "the id of the PR automation instance to use"
-      arg :branch,  :string
-      arg :context, :json
+      arg :id,         non_null(:id), description: "the id of the PR automation instance to use"
+      arg :identifier, :string
+      arg :branch,     :string
+      arg :context,    :json
 
       safe_resolve &Deployments.create_pull_request/2
     end

--- a/lib/console/graphql/deployments/pipeline.ex
+++ b/lib/console/graphql/deployments/pipeline.ex
@@ -107,6 +107,7 @@ defmodule Console.GraphQl.Deployments.Pipeline do
     field :name,             :string, description: "the name of the source service"
     field :source_id,        :id, description: "the id of the service to promote from"
     field :pr_automation_id, :id, description: "the id of a pr automation to update this service"
+    field :repository,       :string, description: "overrides the repository slug for the referenced pr automation"
     field :secrets,          list_of(:string), description: "the secrets to copy over in a promotion"
   end
 
@@ -259,8 +260,9 @@ defmodule Console.GraphQl.Deployments.Pipeline do
 
   @desc "how a promotion for a service will be performed"
   object :promotion_criteria do
-    field :id,      non_null(:id)
-    field :source,  :service_deployment,
+    field :id,         non_null(:id)
+    field :repository, :string, description: "overrides the repository slug for the referenced pr automation"
+    field :source,     :service_deployment,
       description: "the source service in a prior stage to promote settings from",
       resolve: dataloader(Deployments)
     field :secrets, list_of(:string),

--- a/lib/console/graphql/resolvers/deployments/git.ex
+++ b/lib/console/graphql/resolvers/deployments/git.ex
@@ -96,8 +96,8 @@ defmodule Console.GraphQl.Resolvers.Deployments.Git do
   def delete_pr_automation(%{id: id}, %{context: %{current_user: user}}),
     do: Git.delete_pr_automation(id, user)
 
-  def create_pull_request(%{id: id, branch: branch, context: ctx}, %{context: %{current_user: user}}),
-    do: Git.create_pull_request(ctx, id, branch, user)
+  def create_pull_request(%{id: id, branch: branch, context: ctx} = args, %{context: %{current_user: user}}),
+    do: Git.create_pull_request(%{}, ctx, id, branch, args[:identifier], user)
 
   def create_pr(%{attributes: attrs}, %{context: %{current_user: user}}),
     do: Git.create_pull_request(attrs, user)

--- a/lib/console/schema/promotion_criteria.ex
+++ b/lib/console/schema/promotion_criteria.ex
@@ -3,7 +3,8 @@ defmodule Console.Schema.PromotionCriteria do
   alias Console.Schema.{StageService, Service, PrAutomation}
 
   schema "promotion_criteria" do
-    field :secrets, {:array, :string}
+    field :secrets,    {:array, :string}
+    field :repository, :string
 
     belongs_to :pr_automation, PrAutomation
     belongs_to :stage_service, StageService
@@ -12,7 +13,7 @@ defmodule Console.Schema.PromotionCriteria do
     timestamps()
   end
 
-  @valid ~w(source_id pr_automation_id secrets)a
+  @valid ~w(repository source_id pr_automation_id secrets)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/priv/repo/migrations/20240627005403_add_repository_promo_criteria.exs
+++ b/priv/repo/migrations/20240627005403_add_repository_promo_criteria.exs
@@ -1,0 +1,9 @@
+defmodule Console.Repo.Migrations.AddRepositoryPromoCriteria do
+  use Ecto.Migration
+
+  def change do
+    alter table(:promotion_criteria) do
+      add :repository, :string
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -514,6 +514,8 @@ type RootMutationType {
     "the id of the PR automation instance to use"
     id: ID!
 
+    identifier: String
+
     branch: String
 
     context: Json
@@ -2312,6 +2314,9 @@ input PromotionCriteriaAttributes {
   "the id of a pr automation to update this service"
   prAutomationId: ID
 
+  "overrides the repository slug for the referenced pr automation"
+  repository: String
+
   "the secrets to copy over in a promotion"
   secrets: [String]
 }
@@ -2517,6 +2522,9 @@ type StageService {
 "how a promotion for a service will be performed"
 type PromotionCriteria {
   id: ID!
+
+  "overrides the repository slug for the referenced pr automation"
+  repository: String
 
   "the source service in a prior stage to promote settings from"
   source: ServiceDeployment


### PR DESCRIPTION
This will help users DRY up their automation code, which can be useful for when you want to stamp out repos alongside common lines

## Test Plan
unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
