### PR TITLE
Only fail upgrade insights on `:failed` statuses

### DIFF
--- a/lib/console/deployments/clusters.ex
+++ b/lib/console/deployments/clusters.ex
@@ -450,7 +450,7 @@ defmodule Console.Deployments.Clusters do
     addons = runtime_services(cluster)
     Cluster.changeset(cluster, %{
       upgrade_plan: %{
-        deprecations: length(deps) == 0 && Enum.all?(insights, & &1.status == :passing),
+        deprecations: length(deps) == 0 && Enum.all?(insights, & &1.status != :failed),
         compatibilities: !Enum.any?(addons, fn
           %{addon_version: %Version{} = vsn} ->
             Version.blocking?(vsn, cluster.current_version)


### PR DESCRIPTION
Looks like EKS is really pessimistic with their statuses, think we can say things are upgradeable if not failed.

## Test Plan
existing


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
