### PR TITLE
Fix brittle helm repo test

### DIFF
--- a/test/console/graphql/queries/deployments/git_queries_test.exs
+++ b/test/console/graphql/queries/deployments/git_queries_test.exs
@@ -102,7 +102,7 @@ defmodule Console.GraphQl.Deployments.GitQueriesTest do
         }
       """, %{}, %{current_user: admin_user()})
 
-      [%{"name" => "console", "versions" => [chart | _]} | _] = repo["charts"]
+      %{"console" => %{"versions" => [chart | _]}} = Map.new(repo["charts"], & {&1["name"], &1})
       assert chart["name"] == "console"
       assert chart["version"]
       assert chart["appVersion"]


### PR DESCRIPTION
One of the helm tests made the wrong assumptions about the console helm repository, broken by the new ai-proxy chart added.  This will be more robust going forward.

## Test Plan
fix test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
