### PR TITLE
Tie stack jwts to the lifecycle of a stack run

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1457,7 +1457,7 @@ export type ClusterRegistration = {
   __typename?: 'ClusterRegistration';
   creator?: Maybe<User>;
   /** the handle to apply to the cluster */
-  handle: Scalars['String']['output'];
+  handle?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   insertedAt?: Maybe<Scalars['DateTime']['output']>;
   /** a unique machine id for the created cluster */
@@ -1465,7 +1465,7 @@ export type ClusterRegistration = {
   /** additional metadata to apply to the cluster */
   metadata?: Maybe<Scalars['Map']['output']>;
   /** the name to give to the cluster */
-  name: Scalars['String']['output'];
+  name?: Maybe<Scalars['String']['output']>;
   /** the project the cluster will live in */
   project?: Maybe<Project>;
   /** the tags to apply to the given cluster */

--- a/go/client/client.go
+++ b/go/client/client.go
@@ -741,8 +741,8 @@ type ClusterRegistrationFragment struct {
 	InsertedAt *string                "json:\"insertedAt,omitempty\" graphql:\"insertedAt\""
 	UpdatedAt  *string                "json:\"updatedAt,omitempty\" graphql:\"updatedAt\""
 	MachineID  string                 "json:\"machineId\" graphql:\"machineId\""
-	Name       string                 "json:\"name\" graphql:\"name\""
-	Handle     string                 "json:\"handle\" graphql:\"handle\""
+	Name       *string                "json:\"name,omitempty\" graphql:\"name\""
+	Handle     *string                "json:\"handle,omitempty\" graphql:\"handle\""
 	Metadata   map[string]interface{} "json:\"metadata,omitempty\" graphql:\"metadata\""
 	Tags       []*ClusterTags         "json:\"tags,omitempty\" graphql:\"tags\""
 	Creator    *UserFragment          "json:\"creator,omitempty\" graphql:\"creator\""
@@ -773,13 +773,13 @@ func (t *ClusterRegistrationFragment) GetMachineID() string {
 	}
 	return t.MachineID
 }
-func (t *ClusterRegistrationFragment) GetName() string {
+func (t *ClusterRegistrationFragment) GetName() *string {
 	if t == nil {
 		t = &ClusterRegistrationFragment{}
 	}
 	return t.Name
 }
-func (t *ClusterRegistrationFragment) GetHandle() string {
+func (t *ClusterRegistrationFragment) GetHandle() *string {
 	if t == nil {
 		t = &ClusterRegistrationFragment{}
 	}

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -1152,9 +1152,9 @@ type ClusterRecommendationAttributes struct {
 type ClusterRegistration struct {
 	ID string `json:"id"`
 	// the name to give to the cluster
-	Name string `json:"name"`
+	Name *string `json:"name,omitempty"`
 	// the handle to apply to the cluster
-	Handle string `json:"handle"`
+	Handle *string `json:"handle,omitempty"`
 	// a unique machine id for the created cluster
 	MachineID string `json:"machineId"`
 	// the tags to apply to the given cluster

--- a/lib/console/graphql/deployments/cluster.ex
+++ b/lib/console/graphql/deployments/cluster.ex
@@ -890,8 +890,8 @@ defmodule Console.GraphQl.Deployments.Cluster do
 
   object :cluster_registration do
     field :id,         non_null(:id)
-    field :name,       non_null(:string), description: "the name to give to the cluster"
-    field :handle,     non_null(:string), description: "the handle to apply to the cluster"
+    field :name,       :string, description: "the name to give to the cluster"
+    field :handle,     :string, description: "the handle to apply to the cluster"
     field :machine_id, non_null(:string), description: "a unique machine id for the created cluster"
     field :tags,       list_of(:tag), description: "the tags to apply to the given cluster"
     field :metadata,   :map, description: "additional metadata to apply to the cluster"

--- a/lib/console/schema/cluster_registration.ex
+++ b/lib/console/schema/cluster_registration.ex
@@ -39,6 +39,7 @@ defmodule Console.Schema.ClusterRegistration do
     |> cast(attrs, @valid)
     |> kubernetes_name(:name)
     |> unique_constraint(:handle)
+    |> unique_constraint(:machine_id)
     |> cast_embed(:tags, with: &tag_changeset/2)
     |> backfill_handle()
     |> validate_required(~w(project_id creator_id)a)

--- a/lib/console/schema/stack.ex
+++ b/lib/console/schema/stack.ex
@@ -33,6 +33,8 @@ defmodule Console.Schema.Stack do
     cancelled: 5,
     pending_approval: 6
 
+  defguard is_terminal(s) when s in ~w(failed cancelled successful)a
+
   def running_states(), do: ~w(pending running pending_approval)a
 
   defmodule Configuration do

--- a/priv/repo/migrations/20250120165507_add_machine_id_uniq_constraint.exs
+++ b/priv/repo/migrations/20250120165507_add_machine_id_uniq_constraint.exs
@@ -1,0 +1,7 @@
+defmodule Console.Repo.Migrations.AddMachineIdUniqConstraint do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:cluster_registrations, [:machine_id])
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -5469,10 +5469,10 @@ type ClusterRegistration {
   id: ID!
 
   "the name to give to the cluster"
-  name: String!
+  name: String
 
   "the handle to apply to the cluster"
-  handle: String!
+  handle: String
 
   "a unique machine id for the created cluster"
   machineId: String!

--- a/test/console/deployments/clusters_test.exs
+++ b/test/console/deployments/clusters_test.exs
@@ -1315,6 +1315,14 @@ defmodule Console.Deployments.ClustersTest do
 
       {:error, _} = Clusters.create_cluster_registration(%{machine_id: "blah", project_id: project.id}, user)
     end
+
+    test "it enforces machine id uniqueness" do
+      user = insert(:user)
+      project = insert(:project, write_bindings: [%{user_id: user.id}])
+
+      {:ok, _} = Clusters.create_cluster_registration(%{machine_id: "blah", project_id: project.id}, user)
+      {:error, _} = Clusters.create_cluster_registration(%{machine_id: "blah", project_id: project.id}, user)
+    end
   end
 
   describe "#update_cluster_regstration/3" do

--- a/test/console/deployments/stacks_test.exs
+++ b/test/console/deployments/stacks_test.exs
@@ -1020,4 +1020,26 @@ defmodule Console.Deployments.StacksSyncTest do
       refute run.git.ref == stack.git.ref
     end
   end
+
+  describe "#plural_creds/1" do
+    test "a stack with an actor can create run-bound creds" do
+      user = insert(:user)
+      run  = insert(:stack_run, actor: user)
+
+      {:ok, %{token: token}} = Stacks.plural_creds(run)
+
+      {:ok, actor, _} = Console.Guardian.resource_from_token(token)
+
+      assert actor.id == user.id
+    end
+
+    test "tokens cannot validate if the stack run has completed" do
+      user = insert(:user)
+      run  = insert(:stack_run, actor: user, status: :successful)
+
+      {:ok, %{token: token}} = Stacks.plural_creds(run)
+
+      {:error, _} = Console.Guardian.resource_from_token(token)
+    end
+  end
 end


### PR DESCRIPTION
This will make it impossible to exfil the token after the run (eg via terraform outputs)

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
