### PR TITLE
feat: use cores/bytes as the base unit for component-level metrics

### DIFF
--- a/assets/src/components/component/ComponentMetrics.tsx
+++ b/assets/src/components/component/ComponentMetrics.tsx
@@ -1,25 +1,23 @@
 import { Card, EmptyState } from '@pluralsh/design-system'
-import { useMemo, useState } from 'react'
-import { useOutletContext } from 'react-router-dom'
-import { DURATIONS } from 'utils/time'
-import { filesize } from 'filesize'
-import { isNonNullable } from 'utils/isNonNullable'
-import { useTheme } from 'styled-components'
-import isEmpty from 'lodash/isEmpty'
+import { Graph } from 'components/utils/Graph'
+import GraphHeader from 'components/utils/GraphHeader'
+import LoadingIndicator from 'components/utils/LoadingIndicator'
+
+import RangePicker from 'components/utils/RangePicker'
 
 import {
   MetricResponseFragment,
   useServiceDeploymentComponentMetricsQuery,
 } from 'generated/graphql'
-
-import RangePicker from 'components/utils/RangePicker'
-import { Graph } from 'components/utils/Graph'
-import GraphHeader from 'components/utils/GraphHeader'
-import LoadingIndicator from 'components/utils/LoadingIndicator'
+import isEmpty from 'lodash/isEmpty'
 
 import moment from 'moment/moment'
-
-import { format } from '../apps/app/dashboards/dashboard/misc'
+import { useMemo, useState } from 'react'
+import { useOutletContext } from 'react-router-dom'
+import { useTheme } from 'styled-components'
+import { isNonNullable } from 'utils/isNonNullable'
+import { DURATIONS } from 'utils/time'
+import { Prometheus } from '../../utils/prometheus.ts'
 
 import { ComponentDetailsContext } from './ComponentDetails'
 
@@ -68,13 +66,10 @@ function Graphs({
             flexGrow: 1,
           }}
         >
-          <GraphHeader
-            title="Overall CPU Usage"
-            tooltip="100% usage means that 1 vCore is fully used. Overall usage can exceed 100% if there are more vCores available."
-          />
+          <GraphHeader title="Overall CPU Usage (cores)" />
           <Graph
             data={[{ id: 'cpu', data: cpuValues }]}
-            yFormat={(v) => format(v, 'percent')}
+            yFormat={(v) => Prometheus.format(v, 'cpu')}
             tickRotation={undefined}
           />
         </div>
@@ -87,10 +82,10 @@ function Graphs({
             flexGrow: 1,
           }}
         >
-          <GraphHeader title="Overall Memory Usage" />
+          <GraphHeader title="Overall Memory Usage (bytes)" />
           <Graph
             data={[{ id: 'memory', data: memValues }]}
-            yFormat={filesize}
+            yFormat={(v) => Prometheus.format(v, 'memory')}
             tickRotation={undefined}
           />
         </div>
@@ -142,13 +137,10 @@ function PodGraphs({
             flexGrow: 1,
           }}
         >
-          <GraphHeader
-            title="Pod CPU Usage"
-            tooltip="100% usage means that 1 vCore is fully used. Overall usage can exceed 100% if there are more vCores available."
-          />
+          <GraphHeader title="Pod CPU Usage (cores)" />
           <Graph
             data={cpuGraph}
-            yFormat={(v) => format(v, 'percent')}
+            yFormat={(v) => Prometheus.format(v, 'cpu')}
             tickRotation={undefined}
           />
         </div>
@@ -161,10 +153,10 @@ function PodGraphs({
             flexGrow: 1,
           }}
         >
-          <GraphHeader title="Pod Memory Usage" />
+          <GraphHeader title="Pod Memory Usage (bytes)" />
           <Graph
             data={memGraph}
-            yFormat={filesize}
+            yFormat={(v) => Prometheus.format(v, 'memory')}
             tickRotation={undefined}
           />
         </div>

--- a/assets/src/utils/prometheus.ts
+++ b/assets/src/utils/prometheus.ts
@@ -79,9 +79,10 @@ function format(value: number, type: 'cpu' | 'memory'): string {
   }
 }
 
-// values is expected to be provided normalized to the core base
+// values is expected to be provided normalized to the cores base
 function formatCPU(value: number): string {
   // Normalize from cores to the millicores base
+  // 0.12 (cores) == 120 (millicores)
   value = value * 1000
 
   /** Base for prefixes */
@@ -119,7 +120,7 @@ function formatMemory(value: number): string {
     power += 1
   }
 
-  return `${Number((value / divider).toFixed(0))} ${memoryPowerSuffixes[power]}`
+  return `${Number((value / divider).toFixed(0))}${memoryPowerSuffixes[power]}`
 }
 
 export const Prometheus = {

--- a/assets/src/utils/prometheus.ts
+++ b/assets/src/utils/prometheus.ts
@@ -70,6 +70,58 @@ function enabled(connection: Nullable<HttpConnection>): boolean {
   return !!connection && connection?.host?.length > 0
 }
 
+function format(value: number, type: 'cpu' | 'memory'): string {
+  switch (type) {
+    case 'cpu':
+      return formatCPU(value)
+    case 'memory':
+      return formatMemory(value)
+  }
+}
+
+// values is expected to be provided normalized to the core base
+function formatCPU(value: number): string {
+  // Normalize from cores to the millicores base
+  value = value * 1000
+
+  /** Base for prefixes */
+  const coreBase = 1000
+
+  /** Names of the suffixes where I-th name is for base^I suffix. */
+  const corePowerSuffixes = ['m', '', 'k', 'M', 'G', 'T']
+
+  let divider = 1
+  let power = 0
+
+  while (value / divider >= coreBase && power < corePowerSuffixes.length - 1) {
+    divider *= coreBase
+    power += 1
+  }
+
+  return `${Number((value / divider).toFixed(0))}${corePowerSuffixes[power]}`
+}
+
+function formatMemory(value: number): string {
+  /** Base for binary prefixes */
+  const memoryBase = 1024
+
+  /** Names of the suffixes where I-th name is for base^I suffix. */
+  const memoryPowerSuffixes = ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi']
+
+  let divider = 1
+  let power = 0
+
+  while (
+    value / divider > memoryBase &&
+    power < memoryPowerSuffixes.length - 1
+  ) {
+    divider *= memoryBase
+    power += 1
+  }
+
+  return `${Number((value / divider).toFixed(0))} ${memoryPowerSuffixes[power]}`
+}
+
 export const Prometheus = {
   // Functions
   avg,
@@ -77,6 +129,7 @@ export const Prometheus = {
   toValues,
   pods,
   enabled,
+  format,
   // Types
   CapacityType,
 }


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Updated component-level metric units
  - CPU metrics are now adjusted to the millicores base unit (1000 m == 1 core)
  - Memory metrics are now adjusted to the power of 2 base (1024 bytes == 1 KiB)

#### Before
![image](https://github.com/user-attachments/assets/320d5af0-1e6d-47e0-ad57-362da2ba2d3d)

#### After
![Zrzut ekranu 2024-10-17 124000](https://github.com/user-attachments/assets/5d05e4bc-ee10-4b99-b0f5-c02bb642c415)

#### Mocked
![Zrzut ekranu 2024-10-17 122750](https://github.com/user-attachments/assets/f1114158-dc53-4fe6-bc93-ae66b7eb3db4)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
