### PR TITLE
update pipeline queries fetch policies

### DIFF
--- a/assets/src/components/cd/pipelines/PipelineContexts.tsx
+++ b/assets/src/components/cd/pipelines/PipelineContexts.tsx
@@ -124,6 +124,7 @@ export function PipelineContexts({
 
   const { data } = usePipelineContextsQuery({
     variables: { id: pipeline?.id || '', first: 100 },
+    fetchPolicy: 'cache-and-network',
     skip: !pipeline?.id,
   })
   const tableData = data?.pipeline?.contexts?.edges ?? []

--- a/assets/src/components/cd/pipelines/PipelineDetails.tsx
+++ b/assets/src/components/cd/pipelines/PipelineDetails.tsx
@@ -125,6 +125,7 @@ function PipelineSelector({
   const [isOpen, setIsOpen] = useState(false)
   const { data } = usePipelinesQuery({
     variables: { first: 20, q: throttledInputValue, projectId },
+    fetchPolicy: 'cache-and-network',
   })
   const navigate = useNavigate()
 

--- a/assets/src/components/cd/pipelines/context/PipelineContextDetails.tsx
+++ b/assets/src/components/cd/pipelines/context/PipelineContextDetails.tsx
@@ -24,6 +24,7 @@ export function PipelineContextDetails() {
   const contextId = useParams().contextId!
   const { data, error } = usePipelineContextQuery({
     variables: { id: contextId || '' },
+    fetchPolicy: 'cache-and-network',
     skip: !contextId,
   })
   const context = data?.pipelineContext

--- a/assets/src/components/cd/pipelines/job/PipelineJob.tsx
+++ b/assets/src/components/cd/pipelines/job/PipelineJob.tsx
@@ -108,6 +108,7 @@ export default function PipelineJob() {
 
   const { data, error, refetch } = useJobGateQuery({
     variables: { id: jobId },
+    fetchPolicy: 'cache-and-network',
     pollInterval: POLL_INTERVAL,
   })
 

--- a/assets/src/components/cd/pipelines/job/PipelineJobLogs.tsx
+++ b/assets/src/components/cd/pipelines/job/PipelineJobLogs.tsx
@@ -53,6 +53,7 @@ export default function PipelineJobLogs() {
   )
   const { data: jobGateData } = useJobGateQuery({
     variables: { id },
+    fetchPolicy: 'cache-and-network',
   })
   const jobGateState = jobGateData?.pipelineGate?.state
 
@@ -66,6 +67,7 @@ export default function PipelineJobLogs() {
     refetch,
   } = useJobGateLogsQuery({
     variables: { id, container: containers?.[0]?.name || '', sinceSeconds },
+    fetchPolicy: 'cache-and-network',
     notifyOnNetworkStatusChange: true,
   })
   const data = currentData || previousData


### PR DESCRIPTION
handful of queries related to pipelines were defaulting to cache-first instead of cache-and-network