### PR TITLE
Scope evaluation is interfering with serviceaccount crd creds

### DIFF
--- a/controller/internal/controller/pipeline_controller.go
+++ b/controller/internal/controller/pipeline_controller.go
@@ -116,7 +116,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 	attrs, err := r.pipelineAttributes(ctx, pipeline, project.Status.ID)
 	if err != nil {
 		utils.MarkCondition(pipeline.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
-		return requeue, err
+		return requeue, nil
 	}
 
 	// Calculate SHA to detect changes that should be applied in the Console API.
@@ -130,7 +130,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 	apiPipeline, err := r.sync(ctx, pipeline, *attrs, sha)
 	if err != nil {
 		utils.MarkCondition(pipeline.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
-		return requeue, err
+		return ctrl.Result{}, err
 	}
 
 	// Update resource status.

--- a/lib/console/graphql/deployments/service.ex
+++ b/lib/console/graphql/deployments/service.ex
@@ -492,6 +492,7 @@ defmodule Console.GraphQl.Deployments.Service do
     field :create_service_deployment, :service_deployment do
       middleware Authenticated
       middleware Feature, :cd
+
       arg :cluster_id, :id
       arg :cluster,    :string, description: "the handle of the cluster for this service"
       arg :attributes, non_null(:service_deployment_attributes)
@@ -502,7 +503,7 @@ defmodule Console.GraphQl.Deployments.Service do
     field :update_service_deployment, :service_deployment do
       middleware Authenticated
       middleware Feature, :cd
-      middleware Scope, api: "updateServiceDeployment"
+
       arg :id,         :id
       arg :cluster,    :string, description: "the handle of the cluster for this service"
       arg :name,       :string

--- a/lib/console/graphql/resolvers/deployments/cluster.ex
+++ b/lib/console/graphql/resolvers/deployments/cluster.ex
@@ -15,7 +15,7 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
     |> allow(user, :view)
   end
   def resolve_cluster(%{id: id}, %{context: %{current_user: user}}) when is_binary(id) do
-    Clusters.get_cluster(id)
+    Clusters.get_cluster!(id)
     |> allow(user, :view)
   end
   def resolve_cluster(_, _), do: {:error, "must provide either handle or id"}

--- a/lib/console/graphql/resolvers/deployments/service.ex
+++ b/lib/console/graphql/resolvers/deployments/service.ex
@@ -8,7 +8,7 @@ defmodule Console.GraphQl.Resolvers.Deployments.Service do
 
   def resolve_service(%{cluster: _, name: _} = args, ctx) do
     fetch_service(args)
-    |> allow(actor(ctx), :name)
+    |> allow(actor(ctx), :read)
   end
   def resolve_service(%{id: id}, ctx) do
     Services.get_service!(id)

--- a/test/console/graphql/mutations/deployments/services_mutations_test.exs
+++ b/test/console/graphql/mutations/deployments/services_mutations_test.exs
@@ -198,6 +198,7 @@ defmodule Console.GraphQl.Deployments.ServicesMutationsTest do
       assert conf["value"] == "new-value"
     end
 
+    @tag :skip
     test "enforces scopes" do
       cluster = insert(:cluster, handle: "test")
       user = admin_user()


### PR DESCRIPTION
Pretty sure this is causing forbidden errors when using namespace credentials.  This feature isn't actively used, so disable for now.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
