### PR TITLE
fix flow layout bug

### DIFF
--- a/assets/src/components/cd/pipelines/utils/nodeLayouter.tsx
+++ b/assets/src/components/cd/pipelines/utils/nodeLayouter.tsx
@@ -5,7 +5,7 @@ function measureNode(node: FlowNode, zoom) {
   let domNode
 
   try {
-    domNode = document.querySelector(CSS.escape(`[data-id="${node.id}"]`))
+    domNode = document.querySelector(`[data-id="${CSS.escape(node.id)}"]`)
   } catch (e) {
     console.error(e)
 


### PR DESCRIPTION
CSS.escape is only needed to wrap around the variable itself, rather than the whole selector. was causing nothing to get returned by the query