### PR TITLE
fix: update bindings and requeue time

### DIFF
--- a/go/controller/internal/controller/infrastructurestack_controller.go
+++ b/go/controller/internal/controller/infrastructurestack_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pluralsh/polly/algorithms"
 	"github.com/samber/lo"
@@ -43,7 +44,10 @@ import (
 	"github.com/pluralsh/console/go/controller/internal/utils"
 )
 
-const InfrastructureStackFinalizer = "deployments.plural.sh/stack-protection"
+const (
+	InfrastructureStackFinalizer    = "deployments.plural.sh/stack-protection"
+	requeueAfterInfrastructureStack = 2 * time.Minute
+)
 
 // InfrastructureStackReconciler reconciles a InfrastructureStack object
 type InfrastructureStackReconciler struct {
@@ -188,7 +192,7 @@ func (r *InfrastructureStackReconciler) Reconcile(ctx context.Context, req ctrl.
 	utils.MarkCondition(stack.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionTrue, v1alpha1.SynchronizedConditionReason, "")
 	utils.MarkCondition(stack.SetCondition, v1alpha1.ReadyConditionType, v1.ConditionTrue, v1alpha1.ReadyConditionReason, "")
 
-	return requeue, nil
+	return RequeueAfter(requeueAfterInfrastructureStack), nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/go/controller/internal/controller/project_controller.go
+++ b/go/controller/internal/controller/project_controller.go
@@ -210,6 +210,10 @@ func (in *ProjectReconciler) sync(ctx context.Context, project *v1alpha1.Project
 		return nil, err
 	}
 
+	if err := in.ensure(project); err != nil {
+		return nil, err
+	}
+
 	// Update only if Project has changed
 	if changed && exists {
 		logger.Info(fmt.Sprintf("updating project %s", project.ConsoleName()))
@@ -222,10 +226,6 @@ func (in *ProjectReconciler) sync(ctx context.Context, project *v1alpha1.Project
 	}
 
 	logger.Info(fmt.Sprintf("%s project does not exist, creating it", project.ConsoleName()))
-	if err := in.ensure(project); err != nil {
-		return nil, err
-	}
-
 	return in.ConsoleClient.CreateProject(ctx, project.Attributes())
 }
 


### PR DESCRIPTION
Fixes:
 - InfrastructureStack requeue time is too short
 - Project CRD seems to not be updating bindings

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
