### PR TITLE
small tweaks/fixes

### DIFF
--- a/assets/src/components/cd/logs/LogsCard.tsx
+++ b/assets/src/components/cd/logs/LogsCard.tsx
@@ -69,7 +69,6 @@ export const LogsCard = memo(function LogsCard({
 
   const fetchOlderLogs = useCallback(() => {
     if (loading || !hasNextPage) return
-    if (live) toggleLive()
     fetchMore({
       variables: {
         limit: limit || LIMIT,
@@ -88,18 +87,18 @@ export const LogsCard = memo(function LogsCard({
         return { logAggregation: [...(prev.logAggregation ?? []), ...newLogs] }
       },
     })
-  }, [
-    loading,
-    hasNextPage,
-    live,
-    toggleLive,
-    fetchMore,
-    limit,
-    logs,
-    time?.duration,
-  ])
+  }, [loading, hasNextPage, fetchMore, limit, logs, time?.duration])
 
   const initialLoading = !data && loading
+
+  const onScrollCapture = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      const scrollTop = e.currentTarget.scrollTop
+      if (scrollTop === 0 && !live) toggleLive()
+      else if (scrollTop > 0 && live) toggleLive()
+    },
+    [live, toggleLive]
+  )
 
   return error ? (
     <GqlError error={error} />
@@ -127,6 +126,7 @@ export const LogsCard = memo(function LogsCard({
           setLogLine(row.original)
           setContextPanelOpen(true)
         }}
+        onScrollCapture={onScrollCapture}
       />
       {logLine && (
         <Flyover

--- a/assets/src/components/cd/logs/LogsTable.tsx
+++ b/assets/src/components/cd/logs/LogsTable.tsx
@@ -13,6 +13,7 @@ export function LogsTable({
   fetchMore,
   hasNextPage = false,
   onRowClick,
+  onScrollCapture,
 }: {
   data: LogLineFragment[]
   loading?: boolean
@@ -20,6 +21,7 @@ export function LogsTable({
   fetchMore?: () => void
   hasNextPage?: boolean
   onRowClick?: (_e: any, row: Row<LogLineFragment>) => void
+  onScrollCapture?: (e: React.UIEvent<HTMLDivElement>) => void
 }) {
   const theme = useTheme()
   return (
@@ -38,6 +40,7 @@ export function LogsTable({
       fetchNextPage={fetchMore}
       loading={!!initialLoading}
       padCells={!!initialLoading}
+      onScrollCapture={onScrollCapture}
       css={{
         '& td *': { maxWidth: 'unset' }, // stretches the skeleton loaders out to the end
         background: data.length

--- a/assets/src/components/cost-management/CostManagement.tsx
+++ b/assets/src/components/cost-management/CostManagement.tsx
@@ -6,6 +6,7 @@ import {
   RamIcon,
   Table,
   TagMultiSelectProps,
+  useSetBreadcrumbs,
 } from '@pluralsh/design-system'
 import { Row } from '@tanstack/react-table'
 import { TagsFilter } from 'components/cd/services/ClusterTagsFilter'
@@ -40,10 +41,19 @@ import {
   cpuCostByCluster,
   memoryCostByCluster,
 } from './CostManagementTreeMap'
+import {
+  COST_MANAGEMENT_REL_PATH,
+  COST_MANAGEMENT_ABS_PATH,
+} from 'routes/costManagementRoutesConsts'
 
 export const CM_TREE_MAP_CARD_HEIGHT = 300
 
+const breadcrumbs = [
+  { label: COST_MANAGEMENT_REL_PATH, url: COST_MANAGEMENT_ABS_PATH },
+]
+
 export function CostManagement() {
+  useSetBreadcrumbs(breadcrumbs)
   const theme = useTheme()
   const navigate = useNavigate()
   const projectId = useProjectId()

--- a/assets/src/components/cost-management/details/CostManagementDetails.tsx
+++ b/assets/src/components/cost-management/details/CostManagementDetails.tsx
@@ -27,6 +27,7 @@ import styled from 'styled-components'
 const BIG_PAGE_SIZE = 500
 
 export type CMContextType = {
+  clusterName?: string
   historyQuery: FetchPaginatedDataResult<ClusterUsageHistoryQuery>
   namespacesQuery: FetchPaginatedDataResult<ClusterUsageNamespacesQuery>
   namespaceQ: string
@@ -78,6 +79,7 @@ export function CostManagementDetails() {
 
   const ctx = useMemo(() => {
     return {
+      clusterName: namespacesQuery?.data?.clusterUsage?.cluster?.name,
       historyQuery,
       namespacesQuery,
       namespaceQ,

--- a/assets/src/components/cost-management/details/CostManagementDetailsNamespaces.tsx
+++ b/assets/src/components/cost-management/details/CostManagementDetailsNamespaces.tsx
@@ -7,6 +7,7 @@ import {
   RamIcon,
   SearchIcon,
   Table,
+  useSetBreadcrumbs,
 } from '@pluralsh/design-system'
 
 import { GqlError } from 'components/utils/Alert'
@@ -16,6 +17,10 @@ import { ClusterNamespaceUsageFragment } from 'generated/graphql'
 import { useMemo } from 'react'
 
 import { useOutletContext } from 'react-router-dom'
+import {
+  COST_MANAGEMENT_ABS_PATH,
+  COST_MANAGEMENT_REL_PATH,
+} from 'routes/costManagementRoutesConsts'
 import { useTheme } from 'styled-components'
 import {
   ColCpuCost,
@@ -32,11 +37,21 @@ import {
 } from '../CostManagementTreeMap'
 import { CMContextType } from './CostManagementDetails'
 
+const getBreadcrumbs = (clusterName: string) => [
+  { label: COST_MANAGEMENT_REL_PATH, url: COST_MANAGEMENT_ABS_PATH },
+  { label: clusterName },
+  { label: 'namespaces' },
+]
+
 export function CostManagementDetailsNamespaces() {
   const theme = useTheme()
 
-  const { namespacesQuery, namespaceQ, setNamespaceQ } =
+  const { namespacesQuery, namespaceQ, setNamespaceQ, clusterName } =
     useOutletContext<CMContextType>()
+
+  useSetBreadcrumbs(
+    useMemo(() => getBreadcrumbs(clusterName ?? ''), [clusterName])
+  )
 
   const { data, loading, error, fetchNextPage, setVirtualSlice } =
     namespacesQuery

--- a/assets/src/components/cost-management/details/CostManagementDetailsOverview.tsx
+++ b/assets/src/components/cost-management/details/CostManagementDetailsOverview.tsx
@@ -9,21 +9,34 @@ import {
   Flex,
   LoadingSpinner,
   RamIcon,
+  useSetBreadcrumbs,
 } from '@pluralsh/design-system'
+import { HOME_CARD_MAX_HEIGHT } from 'components/home/HomeCard'
 import { GqlError } from 'components/utils/Alert'
 import { Body1P, Title1H1 } from 'components/utils/typography/Text'
 import dayjs from 'dayjs'
 import { ClusterUsageHistoryFragment } from 'generated/graphql'
-import { ReactNode } from 'react'
+import { ReactNode, useMemo } from 'react'
 import { useOutletContext } from 'react-router-dom'
+import {
+  COST_MANAGEMENT_ABS_PATH,
+  COST_MANAGEMENT_REL_PATH,
+} from 'routes/costManagementRoutesConsts'
 import styled, { useTheme } from 'styled-components'
 import { CMContextType } from './CostManagementDetails'
 import { CostTimeSeriesGraph } from './CostTimeSeriesGraph'
-import { HOME_CARD_MAX_HEIGHT } from 'components/home/HomeCard'
+
+const getBreadcrumbs = (clusterName: string) => [
+  { label: COST_MANAGEMENT_REL_PATH, url: COST_MANAGEMENT_ABS_PATH },
+  { label: clusterName },
+  { label: 'overview' },
+]
 
 export function CostManagementDetailsOverview() {
-  const { historyQuery } = useOutletContext<CMContextType>()
-
+  const { historyQuery, clusterName } = useOutletContext<CMContextType>()
+  useSetBreadcrumbs(
+    useMemo(() => getBreadcrumbs(clusterName ?? ''), [clusterName])
+  )
   const { data, loading, error } = historyQuery
   const usageData = data?.clusterUsage
 

--- a/assets/src/components/cost-management/details/CostManagementDetailsRecommendations.tsx
+++ b/assets/src/components/cost-management/details/CostManagementDetailsRecommendations.tsx
@@ -8,11 +8,15 @@ import {
   SelectButton,
   Table,
   TrashCanIcon,
+  useSetBreadcrumbs,
 } from '@pluralsh/design-system'
+import { GqlError } from 'components/utils/Alert'
+import { DEFAULT_REACT_VIRTUAL_OPTIONS } from 'components/utils/table/useFetchPaginatedData'
 import {
   ClusterScalingRecommendationFragment,
   ScalingRecommendationType,
 } from 'generated/graphql'
+import { useMemo } from 'react'
 import { useOutletContext } from 'react-router-dom'
 import {
   ColCpuChange,
@@ -21,9 +25,17 @@ import {
   ColScalingPr,
 } from './ClusterScalingRecsTableCols'
 import { CMContextType } from './CostManagementDetails'
-import { useMemo } from 'react'
-import { DEFAULT_REACT_VIRTUAL_OPTIONS } from 'components/utils/table/useFetchPaginatedData'
-import { GqlError } from 'components/utils/Alert'
+
+import {
+  COST_MANAGEMENT_ABS_PATH,
+  COST_MANAGEMENT_REL_PATH,
+} from 'routes/costManagementRoutesConsts'
+
+const getBreadcrumbs = (clusterName: string) => [
+  { label: COST_MANAGEMENT_REL_PATH, url: COST_MANAGEMENT_ABS_PATH },
+  { label: clusterName },
+  { label: 'recommendations' },
+]
 
 export function CostManagementDetailsRecommendations() {
   const {
@@ -32,7 +44,12 @@ export function CostManagementDetailsRecommendations() {
     setRecommendationsQ,
     recType,
     setRecType,
+    clusterName,
   } = useOutletContext<CMContextType>()
+
+  useSetBreadcrumbs(
+    useMemo(() => getBreadcrumbs(clusterName ?? ''), [clusterName])
+  )
 
   const { data, loading, error, fetchNextPage, setVirtualSlice } =
     recommendationsQuery

--- a/assets/src/components/cost-management/details/CostTimeSeriesGraph.tsx
+++ b/assets/src/components/cost-management/details/CostTimeSeriesGraph.tsx
@@ -1,10 +1,11 @@
 import { ResponsiveLine } from '@nivo/line'
+import { EmptyState } from '@pluralsh/design-system'
+import { HOME_CARD_MAX_HEIGHT } from 'components/home/HomeCard'
+import dayjs from 'dayjs'
 import { ClusterUsageHistoryFragment } from 'generated/graphql'
 import styled, { useTheme } from 'styled-components'
-import { graphTheme, SliceTooltip } from '../../utils/Graph'
-import dayjs from 'dayjs'
 import { COLORS } from 'utils/color'
-import { HOME_CARD_MAX_HEIGHT } from 'components/home/HomeCard'
+import { graphTheme, SliceTooltip } from '../../utils/Graph'
 
 export function CostTimeSeriesGraph({
   history,
@@ -13,6 +14,9 @@ export function CostTimeSeriesGraph({
 }) {
   const theme = useTheme()
   const data = getGraphData(history)
+
+  if (!data) return <EmptyState message="No time-series data available" />
+
   return (
     <GraphWrapperSC>
       <ResponsiveLine
@@ -124,7 +128,10 @@ const getGraphData = (history: ClusterUsageHistoryFragment[]) => {
     })
   })
 
-  return [cpuData, memoryData, storageData]
+  const data = [cpuData, memoryData, storageData]
+
+  // return null instead of empty arrays if there's no data at all
+  return data.some((obj) => obj.data.length > 0) ? data : null
 }
 
 const GraphWrapperSC = styled.div((_) => ({


### PR DESCRIPTION
fixes a bug that was causing cost management details view to crash if there was no data for the time series graph

adds breadcrumbs to cost management views

changes log views to toggle live state off when the user scrolls down, and back on when scrolled to the top (also triggers when "back to top" is clicked)