### PR TITLE
Add support for Anthropic/streaming on explain-with-ai

### DIFF
--- a/assets/src/components/ai/chatbot/AISuggestFix.tsx
+++ b/assets/src/components/ai/chatbot/AISuggestFix.tsx
@@ -32,18 +32,20 @@ function fixMessage(fix: string): ChatMessage {
   }
 }
 
-function Loading({
+export function Loading({
   insightId,
+  scopeId,
   scrollToBottom,
   setStreaming,
 }: {
-  insightId: string
+  insightId?: string
+  scopeId?: string
   scrollToBottom: () => void
   setStreaming: Dispatch<SetStateAction<boolean>>
 }): ReactNode {
   const [streamedMessage, setStreamedMessage] = useState<AiDelta[]>([])
   useAiChatStreamSubscription({
-    variables: { insightId },
+    variables: { insightId, scopeId },
     onData: ({ data: { data } }) => {
       setStreaming(true)
       if ((data?.aiStream?.seq ?? 1) % 120 === 0) scrollToBottom()

--- a/assets/src/generated/graphql-kubernetes.ts
+++ b/assets/src/generated/graphql-kubernetes.ts
@@ -1,4 +1,4 @@
- 
+/* eslint-disable */
 /* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';

--- a/assets/src/generated/graphql-plural.ts
+++ b/assets/src/generated/graphql-plural.ts
@@ -1,4 +1,4 @@
- 
+/* eslint-disable */
 /* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1,4 +1,4 @@
- 
+/* eslint-disable */
 /* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
@@ -9657,6 +9657,7 @@ export type AiCompletionQueryVariables = Exact<{
   system: Scalars['String']['input'];
   input?: InputMaybe<Scalars['String']['input']>;
   chat?: InputMaybe<Array<InputMaybe<ChatMessage>> | InputMaybe<ChatMessage>>;
+  scopeId?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -9773,6 +9774,7 @@ export type DeleteChatThreadMutation = { __typename?: 'RootMutationType', delete
 export type AiChatStreamSubscriptionVariables = Exact<{
   threadId?: InputMaybe<Scalars['ID']['input']>;
   insightId?: InputMaybe<Scalars['ID']['input']>;
+  scopeId?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
@@ -14892,8 +14894,8 @@ export type AiLazyQueryHookResult = ReturnType<typeof useAiLazyQuery>;
 export type AiSuspenseQueryHookResult = ReturnType<typeof useAiSuspenseQuery>;
 export type AiQueryResult = Apollo.QueryResult<AiQuery, AiQueryVariables>;
 export const AiCompletionDocument = gql`
-    query AICompletion($system: String!, $input: String, $chat: [ChatMessage]) {
-  aiCompletion(system: $system, input: $input, chat: $chat)
+    query AICompletion($system: String!, $input: String, $chat: [ChatMessage], $scopeId: String) {
+  aiCompletion(system: $system, input: $input, chat: $chat, scopeId: $scopeId)
 }
     `;
 
@@ -14912,6 +14914,7 @@ export const AiCompletionDocument = gql`
  *      system: // value for 'system'
  *      input: // value for 'input'
  *      chat: // value for 'chat'
+ *      scopeId: // value for 'scopeId'
  *   },
  * });
  */
@@ -15451,8 +15454,8 @@ export type DeleteChatThreadMutationHookResult = ReturnType<typeof useDeleteChat
 export type DeleteChatThreadMutationResult = Apollo.MutationResult<DeleteChatThreadMutation>;
 export type DeleteChatThreadMutationOptions = Apollo.BaseMutationOptions<DeleteChatThreadMutation, DeleteChatThreadMutationVariables>;
 export const AiChatStreamDocument = gql`
-    subscription AIChatStream($threadId: ID, $insightId: ID) {
-  aiStream(threadId: $threadId, insightId: $insightId) {
+    subscription AIChatStream($threadId: ID, $insightId: ID, $scopeId: String) {
+  aiStream(threadId: $threadId, insightId: $insightId, scopeId: $scopeId) {
     seq
     content
   }
@@ -15473,6 +15476,7 @@ export const AiChatStreamDocument = gql`
  *   variables: {
  *      threadId: // value for 'threadId'
  *      insightId: // value for 'insightId'
+ *      scopeId: // value for 'scopeId'
  *   },
  * });
  */

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -6673,6 +6673,7 @@ export type RootQueryTypeAiArgs = {
 export type RootQueryTypeAiCompletionArgs = {
   chat?: InputMaybe<Array<InputMaybe<ChatMessage>>>;
   input?: InputMaybe<Scalars['String']['input']>;
+  scopeId?: InputMaybe<Scalars['String']['input']>;
   system: Scalars['String']['input'];
 };
 
@@ -7724,6 +7725,7 @@ export type RootSubscriptionType = {
 
 export type RootSubscriptionTypeAiStreamArgs = {
   insightId?: InputMaybe<Scalars['ID']['input']>;
+  scopeId?: InputMaybe<Scalars['String']['input']>;
   threadId?: InputMaybe<Scalars['ID']['input']>;
 };
 

--- a/assets/src/graph/ai.graphql
+++ b/assets/src/graph/ai.graphql
@@ -127,8 +127,13 @@ query AI($prompt: String!) {
   ai(prompt: $prompt)
 }
 
-query AICompletion($system: String!, $input: String, $chat: [ChatMessage]) {
-  aiCompletion(system: $system, input: $input, chat: $chat)
+query AICompletion(
+  $system: String!
+  $input: String
+  $chat: [ChatMessage]
+  $scopeId: String
+) {
+  aiCompletion(system: $system, input: $input, chat: $chat, scopeId: $scopeId)
 }
 
 query AISuggestedFix($insightID: ID!) {
@@ -230,8 +235,8 @@ mutation DeleteChatThread($id: ID!) {
   }
 }
 
-subscription AIChatStream($threadId: ID, $insightId: ID) {
-  aiStream(threadId: $threadId, insightId: $insightId) {
+subscription AIChatStream($threadId: ID, $insightId: ID, $scopeId: String) {
+  aiStream(threadId: $threadId, insightId: $insightId, scopeId: $scopeId) {
     seq
     content
   }

--- a/lib/console/ai/stream.ex
+++ b/lib/console/ai/stream.ex
@@ -20,4 +20,5 @@ defmodule Console.AI.Stream do
 
   def topic(:insight, id, %User{id: uid}), do: "ai:insight:#{id}:#{uid}"
   def topic(:thread, id, %User{id: uid}), do: "ai:thread:#{id}:#{uid}"
+  def topic(:freeform, id, %User{id: uid}), do: "ai:freeform:#{id}:#{uid}"
 end

--- a/lib/console/ai/stream/exec.ex
+++ b/lib/console/ai/stream/exec.ex
@@ -4,8 +4,14 @@ defmodule Console.AI.Stream.Exec do
 
   def openai(fun, %AIStream{} = stream), do: exec(fun, stream, &handle_openai/1)
 
+  def anthropic(fun, %AIStream{} = stream), do: exec(fun, stream, &handle_anthropic/1)
+
   defp handle_openai(%{"choices" => [%{"delta" => %{"content" => c}} | _]}) when is_binary(c), do: c
   defp handle_openai(_), do: :pass
+
+  defp handle_anthropic(%{"type" => "content_block_start", "content_block" => %{"text" => t}}) when is_binary(t), do: t
+  defp handle_anthropic(%{"type" => "content_block_delta", "delta" => %{"text" => t}}) when is_binary(t), do: t
+  defp handle_anthropic(_), do: :pass
 
   defp exec(fun, %AIStream{} = stream, reducer) when is_function(reducer, 1) do
     build_stream(fun)

--- a/lib/console/graphql/resolvers/ai.ex
+++ b/lib/console/graphql/resolvers/ai.ex
@@ -58,19 +58,25 @@ defmodule Console.GraphQl.Resolvers.AI do
   def resolve_cluster_insight_component(%{id: id}, %{context: %{current_user: user}}),
     do: Clusters.insight_component(id, user)
 
-  def ai_completion(%{system: system, input: input}, _) when is_binary(input),
-    do: Provider.completion([{:user, input}], preface: system)
+  def ai_completion(%{system: system, input: input} = args, %{context: %{current_user: user}}) when is_binary(input) do
+    maybe_stream(args, user)
+    Provider.completion([{:user, input}], preface: system)
+  end
 
   def ai_completion(%{system: system, chat: chat} = args, %{context: %{current_user: user}}) when is_list(chat) do
-    if is_binary(args[:scope_id]) do
-      Stream.topic(:freeform, args[:scope_id], user)
-      |> Stream.enable()
-    end
+    maybe_stream(args, user)
 
     Enum.map(chat, fn %{role: r, content: c} -> {r, c} end)
     |> Provider.completion(preface: system)
   end
   def ai_completion(_, _), do: {:error, "need to pass either a raw input or a chat history"}
+
+  defp maybe_stream(args, user) do
+    if is_binary(args[:scope_id]) do
+      Stream.topic(:freeform, args[:scope_id], user)
+      |> Stream.enable()
+    end
+  end
 
   def ai_suggested_fix(%{insight_id: id}, %{context: %{current_user: user}}) do
     Stream.topic(:insight, id, user)

--- a/lib/console/graphql/resolvers/ai.ex
+++ b/lib/console/graphql/resolvers/ai.ex
@@ -61,7 +61,12 @@ defmodule Console.GraphQl.Resolvers.AI do
   def ai_completion(%{system: system, input: input}, _) when is_binary(input),
     do: Provider.completion([{:user, input}], preface: system)
 
-  def ai_completion(%{system: system, chat: chat}, _) when is_list(chat) do
+  def ai_completion(%{system: system, chat: chat} = args, %{context: %{current_user: user}}) when is_list(chat) do
+    if is_binary(args[:scope_id]) do
+      Stream.topic(:freeform, args[:scope_id], user)
+      |> Stream.enable()
+    end
+
     Enum.map(chat, fn %{role: r, content: c} -> {r, c} end)
     |> Provider.completion(preface: system)
   end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -441,6 +441,9 @@ type RootQueryType {
 
     "a list of chat prompts to give to the llm"
     chat: [ChatMessage]
+
+    "a scope id to use when streaming responses back to the client"
+    scopeId: String
   ): String
 
   "Use the content of an insight and additional context from its associated object to suggest a fix"
@@ -958,6 +961,9 @@ type RootSubscriptionType {
 
     "the thread id for streaming a chat suggestion"
     threadId: ID
+
+    "an arbitrary scope id to use for explain w\/ ai"
+    scopeId: String
   ): AiDelta
 }
 


### PR DESCRIPTION
adds arbitrary scope id for streaming subscriptions for explain modals, add streaming anthropic support too

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced streaming capabilities for AI responses, enhancing real-time interaction.
	- Added support for a new `:freeform` topic type in the AI streaming module.
	- Enhanced GraphQL API with new fields and arguments for better context and error reporting.

- **Bug Fixes**
	- Improved handling of AI insights and errors during the compilation process.

- **Documentation**
	- Updated GraphQL schema documentation to reflect new fields and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->