### PR TITLE
AI Chat Tool for Alerts

### DIFF
--- a/lib/console/ai/chat/engine.ex
+++ b/lib/console/ai/chat/engine.ex
@@ -9,7 +9,8 @@ defmodule Console.AI.Chat.Engine do
     Pods,
     Component,
     Prs,
-    Pipelines
+    Pipelines,
+    Alerts
   }
   alias Console.AI.Tools.Knowledge.{
     CreateEntity,
@@ -43,7 +44,8 @@ defmodule Console.AI.Chat.Engine do
     Pods,
     Component,
     Prs,
-    Pipelines
+    Pipelines,
+    Alerts
   ]
 
   @memory_tools [

--- a/lib/console/ai/tools/alerts.ex
+++ b/lib/console/ai/tools/alerts.ex
@@ -1,0 +1,51 @@
+defmodule Console.AI.Tools.Alerts do
+  use Ecto.Schema
+  import Ecto.Changeset
+  import Console.AI.Tools.Utils
+  alias Console.Schema.{Alert, Flow}
+
+  embedded_schema do
+    field :severities, {:array, :string}
+    field :state,      :string
+    field :types,       {:array, :string}
+  end
+
+  @valid ~w(severities state types)a
+
+  def changeset(model, attrs) do
+    model
+    |> cast(attrs, @valid)
+  end
+
+  @json_schema Console.priv_file!("tools/alerts.json") |> Jason.decode!()
+
+  def json_schema(), do: @json_schema
+  def name(), do: plrl_tool("alerts")
+  def description(), do: "Shows alerts for the current flow, with optional filtering by severity, state, and type."
+
+  def implement(%__MODULE__{severities: severities, state: state, types: types}) do
+    case Console.AI.Tool.flow() do
+      %Flow{id: flow_id} ->
+        Alert.for_flow(flow_id)
+        |> apply_filters(%{severities: severities, state: state, types: types})
+        |> Console.Repo.all()
+        |> model()
+        |> Jason.encode()
+      nil ->
+        {:error, "no flow found"}
+    end
+  end
+
+  defp apply_filters(query, filters) do
+    Enum.reduce(filters, query, fn
+      {:severities, severities}, q -> Alert.for_severities(q, severities)
+      {:state, state}, q -> Alert.for_state(q, state)
+      {:types, types}, q -> Alert.for_types(q, types)
+      _, q -> q
+    end)
+  end
+
+  defp model(alerts) do
+    Enum.map(alerts, &Map.take(&1, ~w(type severity state title url message annotations project_id cluster_id service_id)a))
+  end
+end

--- a/lib/console/schema/alert.ex
+++ b/lib/console/schema/alert.ex
@@ -58,7 +58,8 @@ defmodule Console.Schema.Alert do
   def for_flow(query \\ __MODULE__, id) do
     from(a in query,
       join: s in assoc(a, :service),
-      where: s.flow_id == ^id
+      where: s.flow_id == ^id,
+      distinct: true
     )
   end
 
@@ -72,6 +73,18 @@ defmodule Console.Schema.Alert do
     from(a in query, order_by: [desc: coalesce(a.updated_at, a.inserted_at)])
   end
   def ordered(query, order), do: from(a in query, order_by: ^order)
+
+  def for_state(query \\ __MODULE__, state) do
+    from(a in query, where: a.state == ^state)
+  end
+
+  def for_types(query \\ __MODULE__, types) do
+    from(a in query, where: a.type in ^types)
+  end
+
+  def for_severities(query \\ __MODULE__, severities) do
+    from(a in query, where: a.severity in ^severities)
+  end
 
   @valid ~w(type severity state title message fingerprint annotations url project_id cluster_id insight_id service_id)a
 

--- a/priv/tools/alerts.json
+++ b/priv/tools/alerts.json
@@ -1,0 +1,28 @@
+{
+    "type": "object",
+    "properties": {
+        "severities": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": ["low", "medium", "high", "critical", "undefined"]
+            },
+            "description": "Optional. Filter alerts by one or more severity levels. If omitted, alerts of all severities are returned."
+        },
+        "state": {
+            "type": "string",
+            "enum": ["firing", "resolved"],
+            "description": "Optional. Filter alerts by state (e.g., 'firing' for only active alerts). If omitted, alerts of all states are returned."
+        },
+        "types": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": ["grafana", "pagerduty", "newrelic", "datadog"]
+            },
+            "description": "Optional. Filter alerts by type. If omitted, alerts of all types are returned."
+        }
+    },
+    "required": [],
+    "additionalProperties": false
+}


### PR DESCRIPTION
Implement tool to fetch Alerts for AI chat. Allow filtering by type (newrelic, pagerduty, etc), severity (critical, low, etc), and state (firing, resolved).

Also minor modification to `Alert.for_flow` where we add the `distinct: true` condition to make sure we do not get duplicates.

## Test Plan
Unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console