### PR TITLE
Handle empty strings in string pr automation context

### DIFF
--- a/lib/console/deployments/pr/validation.ex
+++ b/lib/console/deployments/pr/validation.ex
@@ -35,7 +35,7 @@ defmodule Console.Deployments.Pr.Validation do
     end
   end
 
-  defp do_validate(%Configuration{type: :string}, val) when is_binary(val), do: :ok
+  defp do_validate(%Configuration{type: :string}, val) when is_binary(val) and byte_size(val) > 0, do: :ok
   defp do_validate(%Configuration{type: t}, val),
     do: {:error, "value #{inspect(val)} does not match type #{String.upcase(to_string(t))}"}
 end

--- a/test/console/deployments/git_test.exs
+++ b/test/console/deployments/git_test.exs
@@ -318,6 +318,28 @@ defmodule Console.Deployments.GitTest do
       assert err =~ "does not match regex"
     end
 
+    test "it will reject a pull request w/ empty string configs" do
+      user = insert(:user)
+      conn = insert(:scm_connection, token: "some-pat")
+      pra = insert(:pr_automation,
+        identifier: "pluralsh/console",
+        cluster: build(:cluster),
+        connection: conn,
+        updates: %{regexes: ["regex"], match_strategy: :any, files: ["file.yaml"], replace_template: "replace"},
+        write_bindings: [%{user_id: user.id}],
+        create_bindings: [%{user_id: user.id}],
+        configuration: [
+          %{name: "first", type: :int},
+          %{name: "second", type: :string}
+        ]
+      )
+
+      {:error, _} = Git.create_pull_request(%{
+        "first" => 10,
+        "second" => ""
+      }, pra.id, "pr-test", user)
+    end
+
     test "it can create a pull request with a github app" do
       user = insert(:user)
       {:ok, pem_string, _} = Console.keypair("console@plural.sh")


### PR DESCRIPTION
We were passing those for string types even though it's prob invalid.  Rejecting them here.

## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
