### PR TITLE
fix: properly cache-and-network on k8s dashboard resource lists

### DIFF
--- a/assets/src/components/kubernetes/common/ResourceList.tsx
+++ b/assets/src/components/kubernetes/common/ResourceList.tsx
@@ -115,6 +115,7 @@ export function ResourceList<
     client: KubernetesClient(cluster?.id ?? ''),
     skip: !cluster,
     pollInterval: 30_000,
+    fetchPolicy: 'cache-and-network',
     variables: {
       filterBy: `name,${filter}`,
       sortBy,
@@ -125,24 +126,28 @@ export function ResourceList<
   })
 
   const resourceList = data?.[queryName] as TResourceList
+  const isLoading = useMemo(
+    () => loading && !resourceList,
+    [loading, resourceList]
+  )
   const items = useMemo(
     () =>
-      loading
+      isLoading
         ? Array(SKELETON_ITEMS).fill({})
         : (resourceList?.[itemsKey] as Array<TResource>) ?? [],
-    [itemsKey, loading, resourceList]
+    [isLoading, itemsKey, resourceList]
   )
   const { page, hasNextPage } = usePageInfo(items, resourceList?.listMeta)
 
   const columnsData = useMemo(
     () =>
-      loading
+      isLoading
         ? columns.map((col) => ({
             ...col,
             cell: <Skeleton />,
           }))
         : columns,
-    [columns, loading]
+    [isLoading, columns]
   )
 
   const fetchNextPage = useCallback(() => {

--- a/assets/src/components/kubernetes/workloads/Pods.tsx
+++ b/assets/src/components/kubernetes/workloads/Pods.tsx
@@ -5,7 +5,6 @@ import {
   Tooltip,
   useSetBreadcrumbs,
 } from '@pluralsh/design-system'
-
 import { filesize } from 'filesize'
 
 import {
@@ -26,11 +25,8 @@ import {
 import { useCluster } from '../Cluster'
 import { ContainerStatuses } from '../../cluster/ContainerStatuses'
 import { ContainerStatusT } from '../../cluster/pods/PodsList'
-
 import { Kind } from '../common/types'
-
 import ResourceLink from '../common/ResourceLink'
-
 import { UsageText } from '../../cluster/TableElements'
 
 import { WorkloadImages, toReadiness } from './utils'


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Fix for fetch policy on k8s dashboard resource list views. It will now get data from the cache if available to show immediately and at the same time make an API request to get the latest data.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
