### PR TITLE
feat: add default plural=edge tag when registering edge devices

### DIFF
--- a/assets/src/components/edge/CompleteClusterRegistrationModal.tsx
+++ b/assets/src/components/edge/CompleteClusterRegistrationModal.tsx
@@ -22,7 +22,7 @@ function CompleteClusterRegistrationModal({
   const theme = useTheme()
   const [name, setName] = useState('')
   const [handle, setHandle] = useState('')
-  const [tags, setTags] = useState<Record<string, string>>({})
+  const [tags, setTags] = useState<Record<string, string>>({ plural: 'edge' })
 
   const [mutation, { loading, error }] = useUpdateClusterRegistrationMutation({
     onCompleted: () => {


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Added a predefined tag to edge clusters to be able to easily target edge/non-edge clusters.

![Zrzut ekranu 2025-01-27 120720](https://github.com/user-attachments/assets/fa0bcc55-2d93-4f8f-a184-8b25806e7c6f)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
