### PR TITLE
Add `stack.run` to event list

### DIFF
--- a/lib/console/schema/notification_router.ex
+++ b/lib/console/schema/notification_router.ex
@@ -52,7 +52,7 @@ defmodule Console.Schema.NotificationRouter do
 
   @valid ~w(name events)a
 
-  @events ~w(* service.update cluster.create pipeline.update pr.create pr.close)
+  @events ~w(* service.update stack.run cluster.create pipeline.update pr.create pr.close)
   @error_msg "events must all be one of [#{Enum.join(@events, ",")}]"
 
   def changeset(model, attrs \\ %{}) do


### PR DESCRIPTION
We introduced this notification event, but you currently can't create routers that filter on it.

## Test Plan
regression


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
