### PR TITLE
enhancement: Prod 2310/backfill chart versions on compatibility tables

### DIFF
--- a/static/compatibilities/argo-rollouts.yaml
+++ b/static/compatibilities/argo-rollouts.yaml
@@ -1,23 +1,28 @@
 icon: https://avatars.githubusercontent.com/u/30269780?s=200&v=4
 git_url: https://github.com/argoproj/argo-rollouts
 release_url: https://github.com/argoproj/argo-rollouts/releases/tag/v{vsn}
+helm_repository_url: https://argoproj.github.io/argo-helm
 versions:
 - version: 1.7.0
   kube: ['1.29', '1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 2.36.0
 - version: 1.6.0
   kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
   requirements: []
   incompatibilities: []
+  chart_version: 2.32.0
 - version: 1.2.0
   kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
   requirements: []
   incompatibilities: []
+  chart_version: 2.12.0
 - version: 1.1.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 2.2.0
 - version: 0.0.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []

--- a/static/compatibilities/cert-manager.yaml
+++ b/static/compatibilities/cert-manager.yaml
@@ -1,6 +1,7 @@
 icon: https://raw.githubusercontent.com/cert-manager/cert-manager/d53c0b9270f8cd90d908460d69502694e1838f5f/logo/logo-small.png
 git_url: https://github.com/cert-manager/cert-manager
 release_url: https://github.com/cert-manager/cert-manager/releases/tag/v{vsn}
+chart_url: https://charts.jetstack.io
 versions:
 - version: 1.15.0
   kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24']

--- a/static/compatibilities/cert-manager.yaml
+++ b/static/compatibilities/cert-manager.yaml
@@ -1,7 +1,7 @@
 icon: https://raw.githubusercontent.com/cert-manager/cert-manager/d53c0b9270f8cd90d908460d69502694e1838f5f/logo/logo-small.png
 git_url: https://github.com/cert-manager/cert-manager
 release_url: https://github.com/cert-manager/cert-manager/releases/tag/v{vsn}
-chart_url: https://charts.jetstack.io
+helm_repository_url: https://charts.jetstack.io
 versions:
 - version: 1.15.0
   kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24']

--- a/static/compatibilities/cert-manager.yaml
+++ b/static/compatibilities/cert-manager.yaml
@@ -7,94 +7,116 @@ versions:
   kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 1.15.0
 - version: 1.14.0
   kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 1.14.0
 - version: 1.13.0
   kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
   requirements: []
   incompatibilities: []
+  chart_version: 1.13.0
 - version: 1.12.0
   kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
   requirements: []
   incompatibilities: []
+  chart_version: 1.12.0
 - version: 1.11.0
   kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
   requirements: []
   incompatibilities: []
+  chart_version: 1.11.0
 - version: 1.10.0
   kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
   requirements: []
   incompatibilities: []
+  chart_version: 1.10.0
 - version: 1.9.0
   kube: ['1.24', '1.23', '1.22', '1.21', '1.20']
   requirements: []
   incompatibilities: []
+  chart_version: 1.9.0
 - version: 1.8.0
   kube: ['1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.8.0
 - version: 1.7.0
   kube: ['1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
   requirements: []
   incompatibilities: []
+  chart_version: 1.7.0
 - version: 1.6.0
   kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
   requirements: []
   incompatibilities: []
+  chart_version: 1.6.0
 - version: 1.5.0
   kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 1.5.0
 - version: 1.4.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 1.4.0
 - version: 1.3.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 1.3.0
 - version: 1.2.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 1.2.0
 - version: 1.1.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12',
     '1.11']
   requirements: []
   incompatibilities: []
+  chart_version: 1.1.0
 - version: 1.0.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12',
     '1.11']
   requirements: []
   incompatibilities: []
+  chart_version: 1.0.0
 - version: 0.16.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12',
     '1.11']
   requirements: []
   incompatibilities: []
+  chart_version: 0.16.0
 - version: 0.15.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12',
     '1.11']
   requirements: []
   incompatibilities: []
+  chart_version: 0.15.0
 - version: 0.14.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12',
     '1.11']
   requirements: []
   incompatibilities: []
+  chart_version: 0.14.0
 - version: 0.13.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12',
     '1.11']
   requirements: []
   incompatibilities: []
+  chart_version: 0.13.0
 - version: 0.12.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12',
     '1.11']
   requirements: []
   incompatibilities: []
+  chart_version: 0.12.0
 - version: 0.11.0
   kube: ['1.9']
   requirements: []
   incompatibilities: []
+  chart_version: 0.11.0

--- a/static/compatibilities/cilium.yaml
+++ b/static/compatibilities/cilium.yaml
@@ -1,32 +1,39 @@
 icon: https://avatars.githubusercontent.com/u/21054566?s=48&v=4
 release_url: https://github.com/cilium/cilium/releases/tag/{vsn}
+helm_repository_url: https://helm.cilium.io/
 versions:
 - version: 1.15.0
   kube: ['1.29', '1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 1.15.0
 - version: 1.14.0
-  kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21','1.20', '1.19']
+  kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.14.0
 - version: 1.13.0
-  kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21','1.20', '1.19', '1.18', '1.17', '1.16']
+  kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 1.13.0
 - version: 1.12.0
-  kube: ['1.24', '1.23', '1.22', '1.21','1.20', '1.19', '1.18', '1.17', '1.16']
+  kube: ['1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 1.12.0
 - version: 1.11.0
   kube: ['1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 1.11.0
 - version: 1.10.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 1.10.0
 - version: 1.9
-  kube: ["1.19", "1.18", "1.17", "1.16", "1.15", "1.14", "1.13", "1.12"]
+  kube: ['1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12']
   requirements: []
   incompatibilities: []
-  

--- a/static/compatibilities/contour.yaml
+++ b/static/compatibilities/contour.yaml
@@ -1,27 +1,33 @@
 icon: https://raw.githubusercontent.com/projectcontour/contour/main/assets/logo.png
 git_url: https://github.com/projectcontour/contour
 release_url: https://github.com/projectcontour/contour/releases/tag/v{vsn}
+helm_repository_url: https://charts.bitnami.com/bitnami
 versions:
 - version: 1.29.0
   kube: ['1.30', '1.29', '1.28']
   requirements: []
   incompatibilities: []
+  chart_version: 18.0.0
 - version: 1.28.4
   kube: ['1.29', '1.28', '1.27']
   requirements: []
   incompatibilities: []
+  chart_version: 17.0.12
 - version: 1.28.3
   kube: ['1.29', '1.28', '1.27']
   requirements: []
   incompatibilities: []
+  chart_version: 17.0.5
 - version: 1.28.2
   kube: ['1.29', '1.28', '1.27']
   requirements: []
   incompatibilities: []
+  chart_version: 17.0.1
 - version: 1.28.1
   kube: ['1.29', '1.28', '1.27']
   requirements: []
   incompatibilities: []
+  chart_version: 16.0.0
 - version: 1.28.0
   kube: ['1.29', '1.28', '1.27']
   requirements: []
@@ -38,10 +44,12 @@ versions:
   kube: ['1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 15.5.1
 - version: 1.27.0
   kube: ['1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 15.0.0
 - version: 1.26.3
   kube: ['1.28', '1.27', '1.26']
   requirements: []
@@ -54,10 +62,12 @@ versions:
   kube: ['1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 13.1.5
 - version: 1.26.0
   kube: ['1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 13.0.0
 - version: 1.25.3
   kube: ['1.27', '1.26', '1.25']
   requirements: []
@@ -66,14 +76,17 @@ versions:
   kube: ['1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 12.2.4
 - version: 1.25.1
   kube: ['1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 12.2.3
 - version: 1.25.0
   kube: ['1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 12.0.0
 - version: 1.24.6
   kube: ['1.26', '1.25', '1.24']
   requirements: []
@@ -86,18 +99,22 @@ versions:
   kube: ['1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 11.3.1
 - version: 1.24.3
   kube: ['1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 11.1.3
 - version: 1.24.2
   kube: ['1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 11.0.4
 - version: 1.24.1
   kube: ['1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 11.0.0
 - version: 1.24.0
   kube: ['1.26', '1.25', '1.24']
   requirements: []
@@ -118,18 +135,22 @@ versions:
   kube: ['1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
+  chart_version: 10.2.2
 - version: 1.23.2
   kube: ['1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
+  chart_version: 10.1.3
 - version: 1.23.1
   kube: ['1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
+  chart_version: 10.1.2
 - version: 1.23.0
   kube: ['1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
+  chart_version: 10.0.0
 - version: 1.22.6
   kube: ['1.24', '1.23', '1.22']
   requirements: []
@@ -154,10 +175,12 @@ versions:
   kube: ['1.24', '1.23', '1.22']
   requirements: []
   incompatibilities: []
+  chart_version: 9.1.2
 - version: 1.22.0
   kube: ['1.24', '1.23', '1.22']
   requirements: []
   incompatibilities: []
+  chart_version: 9.0.0
 - version: 1.21.3
   kube: ['1.23', '1.22', '1.21']
   requirements: []
@@ -170,10 +193,12 @@ versions:
   kube: ['1.23', '1.22', '1.21']
   requirements: []
   incompatibilities: []
+  chart_version: 8.0.1
 - version: 1.21.0
   kube: ['1.23', '1.22', '1.21']
   requirements: []
   incompatibilities: []
+  chart_version: 8.0.0
 - version: 1.20.2
   kube: ['1.23', '1.22', '1.21']
   requirements: []
@@ -182,6 +207,7 @@ versions:
   kube: ['1.23', '1.22', '1.21']
   requirements: []
   incompatibilities: []
+  chart_version: 7.10.1
 - version: 1.20.0
   kube: ['1.23', '1.22', '1.21']
   requirements: []

--- a/static/compatibilities/external-dns.yaml
+++ b/static/compatibilities/external-dns.yaml
@@ -1,47 +1,56 @@
 icon: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/img/external-dns.png?raw=true
 git_url: https://github.com/kubernetes-sigs/external-dns
 release_url: https://github.com/kubernetes-sigs/external-dns/releases/tag/v{vsn}
+chart_url: https://kubernetes-sigs.github.io/external-dns
 versions:
 - version: 0.14.2
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.14.5
 - version: 0.14.1
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.14.4
 - version: 0.14.0
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.14.0
 - version: 0.13.6
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.13.1
 - version: 0.13.5
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.13.0
 - version: 0.13.4
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.12.2
 - version: 0.13.2
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.12.1
 - version: 0.13.1
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.12.0
 - version: 0.13.0
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
@@ -52,6 +61,7 @@ versions:
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.11.0
 - version: 0.12.1
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
@@ -62,6 +72,7 @@ versions:
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.10.0
 - version: 0.11.1
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
@@ -72,26 +83,31 @@ versions:
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.9.0
 - version: 0.10.2
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.7.0
 - version: 0.10.1
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.4.0
 - version: 0.10.0
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
     '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 1.3.0
 - version: 0.9.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12',
     '1.11', '1.10']
   requirements: []
   incompatibilities: []
+  chart_version: 1.2.0
 - version: 0.8.0
   kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15', '1.14', '1.13', '1.12',
     '1.11', '1.10']

--- a/static/compatibilities/external-dns.yaml
+++ b/static/compatibilities/external-dns.yaml
@@ -1,7 +1,7 @@
 icon: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/img/external-dns.png?raw=true
 git_url: https://github.com/kubernetes-sigs/external-dns
 release_url: https://github.com/kubernetes-sigs/external-dns/releases/tag/v{vsn}
-chart_url: https://kubernetes-sigs.github.io/external-dns
+helm_repository_url: https://kubernetes-sigs.github.io/external-dns
 versions:
 - version: 0.14.2
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',

--- a/static/compatibilities/flux.yaml
+++ b/static/compatibilities/flux.yaml
@@ -1,6 +1,7 @@
 icon: https://avatars.githubusercontent.com/u/52158677?s=200&v=4
 git_url: https://github.com/fluxcd/flux2
 release_url: https://github.com/fluxcd/flux2/releases/tag/v{vsn}
+helm_repository_url: https://charts.fluxcd.io
 versions:
 - version: 2.3.0
   kube: ['1.30', '1.29', 1.28']

--- a/static/compatibilities/ingress-nginx.yaml
+++ b/static/compatibilities/ingress-nginx.yaml
@@ -1,6 +1,7 @@
 icon: https://github.com/pluralsh/plural-artifacts/blob/main/ingress-nginx/plural/icons/nginx.png?raw=true
 git_url: https://github.com/kubernetes/ingress-nginx
 release_url: https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v{vsn}
+chart_url: https://helm.nginx.com/stable/index.yaml
 versions:
 - version: 1.10.1
   kube: ['1.29', '1.28', '1.27', '1.26']

--- a/static/compatibilities/ingress-nginx.yaml
+++ b/static/compatibilities/ingress-nginx.yaml
@@ -1,7 +1,7 @@
 icon: https://github.com/pluralsh/plural-artifacts/blob/main/ingress-nginx/plural/icons/nginx.png?raw=true
 git_url: https://github.com/kubernetes/ingress-nginx
 release_url: https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v{vsn}
-chart_url: https://helm.nginx.com/stable/index.yaml
+chart_url: https://helm.nginx.com/stable
 versions:
 - version: 1.10.1
   kube: ['1.29', '1.28', '1.27', '1.26']

--- a/static/compatibilities/ingress-nginx.yaml
+++ b/static/compatibilities/ingress-nginx.yaml
@@ -7,10 +7,12 @@ versions:
   kube: ['1.29', '1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 0.8.1
 - version: 1.10.0
   kube: ['1.29', '1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 0.8.0
 - version: 1.9.6
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25']
   requirements: []
@@ -31,10 +33,12 @@ versions:
   kube: ['1.28', '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 0.7.1
 - version: 1.9.0
   kube: ['1.28', '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 0.7.0
 - version: 1.8.4
   kube: ['1.27', '1.26', '1.25', '1.24']
   requirements: []
@@ -43,6 +47,7 @@ versions:
   kube: ['1.27', '1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 0.5.1
 - version: 1.6.4
   kube: ['1.26', '1.25', '1.24', '1.23']
   requirements: []
@@ -51,6 +56,7 @@ versions:
   kube: ['1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
+  chart_version: 0.3.1
 - version: 1.4.0
   kube: ['1.25', '1.24', '1.23', '1.22']
   requirements: []

--- a/static/compatibilities/ingress-nginx.yaml
+++ b/static/compatibilities/ingress-nginx.yaml
@@ -1,67 +1,75 @@
 icon: https://github.com/pluralsh/plural-artifacts/blob/main/ingress-nginx/plural/icons/nginx.png?raw=true
 git_url: https://github.com/kubernetes/ingress-nginx
 release_url: https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v{vsn}
-chart_url: https://helm.nginx.com/stable
+helm_repository_url: https://kubernetes.github.io/ingress-nginx
 versions:
 - version: 1.10.1
   kube: ['1.29', '1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
-  chart_version: 0.8.1
+  chart_version: 4.10.1
 - version: 1.10.0
   kube: ['1.29', '1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
-  chart_version: 0.8.0
+  chart_version: 4.10.0
 - version: 1.9.6
   kube: ['1.29', '1.28', '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 4.9.1
 - version: 1.9.5
   kube: ['1.28', '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 4.9.0
 - version: 1.9.4
   kube: ['1.28', '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 4.8.3
 - version: 1.9.3
   kube: ['1.28', '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 4.8.2
 - version: 1.9.1
   kube: ['1.28', '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
-  chart_version: 0.7.1
+  chart_version: 4.8.1
 - version: 1.9.0
   kube: ['1.28', '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
-  chart_version: 0.7.0
+  chart_version: 4.8.0
 - version: 1.8.4
   kube: ['1.27', '1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 4.7.3
 - version: 1.7.1
   kube: ['1.27', '1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
-  chart_version: 0.5.1
+  chart_version: 4.6.1
 - version: 1.6.4
   kube: ['1.26', '1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
+  chart_version: 4.5.2
 - version: 1.5.1
   kube: ['1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
-  chart_version: 0.3.1
+  chart_version: 4.4.0
 - version: 1.4.0
   kube: ['1.25', '1.24', '1.23', '1.22']
   requirements: []
   incompatibilities: []
+  chart_version: 4.3.0
 - version: 1.3.1
   kube: ['1.24', '1.23', '1.22', '1.21', '1.20']
   requirements: []
   incompatibilities: []
+  chart_version: 4.2.4

--- a/static/compatibilities/istio.yaml
+++ b/static/compatibilities/istio.yaml
@@ -1,6 +1,7 @@
 icon: https://raw.githubusercontent.com/pluralsh/plural-artifacts/main/istio/plural/icons/istio.png?raw=true
 git_url: https://github.com/istio/istio
 release_url: https://github.com/istio/istio/releases/tag/{vsn}
+helm_repository_url: https://istio-release.storage.googleapis.com/charts
 versions:
 - version: 1.22.0
   kube: ['1.30', '1.29', 1.28', '1.27']

--- a/static/compatibilities/jaeger.yaml
+++ b/static/compatibilities/jaeger.yaml
@@ -1,6 +1,7 @@
 icon: https://avatars.githubusercontent.com/u/28545596?s=200&v=4
 git_url: https://github.com/jaegertracing/jaeger
 release_url: https://github.com/jaegertracing/jaeger/releases/tag/v{vsn}
+helm_repository_url: https://jaegertracing.github.io/helm-charts
 versions:
 - version: 1.57.0
   kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
@@ -22,6 +23,7 @@ versions:
   kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 0.74.1
 - version: 1.52.0
   kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []
@@ -30,6 +32,7 @@ versions:
   kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 0.72.0
 - version: 1.50.0
   kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []
@@ -54,6 +57,7 @@ versions:
   kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 0.71.0
 - version: 1.44.0
   kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []
@@ -66,6 +70,7 @@ versions:
   kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []
   incompatibilities: []
+  chart_version: 0.69.0
 - version: 1.41.0
   kube: ['1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
   requirements: []

--- a/static/compatibilities/keda.yaml
+++ b/static/compatibilities/keda.yaml
@@ -1,36 +1,45 @@
 icon: https://avatars.githubusercontent.com/u/49917779?s=48&v=4
 git_url: https://github.com/kedacore/keda
 release_url: https://github.com/kedacore/keda/releases/tag/v{vsn}
+helm_repository_url: https://kedacore.github.io/charts
 versions:
 - version: 2.14.0
   kube: ['1.29', '1.28', '1.27']
   requirements: []
   incompatibilities: []
+  chart_version: 2.14.0
 - version: 2.13.0
   kube: ['1.29', '1.28', '1.27']
   requirements: []
   incompatibilities: []
+  chart_version: 2.13.0
 - version: 2.12.0
   kube: ['1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 2.12.0
 - version: 2.11.0
   kube: ['1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 2.11.0
 - version: 2.10.0
   kube: ['1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 2.10.0
 - version: 2.9.0
   kube: ['1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
+  chart_version: 2.9.0
 - version: 2.8.0
   kube: ['1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
   requirements: []
   incompatibilities: []
+  chart_version: 2.8.0
 - version: 2.7.0
   kube: ['1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
   requirements: []
   incompatibilities: []
+  chart_version: 2.7.0

--- a/static/compatibilities/kube-prometheus-stack.yaml
+++ b/static/compatibilities/kube-prometheus-stack.yaml
@@ -2,6 +2,7 @@ icon: https://github.com/pluralsh/plural-artifacts/blob/main/monitoring/plural/i
 git_url: https://github.com/prometheus-community/helm-charts
 release_url: https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-{vsn}
 readme_url: https://raw.githubusercontent.com/prometheus-community/helm-charts/main/charts/kube-prometheus-stack/README.md
+helm_repository_url: https://prometheus-community.github.io/helm-charts
 versions:
 - version: 54.0.0
   kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']

--- a/static/compatibilities/kyverno.yaml
+++ b/static/compatibilities/kyverno.yaml
@@ -1,32 +1,40 @@
 icon: https://avatars.githubusercontent.com/u/68448710?s=48&v=4
 git_url: https://github.com/kyverno/kyverno
 release_url: https://github.com/kyverno/kyverno/releases/tag/v{vsn}
+helm_repository_url: https://kyverno.github.io/kyverno/
 versions:
 - version: 1.12.0
   kube: ['1.29', '1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
+  chart_version: 3.2.0
 - version: 1.11.0
   kube: ['1.28', '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
+  chart_version: 3.1.0
 - version: 1.10.0
   kube: ['1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 3.0.0
 - version: 1.9.0
   kube: ['1.26', '1.25', '1.24']
   requirements: []
   incompatibilities: []
+  chart_version: 2.7.0
 - version: 1.8.0
   kube: ['1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
+  chart_version: 2.6.0
 - version: 1.7.0
   kube: ['1.23', '1.22', '1.21']
   requirements: []
   incompatibilities: []
+  chart_version: 2.4.0
 - version: 1.6.0
   kube: ['1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []
+  chart_version: 2.2.0

--- a/static/compatibilities/linkerd.yaml
+++ b/static/compatibilities/linkerd.yaml
@@ -1,6 +1,7 @@
 icon: https://avatars.githubusercontent.com/u/25301026?s=200&v=4
 git_url: https://github.com/linkerd/linkerd2
 release_url: https://github.com/linkerd/linkerd2/releases/tag/{vsn}
+helm_repository_url: https://helm.linkerd.io/stable
 versions:
 - version: 2.14
   kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
@@ -18,7 +19,7 @@ versions:
   kube: ['1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
   requirements: []
   incompatibilities: []
-- version: 2.10
+- version: 2.1
   kube: ['1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
   requirements: []
   incompatibilities: []

--- a/utils/compatibility/main.py
+++ b/utils/compatibility/main.py
@@ -2,7 +2,7 @@
 import os
 import importlib
 from colorama import Fore, Style
-from utils import read_yaml, print_error, print_warning, update_chart_versions
+from utils import read_yaml, print_error, print_warning
 
 
 def call_scraper(scraper):
@@ -35,7 +35,5 @@ if "names" not in manifest:
 
 for name in manifest["names"]:
     print(Fore.GREEN + f"Calling scraper for {name}" + Style.RESET_ALL)
-    # call_scraper(name)
-    if name == "ingress-nginx":
-        update_chart_versions(name)
+    call_scraper(name)
     print("\n")

--- a/utils/compatibility/main.py
+++ b/utils/compatibility/main.py
@@ -35,6 +35,12 @@ if "names" not in manifest:
 
 for name in manifest["names"]:
     if name == "cert-manager":
-        print(Fore.GREEN + f"Calling scraper for {name}" + Style.RESET_ALL)
+        print(
+            Fore.BLUE
+            + "Calling scraper for"
+            + Fore.YELLOW
+            + f" {name}"
+            + Style.RESET_ALL
+        )
         call_scraper(name)
         print("\n")

--- a/utils/compatibility/main.py
+++ b/utils/compatibility/main.py
@@ -34,7 +34,7 @@ if "names" not in manifest:
     print_error("No names found in the manifest file.")
 
 for name in manifest["names"]:
-    if name == "cert-manager":
+    if name == "ingress-nginx":
         print(
             Fore.BLUE
             + "Calling scraper for"

--- a/utils/compatibility/main.py
+++ b/utils/compatibility/main.py
@@ -1,8 +1,8 @@
 # main.py
 import os
 import importlib
-from utils import read_yaml, print_error, print_warning
 from colorama import Fore, Style
+from utils import read_yaml, print_error, print_warning, update_chart_versions
 
 
 def call_scraper(scraper):
@@ -35,5 +35,7 @@ if "names" not in manifest:
 
 for name in manifest["names"]:
     print(Fore.GREEN + f"Calling scraper for {name}" + Style.RESET_ALL)
-    call_scraper(name)
+    # call_scraper(name)
+    if name == "ingress-nginx":
+        update_chart_versions(name)
     print("\n")

--- a/utils/compatibility/main.py
+++ b/utils/compatibility/main.py
@@ -34,6 +34,7 @@ if "names" not in manifest:
     print_error("No names found in the manifest file.")
 
 for name in manifest["names"]:
-    print(Fore.GREEN + f"Calling scraper for {name}" + Style.RESET_ALL)
-    call_scraper(name)
-    print("\n")
+    if name == "cert-manager":
+        print(Fore.GREEN + f"Calling scraper for {name}" + Style.RESET_ALL)
+        call_scraper(name)
+        print("\n")

--- a/utils/compatibility/main.py
+++ b/utils/compatibility/main.py
@@ -34,13 +34,12 @@ if "names" not in manifest:
     print_error("No names found in the manifest file.")
 
 for name in manifest["names"]:
-    if name == "ingress-nginx":
-        print(
-            Fore.BLUE
-            + "Calling scraper for"
-            + Fore.YELLOW
-            + f" {name}"
-            + Style.RESET_ALL
-        )
-        call_scraper(name)
-        print("\n")
+    print(
+        Fore.BLUE
+        + "Calling scraper for"
+        + Fore.MAGENTA
+        + f" {name}"
+        + Style.RESET_ALL
+    )
+    call_scraper(name)
+    print("\n")

--- a/utils/compatibility/scrapers/argo-rollouts.py
+++ b/utils/compatibility/scrapers/argo-rollouts.py
@@ -1,0 +1,49 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "argo-rollouts"
+compatibility_url = "https://argoproj.github.io/rollouts/"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/scrapers/cert-manager.py
+++ b/utils/compatibility/scrapers/cert-manager.py
@@ -2,7 +2,12 @@
 
 from bs4 import BeautifulSoup
 from collections import OrderedDict
-from utils import print_error, fetch_page, update_compatibility_info
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
 
 
 def parse_page(content):
@@ -85,3 +90,4 @@ def scrape():
     update_compatibility_info(
         "../../static/compatibilities/cert-manager.yaml", rows
     )
+    update_chart_versions("cert-manager")

--- a/utils/compatibility/scrapers/cilium.py
+++ b/utils/compatibility/scrapers/cilium.py
@@ -1,0 +1,49 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "cilium"
+compatibility_url = (
+    "https://docs.cilium.io/en/stable/network/kubernetes/compatibility/"
+)
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/scrapers/contour.py
+++ b/utils/compatibility/scrapers/contour.py
@@ -1,0 +1,47 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "contour"
+compatibility_url = "https://projectcontour.io/resources/compatibility-matrix"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/scrapers/external-dns.py
+++ b/utils/compatibility/scrapers/external-dns.py
@@ -3,7 +3,7 @@
 import requests
 from collections import OrderedDict
 from packaging.version import Version
-from utils import print_error, update_compatibility_info
+from utils import print_error, update_compatibility_info, update_chart_versions
 
 GITHUB_REPO_URL = "https://github.com/kubernetes-sigs/external-dns"
 GITHUB_API_TAGS_URL = (
@@ -81,3 +81,4 @@ def scrape():
     update_compatibility_info(
         "../../static/compatibilities/external-dns.yaml", rows
     )
+    update_chart_versions("external-dns")

--- a/utils/compatibility/scrapers/flux.py
+++ b/utils/compatibility/scrapers/flux.py
@@ -8,8 +8,8 @@ from utils import (
     update_chart_versions,
 )
 
-app_name = "new-app"
-compatibility_url = "https://cert-manager.io/docs/releases/"
+app_name = "flux"
+compatibility_url = "https://fluxcd.io/flux/installation"
 
 
 def parse_page(content):

--- a/utils/compatibility/scrapers/ingress-nginx.py
+++ b/utils/compatibility/scrapers/ingress-nginx.py
@@ -77,4 +77,4 @@ def scrape():
     update_compatibility_info(
         "../../static/compatibilities/ingress-nginx.yaml", rows
     )
-    update_chart_versions("ingress-nginx", "nginx-ingress")
+    update_chart_versions("ingress-nginx")

--- a/utils/compatibility/scrapers/ingress-nginx.py
+++ b/utils/compatibility/scrapers/ingress-nginx.py
@@ -2,7 +2,12 @@
 
 from bs4 import BeautifulSoup
 from collections import OrderedDict
-from utils import print_error, fetch_page, update_compatibility_info
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
 
 
 def parse_page(content):
@@ -56,3 +61,4 @@ def scrape():
     update_compatibility_info(
         "../../static/compatibilities/ingress-nginx.yaml", rows
     )
+    update_chart_versions("ingress-nginx", "nginx-ingress")

--- a/utils/compatibility/scrapers/ingress-nginx.py
+++ b/utils/compatibility/scrapers/ingress-nginx.py
@@ -14,15 +14,13 @@ def parse_page(content):
         "h3", text="Supported Versions table"
     )
     if not supported_versions_section:
-        print_error(
-            "Could not find the 'Supported Versions table' section on the page."
-        )
+        print_error("Could not find the 'Supported Versions table' section.")
         return None
 
     table = supported_versions_section.find_next("table")
     if not table:
         print_error(
-            "Could not find the table following the 'Supported Versions table' section."
+            "Could not find the table 'Supported Versions table' section."
         )
         return None
     return table

--- a/utils/compatibility/scrapers/istio.py
+++ b/utils/compatibility/scrapers/istio.py
@@ -1,0 +1,47 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "istio"
+compatibility_url = "https://istio.io/latest/docs/releases/supported-releases/"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name, "base")

--- a/utils/compatibility/scrapers/jaeger.py
+++ b/utils/compatibility/scrapers/jaeger.py
@@ -1,0 +1,47 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "jaeger"
+compatibility_url = "https://cert-manager.io/docs/releases/"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/scrapers/keda.py
+++ b/utils/compatibility/scrapers/keda.py
@@ -1,0 +1,47 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "keda"
+compatibility_url = "https://cert-manager.io/docs/releases/"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/scrapers/kube-prometheus-stack.py
+++ b/utils/compatibility/scrapers/kube-prometheus-stack.py
@@ -1,0 +1,47 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "kube-prometheus-stack"
+compatibility_url = "https://github.com/prometheus-operator/kube-prometheus"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/scrapers/kyverno.py
+++ b/utils/compatibility/scrapers/kyverno.py
@@ -1,0 +1,47 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "kyverno"
+compatibility_url = "https://kyverno.io/docs/installation"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/scrapers/linkerd.py
+++ b/utils/compatibility/scrapers/linkerd.py
@@ -8,8 +8,8 @@ from utils import (
     update_chart_versions,
 )
 
-app_name = "new-app"
-compatibility_url = "https://cert-manager.io/docs/releases/"
+app_name = "linkerd"
+compatibility_url = "https://linkerd.io/2.15/reference/k8s-versions"
 
 
 def parse_page(content):
@@ -44,4 +44,4 @@ def scrape():
     else:
         print_error("No compatibility information found.")
 
-    update_chart_versions(app_name)
+    update_chart_versions(app_name, app_name + "2")

--- a/utils/compatibility/scrapers/new-scraper copy 3.py
+++ b/utils/compatibility/scrapers/new-scraper copy 3.py
@@ -1,0 +1,47 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "new-app"
+compatibility_url = "https://cert-manager.io/docs/releases/"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/scrapers/new-scraper copy.py
+++ b/utils/compatibility/scrapers/new-scraper copy.py
@@ -1,0 +1,47 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "new-app"
+compatibility_url = "https://cert-manager.io/docs/releases/"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/scrapers/new-scraper.py
+++ b/utils/compatibility/scrapers/new-scraper.py
@@ -1,0 +1,47 @@
+# scrapers/cert_manager.py
+
+from bs4 import BeautifulSoup
+from utils import (
+    print_error,
+    fetch_page,
+    update_compatibility_info,
+    update_chart_versions,
+)
+
+app_name = "new-app"
+compatibility_url = "https://cert-manager.io/docs/releases/"
+
+
+def parse_page(content):
+    soup = BeautifulSoup(content, "html.parser")
+    sections = soup.find_all("h2")
+    return sections
+
+
+def find_target_tables(sections):
+    target_tables = []
+    return target_tables
+
+
+def extract_table_data(target_tables):
+    rows = []
+    return rows
+
+
+def scrape():
+
+    page_content = fetch_page(compatibility_url)
+    if not page_content:
+        return
+
+    sections = parse_page(page_content)
+    target_tables = find_target_tables(sections)
+    if target_tables.__len__() >= 1:
+        rows = extract_table_data(target_tables)
+        update_compatibility_info(
+            f"../../static/compatibilities/{app_name}.yaml", rows
+        )
+    else:
+        print_error("No compatibility information found.")
+
+    update_chart_versions(app_name)

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -64,10 +64,12 @@ def update_chart_versions(app_name, chart_name=""):
         print_error(f"No versions found for {app_name}")
         return
 
-    chart_url = compatibility_yaml["chart_url"]
-    chart_index = fetch_page(chart_url + "/index.yaml")
+    helm_repository_url = compatibility_yaml["helm_repository_url"]
+    chart_index = fetch_page(helm_repository_url + "/index.yaml")
     if not chart_index:
-        print_error(f"Failed to fetch the index.yaml from {chart_url}")
+        print_error(
+            f"Failed to fetch the index.yaml from {helm_repository_url}"
+        )
         return
 
     index_yaml = yaml.safe_load(chart_index)

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -18,6 +18,16 @@ def print_warning(message):
     print(Fore.YELLOW + "⚠️ Warning:" + Style.RESET_ALL + f" {message}")
 
 
+def fetch_page(url):
+    response = requests.get(url)
+    if response.status_code != 200:
+        print_error(
+            f"Failed to fetch the page. Status code: {response.status_code}"
+        )
+        return None
+    return response.content
+
+
 def read_yaml(file_path):
     try:
         with open(file_path, "r") as file:
@@ -82,19 +92,11 @@ def update_chart_versions(app_name, chart_name=""):
                 row["chart_version"] = chart_version
 
     if write_yaml(yaml_file_name, compatibility_yaml):
-        print_success(f"Updated chart versions for {app_name}")
+        print_success(
+            "Updated chart versions for" + Fore.CYAN + f" {app_name}"
+        )
     else:
         print_error(f"Failed to update chart versions for {app_name}")
-
-
-def fetch_page(url):
-    response = requests.get(url)
-    if response.status_code != 200:
-        print_error(
-            f"Failed to fetch the page. Status code: {response.status_code}"
-        )
-        return None
-    return response.content
 
 
 # Custom YAML representer for lists that contain only strings
@@ -146,7 +148,9 @@ def update_compatibility_info(filepath, new_versions):
                     data, file, default_flow_style=False, sort_keys=False
                 )
             print_success(
-                "Updated compatibility info in" + Fore.CYAN + f" {filepath}"
+                "Updated compatibility info table: "
+                + Fore.CYAN
+                + f" {filepath}"
             )
         else:
             print_warning("No existing versions found. Writing new data.")

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -140,7 +140,12 @@ def update_compatibility_info(filepath, new_versions):
         else:
             print_warning("No existing versions found. Writing new data.")
             data = {"versions": sort_versions(new_versions)}
-        save_versions(filepath, data)
+        if write_yaml(filepath, data):
+            print_success(
+                f"Updated compatibility info table: {Fore.CYAN}{filepath}"
+            )
+        else:
+            print_error(f"Failed to update compatibility info for {filepath}")
     except Exception as e:
         print_error(f"Failed to update compatibility info: {e}")
 

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -32,7 +32,10 @@ def read_yaml(file_path):
     return None
 
 
-def update_chart_versions(app_name, chart_name):
+def update_chart_versions(app_name, chart_name=""):
+    if not chart_name:
+        chart_name = app_name
+
     compatibility_yaml = read_yaml(
         f"../../static/compatibilities/{app_name}.yaml"
     )
@@ -43,7 +46,7 @@ def update_chart_versions(app_name, chart_name):
         return
 
     chart_url = compatibility_yaml["chart_url"]
-    chart_index = fetch_page(chart_url)
+    chart_index = fetch_page(chart_url + "/index.yaml")
     if not chart_index:
         print_error(f"Failed to fetch the index.yaml from {chart_url}")
         return
@@ -53,25 +56,7 @@ def update_chart_versions(app_name, chart_name):
         print_error(f"Failed to parse the index.yaml for {app_name}")
         return
 
-    try:
-        for versions in compatibility_yaml["versions"]:
-            bin_version = versions["version"]
-            chart_entries = index_yaml["entries"].get(chart_name, [])
-            if not chart_entries:
-                print_warning(f"No chart entries found for {chart_name}")
-                continue
-            latest_chart = max(
-                chart_entries, key=lambda x: Version(x["version"])
-            )
-            chart_version = latest_chart["version"]
-            print("Chart Version: ", chart_version)
-            print("App Version: ", bin_version)
-    except KeyError as e:
-        print_error(f"Key error while processing {app_name}: {e}")
-    except Exception as e:
-        print_error(
-            f"An unexpected error occurred while processing {app_name}: {e}"
-        )
+    print(index_yaml["entries"][chart_name])
 
 
 def fetch_page(url):

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -92,7 +92,9 @@ def update_chart_versions(app_name, chart_name=""):
                 row["chart_version"] = chart_version
 
     if write_yaml(yaml_file_name, compatibility_yaml):
-        print_success("Updated chart versions for" + Fore.CYAN + f" {app_name}")
+        print_success(
+            "Updated chart versions for" + Fore.CYAN + f" {app_name}"
+        )
     else:
         print_error(f"Failed to update chart versions for {app_name}")
 

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -92,9 +92,7 @@ def update_chart_versions(app_name, chart_name=""):
                 row["chart_version"] = chart_version
 
     if write_yaml(yaml_file_name, compatibility_yaml):
-        print_success(
-            "Updated chart versions for" + Fore.CYAN + f" {app_name}"
-        )
+        print_success("Updated chart versions for" + Fore.CYAN + f" {app_name}")
     else:
         print_error(f"Failed to update chart versions for {app_name}")
 

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -117,17 +117,6 @@ def update_versions_data(data, new_versions):
     data["versions"] = sort_versions(list(merged_versions.values()))
 
 
-def save_versions(filepath, data):
-    try:
-        with open(filepath, "w") as file:
-            yaml.dump(data, file, default_flow_style=False, sort_keys=False)
-        print_success(
-            f"Updated compatibility info table: {Fore.CYAN}{filepath}"
-        )
-    except Exception as e:
-        print_error(f"Failed to update compatibility info: {e}")
-
-
 def update_compatibility_info(filepath, new_versions):
     for version in new_versions:
         version["kube"] = sorted(

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -32,6 +32,48 @@ def read_yaml(file_path):
     return None
 
 
+def update_chart_versions(app_name, chart_name):
+    compatibility_yaml = read_yaml(
+        f"../../static/compatibilities/{app_name}.yaml"
+    )
+    if not compatibility_yaml or "versions" not in compatibility_yaml:
+        print_error(
+            f"No versions found for {app_name}, cannot update chart version."
+        )
+        return
+
+    chart_url = compatibility_yaml["chart_url"]
+    chart_index = fetch_page(chart_url)
+    if not chart_index:
+        print_error(f"Failed to fetch the index.yaml from {chart_url}")
+        return
+
+    index_yaml = yaml.safe_load(chart_index)
+    if not index_yaml:
+        print_error(f"Failed to parse the index.yaml for {app_name}")
+        return
+
+    try:
+        for versions in compatibility_yaml["versions"]:
+            bin_version = versions["version"]
+            chart_entries = index_yaml["entries"].get(chart_name, [])
+            if not chart_entries:
+                print_warning(f"No chart entries found for {chart_name}")
+                continue
+            latest_chart = max(
+                chart_entries, key=lambda x: Version(x["version"])
+            )
+            chart_version = latest_chart["version"]
+            print("Chart Version: ", chart_version)
+            print("App Version: ", bin_version)
+    except KeyError as e:
+        print_error(f"Key error while processing {app_name}: {e}")
+    except Exception as e:
+        print_error(
+            f"An unexpected error occurred while processing {app_name}: {e}"
+        )
+
+
 def fetch_page(url):
     response = requests.get(url)
     if response.status_code != 200:


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Updated the `ingress-nginx` scraper to support new readme for nginx and k8s-supported versions
Add helm chart version updater

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
I tested manually and verified the chart versions match the app versions in both the original hem index.yaml and the updated compatibility tables

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [X] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added a meaningful title and summary to convey the impact of this PR to a user.
