### PR TITLE
Fix unloaded notif bindings on sinks

### DIFF
--- a/lib/console/graphql/deployments/notification.ex
+++ b/lib/console/graphql/deployments/notification.ex
@@ -60,7 +60,8 @@ defmodule Console.GraphQl.Deployments.Notification do
     field :type, non_null(:sink_type), description: "the channel type of the sink, eg slack or teams"
 
     field :notification_bindings, list_of(:policy_binding),
-      description: "the users/groups an in-app notification can be delivered to"
+      description: "the users/groups an in-app notification can be delivered to",
+      resolve: dataloader(Deployments)
     field :configuration, non_null(:sink_configuration),
       description: "type specific sink configuration"
 


### PR DESCRIPTION
This was causing errors in the crd reconciliation for notif syncs, should fix

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
