### PR TITLE
feat: guarantee codegen targets are executed on pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=${SCRIPT_DIR%/*}
+CONTROLLER_DIR=go/controller
+CLIENT_DIR=go/client
+CLIENT_GRAPH_DIR=${CLIENT_DIR}/graph
+WARNING_UNSTAGED_MSG="[Warning] Check for any unstaged files and commit them before push"
+
+function get::commit {
+  if git rev-parse --verify HEAD >/dev/null 2>&1; then
+    echo HEAD
+  else
+    # Initial commit: diff against an empty tree object
+    git hash-object -t tree /dev/null
+  fi
+}
+
+function check {
+    against=$1
+
+    # Get a list of files that are about to be commited
+    changed=$(git diff --cached --name-only "${against}")
+
+    # Loop over the files and run configured checks
+    for path in ${changed}; do
+      check::path "${path}"
+    done
+}
+
+function check::path {
+  path=$1
+  changed=false
+
+  if [[ "${path}" == ${CONTROLLER_DIR}/* ]]; then
+    echo Controller files changed
+    ensure::controller
+    changed=true
+  fi
+
+  if [[ "${path}" == ${CLIENT_GRAPH_DIR}/* ]]; then
+    echo Client files changed
+    ensure::client
+    changed=true
+  fi
+
+  if [[ "${changed}" == true ]]; then
+    echo "${WARNING_UNSTAGED_MSG}"
+  fi
+}
+
+function ensure::controller {
+  echo Running codegen...
+  make --no-print-directory --directory="${ROOT_DIR}"/${CONTROLLER_DIR} codegen
+}
+
+function ensure::client {
+  echo Running generate...
+  make --no-print-directory --directory="${ROOT_DIR}"/${CLIENT_DIR} generate
+}
+
+echo Executing pre-commit hook
+check "$(get::commit)"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GIT_COMMIT ?= abd123
 TARGETARCH ?= amd64
 ERLANG_VERSION ?= `grep erlang .tool-versions | cut -d' ' -f2`
 REPO_ROOT ?= `pwd`
+GIT_HOOKS_PATH = .githooks
 
 help:
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -77,7 +78,6 @@ update-schema:
 	cd assets && yarn fix
 	@$(MAKE) --directory go/client --no-print-directory generate
 
-
 k3s:  ## starts a k3d cluster for testing
 	@read -p "cluster name: " name; \
 	k3d cluster create $$name --image docker.io/rancher/k3s:v1.26.11-k3s2
@@ -86,3 +86,7 @@ delete-tag:  ## deletes a tag from git locally and upstream
 	@read -p "Version: " tag; \
 	git tag -d $$tag; \
 	git push origin :$$tag
+
+install-git-hooks: ## enforces usage of git hooks stored under '.githooks' dir
+	@git config --local core.hooksPath ${GIT_HOOKS_PATH}/
+	@echo Successfully configured git hooks, \'core.hooksPath\' now points to \'${GIT_HOOKS_PATH}\'.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ mix deps.get
 mix test
 ```
 
+### Git Hooks
+Custom Git hooks are stored in `.githooks` directory. They ensure that when controller or client files are changed, automated code generation targets are executed. In order to enable git hooks for this repo run:
+```sh
+make install-git-hooks
+```
+
 ### Troubleshooting
 #### Installing Erlang 
 If `asdf install` fails with `cannot find required auxiliary files: install-sh config.guess config.sub` then run:

--- a/go/client/graph/backup.graphql
+++ b/go/client/graph/backup.graphql
@@ -40,4 +40,3 @@ query GetClusterRestore($id: ID!) {
         ...ClusterRestoreFragment
     }
 }
-

--- a/go/controller/Makefile
+++ b/go/controller/Makefile
@@ -43,7 +43,7 @@ build: manifests generate fmt vet ## build manager binary
 	go build -o bin/manager cmd/main.go
 
 .PHONY: run
-run: manifests generate codegen-chart-rbac fmt vet ## run a controller from your host
+run: manifests generate fmt vet ## run a controller from your host
 	go run ./cmd/main.go \
 		--console-url=${PLURAL_CONSOLE_URL}/gql
 
@@ -79,6 +79,9 @@ e2e: ## run e2e tests
 
 ##@ Codegen
 
+.PHONY: codegen
+codegen: manifests generate genmock codegen-helm codegen-crd-docs ## runs all codegen-related targets
+
 .PHONY: manifests
 manifests: ## generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:generateEmbeddedObjectMeta=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
@@ -102,10 +105,6 @@ codegen-helm: manifests ## generate controller helm chart with kustomize
 codegen-chart-crds: ## copy CRDs to the controller helm chart
 	@cp -a config/crd/bases/. $(CONTROLLER_CHART_DIR)/crds
 	@cp -a $(CONTROLLER_CHART_DIR)/crds/. $(PLURAL_CONSOLE_CHART_DIR)/crds
-
-.PHONY: codegen-chart-rbac
-codegen-chart-rbac: codegen-helm ## update controller rbac in the controller helm chart
-	@cp -a tmp/charts/controller/templates/manager-rbac.yaml $(CONTROLLER_CHART_DIR)/templates
 
 .PHONY: codegen-crd-docs
 codegen-crd-docs: ## generate docs from the CRDs


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Updated README to describe how to enable git hooks for this repo
- Added `make install-git-hooks` root target that updates local git `core.hooksPath` for this repo to point to the custom hooks dir
- Added custom `pre-commit` script that checks for staged files path and if `controller` or `client` files were updated, it will run dedicated codegen targets.

```sh
$ git commit -m "initial commit"
Executing pre-commit hook
Client files changed
Running generate...
[Warning] Check for any unstaged files and commit them before push
Controller files changed
Running codegen...
/home/floreks/go/bin/controller-gen rbac:roleName=manager-role crd:generateEmbeddedObjectMeta=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/home/floreks/go/bin/controller-gen object:headerFile=/home/floreks/Projects/plural/console/go/controller/../../go/tools/boilerplate.go.txt paths="./..."
/home/floreks/go/bin/mockery
08 Aug 24 13:56 CEST INF Starting mockery dry-run=false version=v2.43.2
08 Aug 24 13:56 CEST INF Using config: /home/floreks/Projects/plural/console/go/controller/.mockery.yaml dry-run=false version=v2.43.2
08 Aug 24 13:56 CEST INF done parsing, loading dry-run=false version=v2.43.2
08 Aug 24 13:56 CEST INF done loading, visiting interface nodes dry-run=false version=v2.43.2
08 Aug 24 13:56 CEST INF generating mocks for interface dry-run=false interface=ConsoleClient qualified-name=github.com/pluralsh/console/go/controller/internal/client version=v2.43.2
08 Aug 24 13:56 CEST INF writing to file dry-run=false file=internal/test/mocks/ConsoleClient_mock.go interface=ConsoleClient qualified-name=github.com/pluralsh/console/go/controller/internal/client version=v2.43.2
/home/floreks/go/bin/crd-ref-docs --source-path=./api --renderer=markdown --output-path=./docs/api.md --config=config.yaml
2024-08-08T13:56:37.090+0200    INFO    crd-ref-docs    Loading configuration   {"path": "config.yaml"}
2024-08-08T13:56:37.091+0200    INFO    crd-ref-docs    Processing source directory     {"directory": "./api", "depth": 10}
2024-08-08T13:56:37.649+0200    INFO    crd-ref-docs    Rendering output        {"path": "./docs/api.md"}
2024-08-08T13:56:37.664+0200    INFO    crd-ref-docs    CRD reference documentation generated
2024-08-08T13:56:37.664+0200    INFO    crd-ref-docs    Execution time: 573.125899ms
[Warning] Check for any unstaged files and commit them before push
```

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
