### PR TITLE
fix logs polling bug

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -32,7 +32,7 @@
   "packageManager": "yarn@3.6.0",
   "dependencies": {
     "@absinthe/socket": "0.2.1",
-    "@apollo/client": "3.10.3",
+    "@apollo/client": "3.13.8",
     "@dagrejs/dagre": "1.0.4",
     "@docsearch/js": "3.5.2",
     "@docsearch/react": "3.5.2",

--- a/assets/src/components/cd/logs/Logs.tsx
+++ b/assets/src/components/cd/logs/Logs.tsx
@@ -45,40 +45,30 @@ export function Logs({
     DEFAULT_LOG_FLYOVER_FILTERS
   )
 
-  const [live, setLiveState] = useState(true)
+  const [live, setLive] = useState(true)
 
-  const { data, loading, error, fetchMore, startPolling, stopPolling } =
-    useLogAggregationQuery({
-      variables: {
-        clusterId,
-        query: throttledQ,
-        limit: filters.queryLength || DEFAULT_LOG_QUERY_LENGTH,
-        serviceId,
-        time: {
-          before: live ? undefined : toISOStringOrUndef(filters.date, true),
-          duration: secondsToDuration(filters.sinceSeconds),
-          reverse: false,
-        },
-        facets: labels,
+  const { data, loading, error, fetchMore } = useLogAggregationQuery({
+    variables: {
+      clusterId,
+      serviceId,
+      query: throttledQ,
+      limit: filters.queryLength || DEFAULT_LOG_QUERY_LENGTH,
+      time: {
+        before: live ? undefined : toISOStringOrUndef(filters.date, true),
+        duration: secondsToDuration(filters.sinceSeconds),
+        reverse: false,
       },
-      fetchPolicy: 'cache-and-network',
-      notifyOnNetworkStatusChange: true,
-      pollInterval: POLL_INTERVAL,
-      skip: !(clusterId || serviceId),
-    })
+      facets: labels,
+    },
+    fetchPolicy: 'cache-and-network',
+    notifyOnNetworkStatusChange: true,
+    pollInterval: live ? POLL_INTERVAL : 0,
+    skip: !(clusterId || serviceId),
+  })
 
   const logs = useMemo(
     () => data?.logAggregation?.filter(isNonNullable) ?? [],
     [data]
-  )
-
-  const setLive = useCallback(
-    (newVal: boolean) => {
-      if (!newVal) stopPolling()
-      else startPolling(POLL_INTERVAL)
-      setLiveState(newVal)
-    },
-    [startPolling, stopPolling]
   )
 
   const addLabel = useCallback(

--- a/assets/src/components/kubernetes/common/Raw.tsx
+++ b/assets/src/components/kubernetes/common/Raw.tsx
@@ -1,13 +1,9 @@
-import { ApolloError } from '@apollo/client'
 import { CodeEditor } from '@pluralsh/design-system'
 import { dump, load } from 'js-yaml'
 import pluralize from 'pluralize'
 import { ReactElement, useEffect, useMemo, useState } from 'react'
 import { useMatch, useParams } from 'react-router-dom'
 import { useTheme } from 'styled-components'
-
-import { GraphQLErrors } from '@apollo/client/errors'
-import type { GraphQLError } from 'graphql'
 
 import {
   NamespacedResourceQueryVariables,
@@ -20,7 +16,7 @@ import {
 import { KubernetesClient } from '../../../helpers/kubernetes.client'
 import { getKubernetesAbsPath } from '../../../routes/kubernetesRoutesConsts'
 import { hash } from '../../../utils/sha'
-import { GqlError } from '../../utils/Alert'
+import { GqlError, GqlErrorType } from '../../utils/Alert'
 import LoadingIndicator from '../../utils/LoadingIndicator'
 
 export default function Raw(): ReactElement<any> {
@@ -29,7 +25,7 @@ export default function Raw(): ReactElement<any> {
   const pathMatch = useMatch(`${getKubernetesAbsPath(clusterId)}/:kind/*`)
   const [current, setCurrent] = useState<string>()
   const [sha, setSHA] = useState<string>()
-  const [updateError, setUpdateError] = useState<ApolloError>()
+  const [updateError, setUpdateError] = useState<GqlErrorType>()
   const [updating, setUpdating] = useState(false)
   const kind = useMemo(
     () => crd ?? pluralize(pathMatch?.params?.kind || '', 1),
@@ -133,11 +129,7 @@ export default function Raw(): ReactElement<any> {
               },
             })
           } catch (e) {
-            setUpdateError({
-              graphQLErrors: [
-                { message: (e as any)?.message as string } as GraphQLError,
-              ] as GraphQLErrors,
-            } as ApolloError)
+            setUpdateError(e instanceof Error ? e.message : (e as any))
           }
         }}
       />

--- a/assets/src/components/kubernetes/common/create/secret/SecretModal.tsx
+++ b/assets/src/components/kubernetes/common/create/secret/SecretModal.tsx
@@ -1,4 +1,5 @@
-import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
+import { FetchResult } from '@apollo/client'
+import { OperationVariables } from '@apollo/client/core'
 import {
   Button,
   FormField,
@@ -7,24 +8,21 @@ import {
   Modal,
   Select,
 } from '@pluralsh/design-system'
-import styled, { useTheme } from 'styled-components'
-import { SecretType, ToSecretYaml } from './common'
+import { useNamespaces } from 'components/kubernetes/Cluster'
+import { GqlError } from 'components/utils/Alert'
 import {
   DeployFromInputMutation,
   useDeployFromInputMutation,
 } from 'generated/graphql-kubernetes'
-import { useParams } from 'react-router-dom'
-import { useNamespaces } from 'components/kubernetes/Cluster'
 import { KubernetesClient } from 'helpers/kubernetes.client'
-import { FetchResult } from '@apollo/client'
-import { GqlError } from 'components/utils/Alert'
-import { ApolloError, GraphQLErrors } from '@apollo/client/errors'
-import { GraphQLError } from 'graphql'
-import { SecretSSHForm } from './type/SSH'
+import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import styled, { useTheme } from 'styled-components'
+import { SecretType, ToSecretYaml } from './common'
+import { SecretBasicAuthForm } from './type/BasicAuth.tsx'
 import { SecretOpaqueForm } from './type/Opaque'
 import { SecretServiceAccountForm } from './type/ServiceAccount'
-import { OperationVariables } from '@apollo/client/core'
-import { SecretBasicAuthForm } from './type/BasicAuth.tsx'
+import { SecretSSHForm } from './type/SSH'
 
 const FormContainer = styled.div`
   display: flex;
@@ -364,13 +362,7 @@ function ErrorContainer({
       }}
     >
       <GqlError
-        error={
-          {
-            graphQLErrors: [
-              { message: errorMessage } as GraphQLError,
-            ] as GraphQLErrors,
-          } as ApolloError
-        }
+        error={errorMessage}
         header={errorHeader}
       />
     </div>

--- a/assets/src/components/kubernetes/customresources/PinnedCustomResourceDefinitions.tsx
+++ b/assets/src/components/kubernetes/customresources/PinnedCustomResourceDefinitions.tsx
@@ -1,7 +1,6 @@
 import styled, { useTheme } from 'styled-components'
 import { Button, CloseIcon, Toast, Tooltip } from '@pluralsh/design-system'
 import { useState } from 'react'
-import { ApolloError } from 'apollo-boost'
 
 import { useNavigate } from 'react-router-dom'
 
@@ -14,6 +13,7 @@ import { Maybe } from '../../../generated/graphql-kubernetes'
 import { useRefetch } from '../Cluster'
 import { getResourceDetailsAbsPath } from '../../../routes/kubernetesRoutesConsts'
 import { Kind } from '../common/types'
+import { ApolloError } from '@apollo/client'
 
 const DeleteIcon = styled(CloseIcon)(({ theme }) => ({
   marginLeft: theme.spacing.xxsmall,

--- a/assets/src/components/kubernetes/workloads/CronJob.tsx
+++ b/assets/src/components/kubernetes/workloads/CronJob.tsx
@@ -6,7 +6,6 @@ import {
   Toast,
   useSetBreadcrumbs,
 } from '@pluralsh/design-system'
-import { ApolloError } from 'apollo-boost'
 import { ReactElement, useMemo, useState } from 'react'
 import { Outlet, useParams } from 'react-router-dom'
 import { formatLocalizedDateTime } from 'utils/datetime'
@@ -45,6 +44,7 @@ import { NAMESPACE_PARAM } from '../Navigation'
 
 import { Kind } from '../common/types'
 
+import { ApolloError } from '@apollo/client'
 import { getBreadcrumbs } from './CronJobs'
 import { useJobsColumns } from './Jobs'
 

--- a/assets/src/components/utils/Confirm.tsx
+++ b/assets/src/components/utils/Confirm.tsx
@@ -1,9 +1,7 @@
-import { ReactNode, useState } from 'react'
 import { ApolloError } from '@apollo/client'
 import { Button, FormField, Input, Modal } from '@pluralsh/design-system'
+import { ReactNode, useState } from 'react'
 import { useTheme } from 'styled-components'
-import { GraphQLError } from 'graphql'
-import { GraphQLErrors } from '@apollo/client/errors'
 
 import { GqlError } from './Alert'
 
@@ -79,15 +77,7 @@ export function Confirm({
           }}
         >
           <GqlError
-            error={
-              errorMessage
-                ? ({
-                    graphQLErrors: [
-                      { message: errorMessage } as GraphQLError,
-                    ] as GraphQLErrors,
-                  } as ApolloError)
-                : error
-            }
+            error={errorMessage || error}
             header={errorHeader}
           />
         </div>

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -245,9 +245,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:3.10.3":
-  version: 3.10.3
-  resolution: "@apollo/client@npm:3.10.3"
+"@apollo/client@npm:3.13.8":
+  version: 3.13.8
+  resolution: "@apollo/client@npm:3.13.8"
   dependencies:
     "@graphql-typed-document-node/core": ^3.1.1
     "@wry/caches": ^1.0.0
@@ -258,16 +258,15 @@ __metadata:
     optimism: ^0.18.0
     prop-types: ^15.7.2
     rehackt: ^0.1.0
-    response-iterator: ^0.2.6
     symbol-observable: ^4.0.0
     ts-invariant: ^0.10.3
     tslib: ^2.3.0
     zen-observable-ts: ^1.2.5
   peerDependencies:
     graphql: ^15.0.0 || ^16.0.0
-    graphql-ws: ^5.5.5
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    graphql-ws: ^5.5.5 || ^6.0.3
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc
     subscriptions-transport-ws: ^0.9.0 || ^0.11.0
   peerDependenciesMeta:
     graphql-ws:
@@ -278,7 +277,7 @@ __metadata:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: 7ec2565ee7c48db2f6a6bd7d141d5529b8e4b82f2bc59e50ecc71d9ad9364bb27ed1fb0ddaf549815cacc7faf10cafc19c1af8046d20d9bab3fed9ff7819fc8c
+  checksum: 39f058c2681aaa1f95275d8e856976fb1e15f30bdac33758d3cf3c8dc08f111c1cdfa3a30a777ad1088b950cb94336197a81d136a43faa7470cbf2c9746f53ce
   languageName: node
   linkType: hard
 
@@ -10099,7 +10098,7 @@ __metadata:
   resolution: "console@workspace:."
   dependencies:
     "@absinthe/socket": 0.2.1
-    "@apollo/client": 3.10.3
+    "@apollo/client": 3.13.8
     "@apollo/sandbox": 2.7.0
     "@cypress/webpack-preprocessor": 5.17.1
     "@dagrejs/dagre": 1.0.4
@@ -18648,13 +18647,6 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 064d09c1808d0c51b3d90b5d27e198e6d0c5dad0eb57065fd40803d6a20553e5398b07f76739d69cbabc12547058bec6b32106ea66622375fb0d7e8fca6a846c
-  languageName: node
-  linkType: hard
-
-"response-iterator@npm:^0.2.6":
-  version: 0.2.20
-  resolution: "response-iterator@npm:0.2.20"
-  checksum: b881baa3da91351a5dd46c7e57db4b74212d62065aaa6bac9c6059efdff50406ea3d197ead3fa1c69e96f75af99f169254721e356f80bc875d05aba5efa0cc47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
it's not exactly clear what triggers this bug, but it seems like it likely stems from a race condition when "live" is rapidly toggled while the search query is changing (this is expected behavior because changing query filters in most cases will return the scroll to the top, and then the user might immediately scroll down, but "stopPolling" might not necessarily get triggered)

this change simplifies the logic a bit and makes it more declarative

also bumps apollo client minor vsn