### PR TITLE
feat: Example prompts improvements

### DIFF
--- a/assets/src/components/ai/chatbot/ChatbotPanelExamplePrompts.tsx
+++ b/assets/src/components/ai/chatbot/ChatbotPanelExamplePrompts.tsx
@@ -6,9 +6,10 @@ import {
   MinusIcon,
   PlusIcon,
 } from '@pluralsh/design-system'
-import { Dispatch, SetStateAction, useState } from 'react'
+import { Dispatch, SetStateAction, useRef, useState } from 'react'
 import chroma from 'chroma-js'
 import prompts from './prompts.json'
+import { useClickOutside } from '@react-hooks-library/core'
 
 const PROMPTS_LIMIT = 3
 
@@ -95,6 +96,9 @@ export function ChatbotPanelExamplePrompts({
   const theme = useTheme()
   const hasMorePrompts = prompts.length > PROMPTS_LIMIT
   const [showAll, setShowAll] = useState(!hasMorePrompts)
+  const ref = useRef<any>(null)
+
+  useClickOutside(ref, () => setShowPrompts(false))
 
   return (
     <div
@@ -115,29 +119,36 @@ export function ChatbotPanelExamplePrompts({
         css={{
           backdropFilter: 'blur(12px)',
           borderTop: `1px solid ${chroma(theme.colors['border-fill-two']).alpha(0.1).hex()}`,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: theme.spacing.xsmall,
-          padding: theme.spacing.medium,
         }}
       >
-        {(showAll ? prompts : prompts.slice(0, PROMPTS_LIMIT)).map((p, i) => (
-          <Prompt
-            key={i}
-            onClick={() => {
-              sendMessage(p)
-              setShowPrompts(false)
-            }}
-          >
-            {p}
-          </Prompt>
-        ))}
-        {hasMorePrompts && (
-          <PromptsControl
-            showAll={showAll}
-            setShowAll={setShowAll}
-          />
-        )}
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.xsmall,
+            padding: theme.spacing.medium,
+            width: 'max-content',
+          }}
+          ref={ref}
+        >
+          {(showAll ? prompts : prompts.slice(0, PROMPTS_LIMIT)).map((p, i) => (
+            <Prompt
+              key={i}
+              onClick={() => {
+                sendMessage(p)
+                setShowPrompts(false)
+              }}
+            >
+              {p}
+            </Prompt>
+          ))}
+          {hasMorePrompts && (
+            <PromptsControl
+              showAll={showAll}
+              setShowAll={setShowAll}
+            />
+          )}
+        </div>
       </div>
     </div>
   )

--- a/assets/src/components/ai/chatbot/ChatbotPanelExamplePrompts.tsx
+++ b/assets/src/components/ai/chatbot/ChatbotPanelExamplePrompts.tsx
@@ -22,6 +22,7 @@ function Prompt({ children, ...props }: ChipProps) {
         borderRadius: 16,
         height: 32,
       }}
+      width="max-content"
       {...props}
     >
       <MagicWandIcon size={12} />
@@ -48,7 +49,6 @@ function PromptsControl({
 
   return (
     <Chip
-      onClick={() => setShowAll(!showAll)}
       css={{
         borderRadius: 16,
         cursor: 'pointer',
@@ -69,6 +69,8 @@ function PromptsControl({
           color: theme.colors['text-xlight'],
         },
       }}
+      onClick={() => setShowAll(!showAll)}
+      width="max-content"
     >
       {showAll ? <MinusIcon size={12} /> : <PlusIcon size={12} />}
       <span


### PR DESCRIPTION
- Wrap chip to the length of text
- Make click outside close example prompts