### PR TITLE
Virtual Cluster APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ k3s:  ## starts a k3d cluster for testing
 	@read -p "cluster name: " name; \
 	k3d cluster create $$name --image docker.io/rancher/k3s:v1.26.11-k3s2
 
+kind:  ## starts a kind cluster for testing
+	@read -p "cluster name: " name; \
+	kind create cluster --name $$name --image kindest/node:v1.23.4
+
 delete-tag:  ## deletes a tag from git locally and upstream
 	@read -p "Version: " tag; \
 	git tag -d $$tag; \

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -719,6 +719,8 @@ export type Cluster = {
   nodes?: Maybe<Array<Maybe<Node>>>;
   /** the object store connection bound to this cluster for backup/restore */
   objectStore?: Maybe<ObjectStore>;
+  /** the parent of this virtual cluster */
+  parentCluster?: Maybe<Cluster>;
   /** last time the deploy operator pinged this cluster */
   pingedAt?: Maybe<Scalars['DateTime']['output']>;
   /** custom resources with dedicated views for this cluster */
@@ -762,6 +764,8 @@ export type Cluster = {
   version?: Maybe<Scalars['String']['output']>;
   /** Computes a list of statistics for OPA constraint violations w/in this cluster */
   violationStatistics?: Maybe<Array<Maybe<ViolationStatistic>>>;
+  /** whether this is actually a virtual cluster */
+  virtual?: Maybe<Scalars['Boolean']['output']>;
   /** write policy for this cluster */
   writeBindings?: Maybe<Array<Maybe<PolicyBinding>>>;
 };
@@ -1064,14 +1068,17 @@ export type ClusterUpdateAttributes = {
   /** pass a kubeconfig for this cluster (DEPRECATED) */
   kubeconfig?: InputMaybe<KubeconfigAttributes>;
   metadata?: InputMaybe<Scalars['Json']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
   nodePools?: InputMaybe<Array<InputMaybe<NodePoolAttributes>>>;
   protect?: InputMaybe<Scalars['Boolean']['input']>;
+  readBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
   /** if you optionally want to reconfigure the git repository for the cluster service */
   service?: InputMaybe<ClusterServiceAttributes>;
   tags?: InputMaybe<Array<InputMaybe<TagAttributes>>>;
   /** status of the upgrade plan for this cluster */
   upgradePlan?: InputMaybe<UpgradePlanAttributes>;
   version?: InputMaybe<Scalars['String']['input']>;
+  writeBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
 };
 
 /** A consolidated checklist of tasks that need to be completed to upgrade this cluster */
@@ -4369,6 +4376,7 @@ export type RootMutationType = {
   deleteStackDefinition?: Maybe<StackDefinition>;
   deleteUpgradePolicy?: Maybe<UpgradePolicy>;
   deleteUser?: Maybe<User>;
+  deleteVirtualCluster?: Maybe<Cluster>;
   deleteWebhook?: Maybe<Webhook>;
   delinkBackups?: Maybe<Cluster>;
   /** soft deletes a cluster, by deregistering it in our system but not disturbing any kubernetes objects */
@@ -4459,6 +4467,7 @@ export type RootMutationType = {
   upsertNotificationSink?: Maybe<NotificationSink>;
   upsertObservabilityProvider?: Maybe<ObservabilityProvider>;
   upsertPolicyConstraints?: Maybe<Scalars['Int']['output']>;
+  upsertVirtualCluster?: Maybe<Cluster>;
 };
 
 
@@ -4866,6 +4875,11 @@ export type RootMutationTypeDeleteUpgradePolicyArgs = {
 
 
 export type RootMutationTypeDeleteUserArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type RootMutationTypeDeleteVirtualClusterArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -5294,6 +5308,12 @@ export type RootMutationTypeUpsertPolicyConstraintsArgs = {
   constraints?: InputMaybe<Array<InputMaybe<PolicyConstraintAttributes>>>;
 };
 
+
+export type RootMutationTypeUpsertVirtualClusterArgs = {
+  attributes: ClusterAttributes;
+  parentId: Scalars['ID']['input'];
+};
+
 export type RootQueryType = {
   __typename?: 'RootQueryType';
   accessToken?: Maybe<AccessToken>;
@@ -5630,6 +5650,7 @@ export type RootQueryTypeClustersArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   healthy?: InputMaybe<Scalars['Boolean']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
+  parentId?: InputMaybe<Scalars['ID']['input']>;
   projectId?: InputMaybe<Scalars['ID']['input']>;
   q?: InputMaybe<Scalars['String']['input']>;
   tag?: InputMaybe<TagInput>;

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -535,6 +535,8 @@ type Cluster struct {
 	Name string `json:"name"`
 	// if true, this cluster cannot be deleted
 	Protect *bool `json:"protect,omitempty"`
+	// whether this is actually a virtual cluster
+	Virtual *bool `json:"virtual,omitempty"`
 	// desired k8s version for the cluster
 	Version *string `json:"version,omitempty"`
 	// the distribution of kubernetes this cluster is running
@@ -591,6 +593,8 @@ type Cluster struct {
 	Restore *ClusterRestore `json:"restore,omitempty"`
 	// the object store connection bound to this cluster for backup/restore
 	ObjectStore *ObjectStore `json:"objectStore,omitempty"`
+	// the parent of this virtual cluster
+	ParentCluster *Cluster `json:"parentCluster,omitempty"`
 	// list cached nodes for a cluster, this can be stale up to 5m
 	Nodes []*Node `json:"nodes,omitempty"`
 	// list the cached node metrics for a cluster, can also be stale up to 5m
@@ -834,6 +838,7 @@ type ClusterTargetAttributes struct {
 }
 
 type ClusterUpdateAttributes struct {
+	Name    *string `json:"name,omitempty"`
 	Version *string `json:"version,omitempty"`
 	// a short, unique human readable name used to identify this cluster and does not necessarily map to the cloud resource name
 	Handle *string `json:"handle,omitempty"`
@@ -842,12 +847,14 @@ type ClusterUpdateAttributes struct {
 	// pass a kubeconfig for this cluster (DEPRECATED)
 	Kubeconfig *KubeconfigAttributes `json:"kubeconfig,omitempty"`
 	// status of the upgrade plan for this cluster
-	UpgradePlan *UpgradePlanAttributes `json:"upgradePlan,omitempty"`
-	Protect     *bool                  `json:"protect,omitempty"`
-	Distro      *ClusterDistro         `json:"distro,omitempty"`
-	Metadata    *string                `json:"metadata,omitempty"`
-	NodePools   []*NodePoolAttributes  `json:"nodePools,omitempty"`
-	Tags        []*TagAttributes       `json:"tags,omitempty"`
+	UpgradePlan   *UpgradePlanAttributes     `json:"upgradePlan,omitempty"`
+	Protect       *bool                      `json:"protect,omitempty"`
+	Distro        *ClusterDistro             `json:"distro,omitempty"`
+	Metadata      *string                    `json:"metadata,omitempty"`
+	NodePools     []*NodePoolAttributes      `json:"nodePools,omitempty"`
+	Tags          []*TagAttributes           `json:"tags,omitempty"`
+	ReadBindings  []*PolicyBindingAttributes `json:"readBindings,omitempty"`
+	WriteBindings []*PolicyBindingAttributes `json:"writeBindings,omitempty"`
 }
 
 // A consolidated checklist of tasks that need to be completed to upgrade this cluster

--- a/lib/console/deployments/stacks.ex
+++ b/lib/console/deployments/stacks.ex
@@ -24,7 +24,7 @@ defmodule Console.Deployments.Stacks do
     StackCron
   }
 
-  @preloads [:environment, :files, :observable_metrics, :cron, :tags]
+  @preloads [:environment, :files, :observable_metrics, :cron, :tags, :read_bindings, :write_bindings]
 
   @type error :: Console.error
   @type stack_resp :: {:ok, Stack.t} | error

--- a/lib/console/graphql/resolvers/deployments/cluster.ex
+++ b/lib/console/graphql/resolvers/deployments/cluster.ex
@@ -132,6 +132,12 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
   def detach_cluster(%{id: id}, %{context: %{current_user: user}}),
     do: Clusters.detach_cluster(id, user)
 
+  def upsert_virtual_cluster(%{attributes: attrs, parent_id: id}, %{context: %{current_user: user}}),
+    do: Clusters.upsert_virtual_cluster(attrs, id, user)
+
+  def delete_virtual_cluster(%{id: id}, %{context: %{current_user: user}}),
+    do: Clusters.delete_virtual_cluster(id, user)
+
   def create_provider(%{attributes: attrs}, %{context: %{current_user: user}}),
     do: Clusters.create_provider(attrs, user)
 
@@ -169,6 +175,7 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
       {:healthy, h}, q -> Cluster.health(q, h)
       {:backups, e}, q -> Cluster.with_backups(q, !!e)
       {:project_id, id}, q -> Cluster.for_project(q, id)
+      {:parent_id, id}, q -> Cluster.for_parent(q, id)
       _, q -> q
     end)
   end

--- a/lib/console/schema/cluster.ex
+++ b/lib/console/schema/cluster.ex
@@ -87,6 +87,7 @@ defmodule Console.Schema.Cluster do
     field :self,            :boolean, default: false
     field :installed,       :boolean, default: false
     field :protect,         :boolean, default: false
+    field :virtual,         :boolean, default: false
     field :distro,          Distro, default: :generic
     field :metadata,        :map
 
@@ -110,12 +111,13 @@ defmodule Console.Schema.Cluster do
     embeds_one :kubeconfig,     Kubeconfig, on_replace: :update
     embeds_one :cloud_settings, CloudSettings, on_replace: :update
 
-    belongs_to :provider,     ClusterProvider
-    belongs_to :service,      Service
-    belongs_to :credential,   ProviderCredential
-    belongs_to :object_store, ObjectStore
-    belongs_to :restore,      ClusterRestore
-    belongs_to :project,      Project
+    belongs_to :provider,       ClusterProvider
+    belongs_to :service,        Service
+    belongs_to :credential,     ProviderCredential
+    belongs_to :object_store,   ObjectStore
+    belongs_to :restore,        ClusterRestore
+    belongs_to :project,        Project
+    belongs_to :parent_cluster, __MODULE__
 
     has_many :node_pools, ClusterNodePool, on_replace: :delete
     has_many :service_errors, ServiceError, on_replace: :delete
@@ -224,6 +226,10 @@ defmodule Console.Schema.Cluster do
 
   def for_distro(query \\ __MODULE__, distro) do
     from(c in query, where: c.distro == ^distro)
+  end
+
+  def for_parent(query \\ __MODULE__, parent_id) do
+    from(c in query, where: c.parent_cluster_id == ^parent_id)
   end
 
   def statistics(query \\ __MODULE__) do

--- a/lib/console/services/base.ex
+++ b/lib/console/services/base.ex
@@ -9,6 +9,19 @@ defmodule Console.Services.Base do
     end
   end
 
+  def merge_bindings(attrs, resource, types) do
+    Enum.reduce(types, attrs, fn type, attrs ->
+      attr_bindings = Map.get(attrs, type) || []
+      resource_bindings = Map.get(resource, type) || []
+
+      merged = Enum.uniq_by(
+        attr_bindings ++ resource_bindings,
+        & "#{Map.get(&1, :user_id)}:#{Map.get(&1, :group_id)}"
+      )
+      Map.put(attrs, type, merged)
+    end)
+  end
+
   def ok(val), do: {:ok, val}
 
   def should_cache?({:error, _}), do: false

--- a/lib/helm/interface/http.ex
+++ b/lib/helm/interface/http.ex
@@ -28,13 +28,17 @@ defimpl Console.Helm.Interface, for: Console.Helm.Interface.HTTP do
   alias Console.Helm.{Index, Chart}
 
   def index(%{client: client}) do
-    with {:ok, %Req.Response{status: 200, body: body}} <- Req.get(client, url: "/index.yaml"),
-         {:ok, yaml} <- YamlElixir.read_from_string(body) do
+    with {:ok, %Req.Response{status: 200} = resp} <- Req.get(client, url: "/index.yaml"),
+         {:ok, yaml} <- handle_body(resp) do
       {:ok, Index.transform(%Index{entries: yaml["entries"]})}
     else
       _ -> {:error, "fould not fetch helm index"}
     end
   end
+
+  defp handle_body(%Req.Response{status: 200, body: %{} = body}), do: {:ok, body}
+  defp handle_body(%Req.Response{status: 200, body: body}) when is_binary(body),
+    do: YamlElixir.read_from_string(body)
 
   def chart(client, %Index{entries: entries}, chart, vsn) do
     entries = Map.new(entries, & {&1.name, &1.versions})

--- a/priv/repo/migrations/20240817162941_add_vclusters.exs
+++ b/priv/repo/migrations/20240817162941_add_vclusters.exs
@@ -1,0 +1,12 @@
+defmodule Console.Repo.Migrations.AddVclusters do
+  use Ecto.Migration
+
+  def change do
+    alter table(:clusters) do
+      add :virtual, :boolean, default: false
+      add :parent_cluster_id, references(:clusters, type: :uuid, on_delete: :delete_all)
+    end
+
+    create index(:clusters, [:parent_cluster_id])
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -204,7 +204,7 @@ type RootQueryType {
 
   "a relay connection of all clusters visible to the current user"
   clusters(
-    after: String, first: Int, before: String, last: Int, q: String, healthy: Boolean, tag: TagInput, tagQuery: TagQuery, backups: Boolean, projectId: ID
+    after: String, first: Int, before: String, last: Int, q: String, healthy: Boolean, tag: TagInput, tagQuery: TagQuery, backups: Boolean, projectId: ID, parentId: ID
   ): ClusterConnection
 
   "gets summary information for all healthy\/unhealthy clusters in your fleet"
@@ -706,6 +706,10 @@ type RootMutationType {
 
   "registers a list of runtime services discovered for the current cluster"
   registerRuntimeServices(services: [RuntimeServiceAttributes], serviceId: ID): Int
+
+  upsertVirtualCluster(attributes: ClusterAttributes!, parentId: ID!): Cluster
+
+  deleteVirtualCluster(id: ID!): Cluster
 
   "updates only the components of a given service, to be sent after deploy operator syncs"
   updateServiceComponents(
@@ -3423,6 +3427,8 @@ input ClusterPing {
 }
 
 input ClusterUpdateAttributes {
+  name: String
+
   version: String
 
   "a short, unique human readable name used to identify this cluster and does not necessarily map to the cloud resource name"
@@ -3446,6 +3452,10 @@ input ClusterUpdateAttributes {
   nodePools: [NodePoolAttributes]
 
   tags: [TagAttributes]
+
+  readBindings: [PolicyBindingAttributes]
+
+  writeBindings: [PolicyBindingAttributes]
 }
 
 input ClusterServiceAttributes {
@@ -3650,6 +3660,9 @@ type Cluster {
   "if true, this cluster cannot be deleted"
   protect: Boolean
 
+  "whether this is actually a virtual cluster"
+  virtual: Boolean
+
   "desired k8s version for the cluster"
   version: String
 
@@ -3733,6 +3746,9 @@ type Cluster {
 
   "the object store connection bound to this cluster for backup\/restore"
   objectStore: ObjectStore
+
+  "the parent of this virtual cluster"
+  parentCluster: Cluster
 
   "list cached nodes for a cluster, this can be stale up to 5m"
   nodes: [Node]

--- a/test/console/deployments/helm/agent_test.exs
+++ b/test/console/deployments/helm/agent_test.exs
@@ -31,6 +31,20 @@ defmodule Console.Deployments.Helm.AgentTest do
       Process.exit(pid, :kill)
     end
 
+    test "it can handle https chart museum helm repos" do
+      repo = "https://app.plural.sh/cm/rabbitmq"
+      {:ok, pid} = Agent.start(repo)
+
+      {:ok, f, _} = Agent.fetch(pid, "cluster-operator", "x.x.x")
+
+      files = stream_and_untar(f)
+      assert files["Chart.yaml"]
+
+      assert Console.Deployments.Git.get_helm_repository(repo).health == :pullable
+
+      Process.exit(pid, :kill)
+    end
+
     test "it can fetch a chart from an oci registry" do
       repo = "oci://ghcr.io/stefanprodan/charts"
       {:ok, pid} = Agent.start(repo)

--- a/test/console/deployments/stacks_test.exs
+++ b/test/console/deployments/stacks_test.exs
@@ -144,6 +144,29 @@ defmodule Console.Deployments.StacksTest do
       assert_receive {:event, %PubSub.StackUpdated{item: ^stack}}
     end
 
+    test "you can update bindings" do
+      user = admin_user()
+      stack = insert(:stack)
+
+      {:ok, stack} = Stacks.update_stack(%{
+        name: "my-stack",
+        type: :terraform,
+        approval: true,
+        git: %{ref: "main", folder: "terraform"},
+        write_bindings: [%{user_id: user.id}]
+      }, stack.id, user)
+
+      assert stack.name == "my-stack"
+      assert stack.type == :terraform
+      assert stack.approval
+      assert stack.git.ref == "main"
+      assert stack.git.folder == "terraform"
+
+      assert Enum.find(stack.write_bindings, & &1.user_id == user.id)
+
+      assert_receive {:event, %PubSub.StackUpdated{item: ^stack}}
+    end
+
     test "random users cannot update" do
       stack = insert(:stack)
       user = insert(:user)


### PR DESCRIPTION
The idea here is to write some slightly more restrictive upsert/deletion api that could be executed from CRDs reconciled by the deployment operator to install new vclusters, also tracks parentage of the cluster so we can viz it in the UI properly.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
