### PR TITLE
fix scm connection updates

### DIFF
--- a/assets/src/components/pr/scm/EditScmConnection.tsx
+++ b/assets/src/components/pr/scm/EditScmConnection.tsx
@@ -148,8 +148,8 @@ export function ScmConnectionForm({
   const toggleGhAppAuth = (isToggled: boolean) => {
     setGhAppAuth(isToggled)
     updateFormState({
-      token: DEFAULT_ATTRIBUTES.token,
-      github: DEFAULT_ATTRIBUTES.github,
+      token: !isToggled ? undefined : DEFAULT_ATTRIBUTES.token,
+      github: isToggled ? DEFAULT_ATTRIBUTES.github : undefined,
     })
   }
 


### PR DESCRIPTION
was still sending a default struct for github attributes when using token auth