### PR TITLE
feat: update cluster bindings in read-only mode

### DIFF
--- a/go/controller/api/v1alpha1/cluster_types.go
+++ b/go/controller/api/v1alpha1/cluster_types.go
@@ -110,6 +110,20 @@ func (c *Cluster) UpdateAttributes() console.ClusterUpdateAttributes {
 	return attr
 }
 
+func (c *Cluster) ReadOnlyUpdateAttributes() console.ClusterUpdateAttributes {
+	tagAttr := c.TagUpdateAttributes()
+	attr := console.ClusterUpdateAttributes{
+		Handle:   c.Spec.Handle,
+		Tags:     tagAttr.Tags,
+		Metadata: tagAttr.Metadata,
+	}
+	if c.Spec.Bindings != nil {
+		attr.ReadBindings = PolicyBindings(c.Spec.Bindings.Read)
+		attr.WriteBindings = PolicyBindings(c.Spec.Bindings.Write)
+	}
+	return attr
+}
+
 func (c *Cluster) TagUpdateAttributes() console.ClusterUpdateAttributes {
 	var tags []*console.TagAttributes
 	if len(c.Spec.Tags) > 0 {

--- a/go/controller/internal/controller/cluster_controller.go
+++ b/go/controller/internal/controller/cluster_controller.go
@@ -5,6 +5,13 @@ import (
 	goerrors "errors"
 	"fmt"
 
+	console "github.com/pluralsh/console/go/client"
+	"github.com/pluralsh/console/go/controller/api/v1alpha1"
+	"github.com/pluralsh/console/go/controller/internal/cache"
+	consoleclient "github.com/pluralsh/console/go/controller/internal/client"
+	"github.com/pluralsh/console/go/controller/internal/credentials"
+	operrors "github.com/pluralsh/console/go/controller/internal/errors"
+	"github.com/pluralsh/console/go/controller/internal/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,17 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	console "github.com/pluralsh/console/go/client"
-
-	"github.com/pluralsh/console/go/controller/internal/credentials"
-
-	"github.com/pluralsh/console/go/controller/internal/cache"
-
-	"github.com/pluralsh/console/go/controller/api/v1alpha1"
-	consoleclient "github.com/pluralsh/console/go/controller/internal/client"
-	operrors "github.com/pluralsh/console/go/controller/internal/errors"
-	"github.com/pluralsh/console/go/controller/internal/utils"
 )
 
 const (

--- a/go/controller/internal/controller/cluster_controller_test.go
+++ b/go/controller/internal/controller/cluster_controller_test.go
@@ -2,11 +2,11 @@ package controller_test
 
 import (
 	"context"
-	"github.com/Yamashou/gqlgenc/clientv2"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 	"sort"
 
+	"github.com/Yamashou/gqlgenc/clientv2"
 	"github.com/pluralsh/console/go/controller/internal/cache"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
Cluster bindings should be added when in a read-only state

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
