### PR TITLE
Fix regression on clusters page

### DIFF
--- a/assets/src/components/cd/clusters/Clusters.tsx
+++ b/assets/src/components/cd/clusters/Clusters.tsx
@@ -207,7 +207,6 @@ export default function Clusters() {
 
   return (
     <>
-      {!showGettingStarted && <ClustersGettingStarted />}
       {!isDemo ? (
         <div
           css={{
@@ -250,6 +249,7 @@ export default function Clusters() {
       ) : (
         <DemoTable mode={cdIsEnabled ? 'empty' : 'disabled'} />
       )}
+      {showGettingStarted && <ClustersGettingStarted />}
     </>
   )
 }


### PR DESCRIPTION
the logic around the getting started screen was inverted, pushing out the normal clusters table for all users.

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
