### PR TITLE
Add apis to persist insight components at cluster level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ find-versions:
 	az aks get-versions --location eastus --output json > k8s-versions/aks.json
 
 
-update-ollama-helm-chart: ## update ollama Helm chart
+pull-ollama-helm-chart: ## update ollama Helm chart
 	helm repo add ollama-helm https://otwld.github.io/ollama-helm/
 	helm repo update
 	rm -rf charts/ollama

--- a/assets/src/generated/graphql-kubernetes.ts
+++ b/assets/src/generated/graphql-kubernetes.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';

--- a/assets/src/generated/graphql-plural.ts
+++ b/assets/src/generated/graphql-plural.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
@@ -181,6 +181,7 @@ export type AiInsight = {
   /** any errors generated when compiling this insight */
   error?: Maybe<Array<Maybe<ServiceError>>>;
   freshness?: Maybe<InsightFreshness>;
+  id: Scalars['ID']['output'];
   insertedAt?: Maybe<Scalars['DateTime']['output']>;
   /** a deduplication sha for this insight */
   sha?: Maybe<Scalars['String']['output']>;
@@ -916,6 +917,8 @@ export type Cluster = {
   /** internal id of this cluster */
   id: Scalars['ID']['output'];
   insertedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** an ai insight generated about issues discovered which might impact the health of this cluster */
+  insight?: Maybe<AiInsight>;
   /** whether the deploy operator has been registered for this cluster */
   installed?: Maybe<Scalars['Boolean']['output']>;
   /** the url of the kas server you can access this cluster from */
@@ -1154,6 +1157,14 @@ export type ClusterInfo = {
   version?: Maybe<Scalars['String']['output']>;
 };
 
+export type ClusterInsightComponentAttributes = {
+  group?: InputMaybe<Scalars['String']['input']>;
+  kind: Scalars['String']['input'];
+  name: Scalars['String']['input'];
+  namespace?: InputMaybe<Scalars['String']['input']>;
+  version: Scalars['String']['input'];
+};
+
 export type ClusterMetrics = {
   __typename?: 'ClusterMetrics';
   cpu?: Maybe<Array<Maybe<MetricResponse>>>;
@@ -1196,6 +1207,8 @@ export type ClusterNodeMetrics = {
 export type ClusterPing = {
   currentVersion: Scalars['String']['input'];
   distro?: InputMaybe<ClusterDistro>;
+  /** scraped k8s objects to use for cluster insights, don't send at all if not w/in the last scrape interval */
+  insightComponents?: InputMaybe<Array<InputMaybe<ClusterInsightComponentAttributes>>>;
   kubeletVersion?: InputMaybe<Scalars['String']['input']>;
 };
 

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -129,6 +129,7 @@ type AgentMigrationAttributes struct {
 
 // A representation of a LLM-derived insight
 type AiInsight struct {
+	ID string `json:"id"`
 	// a deduplication sha for this insight
 	Sha *string `json:"sha,omitempty"`
 	// the text of this insight
@@ -768,6 +769,8 @@ type Cluster struct {
 	ObjectStore *ObjectStore `json:"objectStore,omitempty"`
 	// the parent of this virtual cluster
 	ParentCluster *Cluster `json:"parentCluster,omitempty"`
+	// an ai insight generated about issues discovered which might impact the health of this cluster
+	Insight *AiInsight `json:"insight,omitempty"`
 	// list cached nodes for a cluster, this can be stale up to 5m
 	Nodes []*Node `json:"nodes,omitempty"`
 	// list the cached node metrics for a cluster, can also be stale up to 5m
@@ -882,6 +885,14 @@ type ClusterInfo struct {
 	Version    *string `json:"version,omitempty"`
 }
 
+type ClusterInsightComponentAttributes struct {
+	Group     *string `json:"group,omitempty"`
+	Version   string  `json:"version"`
+	Kind      string  `json:"kind"`
+	Namespace *string `json:"namespace,omitempty"`
+	Name      string  `json:"name"`
+}
+
 type ClusterMetrics struct {
 	CPU            []*MetricResponse `json:"cpu,omitempty"`
 	Memory         []*MetricResponse `json:"memory,omitempty"`
@@ -922,6 +933,8 @@ type ClusterPing struct {
 	CurrentVersion string         `json:"currentVersion"`
 	KubeletVersion *string        `json:"kubeletVersion,omitempty"`
 	Distro         *ClusterDistro `json:"distro,omitempty"`
+	// scraped k8s objects to use for cluster insights, don't send at all if not w/in the last scrape interval
+	InsightComponents []*ClusterInsightComponentAttributes `json:"insightComponents,omitempty"`
 }
 
 // a CAPI provider for a cluster, cloud is inferred from name if not provided manually

--- a/lib/console/ai/fixer/parent.ex
+++ b/lib/console/ai/fixer/parent.ex
@@ -1,0 +1,27 @@
+defmodule Console.AI.Fixer.Parent do
+  use Console.AI.Evidence.Base
+  import Console.AI.Fixer.Base
+  alias Console.AI.Fixer.Service, as: SvcFixer
+  alias Console.Deployments.{Services}
+  alias Console.Schema.Service
+
+  def parent_prompt(%Service{} = svc, info) do
+    svc = Console.Repo.preload(svc, [:cluster, :repository, :parent])
+    with {:ok, f} <- Services.tarstream(svc),
+         {:ok, code} <- code_prompt(f) do
+      [
+        {:user, """
+        The #{info[:child]} is being instantiated using a Plural service-of-services structure, and will be represented as a #{info[:cr]} kubernetes
+        custom resource#{info[:cr_additional] || ""}.  It is possible this is where the fix needs to happen, especially in the wiring of helm values or
+        terraform variables.
+
+        I will do my best to describe the service itself and show you the manifests that's sourcing that service below:
+        """},
+        {:user, SvcFixer.svc_details(svc)} | code
+      ]
+    else
+      _ -> []
+    end
+  end
+  def parent_prompt(_, _), do: []
+end

--- a/lib/console/deployments/clusters.ex
+++ b/lib/console/deployments/clusters.ex
@@ -545,6 +545,7 @@ defmodule Console.Deployments.Clusters do
   def ping(attrs, %Cluster{id: id}) do
     attrs = Map.merge(attrs, %{pinged_at: Timex.now(), installed: true})
     get_cluster(id)
+    |> Repo.preload([:insight_components])
     |> Cluster.ping_changeset(attrs)
     |> Repo.update()
     |> notify(:ping)

--- a/lib/console/graphql/ai.ex
+++ b/lib/console/graphql/ai.ex
@@ -24,6 +24,7 @@ defmodule Console.GraphQl.AI do
 
   @desc "A representation of a LLM-derived insight"
   object :ai_insight do
+    field :id,        non_null(:id)
     field :sha,       :string, description: "a deduplication sha for this insight"
     field :text,      :string, description: "the text of this insight"
     field :summary,   :string, description: "a shortish summary of this insight"

--- a/lib/console/graphql/deployments/cluster.ex
+++ b/lib/console/graphql/deployments/cluster.ex
@@ -46,9 +46,19 @@ defmodule Console.GraphQl.Deployments.Cluster do
   end
 
   input_object :cluster_ping do
-    field :current_version, non_null(:string)
-    field :kubelet_version, :string
-    field :distro,          :cluster_distro
+    field :current_version,    non_null(:string)
+    field :kubelet_version,    :string
+    field :distro,             :cluster_distro
+    field :insight_components, list_of(:cluster_insight_component_attributes),
+      description: "scraped k8s objects to use for cluster insights, don't send at all if not w/in the last scrape interval"
+  end
+
+  input_object :cluster_insight_component_attributes do
+    field :group,     :string
+    field :version,   non_null(:string)
+    field :kind,      non_null(:string)
+    field :namespace, :string
+    field :name,      non_null(:string)
   end
 
   input_object :cluster_update_attributes do
@@ -323,6 +333,7 @@ defmodule Console.GraphQl.Deployments.Cluster do
     field :restore,          :cluster_restore, resolve: dataloader(Deployments), description: "the active restore for this cluster"
     field :object_store,     :object_store, resolve: dataloader(Deployments), description: "the object store connection bound to this cluster for backup/restore"
     field :parent_cluster,   :cluster, resolve: dataloader(Deployments), description: "the parent of this virtual cluster"
+    field :insight,          :ai_insight, resolve: dataloader(Cluster), description: "an ai insight generated about issues discovered which might impact the health of this cluster"
 
     field :nodes, list_of(:node), description: "list cached nodes for a cluster, this can be stale up to 5m",
       resolve: &Deployments.list_nodes/3

--- a/lib/console/schema/ai_insight.ex
+++ b/lib/console/schema/ai_insight.ex
@@ -21,12 +21,12 @@ defmodule Console.Schema.AiInsight do
     timestamps()
   end
 
-  @spec freshness(t()) :: :fast | :slow | :expired
+  @spec freshness(t()) :: :fresh | :stale | :expired
   def freshness(%__MODULE__{} = insight) do
     at = ts(insight)
     cond do
-      Timex.before?(at, expiry(@slow)) -> :expired
-      Timex.before?(at, expiry(@fast)) -> :stale
+      Timex.before?(at, expiry(hours: -1)) -> :expired
+      Timex.before?(at, expiry(@slow)) -> :stale
       true -> :fresh
     end
   end

--- a/lib/console/schema/cluster.ex
+++ b/lib/console/schema/cluster.ex
@@ -16,7 +16,9 @@ defmodule Console.Schema.Cluster do
     ClusterRestore,
     ObjectStore,
     Project,
-    UpgradeInsight
+    UpgradeInsight,
+    AiInsight,
+    ClusterInsightComponent
   }
 
   defenum Distro, generic: 0, eks: 1, aks: 2, gke: 3, rke: 4, k3s: 5
@@ -118,6 +120,7 @@ defmodule Console.Schema.Cluster do
     belongs_to :object_store,   ObjectStore
     belongs_to :restore,        ClusterRestore
     belongs_to :project,        Project
+    belongs_to :insight,        AiInsight
     belongs_to :parent_cluster, __MODULE__
 
     has_many :upgrade_insights, UpgradeInsight
@@ -126,6 +129,7 @@ defmodule Console.Schema.Cluster do
     has_many :services, Service
     has_many :tags, Tag, on_replace: :delete
     has_many :api_deprecations, through: [:services, :api_deprecations]
+    has_many :insight_components, ClusterInsightComponent, on_replace: :delete
 
     has_many :pr_automations, PrAutomation, on_replace: :delete
     has_many :read_bindings, PolicyBinding,
@@ -376,6 +380,7 @@ defmodule Console.Schema.Cluster do
   def ping_changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, ~w(pinged_at distro kubelet_version current_version installed)a)
+    |> cast_assoc(:insight_components)
     |> change_markers(distro: :distro_changed)
     |> update_vsn()
   end

--- a/lib/console/schema/cluster_insight_component.ex
+++ b/lib/console/schema/cluster_insight_component.ex
@@ -1,0 +1,31 @@
+defmodule Console.Schema.ClusterInsightComponent do
+  use Piazza.Ecto.Schema
+  alias Console.Schema.{Cluster, AiInsight}
+
+  schema "cluster_insight_components" do
+    field :group,     :string
+    field :version,   :string
+    field :kind,      :string
+    field :namespace, :string
+    field :name,      :string
+
+    belongs_to :cluster, Cluster
+    belongs_to :insight, AiInsight
+
+    timestamps()
+  end
+
+  def for_cluster(query \\ __MODULE__, cluster_id) do
+    from(cic in query, where: cic.cluster_id == ^cluster_id)
+  end
+
+  @valid ~w(group version kind namespace name cluster_id)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> cast_assoc(:insight)
+    |> foreign_key_constraint(:cluster_id)
+    |> validate_required([:kind, :name])
+  end
+end

--- a/priv/repo/migrations/20241024163504_cluster_insight_components.exs
+++ b/priv/repo/migrations/20241024163504_cluster_insight_components.exs
@@ -1,0 +1,24 @@
+defmodule Console.Repo.Migrations.ClusterInsightComponents do
+  use Ecto.Migration
+
+  def change do
+    create table(:cluster_insight_components, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :cluster_id, references(:clusters, type: :uuid, on_delete: :delete_all)
+      add :insight_id, references(:ai_insights, type: :uuid, on_delete: :nilify_all)
+      add :group,     :string
+      add :version,   :string
+      add :kind,      :string
+      add :namespace, :string
+      add :name,      :string
+
+      timestamps()
+    end
+
+    create index(:cluster_insight_components, [:cluster_id])
+
+    alter table(:clusters) do
+      add :insight_id, references(:ai_insights, type: :uuid, on_delete: :nilify_all)
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -3863,8 +3863,21 @@ input TagAttributes {
 
 input ClusterPing {
   currentVersion: String!
+
   kubeletVersion: String
+
   distro: ClusterDistro
+
+  "scraped k8s objects to use for cluster insights, don't send at all if not w\/in the last scrape interval"
+  insightComponents: [ClusterInsightComponentAttributes]
+}
+
+input ClusterInsightComponentAttributes {
+  group: String
+  version: String!
+  kind: String!
+  namespace: String
+  name: String!
 }
 
 input ClusterUpdateAttributes {
@@ -4257,6 +4270,9 @@ type Cluster {
 
   "the parent of this virtual cluster"
   parentCluster: Cluster
+
+  "an ai insight generated about issues discovered which might impact the health of this cluster"
+  insight: AiInsight
 
   "list cached nodes for a cluster, this can be stale up to 5m"
   nodes: [Node]
@@ -5738,6 +5754,8 @@ input ChatMessage {
 
 "A representation of a LLM-derived insight"
 type AiInsight {
+  id: ID!
+
   "a deduplication sha for this insight"
   sha: String
 

--- a/test/console/graphql/queries/ai_queries_test.exs
+++ b/test/console/graphql/queries/ai_queries_test.exs
@@ -21,10 +21,16 @@ defmodule Console.GraphQl.AiQueriesTest do
     test "it can generate a suggestion for a fix given an existing insight" do
       user = insert(:user)
       git = insert(:git_repository, url: "https://github.com/pluralsh/deployment-operator.git")
+      parent = insert(:service,
+        repository: git,
+        git: %{ref: "main", folder: "charts/deployment-operator"}
+      )
+
       svc = insert(:service,
         repository: git,
         git: %{ref: "main", folder: "charts/deployment-operator"},
-        write_bindings: [%{user_id: user.id}]
+        write_bindings: [%{user_id: user.id}],
+        parent: parent
       )
       insight = insert(:ai_insight, service: svc)
 


### PR DESCRIPTION
the idea is the agent will periodically gather these and provide them in cluster ping mutations

## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
