### PR TITLE
Add flow id filtering for pr vector search

### DIFF
--- a/lib/console/ai/evidence/alert.ex
+++ b/lib/console/ai/evidence/alert.ex
@@ -7,7 +7,7 @@ defimpl Console.AI.Evidence, for: Console.Schema.Alert do
   def generate(%Alert{state: :firing, service: %Service{} = service} = alert) do
     [{:user, alert_prompt(alert)}]
     |> Logs.with_logging(service, force: true, lines: 100)
-    |> Vector.with_vector_data()
+    |> add_vector_data(service)
     |> Context.prompt({:user, "Please use the data I've listed above to give a clear root cause analysis of this issue."})
     |> Context.result()
   end
@@ -34,4 +34,9 @@ defimpl Console.AI.Evidence, for: Console.Schema.Alert do
     I'll list some of the logs related to this workload to help analyze the root cause.
     """
   end
+
+  defp add_vector_data(ctx, %Service{flow_id: flow_id}) when is_binary(flow_id) do
+    Vector.with_vector_data(ctx, flow_id: flow_id)
+  end
+  defp add_vector_data(ctx, _), do: ctx
 end

--- a/lib/console/ai/pubsub/vector/consumer.ex
+++ b/lib/console/ai/pubsub/vector/consumer.ex
@@ -2,7 +2,8 @@ defmodule Console.AI.PubSub.Vector.Consumer do
   use Piazza.PubSub.Consumer,
     broadcaster: Console.PubSub.Broadcaster,
     max_demand: 10
-  alias Console.AI.{PubSub.Vectorizable, VectorStore}
+  alias Console.AI.PubSub.{Vectorizable, Vector.Indexable}
+  alias Console.AI.VectorStore
   require Logger
 
   def handle_event(event) do
@@ -12,7 +13,8 @@ defmodule Console.AI.PubSub.Vector.Consumer do
     end
   end
 
-  defp insert({:ok, resources}) when is_list(resources), do: Enum.each(resources, &VectorStore.insert/1)
-  defp insert({:ok, res}), do: VectorStore.insert(res)
+  defp insert(%Indexable{data: resources, filters: fs}) when is_list(resources),
+    do: Enum.each(resources, &VectorStore.insert(&1, filters: fs))
+  defp insert(%Indexable{data: res, filters: fs}), do: VectorStore.insert(res, filters: fs)
   defp insert(pass), do: pass
 end

--- a/lib/console/ai/pubsub/vector/protocol.ex
+++ b/lib/console/ai/pubsub/vector/protocol.ex
@@ -9,18 +9,17 @@ defimpl Console.AI.PubSub.Vectorizable, for: Any do
   def resource(_), do: :ok
 end
 
-defimpl Console.AI.PubSub.Vectorizable, for: Console.PubSub.ScmWebhook do
+defimpl Console.AI.PubSub.Vectorizable, for: Console.PubSub.PullRequestCreated do
   alias Console.AI.Tool
+  alias Console.AI.PubSub.Vector.Indexable
   alias Console.Deployments.Pr.Dispatcher
-  alias Console.Schema.{ScmWebhook, ScmConnection}
-  require Logger
+  alias Console.Schema.{PullRequest, ScmConnection}
 
-  def resource(%@for{
-    item: %{"action" => "closed", "pull_request" => %{"merged" => true} = pr},
-    actor: %ScmWebhook{type: :github}
-  }) do
+  def resource(%@for{item: %PullRequest{status: s, url: url, flow_id: flow_id}})
+      when s in ~w(merged closed)a and is_binary(flow_id) do
     with %ScmConnection{} = conn <- Tool.scm_connection(),
-      do: Dispatcher.files(conn, pr)
+         {:ok, files} <- Dispatcher.files(conn, url),
+      do: %Indexable{data: files, filters: [flow_id: flow_id]}
   end
 
   def resource(_), do: :ok
@@ -29,10 +28,11 @@ end
 
 defimpl Console.AI.PubSub.Vectorizable, for: Console.PubSub.AlertResolutionCreated do
   alias Console.Schema.AlertResolution
+  alias Console.AI.PubSub.Vector.Indexable
 
   def resource(%@for{item: resolution}) do
     mini = Console.Repo.preload(resolution, [:alert])
            |> AlertResolution.Mini.new()
-    {:ok, mini}
+    %Indexable{data: mini}
   end
 end

--- a/lib/console/ai/pubsub/vector/types.ex
+++ b/lib/console/ai/pubsub/vector/types.ex
@@ -1,0 +1,4 @@
+defmodule Console.AI.PubSub.Vector.Indexable do
+  @type t :: %__MODULE__{data: any, filters: keyword | nil}
+  defstruct [:data, :filters]
+end

--- a/lib/console/ai/vector/elastic.ex
+++ b/lib/console/ai/vector/elastic.ex
@@ -48,24 +48,32 @@ defmodule Console.AI.Vector.Elastic do
     end
   end
 
-  def insert(%__MODULE__{conn: %Elastic{} = es}, data) do
+  def insert(%__MODULE__{conn: %Elastic{} = es}, data, opts \\ []) do
+    filters = Keyword.get(opts, :filters, [])
     with {datatype, text} <- Content.content(data),
          {:ok, embeddings} <- Provider.embeddings(text) do
       url(es, "#{es.index}/_doc")
-      |> HTTPoison.post(Jason.encode!(%{
+      |> HTTPoison.post(Jason.encode!(doc_filters(%{
         passages: Enum.map(embeddings, fn {passage, vector} -> %{vector: vector, text: passage} end),
         datatype: datatype,
         "@timestamp": DateTime.utc_now(),
         "#{datatype}": Console.mapify(data)
-      }), headers(es))
+      }, filters)), headers(es))
       |> handle_response("could not insert vector into elasticsearch:")
     end
   end
 
+  defp doc_filters(doc, [_ | _] = filters) do
+    Map.put(doc, :filters, Map.new(filters))
+  end
+  defp doc_filters(doc, _), do: doc
+
   def fetch(%__MODULE__{conn: %Elastic{} = es}, text, opts) do
     count = Keyword.get(opts, :count, 5)
+    filters = Keyword.get(opts, :filters, [])
     with {:ok, [{_, embedding} | _]} <- Provider.embeddings(text),
-         {:ok, %Snap.SearchResponse{hits: hits}} <- Console.Logs.Provider.Elastic.search(es, vector_query(embedding, count)) do
+         query = vector_query(embedding, count, filters),
+         {:ok, %Snap.SearchResponse{hits: hits}} <- Console.Logs.Provider.Elastic.search(es, query) do
       Enum.map(hits, fn %Snap.Hit{source: source} ->
         datatype = source["datatype"]
         case source[datatype] do
@@ -78,12 +86,17 @@ defmodule Console.AI.Vector.Elastic do
     end
   end
 
-  defp vector_query(embedding, count) do
-    %{
+  defp vector_query(embedding, count, filters) do
+    query_filters(%{
       size: count,
       knn: %{field: "passages.vector", query_vector: embedding, k: count}
-    }
+    }, filters)
   end
+
+  defp query_filters(query, [_ | _] = filters) do
+    put_in(query, [:knn, :filter], %{term: Map.new(filters, fn {k, v} -> {"#{k}.keyword", v} end)})
+  end
+  defp query_filters(query, _), do: query
 
   defp handle_response({:ok, %HTTPoison.Response{status_code: code}}, _) when code >= 200 and code < 300, do: :ok
   defp handle_response({:ok, %HTTPoison.Response{body: body}}, modifier), do: {:error, "#{modifier}: #{body}"}

--- a/lib/console/ai/vector_store.ex
+++ b/lib/console/ai/vector_store.ex
@@ -24,7 +24,7 @@ defmodule Console.AI.VectorStore do
   @type error :: Console.error
 
   @callback init(store) :: :ok | error
-  @callback insert(store, struct) :: :ok | error
+  @callback insert(store, struct, keyword) :: :ok | error
   @callback fetch(store, [float], keyword) :: {:ok, [data]} | error
 
   @spec enabled?() :: boolean
@@ -35,11 +35,11 @@ defmodule Console.AI.VectorStore do
     end
   end
 
-  def insert(struct) do
+  def insert(struct, opts \\ []) do
     settings = Settings.cached()
     with {:ok, %{__struct__: mod} = store} <- store(settings),
          :ok <- maybe_init(settings, store),
-      do: mod.insert(store, struct)
+      do: mod.insert(store, struct, opts)
   end
 
   @spec fetch(binary, keyword) :: {:ok, [data]} | error

--- a/lib/console/deployments/pr/dispatcher.ex
+++ b/lib/console/deployments/pr/dispatcher.ex
@@ -30,7 +30,7 @@ defmodule Console.Deployments.Pr.Dispatcher do
   @callback review(conn :: ScmConnection.t, pr :: PullRequest.t, message :: binary) :: {:ok, binary} | Console.error
 
 
-  @callback files(conn :: ScmConnection.t, msg :: map) :: {:ok, [File.t]} | Console.error
+  @callback files(conn :: ScmConnection.t, url :: binary) :: {:ok, [File.t]} | Console.error
 
   @doc """
   Fully creates a pr against the working dispatcher implementation
@@ -66,9 +66,9 @@ defmodule Console.Deployments.Pr.Dispatcher do
     impl.review(conn, pr, body)
   end
 
-  def files(%ScmConnection{} = conn, map) do
+  def files(%ScmConnection{} = conn, url) do
     impl = dispatcher(conn)
-    impl.files(conn, map)
+    impl.files(conn, url)
   end
 
   defp external_git(%PrAutomation{repository: %GitRepository{} = git, creates: %{git: %{ref: _, folder: _} = ref}}) do

--- a/lib/console/deployments/pr/file.ex
+++ b/lib/console/deployments/pr/file.ex
@@ -3,7 +3,7 @@ defmodule Console.Deployments.Pr.File do
 
   @type t :: %__MODULE__{sha: binary, contents: binary, filename: binary, patch: binary}
 
-  defstruct [:url, :repo, :title, :sha, :contents, :filename, :patch, :base, :head]
+  defstruct [:url, :repo, :title, :sha, :contents, :filename, :patch, :base, :head, :flow_id]
 
   def new(args) do
     %__MODULE__{

--- a/test/console/ai/cron_test.exs
+++ b/test/console/ai/cron_test.exs
@@ -325,11 +325,14 @@ defmodule Console.AI.CronTest do
           },
         }
       )
+      %{id: flow_id} = flow = insert(:flow)
+      svc = insert(:service, flow: flow)
+
       expect(Console.AI.OpenAI, :completion, 2, fn _, _ -> {:ok, "openai completion"} end)
       expect(Console.AI.OpenAI, :tool_call, fn _, _, _ ->
         {:ok, [%Console.AI.Tool{name: "vector", arguments: %{required: true, query: "some query"}}]}
       end)
-      expect(Console.AI.VectorStore, :fetch, fn "some query" -> {:ok, [
+      expect(Console.AI.VectorStore, :fetch, fn "some query", filters: [flow_id: ^flow_id] -> {:ok, [
         %Console.AI.VectorStore.Response{
           type: :pr,
           pr_file: %Console.Deployments.Pr.File{
@@ -343,7 +346,7 @@ defmodule Console.AI.CronTest do
           }
         }
       ]} end)
-      svc = insert(:service)
+
       alert = insert(:alert, state: :firing, service: svc)
 
       log_document(svc, "error what is happening") |> index_doc()


### PR DESCRIPTION
This should improve the overall data governance around this feature, since indexing by flow limits the search scope to just prs that are chosen to be viewable from the given service

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
