### PR TITLE
Add Cluster ISO Image CRUD gql

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1325,6 +1325,49 @@ export type ClusterInsightComponentAttributes = {
   version: Scalars['String']['input'];
 };
 
+/** A reference to a built ISO image to be used for flashing new edge clusters */
+export type ClusterIsoImage = {
+  __typename?: 'ClusterIsoImage';
+  id: Scalars['ID']['output'];
+  /** the image this iso was pushed to */
+  image: Scalars['String']['output'];
+  insertedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** ssh password for the new device */
+  password?: Maybe<Scalars['String']['output']>;
+  /** the project this cluster will live in (can be inferred from bootstrap token) */
+  project?: Maybe<Project>;
+  /** the registry holding the image */
+  registry: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** ssh username for the new device */
+  user?: Maybe<Scalars['String']['output']>;
+};
+
+export type ClusterIsoImageAttributes = {
+  /** the image this iso was pushed to */
+  image: Scalars['String']['input'];
+  /** ssh password for the new device */
+  password?: InputMaybe<Scalars['String']['input']>;
+  /** the project this cluster will live in (can be inferred from bootstrap token) */
+  projectId?: InputMaybe<Scalars['ID']['input']>;
+  /** the registry holding the image */
+  registry: Scalars['String']['input'];
+  /** ssh username for the new device */
+  user?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ClusterIsoImageConnection = {
+  __typename?: 'ClusterIsoImageConnection';
+  edges?: Maybe<Array<Maybe<ClusterIsoImageEdge>>>;
+  pageInfo: PageInfo;
+};
+
+export type ClusterIsoImageEdge = {
+  __typename?: 'ClusterIsoImageEdge';
+  cursor?: Maybe<Scalars['String']['output']>;
+  node?: Maybe<ClusterIsoImage>;
+};
+
 export type ClusterMetrics = {
   __typename?: 'ClusterMetrics';
   cpu?: Maybe<Array<Maybe<MetricResponse>>>;
@@ -5399,6 +5442,7 @@ export type RootMutationType = {
   createCluster?: Maybe<Cluster>;
   /** upserts a cluster backup resource */
   createClusterBackup?: Maybe<ClusterBackup>;
+  createClusterIsoImage?: Maybe<ClusterIsoImage>;
   createClusterProvider?: Maybe<ClusterProvider>;
   createClusterRegistration?: Maybe<ClusterRegistration>;
   createClusterRestore?: Maybe<ClusterRestore>;
@@ -5441,6 +5485,7 @@ export type RootMutationType = {
   /** deletes a chat from a users history */
   deleteChat?: Maybe<Chat>;
   deleteCluster?: Maybe<Cluster>;
+  deleteClusterIsoImage?: Maybe<ClusterIsoImage>;
   deleteClusterProvider?: Maybe<ClusterProvider>;
   deleteClusterRegistration?: Maybe<ClusterRegistration>;
   deleteCustomStackRun?: Maybe<CustomStackRun>;
@@ -5536,6 +5581,7 @@ export type RootMutationType = {
   /** start a new run from the newest sha in the stack's run history */
   triggerRun?: Maybe<StackRun>;
   updateCluster?: Maybe<Cluster>;
+  updateClusterIsoImage?: Maybe<ClusterIsoImage>;
   updateClusterProvider?: Maybe<ClusterProvider>;
   updateClusterRegistration?: Maybe<ClusterRegistration>;
   updateClusterRestore?: Maybe<ClusterRestore>;
@@ -5678,6 +5724,11 @@ export type RootMutationTypeCreateClusterArgs = {
 
 export type RootMutationTypeCreateClusterBackupArgs = {
   attributes: BackupAttributes;
+};
+
+
+export type RootMutationTypeCreateClusterIsoImageArgs = {
+  attributes: ClusterIsoImageAttributes;
 };
 
 
@@ -5882,6 +5933,11 @@ export type RootMutationTypeDeleteChatArgs = {
 
 
 export type RootMutationTypeDeleteClusterArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type RootMutationTypeDeleteClusterIsoImageArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -6281,6 +6337,12 @@ export type RootMutationTypeUpdateClusterArgs = {
 };
 
 
+export type RootMutationTypeUpdateClusterIsoImageArgs = {
+  attributes: ClusterIsoImageAttributes;
+  id: Scalars['ID']['input'];
+};
+
+
 export type RootMutationTypeUpdateClusterProviderArgs = {
   attributes: ClusterProviderUpdateAttributes;
   id: Scalars['ID']['input'];
@@ -6546,6 +6608,8 @@ export type RootQueryType = {
   clusterGates?: Maybe<Array<Maybe<PipelineGate>>>;
   clusterInfo?: Maybe<ClusterInfo>;
   clusterInsightComponent?: Maybe<ClusterInsightComponent>;
+  clusterIsoImage?: Maybe<ClusterIsoImage>;
+  clusterIsoImages?: Maybe<ClusterIsoImageConnection>;
   clusterManagedNamespaces?: Maybe<ManagedNamespaceConnection>;
   /** fetches an individual cluster provider */
   clusterProvider?: Maybe<ClusterProvider>;
@@ -6840,6 +6904,20 @@ export type RootQueryTypeClusterGateArgs = {
 
 export type RootQueryTypeClusterInsightComponentArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type RootQueryTypeClusterIsoImageArgs = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  image?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type RootQueryTypeClusterIsoImagesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -1028,6 +1028,46 @@ type ClusterInsightComponentAttributes struct {
 	Name      string  `json:"name"`
 }
 
+// A reference to a built ISO image to be used for flashing new edge clusters
+type ClusterIsoImage struct {
+	ID string `json:"id"`
+	// the image this iso was pushed to
+	Image string `json:"image"`
+	// the registry holding the image
+	Registry string `json:"registry"`
+	// ssh username for the new device
+	User *string `json:"user,omitempty"`
+	// ssh password for the new device
+	Password *string `json:"password,omitempty"`
+	// the project this cluster will live in (can be inferred from bootstrap token)
+	Project    *Project `json:"project,omitempty"`
+	InsertedAt *string  `json:"insertedAt,omitempty"`
+	UpdatedAt  *string  `json:"updatedAt,omitempty"`
+}
+
+type ClusterIsoImageAttributes struct {
+	// the image this iso was pushed to
+	Image string `json:"image"`
+	// the registry holding the image
+	Registry string `json:"registry"`
+	// ssh username for the new device
+	User *string `json:"user,omitempty"`
+	// ssh password for the new device
+	Password *string `json:"password,omitempty"`
+	// the project this cluster will live in (can be inferred from bootstrap token)
+	ProjectID *string `json:"projectId,omitempty"`
+}
+
+type ClusterIsoImageConnection struct {
+	PageInfo PageInfo               `json:"pageInfo"`
+	Edges    []*ClusterIsoImageEdge `json:"edges,omitempty"`
+}
+
+type ClusterIsoImageEdge struct {
+	Node   *ClusterIsoImage `json:"node,omitempty"`
+	Cursor *string          `json:"cursor,omitempty"`
+}
+
 type ClusterMetrics struct {
 	CPU            []*MetricResponse `json:"cpu,omitempty"`
 	Memory         []*MetricResponse `json:"memory,omitempty"`

--- a/lib/console/deployments/policies/bootstrap_policies.ex
+++ b/lib/console/deployments/policies/bootstrap_policies.ex
@@ -1,6 +1,8 @@
 defmodule Console.Deployments.BootstrapPolicies do
   use Piazza.Policy
-  alias Console.Schema.{User, BootstrapToken, Project, Cluster, ClusterRegistration}
+  alias Console.Schema.{User, BootstrapToken, Project, Cluster, ClusterRegistration, ClusterISOImage}
+
+  def can?(%User{id: id, bootstrap: %BootstrapToken{project_id: pid}}, %ClusterISOImage{creator_id: id, project_id: pid}, _), do: :pass
 
   def can?(%User{id: id}, %ClusterRegistration{creator_id: id}, _), do: :pass
 

--- a/lib/console/deployments/policies/rbac.ex
+++ b/lib/console/deployments/policies/rbac.ex
@@ -31,7 +31,8 @@ defmodule Console.Deployments.Policies.Rbac do
     Catalog,
     ClusterInsightComponent,
     VulnerabilityReport,
-    ClusterRegistration
+    ClusterRegistration,
+    ClusterISOImage
   }
 
   def globally_readable(query, %User{roles: %{admin: true}}, _), do: query
@@ -86,6 +87,8 @@ defmodule Console.Deployments.Policies.Rbac do
   def evaluate(%VulnerabilityReport{} = comp, user, action),
     do: recurse(comp, user, action, & &1.cluster)
   def evaluate(%ClusterRegistration{} = reg, user, action),
+    do: recurse(reg, user, action, & &1.project)
+  def evaluate(%ClusterISOImage{} = reg, user, action),
     do: recurse(reg, user, action, & &1.project)
   def evaluate(%GlobalService{} = global, %User{} = user, action) do
     recurse(global, user, action, fn
@@ -162,6 +165,8 @@ defmodule Console.Deployments.Policies.Rbac do
   def preload(%GlobalService{} = global),
     do: Repo.preload(global, [project: @bindings])
   def preload(%ClusterRegistration{} = reg),
+    do: Repo.preload(reg, [project: @bindings])
+  def preload(%ClusterISOImage{} = reg),
     do: Repo.preload(reg, [project: @bindings])
   def preload(%ManagedNamespace{} = ns),
     do: Repo.preload(ns, [project: @bindings])

--- a/lib/console/graphql/resolvers/deployments/cluster.ex
+++ b/lib/console/graphql/resolvers/deployments/cluster.ex
@@ -13,7 +13,8 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
     ClusterNamespaceUsage,
     ClusterScalingRecommendation,
     ClusterAuditLog,
-    ClusterRegistration
+    ClusterRegistration,
+    ClusterISOImage
   }
 
   def resolve_cluster(_, %{context: %{cluster: cluster}}), do: {:ok, cluster}
@@ -54,6 +55,15 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
   def resolve_cluster_registration(%{id: id}, %{context: %{current_user: user}}) do
     Clusters.get_cluster_registration!(id)
     |> allow(user, :read)
+  end
+
+  def resolve_cluster_iso_image(%{image: id}, %{context: %{current_user: user}}) do
+    Clusters.get_iso_image_by_image!(id)
+    |> allow(user, :write)
+  end
+  def resolve_cluster_iso_image(%{id: id}, %{context: %{current_user: user}}) do
+    Clusters.get_cluster_iso_image!(id)
+    |> allow(user, :write)
   end
 
   defp get_provider(%{id: id}) when is_binary(id), do: Clusters.get_provider!(id)
@@ -155,6 +165,12 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
 
   def list_cluster_registrations(args, _) do
     ClusterRegistration.ordered()
+    |> paginate(args)
+  end
+
+  def list_cluster_iso_images(args, %{context: %{current_user: user}}) do
+    ClusterISOImage.ordered()
+    |> ClusterISOImage.for_user(user)
     |> paginate(args)
   end
 
@@ -268,6 +284,15 @@ defmodule Console.GraphQl.Resolvers.Deployments.Cluster do
 
   def delete_cluster_registration(%{id: id}, %{context: %{current_user: user}}),
     do: Clusters.delete_cluster_registration(id, user)
+
+  def create_cluster_iso_image(%{attributes: attrs}, %{context: %{current_user: user}}),
+    do: Clusters.create_cluster_iso_image(attrs, user)
+
+  def update_cluster_iso_image(%{id: id, attributes: attrs}, %{context: %{current_user: user}}),
+    do: Clusters.update_cluster_iso_image(attrs, id, user)
+
+  def delete_cluster_iso_image(%{id: id}, %{context: %{current_user: user}}),
+    do: Clusters.delete_cluster_iso_image(id, user)
 
   def ping(%{attributes: attrs}, %{context: %{cluster: cluster}}),
     do: Clusters.ping(attrs, cluster)

--- a/lib/console/schema/cluster_iso_image.ex
+++ b/lib/console/schema/cluster_iso_image.ex
@@ -1,0 +1,45 @@
+defmodule Console.Schema.ClusterISOImage do
+  use Piazza.Ecto.Schema
+  alias Console.Schema.{Project, User, PolicyBinding}
+  alias Console.Deployments.Policies.Rbac
+
+  schema "cluster_iso_images" do
+    field :image,       :string
+    field :registry,    :string
+    field :user,        :string
+    field :password,    Piazza.Ecto.EncryptedString
+
+    belongs_to :project, Project
+    belongs_to :creator, User
+
+    timestamps()
+  end
+
+  def for_user(query \\ __MODULE__, %User{} = user) do
+    Rbac.globally_readable(query, user, fn query, id, groups ->
+      from(c in query,
+        join: p in assoc(c, :project),
+        left_join: b in PolicyBinding,
+          on: b.policy_id == p.write_policy_id,
+        where: b.user_id == ^id or b.group_id in ^groups,
+        distinct: true
+      )
+    end)
+  end
+
+  def for_project(query \\ __MODULE__, pid) do
+    from(cr in query, where: cr.project_id == ^pid)
+  end
+
+  def ordered(query \\ __MODULE__, order \\ [desc: :inserted_at, asc: :image]) do
+    from(cr in query, order_by: ^order)
+  end
+
+  @valid ~w(image registry user password project_id creator_id)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> validate_required(~w(image registry project_id creator_id)a)
+  end
+end

--- a/priv/repo/migrations/20250128165205_add_cluster_isos.exs
+++ b/priv/repo/migrations/20250128165205_add_cluster_isos.exs
@@ -1,0 +1,21 @@
+defmodule Console.Repo.Migrations.AddClusterIsos do
+  use Ecto.Migration
+
+  def change do
+    create table(:cluster_iso_images, primary_key: false) do
+      add :id,         :uuid, primary_key: true
+      add :image,      :string
+      add :project_id, references(:projects, type: :uuid, on_delete: :delete_all)
+      add :creator_id, references(:watchman_users, type: :uuid, on_delete: :nilify_all)
+
+      add :registry,   :string
+      add :user,       :string
+      add :password,   :string
+      add :status,     :integer
+      timestamps()
+    end
+
+    create unique_index(:cluster_iso_images, [:image])
+    create index(:cluster_iso_images, [:project_id])
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -215,6 +215,10 @@ type RootQueryType {
 
   clusterRegistrations(after: String, first: Int, before: String, last: Int): ClusterRegistrationConnection
 
+  clusterIsoImage(id: ID, image: String): ClusterIsoImage
+
+  clusterIsoImages(after: String, first: Int, before: String, last: Int): ClusterIsoImageConnection
+
   serviceDeployments(
     after: String
 
@@ -600,6 +604,12 @@ type RootMutationType {
   updateClusterRegistration(id: ID!, attributes: ClusterRegistrationUpdateAttributes!): ClusterRegistration
 
   deleteClusterRegistration(id: ID!): ClusterRegistration
+
+  createClusterIsoImage(attributes: ClusterIsoImageAttributes!): ClusterIsoImage
+
+  updateClusterIsoImage(id: ID!, attributes: ClusterIsoImageAttributes!): ClusterIsoImage
+
+  deleteClusterIsoImage(id: ID!): ClusterIsoImage
 
   createServiceDeployment(
     clusterId: ID
@@ -4692,6 +4702,23 @@ input ClusterRegistrationUpdateAttributes {
   metadata: Json
 }
 
+input ClusterIsoImageAttributes {
+  "the image this iso was pushed to"
+  image: String!
+
+  "the registry holding the image"
+  registry: String!
+
+  "ssh username for the new device"
+  user: String
+
+  "ssh password for the new device"
+  password: String
+
+  "the project this cluster will live in (can be inferred from bootstrap token)"
+  projectId: ID
+}
+
 "a CAPI provider for a cluster, cloud is inferred from name if not provided manually"
 type ClusterProvider {
   "the id of this provider"
@@ -5505,6 +5532,30 @@ type ClusterRegistration {
   updatedAt: DateTime
 }
 
+"A reference to a built ISO image to be used for flashing new edge clusters"
+type ClusterIsoImage {
+  id: ID!
+
+  "the image this iso was pushed to"
+  image: String!
+
+  "the registry holding the image"
+  registry: String!
+
+  "ssh username for the new device"
+  user: String
+
+  "ssh password for the new device"
+  password: String
+
+  "the project this cluster will live in (can be inferred from bootstrap token)"
+  project: Project
+
+  insertedAt: DateTime
+
+  updatedAt: DateTime
+}
+
 type CloudAddon {
   id: ID!
   distro: ClusterDistro!
@@ -5580,6 +5631,11 @@ type ClusterAuditLogConnection {
 type ClusterRegistrationConnection {
   pageInfo: PageInfo!
   edges: [ClusterRegistrationEdge]
+}
+
+type ClusterIsoImageConnection {
+  pageInfo: PageInfo!
+  edges: [ClusterIsoImageEdge]
 }
 
 enum AuthMethod {
@@ -8233,6 +8289,11 @@ type HelmRepositoryEdge {
 
 type GitRepositoryEdge {
   node: GitRepository
+  cursor: String
+}
+
+type ClusterIsoImageEdge {
+  node: ClusterIsoImage
   cursor: String
 }
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -830,6 +830,15 @@ defmodule Console.Factory do
     }
   end
 
+  def cluster_iso_image_factory do
+    %Schema.ClusterISOImage{
+      image: sequence(:iso, & "iso:#{&1}"),
+      registry: "dkr.plural.sh",
+      project: build(:project),
+      creator: build(:user)
+    }
+  end
+
   def cloud_addon_factory do
     %Schema.CloudAddon{
       cluster: build(:cluster),


### PR DESCRIPTION
This supports basic crud to persist cluster isos and authz reads of existing ISO's stored in OCI. At the moment using project writer access to govern that.

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
