### PR TITLE
fix service table infinite render

### DIFF
--- a/assets/src/components/cd/cluster/ClusterServices.tsx
+++ b/assets/src/components/cd/cluster/ClusterServices.tsx
@@ -94,6 +94,10 @@ export default function ClusterServices() {
       [cluster, clusterId, currentTab?.path, refetch, theme.spacing.small]
     )
   )
+  const context = useMemo(
+    () => ({ setRefetch, clusterId }) as ServicesContextT,
+    [setRefetch, clusterId]
+  )
 
-  return <Outlet context={{ setRefetch, clusterId } as ServicesContextT} />
+  return <Outlet context={context} />
 }

--- a/assets/src/components/cd/services/Services.tsx
+++ b/assets/src/components/cd/services/Services.tsx
@@ -165,5 +165,10 @@ export default function Services() {
     )
   )
 
-  return <Outlet context={{ setRefetch } as ServicesContextT} />
+  const context = useMemo(
+    () => ({ setRefetch }) as ServicesContextT,
+    [setRefetch]
+  )
+
+  return <Outlet context={context} />
 }


### PR DESCRIPTION
certain scenarios were causing the service tables to trigger infinite render loops on scroll since the outlet context object wasn't memoized

this was also causing polling and refetching to be blocked