### PR TITLE
newrelic impl

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -224,6 +224,27 @@ config :console,
   ]
 }|,
 
+  newrelic_webhook_payload: ~s|
+{
+	"id": "d1b1f3fd-995a-4066-88ab-8ce4f6960654",
+	"issueUrl": "https://radar-api.service.newrelic.com/accounts/1/issues/0ea2df1c-adab-45d2-aae0-042b609d2322?notifier=SLACK",
+	"title": "Memory Used % > 90 for at least 2 minutes on 'Some-Entity'",
+	"priority": "CRITICAL",
+	"impactedEntities": ["logs.itg.cloud","MonitorTTFB query"],
+	"totalIncidents": 42,
+	"state": "ACTIVATED",
+	"trigger": "INCIDENT_ADDED",
+	"isCorrelated": false,
+	"createdAt": 1617881246260,
+	"updatedAt": 1617881246260,
+	"sources": ["newrelic"],
+	"alertPolicyNames": ["Policy1","Policy2"],
+	"alertConditionNames": ["condition1","condition2"],
+	"workflowName": "DBA Team workflow",
+  "extra_message": "plrl_project: test-project, plrl_cluster: test-cluster, plrl_service: test-service"
+}
+|,
+
   test_kubeconfig: """
 apiVersion: v1
 clusters:

--- a/lib/console/deployments/observability/webhook/newrelic.ex
+++ b/lib/console/deployments/observability/webhook/newrelic.ex
@@ -1,0 +1,45 @@
+defmodule Console.Deployments.Observability.Webhook.Newrelic do
+  @behaviour Console.Deployments.Observability.Webhook
+  import Console.Deployments.Observability.Webhook.Base
+
+  def associations(:project, payload, acc) do
+    Map.put(acc, :project_id, extract_from_payload(payload, ~r/plrl_project:\s*([^,\s]+)/, &project/1))
+  end
+
+  def associations(:cluster, payload, acc) do
+    Map.put(acc, :cluster_id, extract_from_payload(payload, ~r/plrl_cluster:\s*([^,\s]+)/, &cluster/1))
+  end
+
+  def associations(:service, payload, %{cluster_id: id} = acc) when is_binary(id) do
+    Map.put(acc, :service_id, extract_from_payload(payload, ~r/plrl_service:\s*([^,\s]+)/, fn value ->
+      clean_value = String.replace(value, ~s("), "")
+      service(id, clean_value)
+    end))
+  end
+
+  def associations(_, _, acc), do: acc
+
+  def state(%{"state" => "RESOLVED"}), do: :resolved
+  def state(%{"state" => "ACTIVATED"}), do: :firing
+  def state(_), do: :unknown
+
+  def severity(%{"priority" => "CRITICAL"}), do: :critical
+  def severity(_), do: :medium
+
+  def summary(%{"title" => title, "alertConditionNames" => [_ | _] = conditions}) do
+    "Alert Summary: #{title}\n triggered by: #{Enum.join(conditions, ", ")}"
+  end
+
+  def summary(%{"message" => message}) do
+    "Alert Summary: #{message}"
+  end
+
+  def summary(_), do: "No summary available\n"
+
+  defp extract_from_payload(payload, pattern, wrapper) do
+    case Regex.run(pattern, Jason.encode!(payload)) do
+      [_, value] -> wrapper.(value)
+      _ -> nil
+    end
+  end
+end

--- a/lib/console_web/controllers/webhook_controller.ex
+++ b/lib/console_web/controllers/webhook_controller.ex
@@ -102,5 +102,14 @@ defmodule ConsoleWeb.WebhookController do
     end
   end
 
+  defp verify(conn, %ObservabilityWebhook{type: :newrelic, secret: secret}) do
+    with {_, password} <- Plug.BasicAuth.parse_basic_auth(conn),
+         true <- Plug.Crypto.secure_compare(secret, password) do
+      :ok
+    else
+      _ -> :reject
+    end
+  end
+
   defp verify(_, _), do: :reject
 end

--- a/test/console_web/controllers/webhook_controller_test.exs
+++ b/test/console_web/controllers/webhook_controller_test.exs
@@ -179,6 +179,18 @@ defmodule ConsoleWeb.WebhookControllerTest do
       [] = Console.Repo.all(Console.Schema.Alert)
     end
 
+    test "it will ignore if no associated plural resource is found (newrelic)", %{conn: conn} do
+      hook = insert(:observability_webhook, type: :newrelic)
+
+      conn
+      |> put_req_header("authorization", Plug.BasicAuth.encode_basic_auth("plrl", hook.secret))
+      |> put_req_header("content-type", "application/json")
+      |> post("/ext/v1/webhooks/observability/newrelic/#{hook.external_id}", String.trim(Console.conf(:newrelic_webhook_payload)))
+      |> response(200)
+
+      [] = Console.Repo.all(Console.Schema.Alert)
+    end
+
     test "it can handle payloads with text in body (grafana)", %{conn: conn} do
       hook = insert(:observability_webhook, type: :grafana)
       svc = insert(:service)
@@ -255,5 +267,29 @@ defmodule ConsoleWeb.WebhookControllerTest do
 
       assert_receive {:event, %Console.PubSub.AlertCreated{}}
     end
+  end
+
+  test "it can handle payloads with text in body (newrelic)", %{conn: conn} do
+    hook = insert(:observability_webhook, type: :newrelic)
+    proj = insert(:project, name: "test-project")
+    cluster = insert(:cluster, handle: "test-cluster")
+    svc = insert(:service, name: "test-service", cluster: cluster)
+
+    webhook = String.trim(Console.conf(:newrelic_webhook_payload)) |> Jason.decode!()
+
+    conn
+    |> put_req_header("authorization", Plug.BasicAuth.encode_basic_auth("plrl", hook.secret))
+    |> put_req_header("content-type", "application/json")
+    |> post("/ext/v1/webhooks/observability/newrelic/#{hook.external_id}", Jason.encode!(webhook))
+    |> response(200)
+
+    [alert] = Console.Repo.all(Console.Schema.Alert)
+              |> Enum.map(&Console.Repo.preload(&1, :tags))
+
+    assert alert.service_id == svc.id
+    assert alert.cluster_id == cluster.id
+    assert alert.project_id == proj.id
+
+    assert_receive {:event, %Console.PubSub.AlertCreated{}}
   end
 end


### PR DESCRIPTION
Implement newrelic webhook payload handling. Newrelic webhooks are not guaranteed to have any specific format in terms of the K-V pairs in the JSON. However:
- we can scan for the `plrl_cluster`, `plrl_service`, and `plrl_project` in the raw json text
- we can try and extract certain values from the default payload structure (and use a fillter value if not found)

## Test Plan
Unit test + will functional test after merge

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console