### PR TITLE
Softserve Fix

### DIFF
--- a/dockerfiles/Dockerfile.softserve
+++ b/dockerfiles/Dockerfile.softserve
@@ -43,6 +43,10 @@ EXPOSE 23232
 EXPOSE 23233
 EXPOSE 9418
 
+# needs git for repos to be accessible
+RUN apk update --no-cache
+RUN apk add git
+
 COPY --from=builder /usr/bin/soft /usr/bin/
 COPY --from=builder /go/data /go/data
 


### PR DESCRIPTION
softserve dockerfile bigfix - install git before running server

## Test Plan
from the `dockerfiles` directory:
to build and run container
```
docker build -t git-server -f Dockerfile.softserve .`
docker run -d -p 23231:23231 -p 23232:23232 --name git-server git-server
```
then should be able to clone:
git:
```
git clone git clone http://localhost:23232/deployment-operator.git
```
ssh:
```
git clone ssh://localhost:23231/deployment-operator.git
```

also, can verify that the repos are hosted in the `git-server` by running
```
ssh -p 23231 localhost
```
which should open up the TUI and show the `deployment-operator` and `scaffolds` repos.

## Checklist

- [ ] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
