### PR TITLE
provider impl

### DIFF
--- a/test/console/ai/pubsub/vector/consumer_test.exs
+++ b/test/console/ai/pubsub/vector/consumer_test.exs
@@ -6,7 +6,7 @@ defmodule Console.AI.PubSub.Vector.ConsumerTest do
   import ElasticsearchUtils
 
   describe "PullRequestCreated" do
-    test "it can vector index pr files" do
+    test "it can vector index pr files from github" do
       deployment_settings(ai: %{
         enabled: true,
         vector_store: %{
@@ -49,7 +49,153 @@ defmodule Console.AI.PubSub.Vector.ConsumerTest do
       settings = Console.Deployments.Settings.fetch_consistent()
       assert settings.ai.vector_store.initialized
     end
+
+    test "it can vector index pr files from gitlab" do
+      deployment_settings(ai: %{
+        enabled: true,
+        vector_store: %{
+          enabled: true,
+          store: :elastic,
+          elastic: es_vector_settings(),
+          initialized: false,
+        },
+        provider: :openai,
+        openai: %{access_token: "key"}
+      })
+      drop_index(vector_index())
+
+      insert(:scm_connection, default: true, type: :gitlab)
+      flow = insert(:flow)
+      mr = insert(:pull_request, flow: flow, status: :merged, url: "https://gitlab.com/owner/repo/-/merge_requests/1")
+
+      # Mock OpenAI embeddings call
+      expect(Console.AI.OpenAI, :embeddings, fn _, text -> {:ok, [{text, vector()}]} end)
+
+      # Mock the api to get MR changes
+      expect(HTTPoison, :get, fn "https://gitlab.com/api/v4/projects/owner%2Frepo/merge_requests/1/changes", _ ->
+        {:ok, %HTTPoison.Response{
+          status_code: 200,
+          body: Jason.encode!(%{
+            "sha" => "sha",
+            "title" => "Test MR",
+            "target_branch" => "main",
+            "source_branch" => "feature",
+            "changes" => [%{
+              "new_path" => "terraform/main.tf",
+              "old_path" => "terraform/main.tf",
+              "diff" => "example diff"
+            }]
+          })
+        }}
+      end)
+
+      # Mock the api to get the file content
+      expect(HTTPoison, :get, fn "https://gitlab.com/api/v4/projects/owner%2Frepo/repository/files/terraform%2Fmain.tf?ref=sha", _ ->
+        {:ok, %HTTPoison.Response{
+          status_code: 200,
+          body: Jason.encode!(%{
+            "content" => Base.encode64("terraform content")
+          })
+        }}
+      end)
+
+      event = %PubSub.PullRequestCreated{item: mr}
+      Consumer.handle_event(event)
+      refresh(vector_index())
+
+      {:ok, c} = count_index(vector_index())
+      assert c > 0
+
+      settings = Console.Deployments.Settings.fetch_consistent()
+      assert settings.ai.vector_store.initialized
+    end
+
+    test "it can vector index pr files from bitbucket" do
+      deployment_settings(ai: %{
+        enabled: true,
+        vector_store: %{
+          enabled: true,
+          store: :elastic,
+          elastic: es_vector_settings(),
+        },
+        provider: :openai,
+        openai: %{access_token: "key"}
+      })
+      drop_index(vector_index())
+
+      insert(:scm_connection, default: true, type: :bitbucket)
+      flow = insert(:flow)
+      pr = insert(:pull_request, flow: flow, status: :merged, url: "https://bitbucket.org/workspace/repo/pull-requests/1")
+
+      expect(Console.AI.OpenAI, :embeddings, fn _, text -> {:ok, [{text, vector()}]} end)
+
+      # Mock the API to get the PR info
+      expect(HTTPoison, :get, fn "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/1", _ ->
+        {:ok, %HTTPoison.Response{
+          status_code: 200,
+          body: Jason.encode!(%{
+            "links" => %{
+              # In bitbucket API, the diff and diffstat URLs are part of the PR info response
+              "diff" => %{"href" => "https://api.bitbucket.org/2.0/diff_url"},
+              "diffstat" => %{"href" => "https://api.bitbucket.org/2.0/diffstat_url"}
+            },
+            "title" => "Test PR",
+            "source" => %{
+              "repository" => %{"full_name" => "workspace/repo"},
+              "commit" => %{"hash" => "sha"},
+              "branch" => %{"name" => "feature"}
+            },
+            "destination" => %{
+              "branch" => %{"name" => "main"}
+            }
+          })
+        }}
+      end)
+
+      # See above mock, the basic PR info api provides an URL to get the diff
+      expect(HTTPoison, :get, fn "https://api.bitbucket.org/2.0/diff_url", _ ->
+        {:ok, %HTTPoison.Response{
+          status_code: 200,
+          body: "diff --git a\nsamplediff"
+        }}
+      end)
+
+      # See above mock, the basic PR info api provides an URL to get the diffstat
+      # The diffstat API has a list of all modified files in the PR
+      expect(HTTPoison, :get, fn "https://api.bitbucket.org/2.0/diffstat_url", _ ->
+        {:ok, %HTTPoison.Response{
+          status_code: 200,
+          body: Jason.encode!(%{
+            "values" => [%{
+              "new" => %{
+                "escaped_path" => "terraform/main.tf",
+                "links" => %{"self" => %{"href" => "https://api.bitbucket.org/2.0/raw_url"}}
+              }
+            }]
+          })
+        }}
+      end)
+
+      # Mock the call to get the full file contents
+      expect(HTTPoison, :get, fn "https://api.bitbucket.org/2.0/raw_url", _ ->
+        {:ok, %HTTPoison.Response{
+          status_code: 200,
+          body: "terraform content"
+        }}
+      end)
+
+      event = %PubSub.PullRequestCreated{item: pr}
+      Consumer.handle_event(event)
+      refresh(vector_index())
+
+      {:ok, c} = count_index(vector_index())
+      assert c > 0
+
+      settings = Console.Deployments.Settings.fetch_consistent()
+      assert settings.ai.vector_store.initialized
+    end
   end
+
 
   describe "AlertResolutionCreated" do
     test "it can vector index alerts" do


### PR DESCRIPTION
Implement files function in gitlab and bitbucket providers such that they provide files in the same format as the github provider.

## Test Plan
- Unit tests added in the `consumer_test.exs` test file for the gitlab and bitbucket providers
    - `mix test test/console/ai/pubsub/vector/consumer_test.exs`
- Not included in the PR, but sandbox tested using mix tasks (i.e. essentially copy over the implementation code for the `files` function into a mix task and then run it with the URL of an actual PR)

## Checklist

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
