### PR TITLE
Add insights for terraform plans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ ENV HELM_VERSION=v3.10.3
 ENV TERRAFORM_VERSION=v1.2.9
 
 # renovate: datasource=github-releases depName=pluralsh/plural-cli
-ENV CLI_VERSION=v0.10.0
+ENV CLI_VERSION=v0.10.1
 
 # renovate: datasource=github-tags depName=kubernetes/kubernetes
 ENV KUBECTL_VERSION=v1.25.5

--- a/assets/src/generated/graphql-kubernetes.ts
+++ b/assets/src/generated/graphql-kubernetes.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';

--- a/assets/src/generated/graphql-plural.ts
+++ b/assets/src/generated/graphql-plural.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /* prettier-ignore */
 import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
@@ -197,6 +197,7 @@ export type AiInsight = {
   sha?: Maybe<Scalars['String']['output']>;
   stack?: Maybe<InfrastructureStack>;
   stackRun?: Maybe<StackRun>;
+  stackState?: Maybe<StackState>;
   /** a shortish summary of this insight */
   summary?: Maybe<Scalars['String']['output']>;
   /** the text of this insight */
@@ -8858,8 +8859,12 @@ export type StackSettingsAttributes = {
 export type StackState = {
   __typename?: 'StackState';
   id: Scalars['ID']['output'];
+  insertedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** an insight explaining the state of this stack state, eg the terraform plan it represents */
+  insight?: Maybe<AiInsight>;
   plan?: Maybe<Scalars['String']['output']>;
   state?: Maybe<Array<Maybe<StackStateResource>>>;
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
 };
 
 export type StackStateAttributes = {

--- a/charts/controller/crds/deployments.plural.sh_servicedeployments.yaml
+++ b/charts/controller/crds/deployments.plural.sh_servicedeployments.yaml
@@ -127,6 +127,12 @@ spec:
                 x-kubernetes-validations:
                 - message: Cluster is immutable
                   rule: self == oldSelf
+              configuration:
+                additionalProperties:
+                  type: string
+                description: Configuration is a set of non-secret configuration to
+                  apply for lightweight templating of manifests in this service
+                type: object
               configurationRef:
                 description: ConfigurationRef is a secret reference which should contain
                   service configuration.

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -149,6 +149,7 @@ type AiInsight struct {
 	Cluster                 *Cluster                 `json:"cluster,omitempty"`
 	StackRun                *StackRun                `json:"stackRun,omitempty"`
 	ServiceComponent        *ServiceComponent        `json:"serviceComponent,omitempty"`
+	StackState              *StackState              `json:"stackState,omitempty"`
 	ClusterInsightComponent *ClusterInsightComponent `json:"clusterInsightComponent,omitempty"`
 	InsertedAt              *string                  `json:"insertedAt,omitempty"`
 	UpdatedAt               *string                  `json:"updatedAt,omitempty"`
@@ -5369,6 +5370,10 @@ type StackState struct {
 	ID    string                `json:"id"`
 	Plan  *string               `json:"plan,omitempty"`
 	State []*StackStateResource `json:"state,omitempty"`
+	// an insight explaining the state of this stack state, eg the terraform plan it represents
+	Insight    *AiInsight `json:"insight,omitempty"`
+	InsertedAt *string    `json:"insertedAt,omitempty"`
+	UpdatedAt  *string    `json:"updatedAt,omitempty"`
 }
 
 type StackStateAttributes struct {

--- a/go/controller/api/v1alpha1/servicedeployment_types.go
+++ b/go/controller/api/v1alpha1/servicedeployment_types.go
@@ -160,6 +160,11 @@ type ServiceSpec struct {
 	// ConfigurationRef is a secret reference which should contain service configuration.
 	// +kubebuilder:validation:Optional
 	ConfigurationRef *corev1.SecretReference `json:"configurationRef,omitempty"`
+
+	// Configuration is a set of non-secret configuration to apply for lightweight templating of manifests in this service
+	// +kubebuilder:validation:Optional
+	Configuration map[string]string `json:"configuration,omitempty"`
+
 	// Bindings contain read and write policies of this cluster
 	// +kubebuilder:validation:Optional
 	Bindings *Bindings `json:"bindings,omitempty"`

--- a/go/controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/go/controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -4733,6 +4733,13 @@ func (in *ServiceSpec) DeepCopyInto(out *ServiceSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.Configuration != nil {
+		in, out := &in.Configuration, &out.Configuration
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Bindings != nil {
 		in, out := &in.Bindings, &out.Bindings
 		*out = new(Bindings)

--- a/go/controller/config/crd/bases/deployments.plural.sh_servicedeployments.yaml
+++ b/go/controller/config/crd/bases/deployments.plural.sh_servicedeployments.yaml
@@ -127,6 +127,12 @@ spec:
                 x-kubernetes-validations:
                 - message: Cluster is immutable
                   rule: self == oldSelf
+              configuration:
+                additionalProperties:
+                  type: string
+                description: Configuration is a set of non-secret configuration to
+                  apply for lightweight templating of manifests in this service
+                type: object
               configurationRef:
                 description: ConfigurationRef is a secret reference which should contain
                   service configuration.

--- a/go/controller/internal/controller/servicedeployment_controller.go
+++ b/go/controller/internal/controller/servicedeployment_controller.go
@@ -297,6 +297,20 @@ func (r *ServiceReconciler) genServiceAttributes(ctx context.Context, service *v
 		}
 	}
 
+	if len(service.Spec.Configuration) > 0 {
+		if attr.Configuration == nil {
+			attr.Configuration = make([]*console.ConfigAttributes, 0)
+		}
+
+		for k, v := range service.Spec.Configuration {
+			value := v
+			attr.Configuration = append(attr.Configuration, &console.ConfigAttributes{
+				Name:  k,
+				Value: lo.ToPtr(value),
+			})
+		}
+	}
+
 	for _, contextName := range service.Spec.Contexts {
 		sc, err := r.ConsoleClient.GetServiceContext(contextName)
 		if err != nil {

--- a/lib/console/ai/evidence/stack_run.ex
+++ b/lib/console/ai/evidence/stack_run.ex
@@ -53,7 +53,7 @@ defimpl Console.AI.Evidence, for: Console.Schema.StackRun do
 
   defp fetch_code(%StackRun{} = run) do
     with {:ok, f} <- Stacks.tarstream(run),
-         {:ok, msgs} <- code_prompt(f, run.git.folder, "I'll also include the relevant terraform code below, listed in the format #{file_fmt()}") do
+         {:ok, msgs} <- code_prompt(f, run.git.folder, "I'll also include the relevant #{run.type} code below, listed in the format #{file_fmt()}") do
       msgs
     else
       _ -> []

--- a/lib/console/ai/evidence/stack_state.ex
+++ b/lib/console/ai/evidence/stack_state.ex
@@ -1,0 +1,41 @@
+defimpl Console.AI.Evidence, for: Console.Schema.StackState do
+  use Console.AI.Evidence.Base
+  import Console.AI.Fixer.Base
+  alias Console.Repo
+  alias Console.Deployments.Stacks
+  alias Console.Schema.{StackState, StackRun}
+
+  def generate(%StackState{run: %StackRun{} = run} = state),
+    do: {:ok, [state_description(state) | fetch_code(run)]}
+
+  def insight(%StackState{insight: insight}), do: insight
+
+  def preload(state), do: Repo.preload(state, [:insight, run: [:stack, :cluster, :errors, :repository]])
+
+  defp state_description(%StackState{run: %StackRun{} = run} = state) do
+    {:user, """
+    The Plural stack #{run.stack.name} has a terraform plan generated and the user will want to understand what it means, in particular:
+
+    * expected blast radius of the change
+    * if any critical systems can be affected by the change
+    * whether it's safe to apply
+
+    The plan itself is recorded below:
+
+    ```
+    #{state.plan}
+    ```
+
+    It is sourcing #{run.type} configuration from the git repository at #{run.repository.url} from the folder #{run.git.folder} at ref #{run.git.ref}.
+    """}
+  end
+
+  defp fetch_code(%StackRun{} = run) do
+    with {:ok, f} <- Stacks.tarstream(run),
+         {:ok, msgs} <- code_prompt(f, run.git.folder, "I'll also include the relevant #{run.type} code below, listed in the format #{file_fmt()}") do
+      msgs
+    else
+      _ -> []
+    end
+  end
+end

--- a/lib/console/ai/pubsub/consumer.ex
+++ b/lib/console/ai/pubsub/consumer.ex
@@ -4,7 +4,7 @@ defmodule Console.AI.PubSub.Consumer do
     max_demand: 10
   import Console.Services.Base, only: [handle_notify: 2]
   alias Console.PubSub
-  alias Console.Schema.{AiInsight, Service, Stack}
+  alias Console.Schema.{AiInsight, Service, Stack, StackState}
   alias Console.AI.{PubSub.Insightful, Cron}
   require Logger
 
@@ -19,11 +19,13 @@ defmodule Console.AI.PubSub.Consumer do
   end
 
   def maybe_send_event({:ok, insight} = res) do
-    case Console.Repo.preload(insight, [:stack, :service]) do
+    case Console.Repo.preload(insight, [:stack, :service, :stack_state]) do
       %AiInsight{service: %Service{} = svc} ->
         handle_notify(PubSub.ServiceInsight, {svc, insight})
       %AiInsight{stack: %Stack{} = stack} ->
         handle_notify(PubSub.StackInsight, {stack, insight})
+      %AiInsight{stack_state: %StackState{} = state} ->
+        handle_notify(PubSub.StackStateInsight, {state, insight})
       _ -> :ok
     end
     res

--- a/lib/console/deployments/events.ex
+++ b/lib/console/deployments/events.ex
@@ -73,5 +73,6 @@ defmodule Console.PubSub.AppNotificationCreated, do: use Piazza.PubSub.Event
 defmodule Console.PubSub.ServiceInsight, do: use Piazza.PubSub.Event
 defmodule Console.PubSub.StackInsight, do: use Piazza.PubSub.Event
 defmodule Console.PubSub.ClusterInsight, do: use Piazza.PubSub.Event
+defmodule Console.PubSub.StackStateInsight, do: use Piazza.PubSub.Event
 
 defmodule Console.PubSub.AlertCreated, do: use Piazza.PubSub.Event

--- a/lib/console/deployments/git/cache.ex
+++ b/lib/console/deployments/git/cache.ex
@@ -127,7 +127,7 @@ defmodule Console.Deployments.Git.Cache do
   end
 
   defp new_line(cache, repo, sha, path, filter) do
-    with {:ok, _} <- git(repo, "checkout", [sha]),
+    with {:ok, _} <- git(repo, "checkout", ["-f", sha]),
          {:ok, msg} <- msg(repo),
          {:ok, f} <- tarball(cache, sha, path, filter),
       do: {:ok, Line.new(f, sha, msg)}

--- a/lib/console/deployments/pubsub/recurse.ex
+++ b/lib/console/deployments/pubsub/recurse.ex
@@ -141,6 +141,19 @@ defimpl Console.PubSub.Recurse, for: Console.PubSub.StackRunUpdated do
   def process(_), do: :ok
 end
 
+defimpl Console.PubSub.Recurse, for: Console.PubSub.StackStateInsight do
+  alias Console.Schema.{StackRun, PullRequest, StackState, AiInsight}
+  alias Console.Deployments.Stacks
+
+  def process(%@for{item: {%StackState{} = state, _}}) do
+    case Console.Repo.preload(state, [run: [:pull_request, state: :insight]]) do
+      %StackState{run: %StackRun{pull_request: %PullRequest{}, state: %StackState{insight: %AiInsight{}}} = run} ->
+        Stacks.post_comment(run)
+      _ -> :ok
+    end
+  end
+end
+
 defimpl Console.PubSub.Recurse, for: Console.PubSub.StackRunCreated do
   alias Console.Schema.{Stack, StackRun, PullRequest}
   alias Console.Deployments.Stacks

--- a/lib/console/graphql/ai.ex
+++ b/lib/console/graphql/ai.ex
@@ -92,8 +92,9 @@ defmodule Console.GraphQl.AI do
     field :cluster,           :cluster,              resolve: dataloader(Deployments)
     field :stack_run,         :stack_run,            resolve: dataloader(Deployments)
     field :service_component, :service_component,    resolve: dataloader(Deployments)
+    field :stack_state,       :stack_state,          resolve: dataloader(Deployments)
 
-    field :cluster_insight_component, :cluster_insight_component,    resolve: dataloader(Deployments)
+    field :cluster_insight_component, :cluster_insight_component, resolve: dataloader(Deployments)
 
     timestamps()
   end

--- a/lib/console/graphql/deployments/stack.ex
+++ b/lib/console/graphql/deployments/stack.ex
@@ -167,7 +167,9 @@ defmodule Console.GraphQl.Deployments.Stack do
     field :observable_metrics, list_of(:observable_metric), resolve: dataloader(Deployments), description: "a list of metrics to poll to determine if a stack run should be cancelled"
 
     field :delete_run, :stack_run, resolve: dataloader(Deployments), description: "the run that physically destroys the stack"
-    field :output,     list_of(:stack_output), resolve: dataloader(Deployments), description: "the most recent output for this stack"
+    field :output,     list_of(:stack_output),
+      resolve: filter_loader(dataloader(Deployments), &Deployments.safe_stack_outputs/3),
+      description: "the most recent output for this stack"
     field :state,      :stack_state, resolve: dataloader(Deployments), description: "the most recent state of this stack"
 
     field :project,    :project,            resolve: dataloader(Deployments), description: "The project this stack belongs to"
@@ -276,7 +278,9 @@ defmodule Console.GraphQl.Deployments.Stack do
     field :environment, list_of(:stack_environment), resolve: dataloader(Deployments), description: "environment variables for this stack"
 
     field :stack,   :infrastructure_stack, resolve: dataloader(Deployments), description: "the stack attached to this run"
-    field :output,  list_of(:stack_output), resolve: dataloader(Deployments), description: "the most recent output for this stack"
+    field :output,  list_of(:stack_output),
+      resolve: filter_loader(dataloader(Deployments), &Deployments.safe_stack_outputs/3),
+      description: "the most recent output for this stack"
     field :state,   :stack_state, resolve: dataloader(Deployments), description: "the most recent state of this stack"
     field :errors,  list_of(:service_error),
       resolve: dataloader(Deployments),
@@ -332,6 +336,11 @@ defmodule Console.GraphQl.Deployments.Stack do
     field :id,    non_null(:id)
     field :plan,  :string
     field :state, list_of(:stack_state_resource)
+
+    field :insight, :ai_insight, resolve: dataloader(Deployments),
+      description: "an insight explaining the state of this stack state, eg the terraform plan it represents"
+
+    timestamps()
   end
 
   object :stack_state_resource do

--- a/lib/console/graphql/resolvers/deployments/stack.ex
+++ b/lib/console/graphql/resolvers/deployments/stack.ex
@@ -31,6 +31,14 @@ defmodule Console.GraphQl.Resolvers.Deployments.Stack do
     |> paginate(args)
   end
 
+  def safe_stack_outputs(_, outputs, %{context: %{cluster: %{}}}), do: outputs
+  def safe_stack_outputs(parent, outputs, %{context: %{current_user: user}}) do
+    case allow(parent, user, :write) do
+      {:ok, _} -> outputs
+      _ -> Enum.filter(outputs, & ! &1.secret)
+    end
+  end
+
   defp stack_filters(query, args) do
     Enum.reduce(args, query, fn
       {:project_id, id}, q -> Stack.for_project(q, id)

--- a/lib/console/graphql/schema/base.ex
+++ b/lib/console/graphql/schema/base.ex
@@ -122,7 +122,14 @@ defmodule Console.GraphQl.Schema.Base do
     end
   end
 
-  def safe_resolver(fun) do
+  def filter_loader(dataloader, func) when is_function(dataloader, 3) and is_function(func, 3) do
+    fn parent, args, res ->
+      with {:ok, result} <- dataloader.(parent, args, res),
+        do: {:ok, func.(parent, result, res)}
+    end
+  end
+
+  def safe_resolver(fun) when is_function(fun, 2) do
     fn args, ctx ->
       try do
         case fun.(args, ctx) do

--- a/lib/console/schema/ai_insight.ex
+++ b/lib/console/schema/ai_insight.ex
@@ -5,6 +5,7 @@ defmodule Console.Schema.AiInsight do
     Stack,
     Cluster,
     StackRun,
+    StackState,
     ServiceComponent,
     ClusterInsightComponent
   }
@@ -22,10 +23,11 @@ defmodule Console.Schema.AiInsight do
       field :message, :string
     end
 
-    has_one :service,   Service, foreign_key: :insight_id
-    has_one :stack,     Stack,   foreign_key: :insight_id
-    has_one :cluster,   Cluster, foreign_key: :insight_id
-    has_one :stack_run, StackRun, foreign_key: :insight_id
+    has_one :service,     Service,    foreign_key: :insight_id
+    has_one :stack,       Stack,      foreign_key: :insight_id
+    has_one :cluster,     Cluster,    foreign_key: :insight_id
+    has_one :stack_run,   StackRun,   foreign_key: :insight_id
+    has_one :stack_state, StackState, foreign_key: :insight_id
 
     has_one :service_component, ServiceComponent, foreign_key: :insight_id
     has_one :cluster_insight_component, ClusterInsightComponent, foreign_key: :insight_id

--- a/lib/console/schema/stack_state.ex
+++ b/lib/console/schema/stack_state.ex
@@ -1,6 +1,6 @@
 defmodule Console.Schema.StackState do
   use Piazza.Ecto.Schema
-  alias Console.Schema.{Stack, StackRun}
+  alias Console.Schema.{Stack, StackRun, AiInsight}
 
   schema "stack_states" do
     field :plan, :binary
@@ -13,8 +13,9 @@ defmodule Console.Schema.StackState do
       field :links,         {:array, :string}
     end
 
-    belongs_to :stack, Stack
-    belongs_to :run,   StackRun
+    belongs_to :stack,   Stack
+    belongs_to :run,     StackRun
+    belongs_to :insight, AiInsight, on_replace: :update
 
     timestamps()
   end
@@ -24,8 +25,12 @@ defmodule Console.Schema.StackState do
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, @valid)
+    |> cast_assoc(:insight)
     |> unique_constraint(:run_id)
     |> unique_constraint(:stack_id)
+    |> foreign_key_constraint(:insight_id)
+    |> foreign_key_constraint(:stack_id)
+    |> foreign_key_constraint(:run_id)
     |> cast_embed(:state, with: &state_changeset/2)
   end
 

--- a/plural/helm/console/crds/deployments.plural.sh_servicedeployments.yaml
+++ b/plural/helm/console/crds/deployments.plural.sh_servicedeployments.yaml
@@ -127,6 +127,12 @@ spec:
                 x-kubernetes-validations:
                 - message: Cluster is immutable
                   rule: self == oldSelf
+              configuration:
+                additionalProperties:
+                  type: string
+                description: Configuration is a set of non-secret configuration to
+                  apply for lightweight templating of manifests in this service
+                type: object
               configurationRef:
                 description: ConfigurationRef is a secret reference which should contain
                   service configuration.

--- a/priv/pr/insight.md.eex
+++ b/priv/pr/insight.md.eex
@@ -1,0 +1,8 @@
+Plural AI has generated a summary of what this plan entails [here](<%= @link %>)
+
+<details>
+<summary>Plan Summary</summary>
+
+<%= @insight.text %>
+
+</details>

--- a/priv/repo/migrations/20241121212536_add_insight_id_states.exs
+++ b/priv/repo/migrations/20241121212536_add_insight_id_states.exs
@@ -1,0 +1,9 @@
+defmodule Console.Repo.Migrations.AddInsightIdStates do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stack_states) do
+      add :insight_id, references(:ai_insights, type: :uuid, on_delete: :nilify_all)
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -2037,8 +2037,17 @@ type StackFile {
 
 type StackState {
   id: ID!
+
   plan: String
+
   state: [StackStateResource]
+
+  "an insight explaining the state of this stack state, eg the terraform plan it represents"
+  insight: AiInsight
+
+  insertedAt: DateTime
+
+  updatedAt: DateTime
 }
 
 type StackStateResource {
@@ -6194,6 +6203,8 @@ type AiInsight {
   stackRun: StackRun
 
   serviceComponent: ServiceComponent
+
+  stackState: StackState
 
   clusterInsightComponent: ClusterInsightComponent
 

--- a/test/console/deployments/pubsub/recurse_test.exs
+++ b/test/console/deployments/pubsub/recurse_test.exs
@@ -414,6 +414,21 @@ defmodule Console.Deployments.PubSub.RecurseTest do
     end
   end
 
+  describe "StackStateInsight" do
+    test "it can send a message on a stack plan insight" do
+      insight = insert(:ai_insight)
+      stack   = insert(:stack, connection: build(:scm_connection))
+      pr      = insert(:pull_request, url: "https://github.com/pluralsh/console/pull/10")
+      run     = insert(:stack_run, status: :successful, stack: stack, pull_request: pr)
+      state   = insert(:stack_state, insight: insight, run: run)
+
+      expect(Tentacat.Pulls.Reviews, :create, fn _, _, _, _, _ -> {:ok, %{"id" => "id"}, :ok} end)
+
+      event = %PubSub.StackStateInsight{item: {state, insight}}
+      Recurse.handle_event(event)
+    end
+  end
+
   describe "StackRunCompleted" do
     test "it can dequeue a stack run" do
       stack = insert(:stack)


### PR DESCRIPTION
These are often hard to interpret too so an insight could be useful to have, will also see if i can send them w/ the pr comments

Fixes PROD-2913

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `stack_state` field in AI insights, providing additional context.
	- Added `insight` field to `stack_state` object for detailed stack information.
	- Implemented new association between `AiInsight` and `StackState`.

- **Bug Fixes**
	- Corrected minor typos in test descriptions.

- **Tests**
	- Added new tests for handling `StackRunUpdated` events in a pending approval state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->