### PR TITLE
Pull-less git agent

### DIFF
--- a/controller/internal/controller/globalservice_controller.go
+++ b/controller/internal/controller/globalservice_controller.go
@@ -255,6 +255,7 @@ func (r *GlobalServiceReconciler) handleCreate(sha string, global *v1alpha1.Glob
 	global.Status.ID = &createGlobalService.ID
 	global.Status.SHA = &sha
 	utils.MarkCondition(global.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionTrue, v1alpha1.SynchronizedConditionReason, "")
+	utils.MarkCondition(global.SetCondition, v1alpha1.ReadyConditionType, v1.ConditionTrue, v1alpha1.ReadyConditionReason, "")
 	return nil
 }
 

--- a/controller/internal/controller/globalservice_test.go
+++ b/controller/internal/controller/globalservice_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Global Service Controller", Ordered, func() {
 						},
 						{
 							Type:   v1alpha1.ReadyConditionType.String(),
-							Status: metav1.ConditionFalse,
+							Status: metav1.ConditionTrue,
 							Reason: v1alpha1.ReadyConditionReason.String(),
 						},
 						{

--- a/lib/console/deployments/git/cmd.ex
+++ b/lib/console/deployments/git/cmd.ex
@@ -25,8 +25,15 @@ defmodule Console.Deployments.Git.Cmd do
   def refresh_key(git), do: save_private_key(git)
 
   def fetch(%GitRepository{} = repo) do
-    with {:ok, _} <- git(repo, "fetch", ["--all", "--force", "--prune"]),
-      do: possibly_pull(repo)
+    with {:ok, _} <- git(repo, "fetch", ["--all", "--tags", "--force", "--prune", "--prune-tags"]),
+      do: reset(repo)
+  end
+
+  def reset(repo) do
+    case git(repo, "reset", ["--hard"]) do
+      {:ok, _} = res -> res
+      _ -> {:ok, :ignore}
+    end
   end
 
   def possibly_pull(repo) do


### PR DESCRIPTION
This toys around with trying to remove git pulls from the agent cache entirely.  Since it's been refactored to use local remote refs to find head commits, I think this is possible, and removes fringe possibilities of disturbing the working tree entirely.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
