### PR TITLE
Add parentId to reconciled service deployments

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -4277,6 +4277,7 @@ export type RootMutationType = {
   executeRunbook?: Maybe<RunbookActionResponse>;
   /** forces a pipeline gate to be in open state */
   forceGate?: Maybe<PipelineGate>;
+  impersonateServiceAccount?: Maybe<User>;
   installAddOn?: Maybe<ServiceDeployment>;
   installRecipe?: Maybe<Build>;
   installStack?: Maybe<Build>;
@@ -4798,6 +4799,11 @@ export type RootMutationTypeExecuteRunbookArgs = {
 export type RootMutationTypeForceGateArgs = {
   id: Scalars['ID']['input'];
   state?: InputMaybe<GateState>;
+};
+
+
+export type RootMutationTypeImpersonateServiceAccountArgs = {
+  email: Scalars['String']['input'];
 };
 
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,7 @@ config :console,
   local_cache: Console.LocalCache,
   version: Mix.Project.config[:version],
   kas_dns: "https://kas.example.com",
-  qps: 40,
+  qps: 1_000,
   jwt_pub_key: or_nil.(File.read("config/pubkey.pem"))
 
 config :logger, :console,

--- a/controller/internal/controller/servicedeployment_controller.go
+++ b/controller/internal/controller/servicedeployment_controller.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	ServiceFinalizer = "deployments.plural.sh/service-protection"
+	ServiceFinalizer    = "deployments.plural.sh/service-protection"
+	InventoryAnnotation = "config.k8s.io/owning-inventory"
 )
 
 // ServiceReconciler reconciles a Service object
@@ -258,6 +259,10 @@ func (r *ServiceReconciler) genServiceAttributes(ctx context.Context, service *v
 		Kustomize:       service.Spec.Kustomize.Attributes(),
 		Dependencies:    service.Spec.DependenciesAttribute(),
 		SyncConfig:      syncConfigAttributes,
+	}
+
+	if id, ok := service.GetAnnotations()[InventoryAnnotation]; ok && id != "" {
+		attr.ParentID = lo.ToPtr(id)
 	}
 
 	if len(service.Spec.Imports) > 0 {

--- a/lib/console/deployments/policies/policies.ex
+++ b/lib/console/deployments/policies/policies.ex
@@ -134,8 +134,10 @@ defmodule Console.Deployments.Policies do
   def can?(%User{} = user, %Stack{} = stack, :create) do
     %{cluster: %Cluster{} = cluster} = Repo.preload(stack, [:cluster])
 
-    rbac(user, stack, :write) && can?(user, cluster, :write)
+    rbac(stack, user, :write) && can?(user, cluster, :write)
   end
+
+  def can?(%User{} = user, %User{service_account: true} = sa, :assume), do: rbac(sa, user, :assume)
 
   def can?(%User{} = user, resource, action),
     do: rbac(resource, user, action)

--- a/lib/console/graphql/resolvers/user.ex
+++ b/lib/console/graphql/resolvers/user.ex
@@ -215,6 +215,11 @@ defmodule Console.GraphQl.Resolvers.User do
   def delete_group_member(%{group_id: group_id, user_id: user_id}, _),
     do: Users.delete_group_member(group_id, user_id)
 
+  def impersonate(%{email: email}, %{context: %{current_user: user}}) do
+    Users.impersonate_service_account(email, user)
+    |> with_jwt()
+  end
+
   def create_role(%{attributes: attrs}, _) do
     with_permissions(attrs)
     |> Users.create_role()

--- a/lib/console/graphql/users.ex
+++ b/lib/console/graphql/users.ex
@@ -513,6 +513,14 @@ defmodule Console.GraphQl.Users do
       safe_resolve &User.delete_user/2
     end
 
+    field :impersonate_service_account, :user do
+      middleware Authenticated
+      middleware AllowJwt
+      arg :email, non_null(:string)
+
+      safe_resolve &User.impersonate/2
+    end
+
     field :mark_read, :user do
       middleware Authenticated
       arg :type, :read_type

--- a/lib/console/schema/managed_namespace.ex
+++ b/lib/console/schema/managed_namespace.ex
@@ -12,13 +12,7 @@ defmodule Console.Schema.ManagedNamespace do
 
     def changeset(model, attrs \\ %{}) do
       model
-      |> cast(attrs, ~w(distro)a)
-      |> cast_embed(:tags, with: &tag_changeset/2)
-    end
-
-    defp tag_changeset(model, attrs) do
-      model
-      |> cast(attrs, ~w(name value)a)
+      |> cast(attrs, ~w(distro tags)a)
     end
   end
 

--- a/lib/console/schema/service.ex
+++ b/lib/console/schema/service.ex
@@ -266,6 +266,17 @@ defmodule Console.Schema.Service do
     )
   end
 
+  def tree(query \\ __MODULE__) do
+    recursion_query = from(s in __MODULE__, join: d in "descendants", on: d.id == s.parent_id)
+    cte_query = union_all(query, ^recursion_query)
+
+    __MODULE__
+    |> recursive_ctes(true)
+    |> with_cte("descendants", as: ^cte_query)
+    |> join(:inner, [s], d in "descendants", on: s.id == d.id)
+    |> distinct(true)
+  end
+
   def docs_path(%__MODULE__{docs_path: p}) when is_binary(p), do: p
   def docs_path(%__MODULE__{git: %{folder: p}}), do: Path.join(p, "docs")
 

--- a/lib/console/services/users.ex
+++ b/lib/console/services/users.ex
@@ -364,6 +364,17 @@ defmodule Console.Services.Users do
     {:ok, user}
   end
 
+  @doc """
+  Determines if a service account can be assumed by the acting user
+  """
+  @spec impersonate_service_account(User.t | binary, User.t) :: user_resp
+  def impersonate_service_account(%User{} = sa, %User{} = user),
+    do: Console.Deployments.Policies.allow(sa, user, :assume)
+  def impersonate_service_account(email, %User{} = user) when is_binary(email) do
+    get_user_by_email!(email)
+    |> impersonate_service_account(user)
+  end
+
   @spec mark_read(User.t, :read | :build) :: user_resp
   def mark_read(%User{} = user, type \\ :read) do
     key = read_timestamp(type)

--- a/priv/repo/migrations/20240709123933_drop_parent_id_fkey.exs
+++ b/priv/repo/migrations/20240709123933_drop_parent_id_fkey.exs
@@ -1,0 +1,9 @@
+defmodule Console.Repo.Migrations.DropParentIdFkey do
+  use Ecto.Migration
+
+  def change do
+    alter table(:services) do
+      modify :parent_id, :uuid, from: references(:services, type: :uuid, on_delete: :nilify_all)
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -410,6 +410,8 @@ type RootMutationType {
 
   deleteUser(id: ID!): User
 
+  impersonateServiceAccount(email: String!): User
+
   markRead(type: ReadType): User
 
   createGroup(attributes: GroupAttributes!): Group

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -30,6 +30,7 @@ defmodule Console.Factory do
   def user_factory do
     %Schema.User{
       name: "Some User",
+      assume_policy_id: Ecto.UUID.generate(),
       email: sequence(:user, &"user-#{&1}@example.com")
     }
   end


### PR DESCRIPTION
This will let us generate a service tree view in the ui.  Also added a impersonateServiceAccount mutation.

Fixes PROD-2398

## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
