### PR TITLE
feat: add input-based confirmation to CRD delete dialog

### DIFF
--- a/assets/src/components/kubernetes/common/DeleteResource.tsx
+++ b/assets/src/components/kubernetes/common/DeleteResource.tsx
@@ -12,7 +12,7 @@ import { QueryHookOptions } from '@apollo/client/react/types/types'
 import { useTheme } from 'styled-components'
 import { ApolloError, FetchResult, ServerError } from '@apollo/client'
 
-import { Confirm } from '../../utils/Confirm'
+import { Confirm, ConfirmProps } from '../../utils/Confirm'
 import {
   useNamespacedResourceDeleteMutation,
   useResourceDeleteMutation,
@@ -26,11 +26,13 @@ interface DeleteResourceProps {
   refetch?: Nullable<
     (variables?: Partial<QueryHookOptions>) => Promise<unknown> | void
   >
+  customResource?: boolean
 }
 
 export default function DeleteResourceButton({
   resource,
   refetch,
+  customResource = false,
 }: DeleteResourceProps): ReactNode {
   const [open, setOpen] = useState(false)
 
@@ -49,6 +51,11 @@ export default function DeleteResourceButton({
           setOpen={setOpen}
           resource={resource}
           refetch={refetch}
+          confirmationEnabled={
+            customResource ||
+            resource.typeMeta.kind === 'customresourcedefinition'
+          }
+          confirmationText={resource.objectMeta.name}
         />
       )}
     </div>
@@ -84,7 +91,23 @@ function toServerError(data: FetchResult): ServerError {
   } as ServerError
 }
 
-function DeleteResourceModal({ open, setOpen, resource, refetch }): ReactNode {
+interface DeleteResourceModalProps
+  extends Pick<ConfirmProps, 'confirmationEnabled' | 'confirmationText'> {
+  open: boolean
+  setOpen: (open: boolean) => void
+  resource: Resource
+  refetch?: Nullable<
+    (variables?: Partial<QueryHookOptions>) => Promise<unknown> | void
+  >
+}
+
+function DeleteResourceModal({
+  open,
+  setOpen,
+  resource,
+  refetch,
+  ...modalProps
+}: DeleteResourceModalProps): ReactNode {
   const theme = useTheme()
   const [deleting, setDeleting] = useState(false)
   const [deleteNow, setDeleteNow] = useState(false)
@@ -174,6 +197,7 @@ function DeleteResourceModal({ open, setOpen, resource, refetch }): ReactNode {
           </Checkbox>
         </div>
       }
+      {...modalProps}
     />
   )
 }

--- a/assets/src/components/kubernetes/common/DeleteResource.tsx
+++ b/assets/src/components/kubernetes/common/DeleteResource.tsx
@@ -138,11 +138,13 @@ function DeleteResourceModal({
     },
     onError: () => setDeleting(false),
     onCompleted: () =>
-      refetch?.({
-        fetchPolicy: 'no-cache',
-      })
-        .then(() => setOpen(false))
-        .finally(() => setDeleting(false)),
+      refetch
+        ? refetch({
+            fetchPolicy: 'no-cache',
+          })!
+            .then(() => setOpen(false))
+            .finally(() => setDeleting(false))
+        : undefined,
   })
 
   return (

--- a/assets/src/components/kubernetes/common/DeleteResource.tsx
+++ b/assets/src/components/kubernetes/common/DeleteResource.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../../generated/graphql-kubernetes'
 import { KubernetesClient } from '../../../helpers/kubernetes.client'
 
-import { Resource } from './types'
+import { Kind, Resource } from './types'
 
 interface DeleteResourceProps {
   resource: Resource
@@ -53,7 +53,7 @@ export default function DeleteResourceButton({
           refetch={refetch}
           confirmationEnabled={
             customResource ||
-            resource.typeMeta.kind === 'customresourcedefinition'
+            resource.typeMeta.kind === Kind.CustomResourceDefinition
           }
           confirmationText={resource.objectMeta.name}
         />

--- a/assets/src/components/kubernetes/common/ResourceList.tsx
+++ b/assets/src/components/kubernetes/common/ResourceList.tsx
@@ -125,7 +125,7 @@ export function ResourceList<
         isFetchingNextPage={loading}
         reactTableOptions={{
           ...reactTableOptions,
-          ...{ meta: { ...reactTableOptions.meta, refetch } },
+          ...{ meta: { ...reactTableOptions.meta, refetch, customResource } },
         }}
         virtualizeRows
         onRowClick={

--- a/assets/src/components/kubernetes/common/utils.tsx
+++ b/assets/src/components/kubernetes/common/utils.tsx
@@ -100,6 +100,7 @@ export function useDefaultColumns<
           <DeleteResourceButton
             resource={getValue()}
             refetch={table?.options?.meta?.refetch}
+            customResource={table?.options?.meta?.customResource}
           />
         ),
       }),

--- a/assets/src/components/utils/Confirm.tsx
+++ b/assets/src/components/utils/Confirm.tsx
@@ -1,13 +1,13 @@
-import { ReactNode } from 'react'
+import { ReactNode, useState } from 'react'
 import { ApolloError } from '@apollo/client'
-import { Button, Modal } from '@pluralsh/design-system'
+import { Button, FormField, Input, Modal } from '@pluralsh/design-system'
 import { useTheme } from 'styled-components'
 import { GraphQLError } from 'graphql'
 import { GraphQLErrors } from '@apollo/client/errors'
 
 import { GqlError } from './Alert'
 
-type ConfirmProps = {
+export type ConfirmProps = {
   open: boolean
   close: Nullable<(...args: any[]) => unknown>
   title?: ReactNode
@@ -20,6 +20,8 @@ type ConfirmProps = {
   loading?: boolean
   destructive?: boolean
   extraContent?: ReactNode
+  confirmationEnabled?: boolean
+  confirmationText?: Nullable<string>
 }
 
 export function Confirm({
@@ -35,7 +37,12 @@ export function Confirm({
   loading = false,
   destructive = false,
   extraContent,
+  confirmationEnabled = false,
+  confirmationText = 'delete',
 }: ConfirmProps) {
+  const [confirmationInput, setConfirmationInput] = useState('')
+  const isConfirmationValid =
+    !confirmationEnabled || confirmationInput === confirmationText
   const theme = useTheme()
 
   return (
@@ -57,6 +64,7 @@ export function Confirm({
             destructive={destructive}
             onClick={submit}
             loading={loading}
+            disabled={!isConfirmationValid}
             marginLeft="medium"
           >
             {label || 'Confirm'}
@@ -88,6 +96,34 @@ export function Confirm({
         {text}
       </div>
       {extraContent}
+      {confirmationEnabled && (
+        <div css={{ marginTop: theme.spacing.medium }}>
+          <FormField
+            label={<span>Type &quot;{confirmationText}&quot; to confirm</span>}
+            css={{
+              ' label': {
+                width: '100%',
+              },
+              ':focus-within': {
+                borderColor: theme.colors['text-danger-light'],
+              },
+            }}
+          >
+            <Input
+              value={confirmationInput}
+              onChange={(e) => setConfirmationInput(e.target.value)}
+              placeholder={confirmationText}
+              css={{
+                color: theme.colors.text,
+                borderColor: theme.colors['text-danger-light'],
+                '::placeholder': {
+                  color: theme.colors['text-danger-light'],
+                },
+              }}
+            />
+          </FormField>
+        </div>
+      )}
     </Modal>
   )
 }


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Added deletion confirmation safeguards to both CRD and CRD object lists.

![image](https://github.com/user-attachments/assets/9ec5e4da-b30f-48c4-869f-bb657f25df51)
![image](https://github.com/user-attachments/assets/906fbb51-ce16-4f6a-9956-27564aabf790)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally w/ plrl-dev-aws

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console