### PR TITLE
fix: broken readonly feature in project and catalog controllers

### DIFF
--- a/go/controller/internal/controller/project_controller.go
+++ b/go/controller/internal/controller/project_controller.go
@@ -161,6 +161,10 @@ func (in *ProjectReconciler) addOrRemoveFinalizer(ctx context.Context, project *
 }
 
 func (in *ProjectReconciler) isAlreadyExists(ctx context.Context, project *v1alpha1.Project) (bool, error) {
+	if project.Status.HasReadonlyCondition() {
+		return project.Status.IsReadonly(), nil
+	}
+
 	_, err := in.ConsoleClient.GetProject(ctx, nil, lo.ToPtr(project.ConsoleName()))
 	if errors.IsNotFound(err) {
 		return false, nil


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
This fixes an issue with project/catalog CRDs that already exist in the API not being marked correctly as readonly.
`isAlreadyExist` check did not take into account the `readonly` status flag and during the subsequent reconcile
it was flipping the original `readonly: true` to `readonly: false` because project did exist in the API and ID was already synchronized.
Due to this i.e. deleting `readonly` default project was trying to delete the actual project from the API thus blocking CRD deletion and further service deployment cleanup.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Running controller locally on dev env

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
