### PR TITLE
Add project id binding to service contexts

### DIFF
--- a/lib/console/schema/service_context.ex
+++ b/lib/console/schema/service_context.ex
@@ -1,5 +1,6 @@
 defmodule Console.Schema.ServiceContext do
   use Piazza.Ecto.Schema
+  alias Console.Schema.Project
 
   schema "service_contexts" do
     field :name,          :string
@@ -10,15 +11,18 @@ defmodule Console.Schema.ServiceContext do
       field :value, Piazza.Ecto.EncryptedString
     end
 
+    belongs_to :project, Project
+
     timestamps()
   end
 
-  @valid ~w(name configuration)a
+  @valid ~w(name configuration project_id)a
 
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, @valid)
     |> cast_embed(:secrets, with: &secret_changeset/2)
+    |> foreign_key_constraint(:project_id)
     |> validate_required([:name])
   end
 

--- a/priv/repo/migrations/20250528173945_add_project_id_service_context.exs
+++ b/priv/repo/migrations/20250528173945_add_project_id_service_context.exs
@@ -1,0 +1,18 @@
+defmodule Console.Repo.Migrations.AddProjectIdServiceContext do
+  use Ecto.Migration
+  alias Console.Schema.ServiceContext
+  alias Console.Deployments.Settings
+
+  def change do
+    alter table(:service_contexts) do
+      add :project_id, references(:projects, type: :binary_id, on_delete: :delete_all)
+    end
+
+    create index(:service_contexts, [:project_id])
+
+    flush()
+
+    default = Settings.default_project!()
+    Console.Repo.update_all(ServiceContext, set: [project_id: default.id])
+  end
+end

--- a/test/console/deployments/services_test.exs
+++ b/test/console/deployments/services_test.exs
@@ -1151,6 +1151,19 @@ defmodule Console.Deployments.ServicesTest do
       assert ctx.configuration["some"] == "config"
     end
 
+    test "project writers can save their own contexts" do
+      user = insert(:user)
+      project = insert(:project, write_bindings: [%{user_id: user.id}])
+
+      {:ok, ctx} = Services.save_context(%{
+        configuration: %{"some" => "config"},
+        project_id: project.id
+      }, "my-context", user)
+
+      assert ctx.name == "my-context"
+      assert ctx.configuration["some"] == "config"
+    end
+
     test "nonadmins cannot save contexts" do
       {:error, _} = Services.save_context(%{configuration: %{"some" => "config"}}, "my-context", insert(:user))
     end


### PR DESCRIPTION
This allows users to separate permissions a bit more on these resources.  Just defaults to the default project like everything else does.

## Test Plan
unit tests


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console