### PR TITLE
Enable Hydra integration

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -2043,6 +2043,12 @@ export enum Conjunction {
   Or = 'OR'
 }
 
+export type ConsentRequest = {
+  __typename?: 'ConsentRequest';
+  requestedScope?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  skip?: Maybe<Scalars['Boolean']['output']>;
+};
+
 export type ConsoleConfiguration = {
   __typename?: 'ConsoleConfiguration';
   byok?: Maybe<Scalars['Boolean']['output']>;
@@ -3545,6 +3551,12 @@ export type LoginInfo = {
   oidcUri?: Maybe<Scalars['String']['output']>;
 };
 
+export type LoginRequest = {
+  __typename?: 'LoginRequest';
+  requestedScope?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  subject?: Maybe<Scalars['String']['output']>;
+};
+
 export type LogsEvidence = {
   __typename?: 'LogsEvidence';
   clusterId?: Maybe<Scalars['ID']['output']>;
@@ -4099,6 +4111,11 @@ export enum NotificationStatus {
   Resolved = 'RESOLVED'
 }
 
+export type OauthResponse = {
+  __typename?: 'OauthResponse';
+  redirectTo: Scalars['String']['output'];
+};
+
 export type ObjectReference = {
   __typename?: 'ObjectReference';
   name?: Maybe<Scalars['String']['output']>;
@@ -4461,6 +4478,8 @@ export type OidcProvider = {
 /** Configuration settings for creating a new OIDC provider client */
 export type OidcProviderAttributes = {
   authMethod?: InputMaybe<OidcAuthMethod>;
+  /** users and groups able to utilize this provider */
+  bindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
   description?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
   /** the redirect uris oidc is whitelisted to use */
@@ -4469,8 +4488,15 @@ export type OidcProviderAttributes = {
 
 /** Supported OIDC-compatible Auth Providers */
 export enum OidcProviderType {
+  Console = 'CONSOLE',
   Plural = 'PLURAL'
 }
+
+export type OidcStepResponse = {
+  __typename?: 'OidcStepResponse';
+  consent?: Maybe<ConsentRequest>;
+  login?: Maybe<LoginRequest>;
+};
 
 export type OllamaAttributes = {
   /** An http authorization header to use on calls to the Ollama api */
@@ -5817,6 +5843,7 @@ export type RollingUpdate = {
 
 export type RootMutationType = {
   __typename?: 'RootMutationType';
+  acceptLogin?: Maybe<OauthResponse>;
   /** it will add additional context to the given chat from a source object */
   addChatContext?: Maybe<Array<Maybe<Chat>>>;
   addClusterAuditLog?: Maybe<Scalars['Boolean']['output']>;
@@ -5953,6 +5980,7 @@ export type RootMutationType = {
   /** merges configuration for a service */
   mergeService?: Maybe<ServiceDeployment>;
   oauthCallback?: Maybe<User>;
+  oauthConsent?: Maybe<OauthResponse>;
   /** Creates a custom run, with the given command list, to execute w/in the stack's environment */
   onDemandRun?: Maybe<StackRun>;
   /** a regular status ping to be sent by the deploy operator */
@@ -6035,6 +6063,11 @@ export type RootMutationType = {
   upsertUser?: Maybe<User>;
   upsertVirtualCluster?: Maybe<Cluster>;
   upsertVulnerabilities?: Maybe<Scalars['Int']['output']>;
+};
+
+
+export type RootMutationTypeAcceptLoginArgs = {
+  challenge: Scalars['String']['input'];
 };
 
 
@@ -6651,6 +6684,12 @@ export type RootMutationTypeOauthCallbackArgs = {
 };
 
 
+export type RootMutationTypeOauthConsentArgs = {
+  challenge: Scalars['String']['input'];
+  scopes?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
 export type RootMutationTypeOnDemandRunArgs = {
   commands?: InputMaybe<Array<InputMaybe<CommandAttributes>>>;
   context?: InputMaybe<Scalars['Json']['input']>;
@@ -7158,6 +7197,8 @@ export type RootQueryType = {
   observabilityWebhooks?: Maybe<ObservabilityWebhookConnection>;
   observer?: Maybe<Observer>;
   observers?: Maybe<ObserverConnection>;
+  oidcConsent?: Maybe<OidcStepResponse>;
+  oidcLogin?: Maybe<OidcStepResponse>;
   pagedClusterGates?: Maybe<PipelineGateConnection>;
   pagedClusterServices?: Maybe<ServiceDeploymentConnection>;
   persona?: Maybe<Persona>;
@@ -7857,6 +7898,16 @@ export type RootQueryTypeObserversArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   projectId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type RootQueryTypeOidcConsentArgs = {
+  challenge: Scalars['String']['input'];
+};
+
+
+export type RootQueryTypeOidcLoginArgs = {
+  challenge: Scalars['String']['input'];
 };
 
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -166,4 +166,8 @@ config :console, :ttls,
   helm: :timer.minutes(30),
   cluster_metrics: :timer.hours(6)
 
+config :core, Console.Services.OIDC.Hydra,
+  hydra_admin: "http://plural-hydra-admin:4445/admin",
+  hydra_public: "http://plural-hydra-public:4444"
+
 import_config "#{Mix.env()}.exs"

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -1637,6 +1637,11 @@ type ConfigurationValidationAttributes struct {
 	UniqBy *UniqByAttributes `json:"uniqBy,omitempty"`
 }
 
+type ConsentRequest struct {
+	RequestedScope []*string `json:"requestedScope,omitempty"`
+	Skip           *bool     `json:"skip,omitempty"`
+}
+
 type ConsoleConfiguration struct {
 	GitCommit      *string `json:"gitCommit,omitempty"`
 	ConsoleVersion *string `json:"consoleVersion,omitempty"`
@@ -2893,6 +2898,11 @@ type LoginInfo struct {
 	OidcName *string `json:"oidcName,omitempty"`
 }
 
+type LoginRequest struct {
+	RequestedScope []*string `json:"requestedScope,omitempty"`
+	Subject        *string   `json:"subject,omitempty"`
+}
+
 type LogsEvidence struct {
 	ServiceID *string    `json:"serviceId,omitempty"`
 	ClusterID *string    `json:"clusterId,omitempty"`
@@ -3367,6 +3377,10 @@ type NotificationSinkEdge struct {
 	Cursor *string           `json:"cursor,omitempty"`
 }
 
+type OauthResponse struct {
+	RedirectTo string `json:"redirectTo"`
+}
+
 type ObjectReference struct {
 	Name      *string `json:"name,omitempty"`
 	Namespace *string `json:"namespace,omitempty"`
@@ -3664,8 +3678,15 @@ type OidcProviderAttributes struct {
 	Name        string          `json:"name"`
 	AuthMethod  *OidcAuthMethod `json:"authMethod,omitempty"`
 	Description *string         `json:"description,omitempty"`
+	// users and groups able to utilize this provider
+	Bindings []*PolicyBindingAttributes `json:"bindings,omitempty"`
 	// the redirect uris oidc is whitelisted to use
 	RedirectUris []*string `json:"redirectUris,omitempty"`
+}
+
+type OidcStepResponse struct {
+	Login   *LoginRequest   `json:"login,omitempty"`
+	Consent *ConsentRequest `json:"consent,omitempty"`
 }
 
 type OllamaAttributes struct {
@@ -7958,16 +7979,18 @@ func (e OidcAuthMethod) MarshalGQL(w io.Writer) {
 type OidcProviderType string
 
 const (
-	OidcProviderTypePlural OidcProviderType = "PLURAL"
+	OidcProviderTypePlural  OidcProviderType = "PLURAL"
+	OidcProviderTypeConsole OidcProviderType = "CONSOLE"
 )
 
 var AllOidcProviderType = []OidcProviderType{
 	OidcProviderTypePlural,
+	OidcProviderTypeConsole,
 }
 
 func (e OidcProviderType) IsValid() bool {
 	switch e {
-	case OidcProviderTypePlural:
+	case OidcProviderTypePlural, OidcProviderTypeConsole:
 		return true
 	}
 	return false

--- a/lib/console/cost/pr.ex
+++ b/lib/console/cost/pr.ex
@@ -26,9 +26,9 @@ defmodule Console.Cost.Pr do
     end
   end
 
-  def create(id, %User{} = user) when is_binary(id) do
+  def suggestion(id, %User{} = user) when is_binary(id) do
     Repo.get!(ClusterScalingRecommendation, id)
-    |> create(user)
+    |> suggestion(user)
   end
 
   @doc """

--- a/lib/console/graphql.ex
+++ b/lib/console/graphql.ex
@@ -26,6 +26,7 @@ defmodule Console.GraphQl do
   import_types Console.GraphQl.Plural
   import_types Console.GraphQl.AI
   import_types Console.GraphQl.Deployments
+  import_types Console.GraphQl.OIDC
 
   @sources [
     AI,
@@ -67,6 +68,7 @@ defmodule Console.GraphQl do
     import_fields :plural_queries
     import_fields :deployment_queries
     import_fields :ai_queries
+    import_fields :oidc_queries
   end
 
   mutation do
@@ -74,6 +76,7 @@ defmodule Console.GraphQl do
     import_fields :kubernetes_mutations
     import_fields :deployment_mutations
     import_fields :ai_mutations
+    import_fields :oidc_mutations
   end
 
   subscription do

--- a/lib/console/graphql/deployments/oauth.ex
+++ b/lib/console/graphql/deployments/oauth.ex
@@ -5,6 +5,7 @@ defmodule Console.GraphQl.Deployments.OAuth do
   @desc "Supported OIDC-compatible Auth Providers"
   enum :oidc_provider_type do
     value :plural
+    value :console
   end
 
   @desc "Supported methods for fetching an OIDC auth token"
@@ -18,6 +19,8 @@ defmodule Console.GraphQl.Deployments.OAuth do
     field :name,          non_null(:string)
     field :auth_method,   :oidc_auth_method
     field :description,   :string
+    field :bindings,      list_of(:policy_binding_attributes),
+      description: "users and groups able to utilize this provider"
     field :redirect_uris, list_of(:string), description: "the redirect uris oidc is whitelisted to use"
   end
 

--- a/lib/console/graphql/oidc.ex
+++ b/lib/console/graphql/oidc.ex
@@ -1,0 +1,54 @@
+defmodule Console.GraphQl.OIDC do
+  use Console.GraphQl.Schema.Base
+  alias Console.GraphQl.Resolvers.OAuth
+
+  object :oauth_response do
+    field :redirect_to, non_null(:string)
+  end
+
+  object :consent_request do
+    field :requested_scope, list_of(:string)
+    field :skip,            :boolean
+  end
+
+  object :login_request do
+    field :requested_scope, list_of(:string)
+    field :subject,         :string
+  end
+
+  object :oidc_step_response do
+    field :login,      :login_request
+    field :consent,    :consent_request
+  end
+
+  object :oidc_queries do
+    field :oidc_login, :oidc_step_response do
+      arg :challenge, non_null(:string)
+
+      resolve &OAuth.resolve_oidc_login/2
+    end
+
+    field :oidc_consent, :oidc_step_response do
+      arg :challenge, non_null(:string)
+
+      resolve &OAuth.resolve_oidc_consent/2
+    end
+  end
+
+  object :oidc_mutations do
+    field :accept_login, :oauth_response do
+      middleware Authenticated
+      arg :challenge, non_null(:string)
+
+      safe_resolve &OAuth.accept_login/2
+    end
+
+    field :oauth_consent, :oauth_response do
+      middleware Authenticated
+      arg :challenge, non_null(:string)
+      arg :scopes, list_of(:string)
+
+      safe_resolve &OAuth.accept_consent/2
+    end
+  end
+end

--- a/lib/console/graphql/resolvers/oauth.ex
+++ b/lib/console/graphql/resolvers/oauth.ex
@@ -1,0 +1,30 @@
+defmodule Console.GraphQl.Resolvers.OAuth do
+  use Console.GraphQl.Resolvers.Base, model: Console.Schema.OIDCProvider
+  alias Console.Schema.{OIDCProvider}
+  alias Console.Services.OIDC
+
+  def list_oidc_providers(args, _) do
+    OIDCProvider.ordered()
+    |> paginate(args)
+  end
+
+  def resolve_oidc_login(%{challenge: challenge}, _) do
+    OIDC.get_login(challenge)
+    |> oidc_response(:v2)
+  end
+
+  def resolve_oidc_consent(%{challenge: challenge}, _) do
+    OIDC.get_consent(challenge)
+    |> oidc_response(:v2)
+  end
+
+  def accept_login(%{challenge: challenge}, %{context: %{current_user: user}}),
+    do: OIDC.handle_login(challenge, user)
+
+  def accept_consent(%{challenge: challenge, scopes: scopes}, %{context: %{current_user: user}}),
+    do: OIDC.consent(challenge, scopes, user)
+
+  defp oidc_response({:ok, provider}, :v2),
+    do: {:ok, Map.take(provider, [:login, :consent])}
+  defp oidc_response(error, _), do: error
+end

--- a/lib/console/policies/oidc.ex
+++ b/lib/console/policies/oidc.ex
@@ -1,0 +1,11 @@
+defmodule Console.Policies.OIDC do
+  use Piazza.Policy
+  alias Console.Schema.{User}
+
+  def can?(%User{roles: %{admin: true}}, _, _), do: :pass
+
+  def can?(user, %Ecto.Changeset{} = cs, action),
+    do: can?(user, apply_changes(cs), action)
+
+  def can?(_, _, _), do: {:error, :forbidden}
+end

--- a/lib/console/schema/oidc_provider.ex
+++ b/lib/console/schema/oidc_provider.ex
@@ -1,0 +1,42 @@
+defmodule Console.Schema.OIDCProvider do
+  use Piazza.Ecto.Schema
+  alias Console.Schema.PolicyBinding
+
+  defenum AuthMethod, post: 0, basic: 1
+
+  schema "oidc_providers" do
+    field :name,          :string
+    field :description,   :string
+    field :icon,          :string
+    field :client_id,     :string
+    field :client_secret, :string
+    field :redirect_uris, {:array, :string}
+    field :auth_method,   AuthMethod
+    field :bindings_id,   :binary_id
+
+    field :login,   :map, virtual: true
+    field :consent, :map, virtual: true
+
+    has_many :bindings, PolicyBinding,
+      on_replace:  :delete,
+      foreign_key: :policy_id,
+      references:  :bindings_id
+
+    timestamps()
+  end
+
+  def ordered(query \\ __MODULE__, order \\ [asc: :name]) do
+    from(p in query, order_by: ^order)
+  end
+
+  @valid ~w(name description icon client_id client_secret redirect_uris auth_method)a
+
+  def changeset(model, attrs \\ %{}) do
+    model
+    |> cast(attrs, @valid)
+    |> cast_assoc(:bindings)
+    |> put_new_change(:bindings_id, &Ecto.UUID.generate/0)
+    |> unique_constraint(:client_id)
+    |> validate_required(~w(name client_id client_secret redirect_uris auth_method)a)
+  end
+end

--- a/lib/console/services/oidc.ex
+++ b/lib/console/services/oidc.ex
@@ -1,0 +1,161 @@
+defmodule Console.Services.OIDC do
+  @moduledoc """
+  Business logic for managing API-driven OIDC clients via Ory Hydra, not for managing login
+  to the console itself.
+  """
+  use Console.Services.Base
+  import Console.Policies.OIDC
+  alias Console.Schema.{User, OIDCProvider}
+  alias Console.Services.OIDC.Hydra
+  require Logger
+
+  @type error :: {:error, term}
+  @type oauth_resp :: {:ok, %Hydra.Response{}} | error
+  @type oidc_resp :: {:ok, OidcProvider.t} | error
+
+  @oidc_scopes "profile code openid offline_access offline"
+  @grant_types ~w(authorization_code refresh_token client_credentials)
+
+  def get_provider(id), do: Repo.get(OIDCProvider, id)
+
+  def get_provider!(id), do: Repo.get!(OIDCProvider, id)
+
+  def get_provider_by_client!(client_id) do
+    Repo.get_by!(OIDCProvider, client_id: client_id)
+    |> Repo.preload([:bindings])
+  end
+
+  @doc """
+  Creates a new oidc provider for a given installation, enabling a log-in with plural experience
+  """
+  @spec create_oidc_provider(map, User.t) :: oidc_resp
+  def create_oidc_provider(attrs, %User{} = user) do
+    start_transaction()
+    |> add_operation(:client, fn _ ->
+      Map.take(attrs, [:redirect_uris])
+      |> Map.put(:scope, @oidc_scopes)
+      |> Map.put(:grant_types, @grant_types)
+      |> Map.put(:token_endpoint_auth_method, oidc_auth_method(attrs.auth_method))
+      |> Hydra.create_client()
+    end)
+    |> add_operation(:oidc_provider, fn
+      %{client: %{client_id: cid, client_secret: secret}} ->
+        attrs = Map.merge(attrs, %{
+          client_id: cid,
+          client_secret: secret
+        })
+        %OIDCProvider{}
+        |> OIDCProvider.changeset(attrs)
+        |> allow(user, :create)
+        |> when_ok(:insert)
+    end)
+    |> execute(extract: :oidc_provider)
+  end
+
+  defp oidc_auth_method(:basic), do: "client_secret_basic"
+  defp oidc_auth_method(:post), do: "client_secret_post"
+
+  @doc """
+  Updates the spec of an installation's oidc provider
+  """
+  @spec update_oidc_provider(map, binary, User.t) :: oidc_resp
+  def update_oidc_provider(attrs, id, %User{} = user) do
+    start_transaction()
+    |> add_operation(:oidc, fn _ ->
+      get_provider!(id)
+      |> Repo.preload([:bindings])
+      |> OIDCProvider.changeset(attrs)
+      |> allow(user, :edit)
+      |> when_ok(:update)
+    end)
+    |> add_operation(:client, fn
+      %{oidc: %{client_id: id, auth_method: auth_method}} ->
+        attrs = Map.take(attrs, [:redirect_uris])
+                |> Map.put(:scope, @oidc_scopes)
+                |> Map.put(:token_endpoint_auth_method, oidc_auth_method(auth_method))
+        Hydra.update_client(id, attrs)
+    end)
+    |> execute(extract: :oidc)
+  end
+
+  @doc """
+  Deletes an oidc provider and its hydra counterpart
+  """
+  @spec delete_oidc_provider(binary, User.t) :: oidc_resp
+  def delete_oidc_provider(id, %User{} = user) do
+    start_transaction()
+    |> add_operation(:oidc, fn _ ->
+      get_provider!(id)
+      |> allow(user, :edit)
+      |> when_ok(:delete)
+    end)
+    |> add_operation(:client, fn %{oidc: %{client_id: id}} ->
+      with :ok <- Hydra.delete_client(id),
+        do: {:ok, nil}
+    end)
+    |> execute(extract: :oidc)
+  end
+
+  @doc """
+  Gets the data related to a specific login
+  """
+  @spec get_login(binary) :: {:ok, OIDCProvider.t} | error
+  def get_login(challenge) do
+    with {:ok, %{client: client} = login} <- Hydra.get_login(challenge),
+         provider <- get_provider_by_client!(client.client_id) do
+      {:ok, %{provider | login: login}}
+    end
+  end
+
+  @doc """
+  Get the data related to a consent screen
+  """
+  @spec get_consent(binary) :: {:ok, OIDCProvider.t} | error
+  def get_consent(challenge) do
+    with {:ok, %{client: client} = consent} <- Hydra.get_consent(challenge),
+         provider <- get_provider_by_client!(client.client_id) do
+      {:ok, %{provider | consent: consent}}
+    end
+  end
+
+  @doc """
+  Determines if a user is eligible to login, and either accepts or rejects the login
+  request appropriately.
+  """
+  @spec handle_login(binary, User.t) :: oauth_resp
+  def handle_login(challenge, %User{} = user) do
+    user = Console.Services.Rbac.preload(user)
+           |> Console.Repo.preload([:groups])
+    with {:ok, provider} <- get_login(challenge),
+         true <- eligible?(provider, user) do
+      Hydra.accept_login(challenge, user)
+    else
+      false -> Hydra.reject_login(challenge)
+      error -> error
+    end
+  end
+
+  @doc """
+  Consents to the scopes granted in the login exchanges and hydrates an id token
+  """
+  @spec consent(binary, [binary], User.t) :: oauth_resp
+  def consent(challenge, scopes \\ ["profile", "offline_access", "offline"], %User{} = user) do
+    user = Console.Repo.preload(user, [:groups])
+    with {:ok, _} <- get_consent(challenge),
+      do: Hydra.accept_consent(user, challenge, scopes)
+  end
+
+  @doc """
+  Determines if a user can use this provider to log in, based on its configured policy
+  """
+  @spec eligible?(OIDCProvider.t, User.t) :: boolean
+  def eligible?(%OIDCProvider{bindings: bindings}, %User{} = user) do
+    group_ids = Enum.filter(bindings, & &1.group_id)
+                |> Enum.map(& &1.group_id)
+                |> MapSet.new()
+    user_groups = Enum.map(user.groups, & &1.id) |> MapSet.new()
+
+    with false <- Enum.any?(bindings, & &1.user_id == user.id),
+      do: !MapSet.disjoint?(user_groups, group_ids)
+  end
+end

--- a/lib/console/services/oidc/hydra.ex
+++ b/lib/console/services/oidc/hydra.ex
@@ -1,0 +1,162 @@
+defmodule Console.Services.OIDC.Hydra do
+  require Logger
+  alias Console.Schema.{User}
+
+  defmodule Response, do: defstruct [:redirect_to]
+  defmodule Client do
+    defstruct [
+      :client_id,
+      :client_secret,
+      :client_uri,
+      :redirect_uris,
+      :client_name,
+      :logo_uri
+    ]
+  end
+
+  defmodule LoginRequest do
+    defstruct [
+      :client,
+      :oidc_context,
+      :requested_scope,
+      :subject
+    ]
+  end
+
+  defmodule ConsentRequest do
+    defstruct [
+      :client,
+      :oidc_context,
+      :requested_scope,
+      :subject,
+      :skip
+    ]
+  end
+
+  defmodule Configuration do
+    defstruct [
+      :issuer,
+      :authorization_endpoint,
+      :token_endpoint,
+      :jwks_uri,
+      :userinfo_endpoint
+    ]
+  end
+
+
+  def get_configuration() do
+    public_url("/.well-known/openid-configuration")
+    |> HTTPoison.get(headers())
+    |> handle_response(%Configuration{})
+  end
+
+  def get_client(id) do
+    admin_url("/clients/#{id}")
+    |> HTTPoison.get(headers())
+    |> handle_response(%Client{})
+  end
+
+  def create_client(attrs) do
+    admin_url("/clients")
+    |> HTTPoison.post(Jason.encode!(attrs), headers())
+    |> handle_response(%Client{})
+  end
+
+  def update_client(client_id, attrs) do
+    admin_url("/clients/#{client_id}")
+    |> HTTPoison.put(Jason.encode!(attrs), headers())
+    |> handle_response(%Client{})
+  end
+
+  def delete_client(client_id) do
+    admin_url("/clients/#{client_id}")
+    |> HTTPoison.delete(headers())
+    |> case do
+      {:ok, %{status_code: 204}} -> :ok
+      error ->
+        Logger.error "Failed to delete hydra client: #{inspect(error)}"
+        {:error, :unauthorized}
+    end
+  end
+
+  def get_login(challenge) do
+    admin_url("/oauth2/auth/requests/login?login_challenge=#{challenge}")
+    |> HTTPoison.get(headers())
+    |> handle_response(%LoginRequest{client: %Client{}})
+  end
+
+  def accept_login(challenge, user) do
+    body = Jason.encode!(%{subject: user.id, remember: false})
+    admin_url("/oauth2/auth/requests/login/accept?login_challenge=#{challenge}")
+    |> HTTPoison.put(body, headers())
+    |> handle_response(%Response{})
+  end
+
+  def reject_login(challenge) do
+    admin_url("/oauth2/auth/requests/login/reject?login_challenge=#{challenge}")
+    |> HTTPoison.put("{}", headers())
+    |> handle_response(%Response{})
+  end
+
+  def get_consent(challenge) do
+    admin_url("/oauth2/auth/requests/consent?consent_challenge=#{challenge}")
+    |> HTTPoison.get(headers())
+    |> handle_response(%ConsentRequest{client: %Client{}})
+  end
+
+  def accept_consent(user, challenge, scopes) do
+    body = Jason.encode!(%{
+      grant_scope: scopes,
+      remember: false,
+      session: %{
+        id_token: user_details(user),
+        access_token: user_details(user)
+      }
+    })
+    admin_url("/oauth2/auth/requests/consent/accept?consent_challenge=#{challenge}")
+    |> HTTPoison.put(body, headers())
+    |> handle_response(%Response{})
+  end
+
+  def reject_consent(challenge) do
+    admin_url("/oauth2/auth/requests/consent/accept?consent_challenge=#{challenge}")
+    |> HTTPoison.put("{}", headers())
+    |> handle_response(%Response{})
+  end
+
+  defp handle_response({:ok, %{status_code: code, body: body}}, type) when code in 200..299,
+    do: {:ok, Poison.decode!(body, as: type)}
+  defp handle_response(error, _) do
+    Logger.error "Failed to call hydra: #{inspect(error)}"
+    {:error, hydra_error(error)}
+  end
+
+  defp user_details(user) do
+    %{
+      groups: user_groups(user),
+      admin: admin?(user),
+      profile: user.profile,
+      name: user.name,
+      email: user.email
+    }
+  end
+
+  defp admin?(%User{roles: %{admin: true}}), do: true
+  defp admin?(_), do: false
+
+  defp user_groups(%User{groups: groups}) when is_list(groups),
+    do: Enum.map(groups, & &1.name)
+  defp user_groups(_), do: []
+
+  defp admin_url(path), do: "#{conf(:hydra_admin)}#{path}"
+
+  defp public_url(path), do: "#{conf(:hydra_public)}#{path}"
+
+  defp conf(key), do: Console.conf(__MODULE__)[key]
+
+  defp hydra_error({:error, _}), do: "internal network error"
+  defp hydra_error({:ok, %HTTPoison.Response{status_code: code, body: body}}),
+    do: "hydra error: code=#{code}, body=#{body}"
+
+  defp headers(), do: [{"accept", "application/json"}, {"content-type", "application/json"}]
+end

--- a/priv/repo/migrations/20250408160809_add_oidc_schemas.exs
+++ b/priv/repo/migrations/20250408160809_add_oidc_schemas.exs
@@ -1,0 +1,22 @@
+defmodule Console.Repo.Migrations.AddOidcSchemas do
+  use Ecto.Migration
+
+  def change do
+    create table(:oidc_providers, primary_key: false) do
+      add :id,                :uuid, primary_key: true
+      add :name,              :string
+      add :description,       :string
+      add :icon,              :string
+      add :client_id,         :string
+      add :client_secret,     :string
+      add :redirect_uris,     {:array, :string}
+      add :auth_method,       :integer
+
+      add :bindings_id,       :uuid
+
+      timestamps()
+    end
+
+    create unique_index(:oidc_providers, [:client_id])
+  end
+end

--- a/rel/runtime.exs
+++ b/rel/runtime.exs
@@ -237,3 +237,9 @@ if is_set("BACKUP_ACCESS_KEY") and is_set("BACKUP_SECRET_ACCESS_KEY") do
     s3_access_key_id: get_env("BACKUP_ACCESS_KEY"),
     s3_secret_access_key: get_env("BACKUP_SECRET_ACCESS_KEY")
 end
+
+if is_set("CONSOLE_HYDRA_ADMIN") and is_set("CONSOLE_HYDRA_PUBLIC") do
+  config :console, Console.Services.OIDC.Hydra,
+    hydra_admin: get_env("CONSOLE_HYDRA_ADMIN"),
+    hydra_public: get_env("CONSOLE_HYDRA_PUBLIC")
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -448,6 +448,10 @@ type RootQueryType {
   aiPins(after: String, first: Int, before: String, last: Int): AiPinConnection
 
   aiPin(insightId: ID, threadId: ID): AiPin
+
+  oidcLogin(challenge: String!): OidcStepResponse
+
+  oidcConsent(challenge: String!): OidcStepResponse
 }
 
 type RootMutationType {
@@ -955,6 +959,10 @@ type RootMutationType {
   deletePin(id: ID!): AiPin
 
   aiFixPr(insightId: ID!, messages: [ChatMessage]): PullRequest
+
+  acceptLogin(challenge: String!): OauthResponse
+
+  oauthConsent(challenge: String!, scopes: [String]): OauthResponse
 }
 
 type RootSubscriptionType {
@@ -978,6 +986,25 @@ type RootSubscriptionType {
     "the id of the scaling recommendation you're streaming a cost PR suggestion for"
     recommendationId: ID
   ): AiDelta
+}
+
+type OauthResponse {
+  redirectTo: String!
+}
+
+type ConsentRequest {
+  requestedScope: [String]
+  skip: Boolean
+}
+
+type LoginRequest {
+  requestedScope: [String]
+  subject: String
+}
+
+type OidcStepResponse {
+  login: LoginRequest
+  consent: ConsentRequest
 }
 
 input PolicyBindingAttributes {
@@ -1177,6 +1204,7 @@ type McpServerAuditConnection {
 "Supported OIDC-compatible Auth Providers"
 enum OidcProviderType {
   PLURAL
+  CONSOLE
 }
 
 "Supported methods for fetching an OIDC auth token"
@@ -1192,6 +1220,9 @@ input OidcProviderAttributes {
   authMethod: OidcAuthMethod
 
   description: String
+
+  "users and groups able to utilize this provider"
+  bindings: [PolicyBindingAttributes]
 
   "the redirect uris oidc is whitelisted to use"
   redirectUris: [String]

--- a/test/console/graphql/mutations/oauth_mutations_test.exs
+++ b/test/console/graphql/mutations/oauth_mutations_test.exs
@@ -1,0 +1,54 @@
+defmodule Console.GraphQl.OAuthMutationsTest do
+  use Console.DataCase, async: true
+  use Mimic
+
+  describe "acceptLogin" do
+    test "it can confirm an oauth login" do
+      %{id: id} = user = insert(:user)
+      provider = insert(:oidc_provider, bindings: [%{user_id: user.id}])
+
+      expect(HTTPoison, :get, fn _, _ ->
+        body = Jason.encode!(%{client: %{client_id: provider.client_id}})
+        {:ok, %{status_code: 200, body: body}}
+      end)
+
+      expect(HTTPoison, :put, fn _, body, _ ->
+        resp = Jason.encode!(%{redirect_to: "example.com"})
+        case Jason.decode!(body) do
+          %{"subject" => ^id} -> {:ok, %{status_code: 200, body: resp}}
+          _ -> {:error, :invalid}
+        end
+      end)
+
+      {:ok, %{data: %{"acceptLogin" => result}}} = run_query("""
+        mutation Accept($challenge: String!) {
+          acceptLogin(challenge: $challenge) { redirectTo }
+        }
+      """, %{"challenge" => "chall"}, %{current_user: user})
+
+      assert result["redirectTo"] == "example.com"
+    end
+  end
+
+  describe "oauthConsent" do
+    test "it can consent to an oauth login" do
+      user = insert(:user)
+      provider = insert(:oidc_provider)
+
+      expect(HTTPoison, :put, fn _, _, _ ->
+        {:ok, %{status_code: 200, body: Jason.encode!(%{redirect_to: "example.com"})}}
+      end)
+      expect(HTTPoison, :get, fn _, _ ->
+        {:ok, %{status_code: 200, body: Jason.encode!(%{client: %{client_id: provider.client_id}})}}
+      end)
+
+      {:ok, %{data: %{"oauthConsent" => result}}} = run_query("""
+        mutation Consent($challenge: String!, $scopes: [String]) {
+          oauthConsent(challenge: $challenge, scopes: $scopes) { redirectTo }
+        }
+      """, %{"challenge" => "chall", "scopes" => ["profile"]}, %{current_user: user})
+
+      assert result["redirectTo"] == "example.com"
+    end
+  end
+end

--- a/test/console/graphql/queries/oauth_queries_test.exs
+++ b/test/console/graphql/queries/oauth_queries_test.exs
@@ -1,0 +1,44 @@
+defmodule Console.GraphQl.OAuthQueriesTest do
+  use Console.DataCase, async: true
+  use Mimic
+
+  describe "oidcLogin" do
+    test "it can fetch an oauth login's details" do
+      provider = insert(:oidc_provider)
+      expect(HTTPoison, :get, fn _, _ ->
+        body = Jason.encode!(%{client: %{client_id: provider.client_id}, requested_scope: ["openid"]})
+        {:ok, %{status_code: 200, body: body}}
+      end)
+
+      {:ok, %{data: %{"oidcLogin" => result}}} = run_query("""
+        query Login($challenge: String!) {
+          oidcLogin(challenge: $challenge) {
+            login { requestedScope }
+          }
+        }
+      """, %{"challenge" => "challenge"})
+
+      assert result["login"]["requestedScope"] == ["openid"]
+    end
+  end
+
+  describe "oidcConsent" do
+    test "it can fetch an oauth login's details" do
+      provider = insert(:oidc_provider)
+      expect(HTTPoison, :get, fn _, _ ->
+        body = Jason.encode!(%{client: %{client_id: provider.client_id}, requested_scope: ["openid"]})
+        {:ok, %{status_code: 200, body: body}}
+      end)
+
+      {:ok, %{data: %{"oidcConsent" => result}}} = run_query("""
+        query Login($challenge: String!) {
+          oidcConsent(challenge: $challenge) {
+            consent { requestedScope }
+          }
+        }
+      """, %{"challenge" => "challenge"})
+
+      assert result["consent"]["requestedScope"] == ["openid"]
+    end
+  end
+end

--- a/test/console/services/oidc_test.exs
+++ b/test/console/services/oidc_test.exs
@@ -1,0 +1,157 @@
+defmodule Console.Services.OIDCTest do
+  use Console.DataCase, async: true
+  alias Console.Services.OIDC
+  use Mimic
+
+  describe "#create_oidc_provider/2" do
+    test "admins can create an oidc provider" do
+      group = insert(:group)
+      expect(HTTPoison, :post, fn _, _, _ ->
+        {:ok, %{status_code: 200, body: Jason.encode!(%{client_id: "123", client_secret: "secret"})}}
+      end)
+      user = insert(:user)
+
+      {:ok, oidc} = OIDC.create_oidc_provider(%{
+        name: "test",
+        redirect_uris: ["https://example.com"],
+        auth_method: :basic,
+        bindings: [%{user_id: user.id}, %{group_id: group.id}]
+      }, admin_user())
+
+      assert oidc.client_id == "123"
+      assert oidc.client_secret == "secret"
+      assert oidc.redirect_uris == ["https://example.com"]
+
+      [first, second] = oidc.bindings
+
+      assert first.user_id == user.id
+      assert second.group_id == group.id
+    end
+  end
+
+  describe "#update_oidc_provider/2" do
+    test "admins can update your own providers" do
+      user = admin_user()
+      oidc = insert(:oidc_provider)
+      expect(HTTPoison, :put, fn _, _, _ ->
+        {:ok, %{status_code: 200, body: Jason.encode!(%{client_id: "123", client_secret: "secret"})}}
+      end)
+
+      {:ok, updated} = OIDC.update_oidc_provider(%{
+        redirect_uris: ["https://example.com"],
+        auth_method: :basic
+      }, oidc.id, user)
+
+      assert updated.id == oidc.id
+      assert updated.auth_method == :basic
+    end
+
+    test "others cannot update your provider" do
+      oidc = insert(:oidc_provider)
+
+      {:error, :forbidden} = OIDC.update_oidc_provider(%{
+        redirect_uris: ["https://example.com"],
+        auth_method: :basic
+      }, oidc.id, insert(:user))
+    end
+  end
+
+  describe "#delete_oidc_provider/2" do
+    test "admins can delete providers" do
+      user = admin_user()
+      oidc = insert(:oidc_provider)
+      expect(HTTPoison, :delete, fn _, _ -> {:ok, %{status_code: 204, body: ""}} end)
+
+      {:ok, deleted} = OIDC.delete_oidc_provider(oidc.id, user)
+
+      assert deleted.id == oidc.id
+      refute refetch(deleted)
+    end
+
+    test "others cannot delete your provider" do
+      oidc = insert(:oidc_provider)
+
+      {:error, :forbidden} = OIDC.delete_oidc_provider(oidc.id, insert(:user))
+    end
+  end
+
+  describe "#get_login/1" do
+    test "It can get information related to an OIDC login" do
+      provider = insert(:oidc_provider)
+      expect(HTTPoison, :get, fn _, _ ->
+        body = Jason.encode!(%{client: %{client_id: provider.client_id}})
+        {:ok, %{status_code: 200, body: body}}
+      end)
+
+      {:ok, result} = OIDC.get_login("challenge")
+
+      assert result.id == provider.id
+    end
+  end
+
+  describe "#handle_login/2" do
+    test "If a user is bound by a provider, they can log in" do
+      %{id: id} = user = insert(:user)
+      provider = insert(:oidc_provider, bindings: [%{user_id: id}])
+
+      expect(HTTPoison, :get, fn _, _ ->
+        body = Jason.encode!(%{client: %{client_id: provider.client_id}})
+        {:ok, %{status_code: 200, body: body}}
+      end)
+
+      expect(HTTPoison, :put, fn _, body, _ ->
+        resp = Jason.encode!(%{redirect_to: "example.com"})
+        case Jason.decode!(body) do
+          %{"subject" => ^id} -> {:ok, %{status_code: 200, body: resp}}
+          _ -> {:error, :invalid}
+        end
+      end)
+
+      {:ok, %{redirect_to: url}} = OIDC.handle_login("challenge", user)
+
+      assert url == "example.com"
+    end
+
+    test "if a user is not bound, the login is rejected" do
+      %{id: id} = user = insert(:user)
+      provider = insert(:oidc_provider)
+
+      expect(HTTPoison, :get, fn _, _ ->
+        body = Jason.encode!(%{client: %{client_id: provider.client_id}})
+        {:ok, %{status_code: 200, body: body}}
+      end)
+
+      expect(HTTPoison, :put, fn _, body, _ ->
+        resp = Jason.encode!(%{redirect_url: "example.com"})
+        case Jason.decode!(body) do
+          %{"subject" => ^id} -> {:error, :invalid}
+          _ -> {:ok, %{status_code: 200, body: resp}}
+        end
+      end)
+
+      {:ok, %{redirect_to: _}} = OIDC.handle_login("challenge", user)
+    end
+  end
+
+  describe "#consent/3" do
+    test "it will accept an OIDC consent request" do
+      me = self()
+      user = insert(:user, roles: %{admin: true})
+      provider = insert(:oidc_provider)
+      expect(HTTPoison, :put, fn _, body, _ ->
+        send(me, {:body, Jason.decode!(body)})
+        {:ok, %{status_code: 200, body: Jason.encode!(%{redirect_to: "example.com"})}}
+      end)
+
+      expect(HTTPoison, :get, fn _, _ ->
+        {:ok, %{status_code: 200, body: Jason.encode!(%{client: %{client_id: provider.client_id}})}}
+      end)
+
+      {:ok, %{redirect_to: _}} = OIDC.consent("challenge", "profile", user)
+
+      assert_receive {:body, %{
+        "session" => %{"id_token" => %{"groups" => _, "name" => _, "profile" => _, "admin" => true}}
+      }}
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -896,6 +896,16 @@ defmodule Console.Factory do
     }
   end
 
+  def oidc_provider_factory do
+    %Schema.OIDCProvider{
+      name: sequence(:oidc_provider, & "oidc-#{&1}"),
+      client_id: sequence(:oidc_provider, & "oidc-client-#{&1}"),
+      client_secret: Ecto.UUID.generate(),
+      redirect_uris: ["https://example.com"],
+      bindings_id: Ecto.UUID.generate(),
+    }
+  end
+
   def setup_rbac(user, repos \\ ["*"], perms) do
     role = insert(:role, repositories: repos, permissions: Map.new(perms))
     insert(:role_binding, role: role, user: user)


### PR DESCRIPTION
This mostly copies in Plural's hydra oidc client integration into the console repo.  This will allow the console itself to be auth providers for a variety of apps which will help enterprise/fully self-hosted usecases.

## Test Plan
unit test


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
