### PR TITLE
fix: /cd/clusters page prefetches tags even if tag selector isn't interacted w/

### DIFF
--- a/assets/src/components/cd/services/ClusterTagsFilter.tsx
+++ b/assets/src/components/cd/services/ClusterTagsFilter.tsx
@@ -79,9 +79,7 @@ export function TagsFilter({
         },
         ...comboBoxProps,
       }}
-      selectProps={{
-        ...selectProps,
-      }}
+      selectProps={selectProps}
       selectedTagKeys={selectedTagKeys}
       setSelectedTagKeys={setSelectedTagKeys}
       inputValue={inputValue}


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
