### PR TITLE
Implement manifest digest api

### DIFF
--- a/lib/console.ex
+++ b/lib/console.ex
@@ -222,6 +222,20 @@ defmodule Console do
     |> Base.encode16(case: :lower)
   end
 
+  def all(items, res \\ [])
+  def all([{:error, _} = err | _], _), do: err
+  def all([{:ok, next} | rest], res), do: all(rest, [next | res])
+  def all([v | rest], res), do: all(rest, [v | res])
+  def all([], res), do: {:ok, res}
+
+  def probe(map, [k]), do: Map.get(map, k)
+  def probe(map, [k | rest]) do
+    case map do
+      %{^k => next} when is_map(next) -> probe(next, rest)
+      _ -> nil
+    end
+  end
+
   def put_path(map, [k], value), do: Map.put(map, k, value)
   def put_path(map, [k | rest], value) do
     case map do

--- a/lib/console/deployments/git.ex
+++ b/lib/console/deployments/git.ex
@@ -28,6 +28,9 @@ defmodule Console.Deployments.Git do
   @type automation_resp :: {:ok, PrAutomation.t} | Console.error
   @type pull_request_resp :: {:ok, PullRequest.t} | Console.error
 
+  @decorate cacheable(cache: @cache, key: {:git_repo, id}, opts: [ttl: @ttl])
+  def cached!(id), do: Repo.get!(GitRepository, id)
+
   def get_repository(id), do: Repo.get(GitRepository, id)
 
   def get_repository!(id), do: Repo.get!(GitRepository, id)

--- a/lib/console/deployments/git/discovery.ex
+++ b/lib/console/deployments/git/discovery.ex
@@ -21,6 +21,11 @@ defmodule Console.Deployments.Git.Discovery do
       do: Agent.fetch(pid, ref)
   end
 
+  def digest(%GitRepository{} = repo, ref) do
+    with {:ok, pid} <- find(repo),
+      do: Agent.digest(pid, ref)
+  end
+
   def sha(%GitRepository{} = repo, ref) do
     with {:ok, pid} <- find(repo),
       do: Agent.sha(pid, ref)

--- a/lib/console/deployments/helm/agent_cache.ex
+++ b/lib/console/deployments/helm/agent_cache.ex
@@ -55,6 +55,7 @@ defmodule Console.Deployments.Helm.AgentCache do
          {:ok, _} <- Client.download(url, File.stream!(tmp)),
          :ok <- Utils.clean_chart(tmp, path, chart),
          line <- Line.new(path, chart, vsn, digest),
+         :ok <- File.rm(tmp),
       do: {:ok, line, put_in(cache.cache[{chart, vsn}], line)}
   end
 

--- a/lib/console/deployments/helm/cache.ex
+++ b/lib/console/deployments/helm/cache.ex
@@ -79,11 +79,11 @@ defmodule Console.Deployments.Helm.Cache do
     end
   end
 
-  defp reason(%HelmChart{status: %Status{conditions: [_ | _] = conditions}}) do
+  def reason(%HelmChart{status: %Status{conditions: [_ | _] = conditions}}) do
     case Enum.find(conditions, & &1.type == "Ready") do
       %Status.Conditions{message: msg} -> msg
       _ -> "downloading"
     end
   end
-  defp reason(_), do: "downloading"
+  def reason(_), do: "downloading"
 end

--- a/lib/console/deployments/helm/charts.ex
+++ b/lib/console/deployments/helm/charts.ex
@@ -2,8 +2,21 @@ defmodule Console.Deployments.Helm.Charts do
   alias Kube.Client
   alias Kube.HelmChart
   alias Console.Schema.Service
-  alias Console.Deployments.Helm.Server
+  alias Console.Deployments.Helm.{Server, Cache}
   alias Kazan.Models.Apimachinery.Meta.V1, as: MetaV1
+
+
+  @doc """
+  Fetch just the sha for a given chart if known
+  """
+  @spec digest(Service.t) :: {:ok, binary} | Console.error
+  def digest(%Service{} = svc) do
+    case get(svc) do
+      {:ok, %{status: %{artifact: %{digest: d}}}} when is_binary(d) -> {:ok, d}
+      {:ok, c} -> {:error, "Chart not yet loaded: #{Cache.reason(c)}"}
+      err -> err
+    end
+  end
 
   @doc """
   Downloads a chart artifact from the found chart crd of the given service

--- a/lib/console/deployments/helm/discovery.ex
+++ b/lib/console/deployments/helm/discovery.ex
@@ -14,6 +14,11 @@ defmodule Console.Deployments.Helm.Discovery do
       do: Agent.fetch(pid, chart, vsn)
   end
 
+  def digest(url, chart, vsn) do
+    with {:ok, pid} <- agent(url),
+      do: Agent.digest(pid, chart, vsn)
+  end
+
   defp maybe_rpc(id, module, func, args) do
     me = node()
     case worker_node(id) do

--- a/lib/console_web/endpoint.ex
+++ b/lib/console_web/endpoint.ex
@@ -38,6 +38,8 @@ defmodule ConsoleWeb.Endpoint do
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library(),
+    length: 20_000_000,
+    ready_length: 20_000_000,
     body_reader: {ConsoleWeb.CacheBodyReader, :read_body, []}
 
   plug Plug.MethodOverride

--- a/lib/console_web/router.ex
+++ b/lib/console_web/router.ex
@@ -49,6 +49,7 @@ defmodule ConsoleWeb.Router do
         document_providers: [Console.GraphQl.Apq, Absinthe.Plug.DocumentProvider.Default]
 
       scope "/v1", ConsoleWeb do
+        get "/digests", GitController, :digest
         get "/git/tarballs", GitController, :tarball
         get "/git/stacks/tarballs", GitController, :stack_tarball
 
@@ -78,6 +79,7 @@ defmodule ConsoleWeb.Router do
 
     scope "/v1", ConsoleWeb do
       get "/logs/:repo/download", LogController, :download
+      get "/digests", GitController, :digest
       get "/git/tarballs", GitController, :tarball
       get "/git/stacks/tarballs", GitController, :stack_tarball
     end


### PR DESCRIPTION
This will allow the agent to determine if downloading manifests can be bypassed, hopefully giving another meaningful increase in overall throughput for the agent.  It is annoyingly complex due to the fact we source manifests from many locations, but it should mirror the manifest tar logic and incorporate all information into a consistently compiled sha.


## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
