### PR TITLE
Custom Stack Definitions CRUD

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1434,6 +1434,14 @@ export type CrossVersionResourceTarget = {
   name?: Maybe<Scalars['String']['output']>;
 };
 
+export type CustomRunStep = {
+  __typename?: 'CustomRunStep';
+  args?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  cmd: Scalars['String']['output'];
+  requireApproval?: Maybe<Scalars['Boolean']['output']>;
+  stage: StepStage;
+};
+
 export type CustomStackRun = {
   __typename?: 'CustomStackRun';
   /** the list of commands that will be executed */
@@ -1473,6 +1481,13 @@ export type CustomStackRunEdge = {
   __typename?: 'CustomStackRunEdge';
   cursor?: Maybe<Scalars['String']['output']>;
   node?: Maybe<CustomStackRun>;
+};
+
+export type CustomStepAttributes = {
+  args?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  cmd: Scalars['String']['input'];
+  requireApproval?: InputMaybe<Scalars['Boolean']['input']>;
+  stage?: InputMaybe<StepStage>;
 };
 
 export type DaemonSet = {
@@ -2123,6 +2138,8 @@ export type InfrastructureStack = {
   /** version/image config for the tool you're using */
   configuration: StackConfiguration;
   customStackRuns?: Maybe<CustomStackRunConnection>;
+  /** the stack definition in-use by this stack */
+  definition?: Maybe<StackDefinition>;
   /** the run that physically destroys the stack */
   deleteRun?: Maybe<StackRun>;
   /** whether this stack was previously deleted and is pending cleanup */
@@ -4207,6 +4224,7 @@ export type RootMutationType = {
   createServiceAccountToken?: Maybe<AccessToken>;
   createServiceDeployment?: Maybe<ServiceDeployment>;
   createStack?: Maybe<InfrastructureStack>;
+  createStackDefinition?: Maybe<StackDefinition>;
   createUpgradePolicy?: Maybe<UpgradePolicy>;
   createWebhook?: Maybe<Webhook>;
   deleteAccessToken?: Maybe<AccessToken>;
@@ -4238,6 +4256,7 @@ export type RootMutationType = {
   deleteServiceContext?: Maybe<ServiceContext>;
   deleteServiceDeployment?: Maybe<ServiceDeployment>;
   deleteStack?: Maybe<InfrastructureStack>;
+  deleteStackDefinition?: Maybe<StackDefinition>;
   deleteUpgradePolicy?: Maybe<UpgradePolicy>;
   deleteUser?: Maybe<User>;
   deleteWebhook?: Maybe<Webhook>;
@@ -4290,6 +4309,8 @@ export type RootMutationType = {
   signIn?: Maybe<User>;
   signup?: Maybe<User>;
   syncGlobalService?: Maybe<GlobalService>;
+  /** start a new run from the newest sha in the stack's run history */
+  triggerRun?: Maybe<StackRun>;
   updateCluster?: Maybe<Cluster>;
   updateClusterProvider?: Maybe<ClusterProvider>;
   updateClusterRestore?: Maybe<ClusterRestore>;
@@ -4317,6 +4338,7 @@ export type RootMutationType = {
   updateServiceDeployment?: Maybe<ServiceDeployment>;
   updateSmtp?: Maybe<Smtp>;
   updateStack?: Maybe<InfrastructureStack>;
+  updateStackDefinition?: Maybe<StackDefinition>;
   updateStackRun?: Maybe<StackRun>;
   updateUser?: Maybe<User>;
   upsertNotificationRouter?: Maybe<NotificationRouter>;
@@ -4548,6 +4570,11 @@ export type RootMutationTypeCreateStackArgs = {
 };
 
 
+export type RootMutationTypeCreateStackDefinitionArgs = {
+  attributes: StackDefinitionAttributes;
+};
+
+
 export type RootMutationTypeCreateUpgradePolicyArgs = {
   attributes: UpgradePolicyAttributes;
 };
@@ -4705,6 +4732,11 @@ export type RootMutationTypeDeleteServiceDeploymentArgs = {
 
 
 export type RootMutationTypeDeleteStackArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type RootMutationTypeDeleteStackDefinitionArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -4925,6 +4957,11 @@ export type RootMutationTypeSyncGlobalServiceArgs = {
 };
 
 
+export type RootMutationTypeTriggerRunArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type RootMutationTypeUpdateClusterArgs = {
   attributes: ClusterUpdateAttributes;
   id: Scalars['ID']['input'];
@@ -5078,6 +5115,12 @@ export type RootMutationTypeUpdateSmtpArgs = {
 
 export type RootMutationTypeUpdateStackArgs = {
   attributes: StackAttributes;
+  id: Scalars['ID']['input'];
+};
+
+
+export type RootMutationTypeUpdateStackDefinitionArgs = {
+  attributes: StackDefinitionAttributes;
   id: Scalars['ID']['input'];
 };
 
@@ -5262,6 +5305,7 @@ export type RootQueryType = {
   serviceStatuses?: Maybe<Array<Maybe<ServiceStatusCount>>>;
   smtp?: Maybe<Smtp>;
   stack?: Maybe<Stack>;
+  stackDefinition?: Maybe<StackDefinition>;
   stackRun?: Maybe<StackRun>;
   statefulSet?: Maybe<StatefulSet>;
   /** adds the ability to search/filter through all tag name/value pairs */
@@ -6086,6 +6130,11 @@ export type RootQueryTypeStackArgs = {
 };
 
 
+export type RootQueryTypeStackDefinitionArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type RootQueryTypeStackRunArgs = {
   id: Scalars['ID']['input'];
 };
@@ -6240,6 +6289,7 @@ export type RunStep = {
   insertedAt?: Maybe<Scalars['DateTime']['output']>;
   logs?: Maybe<Array<Maybe<RunLogs>>>;
   name: Scalars['String']['output'];
+  requireApproval?: Maybe<Scalars['Boolean']['output']>;
   stage: StepStage;
   status: StepStatus;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
@@ -6946,6 +6996,8 @@ export type StackAttributes = {
   configuration: StackConfigurationAttributes;
   /** id of an scm connection to use for pr callbacks */
   connectionId?: InputMaybe<Scalars['ID']['input']>;
+  /** the id of a stack definition to use */
+  definitionId?: InputMaybe<Scalars['ID']['input']>;
   environment?: InputMaybe<Array<InputMaybe<StackEnvironmentAttributes>>>;
   files?: InputMaybe<Array<InputMaybe<StackFileAttributes>>>;
   /** reference w/in the repository where the IaC lives */
@@ -7001,6 +7053,24 @@ export type StackConfigurationAttributes = {
   tag?: InputMaybe<Scalars['String']['input']>;
   /** the semver of the tool you wish to use */
   version?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type StackDefinition = {
+  __typename?: 'StackDefinition';
+  configuration: StackConfiguration;
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  insertedAt?: Maybe<Scalars['DateTime']['output']>;
+  name: Scalars['String']['output'];
+  steps?: Maybe<Array<Maybe<CustomRunStep>>>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type StackDefinitionAttributes = {
+  configuration?: InputMaybe<StackConfigurationAttributes>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  steps?: InputMaybe<Array<InputMaybe<CustomStepAttributes>>>;
 };
 
 export type StackEnvironment = {
@@ -7206,6 +7276,7 @@ export enum StackStatus {
 
 export enum StackType {
   Ansible = 'ANSIBLE',
+  Custom = 'CUSTOM',
   Terraform = 'TERRAFORM'
 }
 
@@ -7307,11 +7378,14 @@ export type SyncConfig = {
   __typename?: 'SyncConfig';
   /** whether the agent should auto-create the namespace for this service */
   createNamespace?: Maybe<Scalars['Boolean']['output']>;
+  /** Whether to require all resources are placed in the same namespace */
+  enforceNamespace?: Maybe<Scalars['Boolean']['output']>;
   namespaceMetadata?: Maybe<NamespaceMetadata>;
 };
 
 export type SyncConfigAttributes = {
   createNamespace?: InputMaybe<Scalars['Boolean']['input']>;
+  enforceNamespace?: InputMaybe<Scalars['Boolean']['input']>;
   namespaceMetadata?: InputMaybe<MetadataAttributes>;
 };
 

--- a/lib/console/deployments/pipelines/stage_worker.ex
+++ b/lib/console/deployments/pipelines/stage_worker.ex
@@ -29,10 +29,13 @@ defmodule Console.Deployments.Pipelines.StageWorker do
       {:ok, _} -> Logger.info "stage #{stage.id} context applied successfully"
       {:error, err} ->
         Logger.info "failed to apply stage context #{stage.id} reason: #{inspect(err)}"
-        Pipelines.add_stage_error(stage, "context", "Failed to apply stage context with error: #{inspect(err)}")
+        Pipelines.add_stage_error(stage, "context", "Failed to apply stage context with error: #{format_error(err)}")
     end
     {:noreply, state}
   end
+
+  defp format_error(err) when is_binary(err), do: "\n#{err}"
+  defp format_error(err), do: inspect(err)
 
   def handle_cast(%PipelineStage{} = stage, state) do
     case Pipelines.build_promotion(stage) do

--- a/lib/console/graphql/deployments/service.ex
+++ b/lib/console/graphql/deployments/service.ex
@@ -35,6 +35,7 @@ defmodule Console.GraphQl.Deployments.Service do
 
   input_object :sync_config_attributes do
     field :create_namespace,   :boolean
+    field :enforce_namespace,  :boolean
     field :namespace_metadata, :metadata_attributes
   end
 
@@ -320,6 +321,7 @@ defmodule Console.GraphQl.Deployments.Service do
   @desc "Advanced configuration of how to sync resources"
   object :sync_config do
     field :create_namespace,   :boolean, description: "whether the agent should auto-create the namespace for this service"
+    field :enforce_namespace,  :boolean, description: "Whether to require all resources are placed in the same namespace"
     field :namespace_metadata, :namespace_metadata
   end
 

--- a/lib/console/graphql/resolvers/deployments.ex
+++ b/lib/console/graphql/resolvers/deployments.ex
@@ -55,7 +55,8 @@ defmodule Console.GraphQl.Resolvers.Deployments do
     StackState,
     ServiceDependency,
     Project,
-    ServiceImport
+    ServiceImport,
+    StackDefinition
   }
 
   def query(Project, _), do: Project
@@ -109,6 +110,7 @@ defmodule Console.GraphQl.Resolvers.Deployments do
   def query(StackState, _), do: StackState
   def query(ServiceDependency, _), do: ServiceDependency
   def query(ServiceImport, _), do: ServiceImport
+  def query(StackDefinition, _), do: StackDefinition
   def query(_, _), do: Cluster
 
   delegates Console.GraphQl.Resolvers.Deployments.Git

--- a/lib/console/graphql/resolvers/deployments/stack.ex
+++ b/lib/console/graphql/resolvers/deployments/stack.ex
@@ -52,6 +52,8 @@ defmodule Console.GraphQl.Resolvers.Deployments.Stack do
     |> paginate(args)
   end
 
+  def resolve_stack_definition(%{id: id}, _), do: {:ok, Stacks.get_definition!(id)}
+
   def resolve_stack(%{id: id}, ctx) do
     Stacks.get_stack!(id)
     |> allow(actor(ctx), :read)
@@ -114,8 +116,20 @@ defmodule Console.GraphQl.Resolvers.Deployments.Stack do
   def delete_custom_stack_run(%{id: id}, %{context: %{current_user: user}}),
     do: Stacks.delete_custom_stack_run(id, user)
 
+  def create_stack_definition(%{attributes: attrs}, %{context: %{current_user: user}}),
+    do: Stacks.create_stack_definition(attrs, user)
+
+  def update_stack_definition(%{id: id, attributes: attrs}, %{context: %{current_user: user}}),
+    do: Stacks.update_stack_definition(attrs, id, user)
+
+  def delete_stack_definition(%{id: id}, %{context: %{current_user: user}}),
+    do: Stacks.delete_stack_definition(id, user)
+
   def create_stack_run(%{stack_id: id, commands: commands} = args, %{context: %{current_user: user}}),
     do: Stacks.create_custom_run(id, commands, args[:context], user)
+
+  def trigger_run(%{id: id}, %{context: %{current_user: user}}),
+    do: Stacks.trigger_run(id, user)
 
   def job_spec(%StackRun{job_spec: %{} = spec}, _, _), do: {:ok, spec}
   def job_spec(_, _, _) do

--- a/lib/console/schema/pull_request.ex
+++ b/lib/console/schema/pull_request.ex
@@ -5,13 +5,14 @@ defmodule Console.Schema.PullRequest do
   defenum Status, open: 0, merged: 1, closed: 2
 
   schema "pull_requests" do
-    field :url,     :string
-    field :status,  Status, default: :open
-    field :title,   :string
-    field :creator, :string
-    field :labels,  {:array, :string}
-    field :ref,     :string
-    field :sha,     :string
+    field :url,        :string
+    field :status,     Status, default: :open
+    field :title,      :string
+    field :creator,    :string
+    field :labels,     {:array, :string}
+    field :ref,        :string
+    field :sha,        :string
+    field :polled_sha, :string
 
     field :review_id, :string
 

--- a/lib/console/schema/run_step.ex
+++ b/lib/console/schema/run_step.ex
@@ -6,12 +6,13 @@ defmodule Console.Schema.RunStep do
   defenum Stage,  plan: 0, verify: 1, apply: 2, init: 3, destroy: 4
 
   schema "run_steps" do
-    field :name,   :string
-    field :status, Status
-    field :stage,  Stage
-    field :cmd,    :string
-    field :args,   {:array, :string}
-    field :index,  :integer
+    field :name,             :string
+    field :status,           Status
+    field :stage,            Stage
+    field :cmd,              :string
+    field :args,             {:array, :string}
+    field :index,            :integer
+    field :require_approval, :boolean
 
     has_many :logs, RunLog, foreign_key: :step_id
 
@@ -20,7 +21,7 @@ defmodule Console.Schema.RunStep do
     timestamps()
   end
 
-  @valid ~w(name status stage cmd args index run_id)a
+  @valid ~w(name status stage cmd args require_approval index run_id)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/lib/console/schema/service.ex
+++ b/lib/console/schema/service.ex
@@ -119,7 +119,8 @@ defmodule Console.Schema.Service do
     embeds_one :sync_config, SyncConfig, on_replace: :update do
       embeds_many :diff_normalizers, DiffNormalizer
       embeds_one :namespace_metadata, Metadata
-      field :create_namespace, :boolean, default: true
+      field :enforce_namespace, :boolean, default: false
+      field :create_namespace,  :boolean, default: true
     end
 
     embeds_one :kustomize, Kustomize, on_replace: :update do
@@ -325,7 +326,7 @@ defmodule Console.Schema.Service do
 
   def sync_config_changeset(model, attrs \\ %{}) do
     model
-    |> cast(attrs, ~w(create_namespace)a)
+    |> cast(attrs, ~w(create_namespace enforce_namespace)a)
     |> cast_embed(:namespace_metadata)
     |> cast_embed(:diff_normalizers)
   end

--- a/lib/console/schema/stack_definition.ex
+++ b/lib/console/schema/stack_definition.ex
@@ -1,0 +1,35 @@
+defmodule Console.Schema.StackDefinition do
+  use Piazza.Ecto.Schema
+  alias Console.Schema.{Stack, RunStep}
+
+  schema "stack_definitions" do
+    field :name,        :string
+    field :description, :string
+
+    embeds_one :configuration, Stack.Configuration, on_replace: :update
+
+    embeds_many :steps, Step, on_replace: :delete do
+      field :stage,            RunStep.Stage
+      field :cmd,              :string
+      field :args,             {:array, :string}
+      field :require_approval, :boolean
+    end
+
+    timestamps()
+  end
+
+  @valid ~w(name description)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> cast_embed(:configuration)
+    |> cast_embed(:steps, with: &step_changeset/2)
+  end
+
+  def step_changeset(model, attrs) do
+    model
+    |> cast(attrs, ~w(stage cmd args require_approval)a)
+    |> validate_required(~w(stage cmd args)a)
+  end
+end

--- a/priv/repo/migrations/20240628202415_add_stack_definitions.exs
+++ b/priv/repo/migrations/20240628202415_add_stack_definitions.exs
@@ -1,0 +1,26 @@
+defmodule Console.Repo.Migrations.AddStackDefinitions do
+  use Ecto.Migration
+
+  def change do
+    create table(:stack_definitions, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :name, :string, nil: false
+      add :description, :string
+
+      add :configuration, :map
+      add :steps,         :map
+
+      timestamps()
+    end
+
+    create unique_index(:stack_definitions, [:name])
+
+    alter table(:stacks) do
+      add :definition_id, references(:stack_definitions, type: :uuid)
+    end
+
+    alter table(:run_steps) do
+      add :require_approval, :boolean
+    end
+  end
+end

--- a/priv/repo/migrations/20240630124210_add_polled_sha.exs
+++ b/priv/repo/migrations/20240630124210_add_polled_sha.exs
@@ -1,0 +1,13 @@
+defmodule Console.Repo.Migrations.AddPolledSha do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stacks) do
+      add :polled_sha, :string
+    end
+
+    alter table(:pull_requests) do
+      add :polled_sha, :string
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -364,6 +364,8 @@ type RootQueryType {
 
   infrastructureStack(id: ID!): InfrastructureStack
 
+  stackDefinition(id: ID!): StackDefinition
+
   infrastructureStacks(after: String, first: Int, before: String, last: Int, q: String, projectId: ID): InfrastructureStackConnection
 
   observabilityProvider(id: ID!): ObservabilityProvider
@@ -743,8 +745,17 @@ type RootMutationType {
 
   deleteCustomStackRun(id: ID!): CustomStackRun
 
+  createStackDefinition(attributes: StackDefinitionAttributes!): StackDefinition
+
+  updateStackDefinition(id: ID!, attributes: StackDefinitionAttributes!): StackDefinition
+
+  deleteStackDefinition(id: ID!): StackDefinition
+
   "Creates a custom run, with the given command list, to execute w\/in the stack's environment"
   onDemandRun(stackId: ID!, commands: [CommandAttributes], context: Json): StackRun
+
+  "start a new run from the newest sha in the stack's run history"
+  triggerRun(id: ID!): StackRun
 
   upsertObservabilityProvider(attributes: ObservabilityProviderAttributes!): ObservabilityProvider
 
@@ -1020,6 +1031,7 @@ enum StackStatus {
 enum StackType {
   TERRAFORM
   ANSIBLE
+  CUSTOM
 }
 
 enum StepStatus {
@@ -1076,6 +1088,9 @@ input StackAttributes {
 
   "id of an scm connection to use for pr callbacks"
   connectionId: ID
+
+  "the id of a stack definition to use"
+  definitionId: ID
 
   readBindings: [PolicyBindingAttributes]
 
@@ -1205,6 +1220,20 @@ input CommandAttributes {
   dir: String
 }
 
+input StackDefinitionAttributes {
+  name: String!
+  description: String
+  steps: [CustomStepAttributes]
+  configuration: StackConfigurationAttributes
+}
+
+input CustomStepAttributes {
+  stage: StepStage
+  cmd: String!
+  args: [String]
+  requireApproval: Boolean
+}
+
 type InfrastructureStack {
   id: ID
 
@@ -1274,6 +1303,9 @@ type InfrastructureStack {
 
   "the git repository you're sourcing IaC from"
   repository: GitRepository
+
+  "the stack definition in-use by this stack"
+  definition: StackDefinition
 
   "the actor of this stack (defaults to root console user)"
   actor: User
@@ -1435,6 +1467,7 @@ type RunStep {
   name: String!
   cmd: String!
   args: [String!]
+  requireApproval: Boolean
   index: Int!
   logs: [RunLogs]
   insertedAt: DateTime
@@ -1508,6 +1541,23 @@ type CustomStackRun {
   insertedAt: DateTime
 
   updatedAt: DateTime
+}
+
+type StackDefinition {
+  id: ID!
+  name: String!
+  description: String
+  configuration: StackConfiguration!
+  steps: [CustomRunStep]
+  insertedAt: DateTime
+  updatedAt: DateTime
+}
+
+type CustomRunStep {
+  cmd: String!
+  args: [String]
+  stage: StepStage!
+  requireApproval: Boolean
 }
 
 type StackCommand {
@@ -2672,6 +2722,7 @@ input ServiceImportAttributes {
 
 input SyncConfigAttributes {
   createNamespace: Boolean
+  enforceNamespace: Boolean
   namespaceMetadata: MetadataAttributes
 }
 
@@ -3104,6 +3155,9 @@ type ServiceStatusCount {
 type SyncConfig {
   "whether the agent should auto-create the namespace for this service"
   createNamespace: Boolean
+
+  "Whether to require all resources are placed in the same namespace"
+  enforceNamespace: Boolean
 
   namespaceMetadata: NamespaceMetadata
 }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -616,6 +616,14 @@ defmodule Console.Factory do
     }
   end
 
+  def stack_definition_factory do
+    %Schema.StackDefinition{
+      name: sequence(:def, & "stack-def-#{&1}"),
+      configuration: %{image: "stack/harness", tag: "0.1.0"},
+      steps: [%{cmd: "cmd", args: ["arg"], stage: :apply}]
+    }
+  end
+
   def setup_rbac(user, repos \\ ["*"], perms) do
     role = insert(:role, repositories: repos, permissions: Map.new(perms))
     insert(:role_binding, role: role, user: user)


### PR DESCRIPTION
This builds the backbone for custom stacks, a definition basically:

* defines the command workflow to be executed by a stack
* also sets common configuration for things like the base image to use.

also added a `triggerRun` mutation as I could see it being useful to programmatically execute these stacks via other tools

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
