### PR TITLE
fix chat evidence bugs

### DIFF
--- a/assets/eslint.config.mjs
+++ b/assets/eslint.config.mjs
@@ -3,6 +3,7 @@ import importPlugin from 'eslint-plugin-import'
 import prettier from 'eslint-plugin-prettier/recommended'
 import react from 'eslint-plugin-react'
 import reactHooksPlugin from 'eslint-plugin-react-hooks'
+import reactCompiler from 'eslint-plugin-react-compiler'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
@@ -31,6 +32,7 @@ export default [
     plugins: {
       react,
       'react-hooks': fixupPluginRules(reactHooksPlugin),
+      'react-compiler': reactCompiler,
     },
 
     settings: {
@@ -80,6 +82,8 @@ export default [
       'react/prop-types': 'off',
       'react/display-name': 'off',
       'react/jsx-key': 'off',
+      // React Compiler
+      'react-compiler/react-compiler': 'warn',
 
       // Prettier
       'prettier/prettier': 'error',

--- a/assets/package.json
+++ b/assets/package.json
@@ -156,6 +156,7 @@
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-prettier": "5.2.3",
     "eslint-plugin-react": "7.37.4",
+    "eslint-plugin-react-compiler": "beta",
     "eslint-plugin-react-hooks": "4.6.2",
     "globals": "15.10.0",
     "husky": "8.0.3",

--- a/assets/src/components/ai/chatbot/ChatbotPanelEvidence.tsx
+++ b/assets/src/components/ai/chatbot/ChatbotPanelEvidence.tsx
@@ -8,8 +8,10 @@ import { PrLinkoutCard } from './ChatMessage'
 
 export function ChatbotPanelEvidence({
   evidence,
+  headerText = 'This chat was created from an insight based on the evidence below:',
 }: {
   evidence: AiInsightEvidenceFragment[]
+  headerText?: string
 }) {
   const { logEvidence, prEvidence } = aggregateInsightEvidence(evidence)
   return (
@@ -19,7 +21,7 @@ export function ChatbotPanelEvidence({
         css={{ fontStyle: 'italic' }}
         $color="text-light"
       >
-        This chat was created from an insight based on the evidence below:
+        {headerText}
       </Body1P>
       <Flex
         direction="column"

--- a/assets/src/components/ai/chatbot/ChatbotPanelInsight.tsx
+++ b/assets/src/components/ai/chatbot/ChatbotPanelInsight.tsx
@@ -1,6 +1,9 @@
-import { AiInsightFragment, AiRole } from 'generated/graphql'
+import { AiInsightFragment, AiRole, EvidenceType } from 'generated/graphql'
 import { ChatbotMessagesWrapper } from './ChatbotPanelThread.tsx'
 import { ChatMessage } from './ChatMessage'
+import { ChatbotPanelEvidence } from './ChatbotPanelEvidence.tsx'
+import { isNonNullable } from 'utils/isNonNullable.ts'
+import { isEmpty } from 'lodash'
 
 export function ChatbotPanelInsight({
   currentInsight,
@@ -9,6 +12,10 @@ export function ChatbotPanelInsight({
   currentInsight: AiInsightFragment
   fullscreen: boolean
 }) {
+  const evidence = currentInsight?.evidence
+    ?.filter(isNonNullable)
+    .filter(({ type }) => type === EvidenceType.Log || type === EvidenceType.Pr) // will change when we support alert evidence
+
   return (
     <ChatbotMessagesWrapper fullscreen={fullscreen}>
       <ChatMessage
@@ -17,6 +24,12 @@ export function ChatbotPanelInsight({
         content={currentInsight.text ?? ''}
         disableActions={true}
       />
+      {!isEmpty(evidence) && (
+        <ChatbotPanelEvidence
+          headerText="This insight was created based on the evidence below:"
+          evidence={evidence ?? []}
+        />
+      )}
     </ChatbotMessagesWrapper>
   )
 }

--- a/assets/src/components/ai/insights/LogsEvidencePanel.tsx
+++ b/assets/src/components/ai/insights/LogsEvidencePanel.tsx
@@ -55,13 +55,9 @@ export function LogsEvidencePanel({
       ) : (
         logs.map((log, i) => (
           <WrapWithIf
+            key={i}
             condition={!isTable}
-            wrapper={
-              <Card
-                clickable
-                key={i}
-              />
-            }
+            wrapper={<Card clickable />}
           >
             <LogEvidenceLineSC
               key={i}

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -738,7 +738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.0, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.6, @babel/parser@npm:^7.25.4, @babel/parser@npm:^7.26.10, @babel/parser@npm:^7.26.9":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.0, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.6, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.25.4, @babel/parser@npm:^7.26.10, @babel/parser@npm:^7.26.9":
   version: 7.26.10
   resolution: "@babel/parser@npm:7.26.10"
   dependencies:
@@ -832,6 +832,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 1329db17009964bc644484c660eab717cb3ca63ac0ab0f67c651a028d1bc2ead51dc4064caea283e46994f1b7221670a35cbc0b4beb6273f55e915494b5aa0b2
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-private-methods@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/plugin-proposal-private-methods@npm:7.18.6"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": ^7.18.6
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 22d8502ee96bca99ad2c8393e8493e2b8d4507576dd054490fd8201a36824373440106f5b098b6d821b026c7e72b0424ff4aeca69ed5f42e48f029d3a156d5ad
   languageName: node
   linkType: hard
 
@@ -10192,6 +10204,7 @@ __metadata:
     eslint-plugin-import: 2.31.0
     eslint-plugin-prettier: 5.2.3
     eslint-plugin-react: 7.37.4
+    eslint-plugin-react-compiler: beta
     eslint-plugin-react-hooks: 4.6.2
     filesize: 10.1.6
     fuse.js: 6.6.2
@@ -12079,6 +12092,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-react-compiler@npm:beta":
+  version: 19.0.0-beta-bafa41b-20250307
+  resolution: "eslint-plugin-react-compiler@npm:19.0.0-beta-bafa41b-20250307"
+  dependencies:
+    "@babel/core": ^7.24.4
+    "@babel/parser": ^7.24.4
+    "@babel/plugin-proposal-private-methods": ^7.18.6
+    hermes-parser: ^0.25.1
+    zod: ^3.22.4
+    zod-validation-error: ^3.0.3
+  peerDependencies:
+    eslint: ">=7"
+  checksum: 64c3e8ef6979db9637ee20da9cbd0e73656a12e51455a1be96c23acd2e80f2d3fe927ac072456e638755d4f94ca37e5f23ae00250c7d5a2a4176c244d02fc484
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-react-hooks@npm:4.6.0":
   version: 4.6.0
   resolution: "eslint-plugin-react-hooks@npm:4.6.0"
@@ -13633,6 +13662,22 @@ __metadata:
     capital-case: ^1.0.4
     tslib: ^2.0.3
   checksum: 571c83eeb25e8130d172218712f807c0b96d62b020981400bccc1503a7cf14b09b8b10498a962d2739eccf231d950e3848ba7d420b58a6acd2f9283439546cd9
+  languageName: node
+  linkType: hard
+
+"hermes-estree@npm:0.25.1":
+  version: 0.25.1
+  resolution: "hermes-estree@npm:0.25.1"
+  checksum: 97f42e9178dff61db017810b4f79f5a2cdbb3cde94b7d99ba84ed632ee2adfcae2244555587951b3151fc036676c68f48f57fbe2b49e253eb1f3f904d284a8b0
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:^0.25.1":
+  version: 0.25.1
+  resolution: "hermes-parser@npm:0.25.1"
+  dependencies:
+    hermes-estree: 0.25.1
+  checksum: 4edcfaa3030931343b540182b83c432aba4cdcb1925952521ab4cfb7ab90c2c1543dfcb042ccd51d5e81e4bfe2809420e85902c2ff95ef7c6c64644ce17138ea
   languageName: node
   linkType: hard
 
@@ -22221,6 +22266,22 @@ __metadata:
   version: 0.8.15
   resolution: "zen-observable@npm:0.8.15"
   checksum: b7289084bc1fc74a559b7259faa23d3214b14b538a8843d2b001a35e27147833f4107590b1b44bf5bc7f6dfe6f488660d3a3725f268e09b3925b3476153b7821
+  languageName: node
+  linkType: hard
+
+"zod-validation-error@npm:^3.0.3":
+  version: 3.4.0
+  resolution: "zod-validation-error@npm:3.4.0"
+  peerDependencies:
+    zod: ^3.18.0
+  checksum: b07fbfc39582dbdf6972f5f5f0c3bac9e6b5e6d2e55ef3dd891fd08f1966ebf1023a4bc270e9b569eaa48ed1684ac2252c9f260b0bd07b167671596e6e4d0fa8
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.4":
+  version: 3.24.2
+  resolution: "zod@npm:3.24.2"
+  checksum: c02455c09678c5055c636d64f9fcda2424fea0aa46ac7d9681e7f41990bc55f488bcd84b9d7cfef0f6e906f51f55b245239d92a9f726248aa74c5b84edf00c2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
only shows evidence info below the original insight in the chat
fixes bug that was showing the evidence header in chat even with empty evidence array

also adds eslint warnings so we can start improving react compiler compatibility