### PR TITLE
Softserve setup

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,6 +69,16 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}}
+      - name: Softserve meta
+        id: meta-softserve
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/pluralsh/softserve
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{version}}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -117,6 +127,20 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            VITE_PROD_SECRET_KEY=${{ secrets.VITE_PROD_SECRET_KEY }}
+      - name: Build and push softserve
+        uses: docker/build-push-action@v3
+        with:
+          context: ".softserve"
+          file: "./softserve/Dockerfile.softserve"
+          push: true
+          tags: ${{ steps.meta-softserve.outputs.tags }}
+          labels: ${{ steps.meta-softserve.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/softserve-cd.yaml
+++ b/.github/workflows/softserve-cd.yaml
@@ -1,0 +1,57 @@
+name: CD / Softserve
+
+on:
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - ".github/workflows/softserve-cd.yaml"
+      - "softserve/**"
+
+permissions:
+  contents: read
+
+jobs:
+  publish-softserve-docker:
+    name: Build and push softserve
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: softserve/
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      packages: 'write'
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - id: meta-softserve
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/pluralsh/softserve
+          tags: |
+            type=semver,pattern={{version}}
+            latest
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3.0.0
+      - uses: docker/build-push-action@v3
+        with:
+          context: "./softserve"
+          file: "./softserve/Dockerfile.softserve"
+          push: true
+          tags: ${{ steps.meta-softserve.outputs.tags }}
+          labels: ${{ steps.meta-softserve.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            VITE_PROD_SECRET_KEY=${{ secrets.VITE_PROD_SECRET_KEY }}

--- a/charts/console/templates/softserve.yaml
+++ b/charts/console/templates/softserve.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.gitServer }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: softserve
+  labels:
+{{ include "console.labels" . | indent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: softserve
+  template:
+    metadata:
+      name: softserve
+      labels:
+        app.kubernetes.io/name: softserve
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ if .Values.podLabels }}
+        {{ toYaml .Values.podLabels | nindent 8 }}
+        {{ end }}
+      {{ if .Values.podAnnotations }}
+      annotations:
+        {{ toYaml .Values.podAnnotations | nindent 8 }}
+      {{ end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}     
+      {{ if .Values.console.securityContext }}
+      securityContext:
+      {{ toYaml .Values.console.securityContext | nindent 8 }}
+      {{ end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: softserve
+        {{ if .Values.console.containerSecurityContext }}
+        securityContext:
+        {{- toYaml .Values.console.containerSecurityContext | nindent 10 }}
+        {{ end }}
+        image: "ghcr.io/pluralsh/softserve:{{ .Chart.AppVersion }}"
+        imagePullPolicy: Never
+        ports:
+          - containerPort: {{ .Values.gitServer.sshPort }}
+          - containerPort: {{ .Values.gitServer.httpPort }}
+          - containerPort: {{ .Values.gitServer.metricsPort }}
+          - containerPort: {{ .Values.gitServer.gitPort }}
+        resources:
+        {{- toYaml .Values.gitServer.resources | nindent 10 }}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: softserve
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: softserve
+  ports:
+    - port: {{ .Values.gitServer.sshPort }}
+      targetPort: {{ .Values.gitServer.sshPort }}
+      name: ssh
+    - port: {{ .Values.gitServer.httpPort }}
+      targetPort: {{ .Values.gitServer.httpPort }}
+      name: http
+    - port: {{ .Values.gitServer.metricsPort }}
+      targetPort: {{ .Values.gitServer.metricsPort }}
+      name: metrics
+    - port: {{ .Values.gitServer.gitPort }}
+      targetPort: {{ .Values.gitServer.gitPort }}
+      name: git
+{{- end }}

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -241,3 +241,10 @@ flux2:
     create: true
   policies:
     create: false
+
+gitServer:
+  enabled: false
+  sshPort: 23231
+  httpPort: 23232
+  metricsPort: 23233
+  gitPort: 9418

--- a/softserve/Dockerfile.softserve
+++ b/softserve/Dockerfile.softserve
@@ -1,0 +1,49 @@
+# in order to get a soft-serve server with the repos we want, we need to:
+# 1. install soft-serve (and its dependencies)
+# 2. create and set the admin SSH key
+# 2. run "soft serve" to start the server (done inside the shellscript)
+# 3. import the repos (also done inside the shellscript)
+# This is all done in builder image since we want our actual soft-serve image to not require github interaction for imports
+FROM golang:alpine3.20 AS builder
+
+EXPOSE 23231
+EXPOSE 23232
+EXPOSE 23233
+EXPOSE 9418
+
+# basics, in case need to access shell to debug/troubleshoot
+RUN apk update --no-cache
+RUN apk add sudo git vim curl
+
+# create keys
+RUN apk add openssh-client
+
+# soft-serve install
+# Reason that we manually install soft-serve instead of using the soft-serve docker image is that
+# the soft-serve image starts the server without allowing us to set admin ssh keys, thus preventing
+# us from importing repos
+RUN go install github.com/charmbracelet/soft-serve/cmd/soft@latest
+RUN mv /go/bin/soft /usr/bin/
+
+# soft-serve data folder
+RUN mkdir -p /data
+
+# copy soft-serve setup script
+COPY softserve_setup.sh .
+RUN chmod 777 softserve_setup.sh
+RUN sh softserve_setup.sh
+ENTRYPOINT [ "soft", "serve" ]
+
+# soft-serve server which will actually run indefinitely
+# we want to copy the /data folder from the builder image since that contains all the files used by soft-serve
+FROM golang:alpine3.20 AS server
+
+EXPOSE 23231
+EXPOSE 23232
+EXPOSE 23233
+EXPOSE 9418
+
+COPY --from=builder /usr/bin/soft /usr/bin/
+COPY --from=builder /go/data /go/data
+
+ENTRYPOINT [ "soft", "serve" ]

--- a/softserve/softserve_setup.sh
+++ b/softserve/softserve_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+ssh-keygen -t rsa -f softserve -N ""
+export SOFT_SERVE_INITIAL_ADMIN_KEYS
+SOFT_SERVE_INITIAL_ADMIN_KEYS=$(cat softserve.pub)
+echo "soft serve admin keys: $SOFT_SERVE_INITIAL_ADMIN_KEYS"
+
+soft serve &
+sleep 10
+echo "started soft serve server"
+
+ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -p 23231 -i softserve admin@localhost repo import deployment-operator https://github.com/pluralsh/deployment-operator.git
+ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -p 23231 -i softserve admin@localhost repo import scaffolds https://github.com/pluralsh/scaffolds.git


### PR DESCRIPTION
set up softserve git server (https://github.com/charmbracelet/soft-serve) to host the deployment-operator and scaffolds repos such that if the user desires, they don't have to connect to github.

https://linear.app/pluralsh/issue/PROD-3247/implement-self-hostability-for-core-plural-deployment-operator-and

## Test Plan
In `softserve-cd.yaml`, initially had it set to `push` instead of `pull_request` - passing wf: https://github.com/pluralsh/console/actions/runs/13704813366

image publish on ghcr: https://github.com/pluralsh/console/pkgs/container/softserve

## Checklist

- [x] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
