### PR TITLE
enhancement: pass raw kubernetes object to explain w/ ai prompt

### DIFF
--- a/assets/src/components/kubernetes/cluster/Namespace.tsx
+++ b/assets/src/components/kubernetes/cluster/Namespace.tsx
@@ -36,7 +36,6 @@ import { Kind } from '../common/types'
 import { getBreadcrumbs } from './Namespaces'
 import { NamespacePhaseChip } from './utils'
 import { useEventsColumns } from './Events'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: 'raw', label: 'Raw' },
@@ -56,10 +55,6 @@ export default function Namespace(): ReactElement {
   })
 
   const namespace = data?.handleGetNamespaceDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Namespace resource: ' + JSON.stringify(namespace)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/cluster/Node.tsx
+++ b/assets/src/components/kubernetes/cluster/Node.tsx
@@ -50,7 +50,6 @@ import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './Nodes'
 import { useEventsColumns } from './Events'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Info' },
@@ -74,8 +73,6 @@ export default function Node(): ReactElement {
   })
 
   const node = data?.handleGetNodeDetail as NodeT
-
-  useExplainWithAI('Describe Kubernetes Node resource: ' + JSON.stringify(node))
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/configuration/ConfigMap.tsx
+++ b/assets/src/components/kubernetes/configuration/ConfigMap.tsx
@@ -26,7 +26,6 @@ import { useCluster } from '../Cluster'
 import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './ConfigMaps'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Data' },
@@ -47,10 +46,6 @@ export default function ConfigMap(): ReactElement {
   })
 
   const cm = data?.handleGetConfigMapDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Config Map resource: ' + JSON.stringify(cm)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/customresources/CustomResource.tsx
+++ b/assets/src/components/kubernetes/customresources/CustomResource.tsx
@@ -24,7 +24,6 @@ import { NAMESPACE_PARAM } from '../Navigation'
 import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './CustomResourceDefinitions'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Raw' },
@@ -42,8 +41,6 @@ export default function CustomResource(): ReactElement {
   })
 
   const cr = data?.handleGetCustomResourceObjectDetail
-
-  useExplainWithAI('Describe Kubernetes Custom Resource: ' + JSON.stringify(cr))
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/customresources/CustomResourceDefinition.tsx
+++ b/assets/src/components/kubernetes/customresources/CustomResourceDefinition.tsx
@@ -39,7 +39,6 @@ import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './CustomResourceDefinitions'
 import { CRDEstablishedChip } from './utils'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Objects' },
@@ -60,10 +59,6 @@ export default function CustomResourceDefinition(): ReactElement {
   })
 
   const crd = data?.handleGetCustomResourceDefinitionDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Custom Resource Definition: ' + JSON.stringify(crd)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/network/Ingress.tsx
+++ b/assets/src/components/kubernetes/network/Ingress.tsx
@@ -41,7 +41,6 @@ import ResourceLink from '../common/ResourceLink'
 
 import { getBreadcrumbs } from './Ingresses'
 import { Endpoints } from './utils'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Info' },
@@ -63,10 +62,6 @@ export default function Ingress(): ReactElement {
   })
 
   const ingress = data?.handleGetIngressDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Ingress resource: ' + JSON.stringify(ingress)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/network/IngressClass.tsx
+++ b/assets/src/components/kubernetes/network/IngressClass.tsx
@@ -17,7 +17,6 @@ import { useCluster } from '../Cluster'
 import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './IngressClasses'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [{ path: 'raw', label: 'Raw' }] as const
 
@@ -34,10 +33,6 @@ export default function IngressClass(): ReactElement {
   })
 
   const ic = data?.handleGetIngressClass
-
-  useExplainWithAI(
-    'Describe Kubernetes Ingress Class resource: ' + JSON.stringify(ic)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/network/NetworkPolicy.tsx
+++ b/assets/src/components/kubernetes/network/NetworkPolicy.tsx
@@ -29,7 +29,6 @@ import { useCluster } from '../Cluster'
 import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './Services'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Info' },
@@ -50,10 +49,6 @@ export default function NetworkPolicy(): ReactElement {
   })
 
   const np = data?.handleGetNetworkPolicyDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Network Policy resource: ' + JSON.stringify(np)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/network/Service.tsx
+++ b/assets/src/components/kubernetes/network/Service.tsx
@@ -55,7 +55,6 @@ import { Kind } from '../common/types'
 import { getBreadcrumbs } from './Services'
 import { Endpoints, serviceTypeDisplayName } from './utils'
 import { useIngressesColumns } from './Ingresses'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Info' },
@@ -79,10 +78,6 @@ export default function Service(): ReactElement {
   })
 
   const service = data?.handleGetServiceDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Service resource: ' + JSON.stringify(service)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/rbac/ClusterRole.tsx
+++ b/assets/src/components/kubernetes/rbac/ClusterRole.tsx
@@ -15,7 +15,6 @@ import { useCluster } from '../Cluster'
 import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './ClusterRoles'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Policy rules' },
@@ -35,10 +34,6 @@ export default function ClusterRole(): ReactElement {
   })
 
   const cr = data?.handleGetClusterRoleDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Cluster Role resource: ' + JSON.stringify(cr)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/rbac/ClusterRoleBinding.tsx
+++ b/assets/src/components/kubernetes/rbac/ClusterRoleBinding.tsx
@@ -19,7 +19,6 @@ import { useCluster } from '../Cluster'
 import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './ClusterRoleBindings'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Subjects' },
@@ -39,10 +38,6 @@ export default function ClusterRoleBinding(): ReactElement {
   })
 
   const crb = data?.handleGetClusterRoleBindingDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Cluster Role Binding resource: ' + JSON.stringify(crb)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/rbac/Role.tsx
+++ b/assets/src/components/kubernetes/rbac/Role.tsx
@@ -23,7 +23,6 @@ import { useCluster } from '../Cluster'
 import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './Roles'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Policy rules' },
@@ -41,8 +40,6 @@ export default function Role(): ReactElement {
   })
 
   const role = data?.handleGetRoleDetail
-
-  useExplainWithAI('Describe Kubernetes Role resource: ' + JSON.stringify(role))
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/rbac/RoleBinding.tsx
+++ b/assets/src/components/kubernetes/rbac/RoleBinding.tsx
@@ -26,7 +26,6 @@ import { useCluster } from '../Cluster'
 import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './RoleBindings'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Subjects' },
@@ -47,10 +46,6 @@ export default function RoleBinding(): ReactElement {
   })
 
   const rb = data?.handleGetRoleBindingDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Role Binding resource: ' + JSON.stringify(rb)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/rbac/ServiceAccount.tsx
+++ b/assets/src/components/kubernetes/rbac/ServiceAccount.tsx
@@ -22,7 +22,6 @@ import { useCluster } from '../Cluster'
 import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './ServiceAccounts'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [{ path: 'raw', label: 'Raw' }] as const
 
@@ -40,11 +39,6 @@ export default function ServiceAccount(): ReactElement {
   })
 
   const serviceAccount = data?.handleGetServiceAccountDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Service Account resource: ' +
-      JSON.stringify(serviceAccount)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/storage/PersistentVolume.tsx
+++ b/assets/src/components/kubernetes/storage/PersistentVolume.tsx
@@ -26,7 +26,6 @@ import { Kind } from '../common/types'
 
 import { PVStatusChip } from './utils'
 import { getBreadcrumbs } from './PersistentVolumes'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Info' },
@@ -46,10 +45,6 @@ export default function PersistentVolume(): ReactElement {
   })
 
   const pv = data?.handleGetPersistentVolumeDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Persistent Volume resource: ' + JSON.stringify(pv)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/storage/PersistentVolumeClaim.tsx
+++ b/assets/src/components/kubernetes/storage/PersistentVolumeClaim.tsx
@@ -26,7 +26,6 @@ import ResourceLink from '../common/ResourceLink'
 
 import { getBreadcrumbs } from './PersistentVolumeClaims'
 import { PVCStatusChip } from './utils'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [{ path: '', label: 'Raw' }] as const
 
@@ -44,11 +43,6 @@ export default function PersistentVolumeClaim(): ReactElement {
   })
 
   const pvc = data?.handleGetPersistentVolumeClaimDetail
-
-  useExplainWithAI(
-    'Describe Kubernetes Persistent Volume Claim resource: ' +
-      JSON.stringify(pvc)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/storage/StorageClass.tsx
+++ b/assets/src/components/kubernetes/storage/StorageClass.tsx
@@ -34,7 +34,6 @@ import {
   colReclaimPolicy,
   colStatus,
 } from './PersistentVolumes'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Persistent Volumes' },
@@ -52,10 +51,6 @@ export default function StorageClass(): ReactElement {
   })
 
   const sc = data?.handleGetStorageClass
-
-  useExplainWithAI(
-    'Describe Kubernetes Storage Class resource: ' + JSON.stringify(sc)
-  )
 
   useSetBreadcrumbs(
     useMemo(

--- a/assets/src/components/kubernetes/workloads/CronJob.tsx
+++ b/assets/src/components/kubernetes/workloads/CronJob.tsx
@@ -47,7 +47,6 @@ import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './CronJobs'
 import { useJobsColumns } from './Jobs'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: 'jobs', label: 'Jobs' },
@@ -107,10 +106,6 @@ export default function CronJob(): ReactElement {
   )
 
   const cronJob = data?.handleGetCronJobDetail as CronJobT
-
-  useExplainWithAI(
-    'Describe Kubernetes Cron Job resource: ' + JSON.stringify(cronJob)
-  )
 
   if (loading) {
     return <LoadingIndicator />

--- a/assets/src/components/kubernetes/workloads/DaemonSet.tsx
+++ b/assets/src/components/kubernetes/workloads/DaemonSet.tsx
@@ -48,7 +48,6 @@ import { Kind } from '../common/types'
 import { getBreadcrumbs } from './DaemonSets'
 import { usePodsColumns } from './Pods'
 import { WorkloadStatusChip } from './utils'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: 'pods', label: 'Pods' },
@@ -95,10 +94,6 @@ export default function DaemonSet(): ReactElement {
   )
 
   const daemonSet = data?.handleGetDaemonSetDetail as DaemonSetT
-
-  useExplainWithAI(
-    'Describe Kubernetes Daemon Set resource: ' + JSON.stringify(daemonSet)
-  )
 
   if (loading) {
     return <LoadingIndicator />

--- a/assets/src/components/kubernetes/workloads/Deployment.tsx
+++ b/assets/src/components/kubernetes/workloads/Deployment.tsx
@@ -54,7 +54,6 @@ import { Kind, Resource, fromResource } from '../common/types'
 import { getBreadcrumbs } from './Deployments'
 import { useReplicaSetsColumns } from './ReplicaSets'
 import { WorkloadStatusChip } from './utils'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: 'replicasets', label: 'Replica Sets' },
@@ -101,10 +100,6 @@ export default function Deployment(): ReactElement {
   )
 
   const deployment = data?.handleGetDeploymentDetail as DeploymentT
-
-  useExplainWithAI(
-    'Describe Kubernetes Deployment resource: ' + JSON.stringify(deployment)
-  )
 
   if (loading) {
     return <LoadingIndicator />

--- a/assets/src/components/kubernetes/workloads/Job.tsx
+++ b/assets/src/components/kubernetes/workloads/Job.tsx
@@ -42,7 +42,6 @@ import { Kind } from '../common/types'
 
 import { getBreadcrumbs } from './Jobs'
 import { usePodsColumns } from './Pods'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: 'conditions', label: 'Conditions' },
@@ -84,8 +83,6 @@ export default function Job(): ReactElement {
   )
 
   const job = data?.handleGetJobDetail as JobT
-
-  useExplainWithAI('Describe Kubernetes Job resource: ' + JSON.stringify(job))
 
   if (loading) {
     return <LoadingIndicator />

--- a/assets/src/components/kubernetes/workloads/Pod.tsx
+++ b/assets/src/components/kubernetes/workloads/Pod.tsx
@@ -70,7 +70,6 @@ import { ShellWithContext } from '../../cluster/containers/ContainerShell'
 
 import { getBreadcrumbs } from './Pods'
 import { toReadiness } from './utils'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: '', label: 'Info' },
@@ -114,8 +113,6 @@ export function Pod(): ReactElement {
   )
 
   const pod = data?.handleGetPodDetail as PodT
-
-  useExplainWithAI('Describe Kubernetes Pod resource: ' + JSON.stringify(pod))
 
   if (loading) {
     return <LoadingIndicator />

--- a/assets/src/components/kubernetes/workloads/ReplicaSet.tsx
+++ b/assets/src/components/kubernetes/workloads/ReplicaSet.tsx
@@ -49,7 +49,6 @@ import { Kind } from '../common/types'
 import { getBreadcrumbs } from './ReplicaSets'
 import { usePodsColumns } from './Pods'
 import { WorkloadStatusChip } from './utils'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: 'pods', label: 'Pods' },
@@ -97,10 +96,6 @@ export default function ReplicaSet(): ReactElement {
   )
 
   const rs = data?.handleGetReplicaSetDetail as ReplicaSetT
-
-  useExplainWithAI(
-    'Describe Kubernetes Replica Set resource: ' + JSON.stringify(rs)
-  )
 
   if (loading) {
     return <LoadingIndicator />

--- a/assets/src/components/kubernetes/workloads/ReplicationController.tsx
+++ b/assets/src/components/kubernetes/workloads/ReplicationController.tsx
@@ -50,7 +50,6 @@ import { Kind } from '../common/types'
 import { getBreadcrumbs } from './ReplicationControllers'
 import { usePodsColumns } from './Pods'
 import { WorkloadStatusChip } from './utils'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: 'pods', label: 'Pods' },
@@ -98,10 +97,6 @@ export default function ReplicationController(): ReactElement {
 
   const rc =
     data?.handleGetReplicationControllerDetail as ReplicationControllerT
-
-  useExplainWithAI(
-    'Describe Kubernetes Replication Controller resource: ' + JSON.stringify(rc)
-  )
 
   if (loading) {
     return <LoadingIndicator />

--- a/assets/src/components/kubernetes/workloads/StatefulSet.tsx
+++ b/assets/src/components/kubernetes/workloads/StatefulSet.tsx
@@ -42,7 +42,6 @@ import { Kind } from '../common/types'
 import { getBreadcrumbs } from './StatefulSets'
 import { usePodsColumns } from './Pods'
 import { WorkloadStatusChip } from './utils'
-import { useExplainWithAI } from '../../ai/AIContext.tsx'
 
 const directory: Array<TabEntry> = [
   { path: 'pods', label: 'Pods' },
@@ -88,10 +87,6 @@ export default function StatefulSet(): ReactElement {
   )
 
   const statefulSet = data?.handleGetStatefulSetDetail as StatefulSetT
-
-  useExplainWithAI(
-    'Describe Kubernetes Stateful Set resource: ' + JSON.stringify(statefulSet)
-  )
 
   if (loading) {
     return <LoadingIndicator />


### PR DESCRIPTION
In Kubernetes Dashboard API raw objects are not part of resource details. To fetch raw objects we are using separate query. Because of that we can reduce number of `useExplainWithAI` calls to just two. One for CD components and one for all Kubernetes resource details.