### PR TITLE
fix(prautomationtrigger): pass identifier to the create pull request mutation

### DIFF
--- a/charts/controller/crds/deployments.plural.sh_prautomationtriggers.yaml
+++ b/charts/controller/crds/deployments.plural.sh_prautomationtriggers.yaml
@@ -40,12 +40,16 @@ spec:
           spec:
             description: PrAutomationTriggerSpec defines the desired state of PrAutomationTrigger
             properties:
+              branch:
+                description: Branch that should be created against [PrAutomation]
+                  base branch
+                type: string
               context:
-                description: Context is a PrAutomation context
+                description: Context is a [PrAutomation] configuration context
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               prAutomationRef:
-                description: PrAutomationRef pointing to source PrAutomation.
+                description: PrAutomationRef pointing to source [PrAutomation]
                 properties:
                   apiVersion:
                     description: API version of the referent.

--- a/go/controller/api/v1alpha1/prautomationtrigger_types.go
+++ b/go/controller/api/v1alpha1/prautomationtrigger_types.go
@@ -25,11 +25,16 @@ import (
 
 // PrAutomationTriggerSpec defines the desired state of PrAutomationTrigger
 type PrAutomationTriggerSpec struct {
-	// PrAutomationRef pointing to source PrAutomation.
+	// PrAutomationRef pointing to source [PrAutomation]
 	// +kubebuilder:validation:Optional
 	PrAutomationRef *corev1.ObjectReference `json:"prAutomationRef,omitempty"`
 
-	// Context is a PrAutomation context
+	// Branch that should be created against [PrAutomation] base branch
+	// +kubebuilder:validation:Required
+	Branch string `json:"branch,omitempty"`
+
+	// Context is a [PrAutomation] configuration context
+	// +kubebuilder:validation:Optional
 	Context runtime.RawExtension `json:"context,omitempty"`
 }
 

--- a/go/controller/config/crd/bases/deployments.plural.sh_prautomationtriggers.yaml
+++ b/go/controller/config/crd/bases/deployments.plural.sh_prautomationtriggers.yaml
@@ -40,12 +40,16 @@ spec:
           spec:
             description: PrAutomationTriggerSpec defines the desired state of PrAutomationTrigger
             properties:
+              branch:
+                description: Branch that should be created against [PrAutomation]
+                  base branch
+                type: string
               context:
-                description: Context is a PrAutomation context
+                description: Context is a [PrAutomation] configuration context
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               prAutomationRef:
-                description: PrAutomationRef pointing to source PrAutomation.
+                description: PrAutomationRef pointing to source [PrAutomation]
                 properties:
                   apiVersion:
                     description: API version of the referent.

--- a/go/controller/docs/api.md
+++ b/go/controller/docs/api.md
@@ -1417,8 +1417,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `prAutomationRef` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectreference-v1-core)_ | PrAutomationRef pointing to source PrAutomation. |  | Optional: {} <br /> |
-| `context` _[RawExtension](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension)_ | Context is a PrAutomation context |  |  |
+| `prAutomationRef` _[ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#objectreference-v1-core)_ | PrAutomationRef pointing to source [PrAutomation] |  | Optional: {} <br /> |
+| `branch` _string_ | Branch that should be created against [PrAutomation] base branch |  | Required: {} <br /> |
+| `context` _[RawExtension](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#RawExtension)_ | Context is a [PrAutomation] configuration context |  | Optional: {} <br /> |
 
 
 #### PrAutomationUpdateConfiguration

--- a/go/controller/internal/client/console.go
+++ b/go/controller/internal/client/console.go
@@ -92,7 +92,7 @@ type ConsoleClient interface {
 	GetServiceContext(name string) (*console.ServiceContextFragment, error)
 	GetPipelineContext(ctx context.Context, id string) (*console.PipelineContextFragment, error)
 	CreatePipelineContext(ctx context.Context, pipelineID string, attributes console.PipelineContextAttributes) (*console.CreatePipelineContext, error)
-	CreatePullRequest(ctx context.Context, prAutomationID string, branch *string, context *string) (*console.CreatePullRequest, error)
+	CreatePullRequest(ctx context.Context, prAutomationID string, identifier, branch, context *string) (*console.CreatePullRequest, error)
 	GetNotificationSink(ctx context.Context, id string) (*console.NotificationSinkFragment, error)
 	DeleteNotificationSink(ctx context.Context, id string) error
 	UpsertNotificationSink(ctx context.Context, attr console.NotificationSinkAttributes) (*console.NotificationSinkFragment, error)

--- a/go/controller/internal/client/prautomation.go
+++ b/go/controller/internal/client/prautomation.go
@@ -3,9 +3,10 @@ package client
 import (
 	"context"
 
-	console "github.com/pluralsh/console/go/client"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	console "github.com/pluralsh/console/go/client"
 )
 
 func (c *client) CreatePrAutomation(ctx context.Context, attributes console.PrAutomationAttributes) (*console.PrAutomationFragment, error) {
@@ -84,6 +85,6 @@ func (c *client) IsPrAutomationExistsByName(ctx context.Context, name string) (b
 	return automation != nil, err
 }
 
-func (c *client) CreatePullRequest(ctx context.Context, prAutomationID string, branch *string, context *string) (*console.CreatePullRequest, error) {
-	return c.consoleClient.CreatePullRequest(ctx, prAutomationID, nil, branch, context)
+func (c *client) CreatePullRequest(ctx context.Context, prAutomationID string, identifier, branch, context *string) (*console.CreatePullRequest, error) {
+	return c.consoleClient.CreatePullRequest(ctx, prAutomationID, identifier, branch, context)
 }

--- a/go/controller/internal/controller/prautomationtrigger_controller.go
+++ b/go/controller/internal/controller/prautomationtrigger_controller.go
@@ -111,7 +111,7 @@ func (r *PrAutomationTriggerReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	// Check if resource already exists in the API and only sync the ID
 	if !isAlreadyExists(trigger) || !trigger.Status.IsSHAEqual(sha) {
-		pr, err := r.ConsoleClient.CreatePullRequest(ctx, prAutomation.Status.GetID(), prAutomation.Spec.Identifier, prAutomation.Spec.Branch, lo.ToPtr(string(trigger.Spec.Context.Raw)))
+		pr, err := r.ConsoleClient.CreatePullRequest(ctx, prAutomation.Status.GetID(), prAutomation.Spec.Identifier, lo.ToPtr(trigger.Spec.Branch), lo.ToPtr(string(trigger.Spec.Context.Raw)))
 		if err != nil {
 			utils.MarkCondition(trigger.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
 			return ctrl.Result{}, err

--- a/go/controller/internal/controller/prautomationtrigger_controller.go
+++ b/go/controller/internal/controller/prautomationtrigger_controller.go
@@ -111,7 +111,7 @@ func (r *PrAutomationTriggerReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	// Check if resource already exists in the API and only sync the ID
 	if !isAlreadyExists(trigger) || !trigger.Status.IsSHAEqual(sha) {
-		pr, err := r.ConsoleClient.CreatePullRequest(ctx, prAutomation.Status.GetID(), prAutomation.Spec.Branch, lo.ToPtr(string(trigger.Spec.Context.Raw)))
+		pr, err := r.ConsoleClient.CreatePullRequest(ctx, prAutomation.Status.GetID(), prAutomation.Spec.Identifier, prAutomation.Spec.Branch, lo.ToPtr(string(trigger.Spec.Context.Raw)))
 		if err != nil {
 			utils.MarkCondition(trigger.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
 			return ctrl.Result{}, err

--- a/go/controller/internal/test/mocks/ConsoleClient_mock.go
+++ b/go/controller/internal/test/mocks/ConsoleClient_mock.go
@@ -674,9 +674,9 @@ func (_c *ConsoleClientMock_CreateProvider_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
-// CreatePullRequest provides a mock function with given fields: ctx, prAutomationID, branch, _a3
-func (_m *ConsoleClientMock) CreatePullRequest(ctx context.Context, prAutomationID string, branch *string, _a3 *string) (*client.CreatePullRequest, error) {
-	ret := _m.Called(ctx, prAutomationID, branch, _a3)
+// CreatePullRequest provides a mock function with given fields: ctx, prAutomationID, identifier, branch, _a4
+func (_m *ConsoleClientMock) CreatePullRequest(ctx context.Context, prAutomationID string, identifier *string, branch *string, _a4 *string) (*client.CreatePullRequest, error) {
+	ret := _m.Called(ctx, prAutomationID, identifier, branch, _a4)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreatePullRequest")
@@ -684,19 +684,19 @@ func (_m *ConsoleClientMock) CreatePullRequest(ctx context.Context, prAutomation
 
 	var r0 *client.CreatePullRequest
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *string, *string) (*client.CreatePullRequest, error)); ok {
-		return rf(ctx, prAutomationID, branch, _a3)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *string, *string, *string) (*client.CreatePullRequest, error)); ok {
+		return rf(ctx, prAutomationID, identifier, branch, _a4)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, *string, *string) *client.CreatePullRequest); ok {
-		r0 = rf(ctx, prAutomationID, branch, _a3)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *string, *string, *string) *client.CreatePullRequest); ok {
+		r0 = rf(ctx, prAutomationID, identifier, branch, _a4)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*client.CreatePullRequest)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, *string, *string) error); ok {
-		r1 = rf(ctx, prAutomationID, branch, _a3)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *string, *string, *string) error); ok {
+		r1 = rf(ctx, prAutomationID, identifier, branch, _a4)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -712,15 +712,16 @@ type ConsoleClientMock_CreatePullRequest_Call struct {
 // CreatePullRequest is a helper method to define mock.On call
 //   - ctx context.Context
 //   - prAutomationID string
+//   - identifier *string
 //   - branch *string
-//   - _a3 *string
-func (_e *ConsoleClientMock_Expecter) CreatePullRequest(ctx interface{}, prAutomationID interface{}, branch interface{}, _a3 interface{}) *ConsoleClientMock_CreatePullRequest_Call {
-	return &ConsoleClientMock_CreatePullRequest_Call{Call: _e.mock.On("CreatePullRequest", ctx, prAutomationID, branch, _a3)}
+//   - _a4 *string
+func (_e *ConsoleClientMock_Expecter) CreatePullRequest(ctx interface{}, prAutomationID interface{}, identifier interface{}, branch interface{}, _a4 interface{}) *ConsoleClientMock_CreatePullRequest_Call {
+	return &ConsoleClientMock_CreatePullRequest_Call{Call: _e.mock.On("CreatePullRequest", ctx, prAutomationID, identifier, branch, _a4)}
 }
 
-func (_c *ConsoleClientMock_CreatePullRequest_Call) Run(run func(ctx context.Context, prAutomationID string, branch *string, _a3 *string)) *ConsoleClientMock_CreatePullRequest_Call {
+func (_c *ConsoleClientMock_CreatePullRequest_Call) Run(run func(ctx context.Context, prAutomationID string, identifier *string, branch *string, _a4 *string)) *ConsoleClientMock_CreatePullRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(*string), args[3].(*string))
+		run(args[0].(context.Context), args[1].(string), args[2].(*string), args[3].(*string), args[4].(*string))
 	})
 	return _c
 }
@@ -730,7 +731,7 @@ func (_c *ConsoleClientMock_CreatePullRequest_Call) Return(_a0 *client.CreatePul
 	return _c
 }
 
-func (_c *ConsoleClientMock_CreatePullRequest_Call) RunAndReturn(run func(context.Context, string, *string, *string) (*client.CreatePullRequest, error)) *ConsoleClientMock_CreatePullRequest_Call {
+func (_c *ConsoleClientMock_CreatePullRequest_Call) RunAndReturn(run func(context.Context, string, *string, *string, *string) (*client.CreatePullRequest, error)) *ConsoleClientMock_CreatePullRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/plural/helm/console/crds/deployments.plural.sh_prautomationtriggers.yaml
+++ b/plural/helm/console/crds/deployments.plural.sh_prautomationtriggers.yaml
@@ -40,12 +40,16 @@ spec:
           spec:
             description: PrAutomationTriggerSpec defines the desired state of PrAutomationTrigger
             properties:
+              branch:
+                description: Branch that should be created against [PrAutomation]
+                  base branch
+                type: string
               context:
-                description: Context is a PrAutomation context
+                description: Context is a [PrAutomation] configuration context
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               prAutomationRef:
-                description: PrAutomationRef pointing to source PrAutomation.
+                description: PrAutomationRef pointing to source [PrAutomation]
                 properties:
                   apiVersion:
                     description: API version of the referent.


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
It was not aligned with the latest schema of the `createPullRequest` mutation. I have aligned the logic with the same resource in our terraform provider.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
