### PR TITLE
make cost management tables bigger and allow y scroll

### DIFF
--- a/assets/src/components/cost-management/CostManagement.tsx
+++ b/assets/src/components/cost-management/CostManagement.tsx
@@ -135,7 +135,7 @@ export function CostManagement() {
         </Card>
       </Flex>
       <Card
-        css={{ overflow: 'hidden' }}
+        css={{ overflow: 'hidden', maxHeight: 300 }}
         header={{
           content: (
             <Flex gap="small">
@@ -174,13 +174,11 @@ export function CostManagement() {
 }
 
 const WrapperSC = styled.div(({ theme }) => ({
-  height: '100%',
   width: '100%',
   padding: theme.spacing.large,
   display: 'flex',
   flexDirection: 'column',
-  gap: theme.spacing.large,
-  overflow: 'hidden',
+  gap: theme.spacing.medium,
 }))
 
 const cols = [

--- a/assets/src/components/cost-management/details/CostManagementDetails.tsx
+++ b/assets/src/components/cost-management/details/CostManagementDetails.tsx
@@ -134,11 +134,10 @@ export function CostManagementDetails() {
 const PageWrapperSC = styled.div(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
-  gap: theme.spacing.large,
+  gap: theme.spacing.medium,
   padding: theme.spacing.large,
   height: '100%',
   width: '100%',
-  overflow: 'hidden',
 }))
 
 const HeaderWrapperSC = styled.div({

--- a/assets/src/components/cost-management/details/CostManagementDetailsNamespaces.tsx
+++ b/assets/src/components/cost-management/details/CostManagementDetailsNamespaces.tsx
@@ -53,8 +53,8 @@ export function CostManagementDetailsNamespaces() {
   return (
     <Flex
       direction="column"
-      gap="large"
-      overflow="hidden"
+      gap="medium"
+      paddingBottom={theme.spacing.large}
     >
       <Flex gap="large">
         <Card
@@ -116,7 +116,7 @@ export function CostManagementDetailsNamespaces() {
           onChange={(e) => setNamespaceQ(e.target.value)}
         />
         <Card
-          css={{ overflow: 'hidden' }}
+          css={{ overflow: 'hidden', maxHeight: 300 }}
           header={{
             content: (
               <Flex gap="small">


### PR DESCRIPTION
was too crammed on smaller screens before 
<img width="1478" alt="Screenshot 2024-12-19 at 10 54 54 PM" src="https://github.com/user-attachments/assets/9d4b20e6-afa0-4e96-a6e6-3a59917359be" />
