### PR TITLE
requeue when referenced object is not found

### DIFF
--- a/go/controller/internal/controller/prautomation_attributes.go
+++ b/go/controller/internal/controller/prautomation_attributes.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"context"
-	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	console "github.com/pluralsh/console/go/client"
 
@@ -33,7 +35,7 @@ func (in *PrAutomationReconciler) attributes(ctx context.Context, pra *v1alpha1.
 		return nil, err
 	}
 	if connectionID == nil {
-		return nil, fmt.Errorf("could not find ScmConnection: %s", pra.Spec.ScmConnectionRef.Name)
+		return nil, errors.NewNotFound(schema.GroupResource{}, pra.Spec.ScmConnectionRef.Name)
 	}
 
 	projectID, err := helper.IDFromRef(pra.Spec.ProjectRef, &v1alpha1.Project{})

--- a/go/controller/internal/controller/prautomation_controller.go
+++ b/go/controller/internal/controller/prautomation_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -85,6 +86,10 @@ func (in *PrAutomationReconciler) Reconcile(ctx context.Context, req reconcile.R
 	// Sync PrAutomation CRD with the Console API
 	apiPrAutomation, err := in.sync(ctx, prAutomation, changed)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Error(err, "unable to find referenced object")
+			return requeue, nil
+		}
 		logger.Error(err, "unable to create or update prAutomation")
 		utils.MarkFalse(prAutomation.SetCondition, v1alpha1.SynchronizedConditionType, v1alpha1.SynchronizedConditionReasonError, err.Error())
 		return ctrl.Result{}, err

--- a/go/controller/internal/controller/prautomation_controller_test.go
+++ b/go/controller/internal/controller/prautomation_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -161,8 +160,7 @@ var _ = Describe("PR Automation Controller", func() {
 					}
 
 					_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: prAutomationObjectKey})
-					Expect(errors.IsNotFound(err)).To(BeTrue())
-					Expect(err).To(MatchError(errors.NewNotFound(common.AsGroupResource(v1alpha1.GroupName, &v1alpha1.ScmConnection{}), scmConnectionName)))
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 		})
@@ -301,7 +299,7 @@ var _ = Describe("PR Automation Controller", func() {
 					})).To(Succeed())
 				})
 
-				It("should error with cluster not found", func() {
+				It("should requeue when cluster not found", func() {
 					fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 					fakeConsoleClient.On("IsPrAutomationExistsByName", mock.Anything, prAutomationName).Return(false, nil)
 					fakeConsoleClient.On("CreatePrAutomation", mock.Anything, mock.Anything).Return(&gqlclient.PrAutomationFragment{
@@ -316,8 +314,7 @@ var _ = Describe("PR Automation Controller", func() {
 					}
 
 					_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: prAutomationObjectKey})
-					Expect(errors.IsNotFound(err)).To(BeTrue())
-					Expect(err).To(MatchError(errors.NewNotFound(common.AsGroupResource(v1alpha1.GroupName, &v1alpha1.Cluster{}), clusterName)))
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 		})


### PR DESCRIPTION
pr automation CRD doesn't requeue effectively when waiting for referenced objects
## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
