### PR TITLE
fix cards with missing padding

### DIFF
--- a/assets/src/components/apps/app/runbooks/runbook/RunbookDisplay.tsx
+++ b/assets/src/components/apps/app/runbooks/runbook/RunbookDisplay.tsx
@@ -30,7 +30,7 @@ export function RunbookDisplay({
     // eslint-disable-next-line react/jsx-no-constructed-context-values
     <DisplayContext.Provider value={{ datasources, context, setContext }}>
       <Card
-        padding="large"
+        css={{ padding: theme.spacing.large }}
         {...props}
       >
         <Flex

--- a/assets/src/components/apps/app/uninstall/Uninstall.tsx
+++ b/assets/src/components/apps/app/uninstall/Uninstall.tsx
@@ -5,8 +5,10 @@ import { BuildType, useCreateBuildMutation } from 'generated/graphql'
 import { Flex, P } from 'honorable'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { useTheme } from 'styled-components'
 
 export default function Uninstall() {
+  const theme = useTheme()
   const navigate = useNavigate()
   const { appName } = useParams()
   const [confirm, setConfirm] = useState('')
@@ -27,7 +29,7 @@ export default function Uninstall() {
       heading="Uninstall"
     >
       <Card
-        padding="large"
+        css={{ padding: theme.spacing.large }}
         overflowY="auto"
         maxHeight="100%"
       >
@@ -51,7 +53,7 @@ export default function Uninstall() {
             body2
             color="text-light"
           >
-            To uninstall the application, type the application’s name {appName}{' '}
+            To uninstall the application, type the application's name {appName}{' '}
             to confirm. This is action is <b>destructive</b> and can result in
             underlying data from the application being deleted.
           </P>

--- a/assets/src/components/billing/BillingFeatureBlockBanner.tsx
+++ b/assets/src/components/billing/BillingFeatureBlockBanner.tsx
@@ -1,5 +1,5 @@
 import { Button, Card } from '@pluralsh/design-system'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 type BillingFeatureBlockBannerPropsType = {
   feature: string
@@ -44,10 +44,12 @@ export default function BillingFeatureBlockBanner({
   description,
   placeholderImageURL,
 }: BillingFeatureBlockBannerPropsType) {
+  const theme = useTheme()
+
   return (
     <Wrapper backgroundImage={placeholderImageURL}>
       <Card
-        padding="large"
+        css={{ padding: theme.spacing.large }}
         fillLevel={2}
         width="100%"
       >

--- a/assets/src/components/builds/build/changelog/Changelog.tsx
+++ b/assets/src/components/builds/build/changelog/Changelog.tsx
@@ -107,7 +107,7 @@ export default function Changelog() {
         {currentTool && (
           <Card
             marginVertical="medium"
-            padding="small"
+            css={{ padding: theme.spacing.small }}
             flexGrow={1}
             flexShrink={1}
             overflowY="auto"

--- a/assets/src/components/cd/cluster/node/NodeInfo.tsx
+++ b/assets/src/components/cd/cluster/node/NodeInfo.tsx
@@ -68,7 +68,7 @@ export default function NodeInfo() {
     >
       <section>
         <SubTitle>Overview</SubTitle>
-        <Card padding="medium">
+        <Card css={{ padding: theme.spacing.medium }}>
           <NodeGraphs
             status={node.status}
             pods={pods}

--- a/assets/src/components/cd/clusters/create/provider/NodeGroupContainer.tsx
+++ b/assets/src/components/cd/clusters/create/provider/NodeGroupContainer.tsx
@@ -141,7 +141,7 @@ function NodeGroupContainer({ provider }): ReactElement {
             <Card
               key={ng.id}
               fillLevel={2}
-              padding="medium"
+              css={{ padding: theme.spacing.medium }}
             >
               <NodeGroupComponent
                 provider={provider}

--- a/assets/src/components/cd/globalServices/details/GlobalServiceInfo.tsx
+++ b/assets/src/components/cd/globalServices/details/GlobalServiceInfo.tsx
@@ -44,9 +44,8 @@ export function PropCard({
 
   return (
     <Card
-      padding="medium"
       {...props}
-      css={{ ...theme.partials.text.body2Bold }}
+      css={{ ...theme.partials.text.body2Bold, padding: theme.spacing.medium }}
     >
       <div
         css={{

--- a/assets/src/components/cluster/ScalingRecommender.tsx
+++ b/assets/src/components/cluster/ScalingRecommender.tsx
@@ -133,6 +133,7 @@ function ContainerRecommendations({
   uncappedTarget,
   setIsModifying,
 }: ContainerRecommendation & { setIsModifying: (arg: boolean) => void }) {
+  const theme = useTheme()
   const recos = [
     ...(lowerBound ? [{ label: 'Lower bound', ...lowerBound }] : []),
     ...(upperBound ? [{ label: 'Upper bound', ...upperBound }] : []),
@@ -147,12 +148,14 @@ function ContainerRecommendations({
         application.
       </P>
       <Card
-        display="grid"
-        gridTemplateColumns="1fr 1fr 1fr"
-        backgroundColor="fill-one"
-        color="text-light"
-        body2LooseLineHeight
-        {...{ ':nth-child(2n) > *': { backgroundColor: 'fill-two' } }}
+        css={{
+          ...theme.partials.text.body2LooseLineHeight,
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr',
+          backgroundColor: theme.colors['fill-one'],
+          color: theme.colors['fill-one'],
+          '&:nth-child(2n) > *': { backgroundColor: theme.colors['fill-two'] },
+        }}
       >
         {recos.map((r) => (
           <RecommendationComp {...r} />

--- a/assets/src/components/cluster/nodes/ClusterMetrics.tsx
+++ b/assets/src/components/cluster/nodes/ClusterMetrics.tsx
@@ -5,6 +5,8 @@ import { useDeploymentSettings } from 'components/contexts/DeploymentSettingsCon
 
 import { Card } from '@pluralsh/design-system'
 
+import { useTheme } from 'styled-components'
+
 import { ClusterMetrics as Metrics } from '../constants'
 
 import { ClusterGauges } from './ClusterGauges'
@@ -26,12 +28,13 @@ export function ClusterMetrics({
   usage: ResourceUsage
   cluster?: ClusterFragment
 }) {
+  const theme = useTheme()
   const { prometheusConnection } = useDeploymentSettings()
 
   if (!prometheusConnection) return null
 
   return (
-    <Card padding="xlarge">
+    <Card css={{ padding: theme.spacing.xlarge }}>
       <Flex
         flex={false}
         direction="column"

--- a/assets/src/components/cluster/nodes/NodeInfo.tsx
+++ b/assets/src/components/cluster/nodes/NodeInfo.tsx
@@ -63,7 +63,7 @@ export default function NodeInfo() {
     >
       <section>
         <SubTitle>Overview</SubTitle>
-        <Card padding="medium">
+        <Card css={{ padding: theme.spacing.medium }}>
           <NodeGraphs
             status={node.status}
             pods={node.pods}

--- a/assets/src/components/cluster/nodes/Nodes.tsx
+++ b/assets/src/components/cluster/nodes/Nodes.tsx
@@ -12,6 +12,8 @@ import { ColumnDef } from '@tanstack/react-table'
 
 import { useDeploymentSettings } from 'components/contexts/DeploymentSettingsContext'
 
+import { useTheme } from 'styled-components'
+
 import { SHORT_POLL_INTERVAL } from '../constants'
 import { NODES_Q } from '../queries'
 
@@ -39,6 +41,7 @@ const breadcrumbs = [{ label: 'nodes', url: '/nodes' }]
 
 export default function Nodes() {
   useSetBreadcrumbs(breadcrumbs)
+  const theme = useTheme()
   const { prometheusConnection } = useDeploymentSettings()
 
   const { data, refetch } = useQuery<{
@@ -91,7 +94,7 @@ export default function Nodes() {
           gap="xlarge"
         >
           {!!prometheusConnection && (
-            <Card padding="xlarge">
+            <Card css={{ padding: theme.spacing.xlarge }}>
               <ClusterMetrics
                 nodes={data.nodes}
                 usage={usage}

--- a/assets/src/components/cluster/pods/PodMetadata.tsx
+++ b/assets/src/components/cluster/pods/PodMetadata.tsx
@@ -7,6 +7,8 @@ import { Pod } from 'generated/graphql'
 import { LabelPairsSection } from 'components/utils/LabelPairsSection'
 import { Readiness, podStatusToReadiness } from 'utils/status'
 
+import { useTheme } from 'styled-components'
+
 import { getPodContainersStats as getContainersStats } from '../containers/getPodContainersStats'
 import { ContainerStatuses } from '../ContainerStatuses'
 
@@ -27,12 +29,13 @@ function phaseToReadiness(phase?: string | null) {
 }
 
 export default function Metadata({ pod }: { pod: Pod }) {
+  const theme = useTheme()
   const { labels, annotations } = pod.metadata
   const containerStats = getContainersStats(pod.status)
 
   return (
     <Flex direction="column">
-      <Card padding="large">
+      <Card css={{ padding: theme.spacing.large }}>
         <Flex
           direction="column"
           gap="large"

--- a/assets/src/components/component/ComponentMetrics.tsx
+++ b/assets/src/components/component/ComponentMetrics.tsx
@@ -170,6 +170,7 @@ function Metric({
   cluster,
   ...props
 }) {
+  const theme = useTheme()
   const clusterInfix = cluster ? `cluster="${cluster?.handle}",` : ''
   const { data } = useUsageQuery({
     variables: {
@@ -216,9 +217,11 @@ function Metric({
 
   return (
     <Card
-      overflow="auto"
-      padding="medium"
-      gap="small"
+      css={{
+        padding: theme.spacing.medium,
+        overflow: 'auto',
+        gap: theme.spacing.small,
+      }}
       {...props}
     >
       {content}

--- a/assets/src/components/stacks/create/CreateStackModalFormFiles.tsx
+++ b/assets/src/components/stacks/create/CreateStackModalFormFiles.tsx
@@ -113,9 +113,9 @@ export function CreateStackModalFormFiles({
           {items.map(({ file, errors }, i) => (
             <Card
               fillLevel={2}
-              padding="medium"
               key={i}
               css={{
+                padding: theme.spacing.medium,
                 display: 'flex',
                 flexDirection: 'column',
                 gap: theme.spacing.small,

--- a/assets/src/components/stacks/job/StackJob.tsx
+++ b/assets/src/components/stacks/job/StackJob.tsx
@@ -27,7 +27,7 @@ export default function StackJob() {
   if (!stack.jobSpec) return <EmptyState message="No job spec found." />
 
   return (
-    <Card padding="medium">
+    <Card css={{ padding: theme.spacing.medium }}>
       <div css={{ display: 'flex', flexWrap: 'wrap' }}>
         <Prop title="Namespace">{stack.jobSpec.namespace}</Prop>
 

--- a/assets/src/components/stacks/overview/StackConfiguration.tsx
+++ b/assets/src/components/stacks/overview/StackConfiguration.tsx
@@ -43,7 +43,7 @@ export default function StackConfiguration() {
   }
 
   return (
-    <Card padding="large">
+    <Card css={{ padding: theme.spacing.large }}>
       <OverlineH1
         as="h3"
         css={{

--- a/assets/src/components/stacks/overview/StackMetadata.tsx
+++ b/assets/src/components/stacks/overview/StackMetadata.tsx
@@ -19,7 +19,7 @@ export default function StackMetadata() {
   const { stack } = useOutletContext() as StackOutletContextT
 
   return (
-    <Card padding="large">
+    <Card css={{ padding: theme.spacing.large }}>
       <OverlineH1
         as="h3"
         css={{

--- a/assets/src/components/stacks/overview/StackRepository.tsx
+++ b/assets/src/components/stacks/overview/StackRepository.tsx
@@ -72,7 +72,7 @@ export default function StackRepository() {
   }
 
   return (
-    <Card padding="large">
+    <Card css={{ padding: theme.spacing.large }}>
       <OverlineH1
         as="h3"
         css={{

--- a/assets/src/components/utils/List.tsx
+++ b/assets/src/components/utils/List.tsx
@@ -72,7 +72,6 @@ const List = forwardRef<HTMLDivElement, ListProps>(
       alignItems="top"
       flexDirection="column"
       cornerSize="large"
-      padding={0}
       margin={0}
       flexGrow={1}
       maxHeight="min-content"


### PR DESCRIPTION
css properties set with honorable props seem to be getting overwritten by styled-components (strange side effect of removing Grommet). unclear what's causing this, but for now just fixed all the cards to use styled for their css instead of honorable in cases where this is a problem