### PR TITLE
fix form toggles

### DIFF
--- a/assets/src/components/pr/automations/prConfigurationUtils.tsx
+++ b/assets/src/components/pr/automations/prConfigurationUtils.tsx
@@ -49,16 +49,17 @@ export function validateAndFilterConfig(
 
     if (conditionMet && name) {
       let value: string | boolean | undefined = configVals[name]
+      const isBool = configItem.type === ConfigurationType.Bool
 
-      if (configItem.type === ConfigurationType.Bool) {
+      if (isBool) {
         value = parseToBool(value)
       }
 
-      if (value) {
-        filteredValues.push({ name, value })
+      if (value !== undefined || isBool) {
+        filteredValues.push({ name, value: value as string | boolean })
       }
 
-      return (!!configItem.optional || !!value) && acc
+      return (!!configItem.optional || !!value || isBool) && acc
     }
 
     return acc

--- a/assets/src/components/settings/global/GlobalSettingsSMTP.tsx
+++ b/assets/src/components/settings/global/GlobalSettingsSMTP.tsx
@@ -22,7 +22,8 @@ export function GlobalSettingsSMTP() {
   const theme = useTheme()
   const { smtp } = useDeploymentSettings()
   const [form, setForm] = useState<SmtpSettingsAttributes>({
-    ...(cleanSmtpForm(smtp) || defaultForm),
+    ...defaultForm,
+    ...cleanSmtpForm(smtp),
     password: '',
   })
   const [showToast, setShowToast] = useState(false)


### PR DESCRIPTION
smtp and pr automation forms were both having issues capturing toggle values (smtp form wasn't actually setting the default to "false" so it would register undefined if there was no toggle, and conversely pr automation form was treating false as undefined)