### PR TITLE
fix secret sharing bugs

### DIFF
--- a/assets/src/components/sharesecret/ConsumeSecret.tsx
+++ b/assets/src/components/sharesecret/ConsumeSecret.tsx
@@ -1,4 +1,3 @@
-import { useNavigate, useParams } from 'react-router-dom'
 import {
   Button,
   Callout,
@@ -6,15 +5,15 @@ import {
   ReturnIcon,
   useSetBreadcrumbs,
 } from '@pluralsh/design-system'
+import { useMemo } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import { useTheme } from 'styled-components'
-import { useEffect, useMemo } from 'react'
 
 import { useConsumeSecretMutation } from '../../generated/graphql'
+import { HOME_ABS_PATH } from '../../routes/consoleRoutesConsts'
 import { InputRevealer } from '../cd/providers/InputRevealer'
 import { Overline } from '../cd/utils/PermissionsModal'
-import LoadingIndicator from '../utils/LoadingIndicator'
 import { Body2BoldP } from '../utils/typography/Text'
-import { HOME_ABS_PATH } from '../../routes/consoleRoutesConsts'
 
 export default function ConsumeSecret() {
   const theme = useTheme()
@@ -27,14 +26,6 @@ export default function ConsumeSecret() {
     variables: { handle },
   })
 
-  useEffect(() => {
-    mutation()
-    // Only run on first mount.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  if (loading) return <LoadingIndicator />
-
   return (
     <div
       css={{
@@ -44,29 +35,60 @@ export default function ConsumeSecret() {
         width: '100%',
       }}
     >
-      {data && (
-        <Card
+      <Card
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.xlarge,
+          maxWidth: 572,
+          padding: theme.spacing.xlarge,
+        }}
+      >
+        <div
           css={{
             display: 'flex',
             flexDirection: 'column',
-            gap: theme.spacing.xlarge,
-            maxWidth: 572,
-            padding: theme.spacing.xlarge,
+            gap: theme.spacing.xsmall,
           }}
         >
-          <div
+          <Overline>Share secret</Overline>
+          <p>
+            A user of this Console has shared a secret with you. After you
+            display this secret a single time it expires.
+          </p>
+        </div>
+        {error ? (
+          <Callout
+            title="You do not have access to this secret"
+            severity="danger"
             css={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: theme.spacing.xsmall,
+              maxWidth: 572,
             }}
           >
-            <Overline>Share secret</Overline>
-            <p>
-              A user of this Console has shared a secret with you. After you
-              display this secret a single time it expires.
-            </p>
-          </div>
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: theme.spacing.medium,
+              }}
+            >
+              <p>
+                Either this URL has already been consumed, or you do not have
+                permission to view this URL. If you think this is a mistake,
+                please contact the system administrator.
+              </p>
+              <Button
+                secondary
+                small
+                startIcon={<ReturnIcon />}
+                onClick={() => navigate(HOME_ABS_PATH)}
+                width="fit-content"
+              >
+                Back home
+              </Button>
+            </div>
+          </Callout>
+        ) : data ? (
           <div
             css={{
               display: 'flex',
@@ -96,40 +118,15 @@ export default function ConsumeSecret() {
               </Button>
             </div>
           </div>
-        </Card>
-      )}
-      {error && (
-        <Callout
-          title="You do not have access to this secret"
-          severity="danger"
-          css={{
-            maxWidth: 572,
-          }}
-        >
-          <div
-            css={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: theme.spacing.medium,
-            }}
+        ) : (
+          <Button
+            loading={loading}
+            onClick={() => mutation()}
           >
-            <p>
-              Either this URL has already been consumed, or you do not have
-              permission to view this URL. If you think this is a mistake,
-              please contact the system administrator.
-            </p>
-            <Button
-              secondary
-              small
-              startIcon={<ReturnIcon />}
-              onClick={() => navigate(HOME_ABS_PATH)}
-              width="fit-content"
-            >
-              Back home
-            </Button>
-          </div>
-        </Callout>
-      )}
+            Consume secret
+          </Button>
+        )}
+      </Card>
     </div>
   )
 }

--- a/assets/src/components/sharesecret/ShareSecretModal.tsx
+++ b/assets/src/components/sharesecret/ShareSecretModal.tsx
@@ -7,9 +7,9 @@ import {
   ReturnIcon,
   Toast,
 } from '@pluralsh/design-system'
+import { LayerPositionType } from '@pluralsh/design-system/dist/components/Layer'
 import {
   Dispatch,
-  FormEvent,
   SetStateAction,
   useCallback,
   useEffect,
@@ -18,7 +18,6 @@ import {
   useState,
 } from 'react'
 import { useTheme } from 'styled-components'
-import { LayerPositionType } from '@pluralsh/design-system/dist/components/Layer'
 
 import { splitBindings } from '../settings/usermanagement/roles/RoleFormBindings'
 import { BindingInput } from '../utils/BindingInput'
@@ -56,7 +55,7 @@ export default function ShareSecretModal({
   useEffect(() => {
     if (toastRef.current)
       toastRef.current.style.setProperty('z-index', `${theme.zIndexes.tooltip}`)
-  }, [theme.zIndexes.tooltip])
+  }, [theme.zIndexes.tooltip, toast])
 
   const { userBindings, groupBindings } = useMemo(() => {
     const { userBindings, groupBindings } = splitBindings(bindings)
@@ -78,35 +77,26 @@ export default function ShareSecretModal({
     },
   })
 
-  const onSubmit = useCallback(
-    (e: FormEvent) => {
-      e.preventDefault()
+  const onSubmit = useCallback(() => {
+    if (disabled) return
 
-      if (disabled) return
-
-      mutation({
-        variables: {
-          attributes: {
-            name,
-            secret,
-            notificationBindings: bindings
-              .filter(isNonNullable)
-              .map(bindingToBindingAttributes),
-          },
+    mutation({
+      variables: {
+        attributes: {
+          name,
+          secret,
+          notificationBindings: bindings
+            .filter(isNonNullable)
+            .map(bindingToBindingAttributes),
         },
-      })
-    },
-    [bindings, disabled, mutation, name, secret]
-  )
+      },
+    })
+  }, [bindings, disabled, mutation, name, secret])
 
-  const onRestart = useCallback(
-    (e: FormEvent) => {
-      e.preventDefault()
-      reset()
-      setCompleted(false)
-    },
-    [reset, setCompleted]
-  )
+  const onRestart = useCallback(() => {
+    reset()
+    setCompleted(false)
+  }, [reset, setCompleted])
 
   return (
     <>
@@ -123,29 +113,22 @@ export default function ShareSecretModal({
                 <Button
                   secondary
                   startIcon={<ReturnIcon />}
-                  type="button"
                   onClick={onRestart}
                 >
                   Restart
                 </Button>
-                <Button
-                  type="button"
-                  onClick={() => setOpen(false)}
-                >
-                  Finish
-                </Button>
+                <Button onClick={() => setOpen(false)}>Finish</Button>
               </>
             ) : (
               <>
                 <Button
-                  type="button"
                   secondary
                   onClick={() => setOpen(false)}
                 >
                   Cancel
                 </Button>
                 <Button
-                  type="submit"
+                  onClick={onSubmit}
                   disabled={disabled}
                   loading={loading}
                 >
@@ -155,8 +138,6 @@ export default function ShareSecretModal({
             )}
           </div>
         }
-        asForm
-        formProps={{ onSubmit }}
         header="Share secret"
         open={open}
         onClose={() => setOpen(false)}
@@ -169,20 +150,14 @@ export default function ShareSecretModal({
             gap: theme.spacing.large,
           }}
         >
-          <FormField
-            required={!completed}
-            label="Secret name"
-          >
+          <FormField label="Secret name">
             <Input
               disabled={completed}
               value={name}
               onChange={(e) => setName(e.currentTarget.value)}
             />
           </FormField>
-          <FormField
-            required={!completed}
-            label="Secret string"
-          >
+          <FormField label="Secret string">
             <Input
               disabled={completed}
               value={secret}


### PR DESCRIPTION
makes it so the user has to explicitly click "consume secret" instead of consuming on render, which seemed to be causing some issues

also fixes a bug that was causing new secrets to generate every time the URL copy button was clicked

<img width="772" alt="Screenshot 2024-10-10 at 1 08 37 PM" src="https://github.com/user-attachments/assets/9d09c717-b084-45d2-b8ec-6df90c582e0b">
<img width="772" alt="Screenshot 2024-10-10 at 1 08 53 PM" src="https://github.com/user-attachments/assets/6013293e-776f-463a-9c00-bf6bd2648ee9">
<img width="772" alt="Screenshot 2024-10-10 at 1 14 07 PM" src="https://github.com/user-attachments/assets/36517031-1bc6-4d01-9e6f-59dfbdae5bff">
