### PR TITLE
wrong format for file arg

### DIFF
--- a/charts/console-rapid/Chart.yaml
+++ b/charts/console-rapid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: console-rapid
 description: rapid channel chart for the plural console (used for testing)
 appVersion: 0.10.23
-version: 0.3.52
+version: 0.3.53
 dependencies:
   - name: kas
     version: 0.1.0

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -56,12 +56,12 @@ spec:
         image: "{{ .Values.global.registry }}/{{ .Values.ociAuth.repository }}:{{ .Values.ociAuth.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.ociAuth.imagePullPolicy }}
         args:
-        - --token-file /shared/token
+        - --token-file=/shared/token
         volumeMounts:
         - name: conf-dir
           mountPath: /shared
         ports:
-        - name: http
+        - name: sidecar
           containerPort: 3000
           protocol: TCP
       - name: console


### PR DESCRIPTION
apparently it's `--token-file=...` instead of space separated

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
