### PR TITLE
update helm chart forms and small fixes

### DIFF
--- a/assets/src/components/cd/services/ServiceSelector.tsx
+++ b/assets/src/components/cd/services/ServiceSelector.tsx
@@ -1,6 +1,5 @@
 import { ListBoxItem, Select } from '@pluralsh/design-system'
 import {
-  ServiceDeploymentDetailsFragment,
   useFlowServicesQuery,
   useServiceDeploymentsTinyQuery,
 } from 'generated/graphql'
@@ -15,26 +14,24 @@ import { useTheme } from 'styled-components'
 import { mapExistingNodes } from 'utils/graphql'
 import { POLL_INTERVAL } from '../ContinuousDeployment'
 
-export function ServiceSelector({
-  currentService,
-}: {
-  currentService: Nullable<ServiceDeploymentDetailsFragment>
-}) {
+export function ServiceSelector() {
   const theme = useTheme()
   const navigate = useNavigate()
 
-  const { flowId } = useParams()
+  const { flowId, serviceId, clusterId } = useParams()
   const referrer = !!flowId ? 'flow' : 'cd'
 
   const { data: clusterServices } = useServiceDeploymentsTinyQuery({
-    variables: { clusterId: currentService?.cluster?.id },
-    skip: !currentService?.cluster?.id || referrer !== 'cd',
+    variables: { clusterId: clusterId ?? '' },
+    skip: referrer !== 'cd',
     pollInterval: POLL_INTERVAL,
     fetchPolicy: 'cache-and-network',
   })
   const { data: flowServices } = useFlowServicesQuery({
     variables: { id: flowId ?? '' },
     skip: referrer !== 'flow',
+    pollInterval: POLL_INTERVAL,
+    fetchPolicy: 'cache-and-network',
   })
 
   const serviceList = useMemo(
@@ -58,7 +55,7 @@ export function ServiceSelector({
 
   const switchService = useCallback(
     (newKey: Key) => {
-      if (typeof newKey === 'string' && newKey !== currentService?.id) {
+      if (typeof newKey === 'string' && newKey !== serviceId) {
         const service = serviceList.find(
           (deployment) => deployment.id === newKey
         )
@@ -71,13 +68,13 @@ export function ServiceSelector({
         )
       }
     },
-    [currentService?.id, flowId, navigate, serviceList, urlSuffix]
+    [flowId, navigate, serviceId, serviceList, urlSuffix]
   )
 
   return (
     <Select
       aria-label="app"
-      selectedKey={currentService?.id}
+      selectedKey={serviceId}
       onSelectionChange={switchService}
     >
       {serviceList.map((service) => (

--- a/assets/src/components/cd/services/deployModal/DeployServiceSettingsHelm.tsx
+++ b/assets/src/components/cd/services/deployModal/DeployServiceSettingsHelm.tsx
@@ -1,30 +1,38 @@
-import {
-  FormField,
-  Input,
-  ListBoxItem,
-  Select,
-  Spinner,
-} from '@pluralsh/design-system'
-import { HelmHealthChip } from 'components/cd/repos/HelmHealthChip'
-import useOnUnMount from 'components/hooks/useOnUnMount'
-import LoadingIndicator from 'components/utils/LoadingIndicator'
-import { InlineLink } from 'components/utils/typography/InlineLink'
-import {
-  NamespacedName,
-  useFluxHelmRepositoriesQuery,
-  useFluxHelmRepositoryQuery,
-} from 'generated/graphql'
-import isEmpty from 'lodash/isEmpty'
-import { useLayoutEffect, useState } from 'react'
+import { FormField, Input } from '@pluralsh/design-system'
+import { isNonNullable } from 'utils/isNonNullable'
 
-function ChartFormValuesRaw({ chart, setChart, version, setVersion }) {
+export function ChartForm({
+  url,
+  setUrl,
+  chart,
+  setChart,
+  version,
+  setVersion,
+}: {
+  url?: Nullable<string>
+  setUrl: (url: string) => void
+  chart: string
+  setChart: (chart: string) => void
+  version: string
+  setVersion: (version: string) => void
+}) {
   return (
     <>
+      {isNonNullable(url) && (
+        <FormField label="URL">
+          <Input
+            placeholder="Optionally specify a Helm chart repository URL"
+            value={url}
+            onChange={(e) => setUrl(e.target?.value)}
+          />
+        </FormField>
+      )}
       <FormField
         required
         label="Chart Name"
       >
         <Input
+          placeholder="Enter chart name"
           value={chart}
           onChange={(e) => setChart(e.target?.value)}
         />
@@ -34,254 +42,11 @@ function ChartFormValuesRaw({ chart, setChart, version, setVersion }) {
         label="Chart Version"
       >
         <Input
+          placeholder="Enter chart version"
           value={version}
           onChange={(e) => setVersion(e.target?.value)}
         />
       </FormField>
-    </>
-  )
-}
-
-function ChartFormValuesDropdown({
-  chart,
-  setChart,
-  charts,
-  version,
-  setVersion,
-  selectedChart,
-  loading,
-}) {
-  return (
-    <>
-      <FormField
-        required
-        label="Chart"
-      >
-        <Select
-          label="Select chart"
-          isDisabled={loading}
-          selectedKey={chart || ''}
-          onSelectionChange={(key) => {
-            setChart(key)
-            if (key !== chart) {
-              setVersion('')
-            }
-          }}
-          rightContent={loading ? <Spinner /> : null}
-        >
-          {(charts || []).map((chart) => (
-            <ListBoxItem
-              key={chart.name}
-              label={chart.name}
-            />
-          ))}
-        </Select>
-      </FormField>
-      <FormField
-        required
-        label="Version"
-      >
-        <Select
-          label={!chart ? 'Must select a chart first' : 'Select version'}
-          selectedKey={version || ''}
-          onSelectionChange={(key) => setVersion(key)}
-          isDisabled={!chart || loading}
-          rightContent={loading ? <Spinner /> : null}
-        >
-          {(selectedChart?.versions || []).map((vsn) => (
-            <ListBoxItem
-              key={vsn.version}
-              label={`${vsn.version} (appVersion=${vsn.appVersion})`}
-            />
-          ))}
-        </Select>
-      </FormField>
-    </>
-  )
-}
-
-export function ChartForm({
-  charts,
-  chart,
-  version,
-  setChart,
-  setVersion,
-  loading,
-  dropdownEnabled,
-}) {
-  const selectedChart = charts?.find((c) => c.name === chart)
-
-  useLayoutEffect(() => {
-    if (!isEmpty(charts)) {
-      if (!charts.find((c) => c.name === chart)) {
-        setVersion('')
-        setChart('')
-      } else if (!selectedChart?.versions?.find((v) => v.version === version)) {
-        setVersion('')
-      }
-    }
-  }, [chart, charts, selectedChart?.versions, setChart, setVersion, version])
-
-  if (dropdownEnabled && (loading || !isEmpty(charts))) {
-    return (
-      <ChartFormValuesDropdown
-        chart={chart}
-        charts={charts}
-        setChart={setChart}
-        selectedChart={selectedChart}
-        version={version}
-        setVersion={setVersion}
-        loading={loading}
-      />
-    )
-  }
-
-  return (
-    <ChartFormValuesRaw
-      chart={chart}
-      setChart={setChart}
-      version={version}
-      setVersion={setVersion}
-    />
-  )
-}
-
-function EmptyState({ loading }) {
-  if (loading) return <LoadingIndicator />
-
-  return <>Looks like you need to register a helm repository first...</>
-}
-
-const keyToRepo = (key) => {
-  const parts = (key || '').split(':')
-
-  if (parts.length === 2) return { namespace: parts[0], name: parts[1] }
-
-  return null
-}
-
-export default function DeployServiceSettingsHelm({
-  repository,
-  setRepository,
-  chart,
-  setChart,
-  version,
-  setVersion,
-}: {
-  repository: NamespacedName | null
-  setRepository: (repository: NamespacedName | null) => void
-  chart: string
-  setChart: (chart: string) => void
-  version: string
-  setVersion: (version: string) => void
-}) {
-  const { data, loading } = useFluxHelmRepositoriesQuery({
-    fetchPolicy: 'cache-and-network',
-  })
-  const [selectIsOpen, setSelectIsOpen] = useState(false)
-
-  const useFluxHelmData = !!repository?.name && !!repository?.namespace
-  const { data: charts, loading: loadingFluxHelmRepository } =
-    useFluxHelmRepositoryQuery({
-      variables: {
-        name: repository?.name || '',
-        namespace: repository?.namespace || '',
-      },
-      skip: !useFluxHelmData,
-    })
-
-  useOnUnMount(() => {
-    if (!(repository && chart && version)) {
-      setRepository(null)
-      setChart('')
-      setVersion('')
-    }
-  })
-
-  if (!data?.fluxHelmRepositories) return <EmptyState loading={loading} />
-
-  const repositories = data?.fluxHelmRepositories
-  const selectedRepository = repositories.find(
-    (r) =>
-      r?.metadata.name === repository?.name &&
-      r?.metadata.namespace === repository?.namespace
-  )
-
-  const selectedKey = repository
-    ? `${repository?.namespace}:${repository?.name}`
-    : ''
-
-  return (
-    <>
-      <FormField
-        label="Repository"
-        hint="Select a chart repository to fetch your chart from"
-        {...(repository
-          ? {
-              caption: (
-                <InlineLink
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    setRepository(null)
-                  }}
-                >
-                  Deselect
-                </InlineLink>
-              ),
-            }
-          : {})}
-      >
-        <Select
-          label="Select Repository"
-          isOpen={selectIsOpen}
-          onOpenChange={(open) => setSelectIsOpen(open)}
-          selectedKey={selectedKey}
-          onSelectionChange={(key) => {
-            setRepository(keyToRepo(key))
-            setSelectIsOpen(false)
-          }}
-          leftContent={
-            selectedRepository && (
-              <HelmHealthChip
-                ready={!!selectedRepository?.status?.ready}
-                message={selectedRepository?.status?.message}
-              />
-            )
-          }
-          dropdownHeader={
-            selectedRepository ? <ListBoxItem label="None" /> : undefined
-          }
-          onHeaderClick={() => {
-            setRepository(null)
-            setSelectIsOpen(false)
-          }}
-        >
-          {(repositories || []).map((repo) => (
-            <ListBoxItem
-              key={`${repo?.metadata.namespace}:${repo?.metadata.name}`}
-              label={repo?.spec.url}
-              leftContent={
-                <HelmHealthChip
-                  ready={!!repo?.status?.ready}
-                  message={repo?.status?.message}
-                />
-              }
-            />
-          ))}
-        </Select>
-      </FormField>
-      {selectedRepository && (
-        <ChartForm
-          charts={charts?.fluxHelmRepository?.charts || []}
-          chart={chart}
-          setChart={setChart}
-          version={version}
-          setVersion={setVersion}
-          loading={loadingFluxHelmRepository}
-          dropdownEnabled={useFluxHelmData}
-        />
-      )}
     </>
   )
 }

--- a/assets/src/components/cd/services/service/ServiceDetails.tsx
+++ b/assets/src/components/cd/services/service/ServiceDetails.tsx
@@ -301,7 +301,7 @@ function ServiceDetailsBase() {
             maxHeight: '100%',
           }}
         >
-          <ServiceSelector currentService={serviceDeployment} />
+          <ServiceSelector />
           <div
             css={{
               overflowY: 'auto',

--- a/assets/src/components/security/Security.tsx
+++ b/assets/src/components/security/Security.tsx
@@ -1,5 +1,6 @@
 import { Flex, SubTab } from '@pluralsh/design-system'
 import { PageHeaderContext } from 'components/cd/ContinuousDeployment'
+import { LinkTabWrap } from 'components/utils/Tabs'
 import { ReactNode, useMemo, useState } from 'react'
 import { Outlet, useNavigate, useParams } from 'react-router-dom'
 import {
@@ -29,16 +30,21 @@ export function Security() {
         <HeaderWrapperSC>
           <Flex>
             {directory.map(({ path, label }) => (
-              <SubTab
-                css={{ width: 'max-content' }}
+              <LinkTabWrap
                 key={path}
+                to={path}
+                textValue={label}
                 active={route?.includes(path)}
-                onClick={() => {
-                  if (!route?.includes(path)) navigate(`${path}`)
-                }}
               >
-                {label}
-              </SubTab>
+                <SubTab
+                  css={{ width: 'max-content' }}
+                  onClick={() => {
+                    if (!route?.includes(path)) navigate(`${path}`)
+                  }}
+                >
+                  {label}
+                </SubTab>
+              </LinkTabWrap>
             ))}
           </Flex>
           {headerContent}


### PR DESCRIPTION
- adds a url input to helm chart settings edit forms if one already exists (and also includes the input by default when initially creating a service deployment)

- replaces the chart and version dropdowns with standard text inputs

- tweaks the service details selector to better prepopulate with cached data, so it won't always appear blank initially while fetching the service (closes PROD-3584)

- makes security page subtabs tab-accessible (closes PROD-3472)