### PR TITLE
Properly communicate ssl_opts in releases

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -5930,7 +5930,8 @@ export type RootQueryTypeObjectStoresArgs = {
 
 
 export type RootQueryTypeObservabilityProviderArgs = {
-  id: Scalars['ID']['input'];
+  id?: InputMaybe<Scalars['ID']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/lib/console/deployments/git.ex
+++ b/lib/console/deployments/git.ex
@@ -250,8 +250,8 @@ defmodule Console.Deployments.Git do
   def update_pr_automation(attrs, id, %User{} = user) do
     get_pr_automation!(id)
     |> Repo.preload([:write_bindings, :create_bindings])
-    |> PrAutomation.changeset(attrs)
     |> allow(user, :write)
+    |> when_ok(&PrAutomation.changeset(&1, attrs))
     |> when_ok(:update)
   end
 
@@ -384,8 +384,8 @@ defmodule Console.Deployments.Git do
       %HelmRepository{} = repo -> repo
       nil -> %HelmRepository{url: url}
     end
-    |> HelmRepository.changeset(attrs)
     |> allow(user, :git)
+    |> when_ok(&HelmRepository.changeset(&1, attrs))
     |> when_ok(&Console.Repo.insert_or_update/1)
   end
 

--- a/lib/console/deployments/global.ex
+++ b/lib/console/deployments/global.ex
@@ -125,7 +125,7 @@ defmodule Console.Deployments.Global do
     |> add_operation(:ns, fn _ ->
       %ManagedNamespace{}
       |> ManagedNamespace.changeset(attrs)
-      |> allow(user, :write)
+      |> allow(user, :create)
       |> when_ok(:insert)
     end)
     |> add_operation(:rev, fn %{ns: ns} ->
@@ -147,8 +147,8 @@ defmodule Console.Deployments.Global do
     |> add_operation(:ns, fn _ ->
       get_namespace!(namespace_id)
       |> Repo.preload([service: :dependencies])
-      |> ManagedNamespace.changeset(attrs)
       |> allow(user, :write)
+      |> when_ok(&ManagedNamespace.changeset(&1, attrs))
       |> when_ok(:update)
     end)
     |> add_operation(:rev, fn %{ns: ns} ->

--- a/lib/console/deployments/pipelines.ex
+++ b/lib/console/deployments/pipelines.ex
@@ -71,8 +71,8 @@ defmodule Console.Deployments.Pipelines do
       attrs = stabilize(pipeline, Map.put(attrs, :name, name))
               |> Map.drop([:edges])
       pipeline
-      |> Pipeline.changeset(attrs)
       |> allow(user, (if pipe, do: :write, else: :create))
+      |> when_ok(&Pipeline.changeset(&1, attrs))
       |> when_ok(&Repo.insert_or_update/1)
     end)
     |> add_operation(:edges, fn %{base: base} ->

--- a/lib/console/deployments/policies/policies.ex
+++ b/lib/console/deployments/policies/policies.ex
@@ -29,9 +29,8 @@ defmodule Console.Deployments.Policies do
   def can?(user, %Ecto.Changeset{} = cs, action),
     do: can?(user, apply_changes(cs), action)
 
-  def can?(user, %{read_bindings: r, write_bindings: w} = resource, :create)
-        when (is_list(r) and length(r) > 0) or (is_list(w) and length(w) > 0),
-    do: can?(user, Map.merge(resource, %{read_bindings: [], write_bindings: []}), :create)
+  def can?(user, %{read_bindings: r, write_bindings: w} = resource, :create) when r != [] and w != [],
+      do: can?(user, Map.merge(resource, %{read_bindings: [], write_bindings: []}), :create)
 
   def can?(%Cluster{id: id}, %ClusterRestore{} = restore, :read) do
     case Repo.preload(restore, [:backup]) do

--- a/lib/console/graphql/deployments/observability.ex
+++ b/lib/console/graphql/deployments/observability.ex
@@ -51,7 +51,8 @@ defmodule Console.GraphQl.Deployments.Observability do
   object :observability_provider_queries do
     field :observability_provider, :observability_provider do
       middleware Authenticated
-      arg :id, non_null(:id)
+      arg :id,   :id
+      arg :name, :string
 
       resolve &Deployments.get_observability_provider/2
     end

--- a/lib/console/graphql/resolvers/deployments/observability.ex
+++ b/lib/console/graphql/resolvers/deployments/observability.ex
@@ -7,7 +7,8 @@ defmodule Console.GraphQl.Resolvers.Deployments.Observability do
   @default_offset 30 * 60
   @nano 1_000_000_000
 
-  def get_observability_provider(%{id: id}, _), do: {:ok, Observability.get_provider!(id)}
+  def get_observability_provider(%{id: id}, _) when is_binary(id), do: {:ok, Observability.get_provider!(id)}
+  def get_observability_provider(%{name: n}, _) when is_binary(n), do: {:ok, Observability.get_provider_by_name!(n)}
 
   def list_observability_providers(args, _) do
     ObservabilityProvider.ordered()

--- a/lib/console/schema/helm_repository.ex
+++ b/lib/console/schema/helm_repository.ex
@@ -6,7 +6,7 @@ defmodule Console.Schema.HelmRepository do
 
   schema "helm_repositories" do
     field :url,         :string
-    field :provider,    Provider
+    field :provider,    Provider, default: :basic
     field :health,      GitRepository.Health
     field :error,       :string
     field :pulled_at,   :utc_datetime_usec

--- a/rel/config/console.exs
+++ b/rel/config/console.exs
@@ -53,15 +53,16 @@ if provider != :gcp do
   config :goth, disabled: true
 end
 
-ssl = case {String.to_existing_atom(get_env("DBSSL") || "true"), get_env("PGROOTSSLCERT")} do
-  {_, cert} when is_binary(cert) and byte_size(cert) > 0 -> [cacertfile: cert]
-  {ssl, _} -> ssl
+ssl_opts = case get_env("PGROOTSSLCERT") do
+  cert when is_binary(cert) and byte_size(cert) > 0 -> [cacertfile: cert]
+  _ -> []
 end
 
 if get_env("POSTGRES_URL") do
   config :console, Console.Repo,
     url: get_env("POSTGRES_URL"),
-    ssl: ssl,
+    ssl: String.to_existing_atom(get_env("DBSSL") || "true"),
+    ssl_opts: ssl_opts,
     pool_size: 10
 else
   config :console, Console.Repo,

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -401,7 +401,7 @@ type RootQueryType {
     after: String, first: Int, before: String, last: Int, q: String, projectId: ID, tagQuery: TagQuery
   ): InfrastructureStackConnection
 
-  observabilityProvider(id: ID!): ObservabilityProvider
+  observabilityProvider(id: ID, name: String): ObservabilityProvider
 
   observabilityProviders(after: String, first: Int, before: String, last: Int): ObservabilityProviderConnection
 

--- a/test/console/deployments/clusters_test.exs
+++ b/test/console/deployments/clusters_test.exs
@@ -500,6 +500,15 @@ defmodule Console.Deployments.ClustersTest do
 
       assert svc.repository_id == new_git.id
     end
+
+    test "nonwriters cannot update" do
+      cluster = insert(:cluster)
+      user = insert(:user)
+
+      {:error, _} = Clusters.update_cluster(%{
+        write_bindings: [%{user_id: user.id}]
+      }, cluster.id, user)
+    end
   end
 
   describe "#rotate_deploy_token/1" do

--- a/test/console/deployments/services_test.exs
+++ b/test/console/deployments/services_test.exs
@@ -331,13 +331,15 @@ defmodule Console.Deployments.ServicesTest do
         configuration: [%{name: "name", value: "other-value"}, %{name: "name2", value: "value"}]
       }, service.id, user)
 
+      rando = insert(:user)
       {:error, _} = Services.update_service(%{
         git: %{
           ref: "master",
           folder: "k8s"
         },
+        write_bindings: [%{user_id: rando.id}],
         configuration: [%{name: "name", value: "other-value"}, %{name: "name2", value: "value"}]
-      }, service.id, insert(:user))
+      }, service.id, rando)
     end
   end
 

--- a/test/console/deployments/settings_test.exs
+++ b/test/console/deployments/settings_test.exs
@@ -29,6 +29,13 @@ defmodule Console.Deployments.SettingsTest do
       assert binding.user_id == user.id
     end
 
+    test "it cannot write escalate" do
+      user = insert(:user)
+      insert(:deployment_settings)
+
+      {:error, _} = Settings.update(%{write_bindings: [%{user_id: user.id}]}, user)
+    end
+
     test "it can create a migration if helm values were modified" do
       admin = admin_user()
       insert(:deployment_settings)
@@ -89,12 +96,16 @@ defmodule Console.Deployments.SettingsTest do
     end
 
     test "nonadmins cannot create projects" do
-      {:error, _} = Settings.create_project(%{name: "test"}, insert(:user))
+      user = insert(:user)
+      {:error, _} = Settings.create_project(%{
+        name: "test",
+        write_bindings: [%{user_id: user.id}]
+      }, user)
     end
   end
 
   describe "#update_project/3" do
-    test "admins can create a new project" do
+    test "admins can update a new project" do
       proj = insert(:project)
       {:ok, updated} = Settings.update_project(%{name: "test"}, proj.id, admin_user())
 
@@ -102,9 +113,13 @@ defmodule Console.Deployments.SettingsTest do
       assert updated.name == "test"
     end
 
-    test "nonadmins cannot create projects" do
+    test "nonadmins cannot update projects" do
       proj = insert(:project)
-      {:error, _} = Settings.update_project(%{name: "test"}, proj.id, insert(:user))
+      user = insert(:user)
+      {:error, _} = Settings.update_project(%{
+        name: "test",
+        write_bindings: [%{user_id: user.id}]
+      }, proj.id, user)
     end
   end
 

--- a/test/console/deployments/stacks_test.exs
+++ b/test/console/deployments/stacks_test.exs
@@ -109,6 +109,7 @@ defmodule Console.Deployments.StacksTest do
     test "random users cannot create" do
       cluster = insert(:cluster)
       repo = insert(:git_repository)
+      user = insert(:user)
 
       {:error, _} = Stacks.create_stack(%{
         name: "my-stack",
@@ -116,8 +117,9 @@ defmodule Console.Deployments.StacksTest do
         approval: true,
         repository_id: repo.id,
         cluster_id: cluster.id,
+        write_bindings: [%{user_id: user.id}],
         git: %{ref: "main", folder: "terraform"},
-      }, insert(:user))
+      }, user)
     end
   end
 
@@ -144,13 +146,15 @@ defmodule Console.Deployments.StacksTest do
 
     test "random users cannot update" do
       stack = insert(:stack)
+      user = insert(:user)
 
       {:error, _} = Stacks.update_stack(%{
         name: "my-stack",
         type: :terraform,
         approval: true,
-        git: %{ref: "main", folder: "terraform"},
-      }, stack.id, insert(:user))
+        write_bindings: [%{user_id: user.id}],
+        git: %{ref: "main", folder: "terraform"}
+      }, stack.id, user)
     end
   end
 


### PR DESCRIPTION
The prior version accidentally used the configuration from a later version of Postgrex, this will work for our current pinned version

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
