### PR TITLE
Limit cluster node and node metrics fetches

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -2272,7 +2272,7 @@ export type InfrastructureStack = {
   type: StackType;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
   /** Arbitrary variables to add to a stack run */
-  variables?: Maybe<Scalars['Json']['output']>;
+  variables?: Maybe<Scalars['Map']['output']>;
   /** the subdirectory you want to run the stack's commands w/in */
   workdir?: Maybe<Scalars['String']['output']>;
   writeBindings?: Maybe<Array<Maybe<PolicyBinding>>>;

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -1855,7 +1855,7 @@ type InfrastructureStack struct {
 	// whether you want Plural to manage the state of this stack
 	ManageState *bool `json:"manageState,omitempty"`
 	// Arbitrary variables to add to a stack run
-	Variables    *string                `json:"variables,omitempty"`
+	Variables    map[string]interface{} `json:"variables,omitempty"`
 	Runs         *StackRunConnection    `json:"runs,omitempty"`
 	PullRequests *PullRequestConnection `json:"pullRequests,omitempty"`
 	// files bound to a run of this stack

--- a/lib/console/deployments/clusters.ex
+++ b/lib/console/deployments/clusters.ex
@@ -153,9 +153,10 @@ defmodule Console.Deployments.Clusters do
 
   defp fetch_nodes(%Cluster{pinged_at: nil, self: false}), do: {:ok, []}
   defp fetch_nodes(%Cluster{} = cluster) do
+    query = Core.list_node!(limit: 100)
     with %Kazan.Server{} = server <- control_plane(cluster),
          _ <- Kube.Utils.save_kubeconfig(server),
-         {:ok, %{items: items}} <- Core.list_node!() |> Kube.Utils.run() do
+         {:ok, %{items: items}} <- Kube.Utils.run(query) do
       {:ok, items}
     else
       _ -> {:ok, []}
@@ -174,7 +175,7 @@ defmodule Console.Deployments.Clusters do
   defp fetch_node_metrics(%Cluster{} = cluster) do
     with %Kazan.Server{} = server <- control_plane(cluster),
          _ <- Kube.Utils.save_kubeconfig(server),
-         {:ok, %{items: items}} <- Kube.Client.list_metrics() do
+         {:ok, %{items: items}} <- Kube.Client.list_metrics(%{"limit" => "100"}) do
       {:ok, items}
     else
       _ -> {:ok, []}

--- a/lib/console/graphql/deployments/stack.ex
+++ b/lib/console/graphql/deployments/stack.ex
@@ -144,7 +144,7 @@ defmodule Console.GraphQl.Deployments.Stack do
     field :cancellation_reason, :string, description: "why this run was cancelled"
     field :workdir,             :string, description: "the subdirectory you want to run the stack's commands w/in"
     field :manage_state,        :boolean, description: "whether you want Plural to manage the state of this stack"
-    field :variables,           :json, description: "Arbitrary variables to add to a stack run"
+    field :variables,           :map, description: "Arbitrary variables to add to a stack run"
 
     connection field :runs, node_type: :stack_run do
       arg :pull_request_id, :id

--- a/lib/kube/client.ex
+++ b/lib/kube/client.ex
@@ -10,7 +10,6 @@ defmodule Kube.Client do
   list_request :list_vertical_pod_autoscalers, Kube.VerticalPodAutoscaler.List
   list_request :list_wireguard_peers, Kube.WireguardPeer.List
   list_request :list_certificate, Kube.Certificate.List
-  list_request :list_postgresqls, Kube.Postgresql.List
   list_request :list_clusters, Kube.Cluster.List
   list_request :list_canaries, Kube.Canary.List
   list_request :list_rollouts, Kube.Rollout.List

--- a/lib/kube/client/base.ex
+++ b/lib/kube/client/base.ex
@@ -76,9 +76,9 @@ defmodule Kube.Client.Base do
 
   defmacro list_all_request(name, model) do
     quote do
-      def unquote(name)() do
+      def unquote(name)(params \\ %{}) do
         {g, v, k} = unquote(model).item_model().gvk()
-        make_request("/apis/#{g}/#{v}/#{k}", "get", unquote(model))
+        make_request("/apis/#{g}/#{v}/#{k}", "get", unquote(model), "", params)
       end
     end
   end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1341,7 +1341,7 @@ type InfrastructureStack {
   manageState: Boolean
 
   "Arbitrary variables to add to a stack run"
-  variables: Json
+  variables: Map
 
   runs(after: String, first: Int, before: String, last: Int, pullRequestId: ID): StackRunConnection
 


### PR DESCRIPTION
We periodically fetch these to expose metrics data, we should bound these to support larger cluster sizes properly.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
