### PR TITLE
Add caching for change detection w/ stacks

### DIFF
--- a/lib/console/deployments/git/agent.ex
+++ b/lib/console/deployments/git/agent.ex
@@ -87,7 +87,8 @@ defmodule Console.Deployments.Git.Agent do
   end
 
   def handle_call({:changes, sha1, sha2, folder}, _, %State{cache: cache} = state) do
-    {:reply, Cache.changes(cache, sha1, sha2, folder), state}
+    {cache, result} = Cache.cached_changes(cache, sha1, sha2, folder)
+    {:reply, result, %{state | cache: cache}}
   end
 
   def handle_call({:fetch, %Service.Git{} = ref}, _, %State{cache: cache} = state) do

--- a/lib/console/deployments/git/discovery.ex
+++ b/lib/console/deployments/git/discovery.ex
@@ -26,6 +26,7 @@ defmodule Console.Deployments.Git.Discovery do
       do: Agent.sha(pid, ref)
   end
 
+  @spec changes(GitRepository.t, binary, binary, binary) :: {:ok, [binary] | :pass, binary} | error
   def changes(%GitRepository{} = repo, sha1, sha2, folder) do
     with {:ok, pid} <- find(repo),
       do: Agent.changes(pid, sha1, sha2, folder)

--- a/lib/console/deployments/pipelines/stage_worker.ex
+++ b/lib/console/deployments/pipelines/stage_worker.ex
@@ -34,9 +34,6 @@ defmodule Console.Deployments.Pipelines.StageWorker do
     {:noreply, state}
   end
 
-  defp format_error(err) when is_binary(err), do: "\n#{err}"
-  defp format_error(err), do: inspect(err)
-
   def handle_cast(%PipelineStage{} = stage, state) do
     case Pipelines.build_promotion(stage) do
       {:ok, _} -> Logger.info "stage #{stage.id} applied successfully"
@@ -51,4 +48,7 @@ defmodule Console.Deployments.Pipelines.StageWorker do
   end
 
   def handle_info(_, state), do: {:noreply, state}
+
+  defp format_error(err) when is_binary(err), do: "\n#{err}"
+  defp format_error(err), do: inspect(err)
 end

--- a/lib/console/deployments/stacks.ex
+++ b/lib/console/deployments/stacks.ex
@@ -456,7 +456,8 @@ defmodule Console.Deployments.Stacks do
 
   defp new_changes(repo, %{folder: folder}, sha1, sha2) do
     case Discovery.changes(repo, sha1, sha2, folder) do
-      {:ok, _, msg} -> {:ok, sha2, msg}
+      {:ok, [_ | _], msg} -> {:ok, sha2, msg}
+      {:ok, :pass, msg} -> {:ok, sha2, msg}
       _ -> {:error, "no changes within #{folder}"}
     end
   end


### PR DESCRIPTION
Stacks need to query git for changes each poll interval to determine if 1. there's a new sha and 2. if there's a file that it's tracking that changed in that new sha.  This can theoretically lead to a lot of contention in the git cache.  this has already been partially solved by adding a tracking column to determine if a sha has already been polled, this change cache will also solve for many stacks polling against the same folder and thus reduce duplicate work there as well.

## Test Plan
existing tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
