### PR TITLE
Use non root user for server process

### DIFF
--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -302,8 +302,11 @@ gitServer:
     repository: ghcr.io/pluralsh/git-server
     tag: ~
   
-  containerSecurityContext: ~
-  securityContext: ~
+  containerSecurityContext: 
+    runAsNonRoot: true
+  securityContext: 
+    runAsUser: 65543
+    runAsGroup: 65543
   resources: ~
   tag: ~
 

--- a/dockerfiles/Dockerfile.softserve
+++ b/dockerfiles/Dockerfile.softserve
@@ -50,4 +50,9 @@ RUN apk add git
 COPY --from=builder /usr/bin/soft /usr/bin/
 COPY --from=builder /go/data /go/data
 
+RUN addgroup -g 65543 softserve
+RUN adduser -u 65543 -G softserve -D softserve
+RUN chown -R softserve:softserve /go/data
+USER softserve
+
 ENTRYPOINT [ "soft", "serve" ]


### PR DESCRIPTION
Run soft-serve server as non-root (https://linear.app/pluralsh/issue/PROD-3414/git-server-ideally-shouldnt-run-as-root)
Make sure that UID is set for our non-root user so that the value can be set in the console helm chart

## Test Plan
spun up container (docker build and docker run), verified that i could still clone repos from it.

## Checklist

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
