### PR TITLE
fix: decrease dashboard api resource requests/limits

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -3,7 +3,7 @@ name: console
 description: >-
   deploys the plural console and additional dependencies, for use in bring-your-own-kube setups
 appVersion: 0.10.40
-version: 0.3.67
+version: 0.3.68
 dependencies:
   - name: kas
     version: 0.1.0

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -196,10 +196,10 @@ dashboard:
     containers:
       resources:
         requests:
-          cpu: 500m
-          memory: 500Mi
+          cpu: 250m
+          memory: 250Mi
         limits:
-          cpu: 2
+          cpu: 1
           memory: 2Gi
       args:
       - --act-as-proxy


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Some cloud provider default nodes/node pools could not schedule the dashboard API due to high resource requests/limits. With caching enabled by default we can lower them.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
