### PR TITLE
fix: datastore resource deletion 

### DIFF
--- a/go/datastore/Makefile
+++ b/go/datastore/Makefile
@@ -44,8 +44,7 @@ build: manifests generate fmt vet ## build manager binary
 
 .PHONY: run
 run: manifests generate fmt vet ## run a controller from your host
-	go run ./cmd/main.go \
-		--console-url=${PLURAL_CONSOLE_URL}/gql
+	go run ./cmd/main.go
 
 .PHONY: release
 release: manifests generate fmt vet ## builds release version of the app. Requires GoReleaser to work.

--- a/go/datastore/api/v1alpha1/elasticsearchindextemplate_types.go
+++ b/go/datastore/api/v1alpha1/elasticsearchindextemplate_types.go
@@ -44,7 +44,7 @@ func (s *ElasticsearchIndexTemplate) SetCondition(condition metav1.Condition) {
 	meta.SetStatusCondition(&s.Status.Conditions, condition)
 }
 
-func (s *ElasticsearchIndexTemplate) GetName() string {
+func (s *ElasticsearchIndexTemplate) GetIndexName() string {
 	if s.Spec.Name != nil && len(*s.Spec.Name) > 0 {
 		return *s.Spec.Name
 	}

--- a/go/datastore/config/samples/all.yaml
+++ b/go/datastore/config/samples/all.yaml
@@ -1,0 +1,106 @@
+apiVersion: dbs.plural.sh/v1alpha1
+kind: ElasticsearchUser
+metadata:
+  labels:
+    app.kubernetes.io/name: elasticsearchuser
+    app.kubernetes.io/instance: elasticsearchuser-sample
+    app.kubernetes.io/part-of: datastore
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: datastore
+  name: elasticsearchuser-sample
+  namespace: default
+spec:
+  credentialsRef:
+    name: elasticsearchcredentials-sample
+  definition:
+    user: lukasz-monitor
+    passwordSecretKeyRef:
+      name: elastic-user
+      key: password
+    role:
+      name: lukasz-monitor
+      clusterPermissions:
+        - monitor
+      indexPermissions:
+        - names: ["logs-*"]
+          privileges: ["read", "view_index_metadata"]
+---
+apiVersion: dbs.plural.sh/v1alpha1
+kind: ElasticsearchIndexTemplate
+metadata:
+  labels:
+    app.kubernetes.io/name: elasticsearchindextemplate
+    app.kubernetes.io/instance: elasticsearchindextemplate-sample
+    app.kubernetes.io/part-of: datastore
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: datastore
+  name: elasticsearchindextemplate-sample
+spec:
+  name: plrl-logs
+  credentialsRef:
+    name: elasticsearchcredentials-sample
+  definition:
+    indexPatterns:
+      - "plrl-logs*"
+    template:
+      settings:
+        lifecycle:
+          name: string
+---
+apiVersion: dbs.plural.sh/v1alpha1
+kind: ElasticsearchILMPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: datastore
+    app.kubernetes.io/managed-by: kustomize
+  name: elasticsearchilmpolicy-sample
+spec:
+  credentialsRef:
+    name: elasticsearchcredentials-sample
+  definition:
+    policy:
+      phases:
+        warm:
+          min_age: 10d
+          actions:
+            forcemerge:
+              max_num_segments: 1
+        delete:
+          min_age: 30d
+          actions:
+            delete: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: elastic-user
+  namespace: default
+data:
+  password: bDdDSWQ5TGdYbnJlUlM1NjA4OGk4UzI2Cg==
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: elastic-secret
+  namespace: default
+data:
+  password: bDdDSWQ5TGdYbnJlUlM1NjA4OGk4UzI2Cg==
+---
+apiVersion: dbs.plural.sh/v1alpha1
+kind: ElasticsearchCredentials
+metadata:
+  labels:
+    app.kubernetes.io/name: elasticsearchcredentials
+    app.kubernetes.io/instance: elasticsearchcredentials-sample
+    app.kubernetes.io/part-of: datastore
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: datastore
+  name: elasticsearchcredentials-sample
+  namespace: default
+spec:
+  url: https://localhost:9222
+  username: elastic
+  insecure: true
+  passwordSecretKeyRef:
+    name: elastic-secret
+    key: password

--- a/go/datastore/config/samples/dbs_v1alpha1_elasticsearchilmpolicy.yaml
+++ b/go/datastore/config/samples/dbs_v1alpha1_elasticsearchilmpolicy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elastic-secret
   namespace: default
 data:
-  password: QnY3MTk0azE1SEc5eThLa0ZocTcxZ2xYCg==
+  password: bDdDSWQ5TGdYbnJlUlM1NjA4OGk4UzI2Cg==
 ---
 apiVersion: dbs.plural.sh/v1alpha1
 kind: ElasticsearchCredentials


### PR DESCRIPTION
 This PR fixes datastore resource deletion. All the resources depend on ElasticsearchCredentials. They must be deleted properly.

- fix reconcile ElasticsearchIndexTemplate (the name was overwritten)

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console