### PR TITLE
fix: GeneratedSecret reconciler

### DIFF
--- a/go/controller/config/samples/deployments_v1alpha1_generatedsecret.yaml
+++ b/go/controller/config/samples/deployments_v1alpha1_generatedsecret.yaml
@@ -2,15 +2,19 @@ apiVersion: deployments.plural.sh/v1alpha1
 kind: GeneratedSecret
 metadata:
   labels:
-    app.kubernetes.io/name: generatedsecret
-    app.kubernetes.io/instance: generatedsecret-sample
-    app.kubernetes.io/part-of: controller
-    app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: controller
-  name: generatedsecret-sample
+    plural.sh/managed-by: agent
+  managedFields: []
+  name: plrl-elastic-user
+  namespace: infra
 spec:
-  template:
-    password: "{{ 10 | randAlphaNum }}"
   destinations:
-  - name: test
-    namespace: default
+    - name: plrl-elastic-user
+      namespace: elastic
+    - name: plrl-elastic-user
+      namespace: infra
+    - name: plrl-elastic-user
+      namespace: plrl-deploy-operator
+  template:
+    password: "{{ 32 | randAlphaNum }}"
+    roles: admin
+    user: plrl


### PR DESCRIPTION
Initially, I assumed the secrets would be created in the same namespace as CRD.

I can't use a controller reference to monitor dependent secrets because secrets can be created in a different namespace than the GeneratedSecret CRD object (cross-namespace references error). I had to use another approach, `EnqueueRequestsFromMapFunc,` to watch newly created secrets. Secrets and CRD object are connected via annotation.


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
