### PR TITLE
PersistentVolume Evidence Module for AI

### DIFF
--- a/lib/console/ai/evidence/base.ex
+++ b/lib/console/ai/evidence/base.ex
@@ -36,12 +36,14 @@ defmodule Console.AI.Evidence.Base do
   def json_blob(json), do: "```json\n#{json}\n```"
 
   def prepend(list, l) when is_list(l), do: l ++ list
+  def prepend(list, msg) when is_binary(msg), do: prepend(list, {:user, msg})
   def prepend(list, msg), do: [msg | list]
 
   def maybe_prepend(nil, l), do: l
   def maybe_prepend(v, l), do: prepend(l, v)
 
   def append(list, l) when is_list(l), do: list ++ l
+  def append(list, msg) when is_binary(msg), do: list ++ [{:user, msg}]
   def append(list, msg), do: list ++ [msg]
 
   def distro(:byok), do: "vanilla"

--- a/lib/console/ai/evidence/component/persistent_volume_claim.ex
+++ b/lib/console/ai/evidence/component/persistent_volume_claim.ex
@@ -8,21 +8,20 @@ defmodule Console.AI.Evidence.Component.PersistentVolumeClaim do
   alias Console.AI.Evidence.Context
 
   def hydrate(%CoreV1.PersistentVolumeClaim{} = pvc) do
-    messages = [
-      {:user, "the persistent volume claim #{component(pvc)} has a current state of:\n#{json_blob(encode(pvc))}"}
-    ] ++ pv_message(pvc)
-
-    messages
+    pv_message(pvc)
+    |> prepend({:user, "the persistent volume claim #{component(pvc)} has a current state of:\n#{json_blob(encode(pvc))}"})
     |> maybe_add_csi_logs(pvc, Repo.preload(get_cluster(), [:operational_layout]))
   end
   def hydrate(_), do: {:ok, []}
 
   defp pv_message(%CoreV1.PersistentVolumeClaim{spec: %{volume_name: name}}) when is_binary(name) do
-    with {:ok, pv} <- CoreV1.read_persistent_volume!(name) |> Kube.Utils.run() do
-      [
-        {:user, "the claim is bound to the persistent volume #{name}, which has a state of:\n#{json_blob(encode(pv))}"}
-      ]
-    else
+    CoreV1.read_persistent_volume!(name)
+    |> Kube.Utils.run()
+    |> case do
+      {:ok, pv} ->
+        [
+          {:user, "the claim is bound to the persistent volume #{name}, which has a state of:\n#{json_blob(encode(pv))}"}
+        ]
       _ -> []
     end
   end
@@ -35,33 +34,23 @@ defmodule Console.AI.Evidence.Component.PersistentVolumeClaim do
     |> Kube.Utils.run()
     |> case do
       {:ok, %StorageV1.StorageClass{provisioner: p}} ->
-        csi_namespace = resolve_csi_namespace(p, ns)
-        history = Enum.concat(history, [
-          {:user, "the storage class #{sc_name} uses the csi provisioner #{p}"},
-          {:user, "analyzing logs for the csi provisioner #{p} in the #{csi_namespace} namespace"}
-        ])
+        csi_ns = resolve_csi_namespace(p, ns)
+        append(history, "the storage class #{sc_name} uses the csi provisioner #{p}, I'll list the logs for the csi provisioner #{p} in the #{csi_ns} namespace if available")
         |> Logs.with_logging(
           cluster,
           force: true,
-          namespaces: [csi_namespace],
+          namespaces: [csi_ns],
           query: p
         )
-        |> Context.history()
-
-        {:ok, history}
+        |> Context.result()
 
       _ -> {:ok, history}
     end
   end
   defp maybe_add_csi_logs(history, _, _), do: {:ok, history}
 
-  defp resolve_csi_namespace(provisioner, %OperationalLayout.Namespaces{} = ns) do
-    case csi_namespace_mapping(provisioner, ns) do
-      ns when is_binary(ns) -> ns
-      _ -> "kube-system"
-    end
-  end
 
-  defp csi_namespace_mapping("ebs.csi.aws.com", %{ebs_csi_driver: ns}), do: ns
-  defp csi_namespace_mapping(_, _), do: nil
+  defp resolve_csi_namespace("ebs.csi.aws.com", %OperationalLayout.Namespaces{ebs_csi_driver: ns})
+    when is_binary(ns), do: ns
+  defp resolve_csi_namespace(_, _), do: "kube-system"
 end

--- a/lib/console/ai/evidence/component/persistent_volume_claim.ex
+++ b/lib/console/ai/evidence/component/persistent_volume_claim.ex
@@ -1,0 +1,67 @@
+defmodule Console.AI.Evidence.Component.PersistentVolumeClaim do
+  use Console.AI.Evidence.Base
+  alias Kazan.Apis.Storage.V1, as: StorageV1
+  alias Kazan.Apis.Core.V1, as: CoreV1
+  alias Console.Repo
+  alias Console.AI.Evidence.Logs
+  alias Console.Schema.{Cluster, OperationalLayout}
+  alias Console.AI.Evidence.Context
+
+  def hydrate(%CoreV1.PersistentVolumeClaim{} = pvc) do
+    messages = [
+      {:user, "the persistent volume claim #{component(pvc)} has a current state of:\n#{json_blob(encode(pvc))}"}
+    ] ++ pv_message(pvc)
+
+    messages
+    |> maybe_add_csi_logs(pvc, Repo.preload(get_cluster(), [:operational_layout]))
+  end
+  def hydrate(_), do: {:ok, []}
+
+  defp pv_message(%CoreV1.PersistentVolumeClaim{spec: %{volume_name: name}}) when is_binary(name) do
+    with {:ok, pv} <- CoreV1.read_persistent_volume!(name) |> Kube.Utils.run() do
+      [
+        {:user, "the claim is bound to the persistent volume #{name}, which has a state of:\n#{json_blob(encode(pv))}"}
+      ]
+    else
+      _ -> []
+    end
+  end
+  defp pv_message(_), do: []
+
+  defp maybe_add_csi_logs(history, %CoreV1.PersistentVolumeClaim{spec: %{storage_class_name: sc_name}}, %Cluster{
+    operational_layout: %OperationalLayout{namespaces: %OperationalLayout.Namespaces{} = ns}
+  } = cluster) when is_binary(sc_name) do
+    StorageV1.read_storage_class!(sc_name)
+    |> Kube.Utils.run()
+    |> case do
+      {:ok, %StorageV1.StorageClass{provisioner: p}} ->
+        csi_namespace = resolve_csi_namespace(p, ns)
+        history = Enum.concat(history, [
+          {:user, "the storage class #{sc_name} uses the csi provisioner #{p}"},
+          {:user, "analyzing logs for the csi provisioner #{p} in the #{csi_namespace} namespace"}
+        ])
+        |> Logs.with_logging(
+          cluster,
+          force: true,
+          namespaces: [csi_namespace],
+          query: p
+        )
+        |> Context.history()
+
+        {:ok, history}
+
+      _ -> {:ok, history}
+    end
+  end
+  defp maybe_add_csi_logs(history, _, _), do: {:ok, history}
+
+  defp resolve_csi_namespace(provisioner, %OperationalLayout.Namespaces{} = ns) do
+    case csi_namespace_mapping(provisioner, ns) do
+      ns when is_binary(ns) -> ns
+      _ -> "kube-system"
+    end
+  end
+
+  defp csi_namespace_mapping("ebs.csi.aws.com", %{ebs_csi_driver: ns}), do: ns
+  defp csi_namespace_mapping(_, _), do: nil
+end

--- a/lib/console/ai/evidence/component/resource.ex
+++ b/lib/console/ai/evidence/component/resource.ex
@@ -7,7 +7,9 @@ defmodule Console.AI.Evidence.Component.Resource do
     Ingress,
     CronJob,
     Job,
-    Certificate
+    Raw,
+    Certificate,
+    PersistentVolumeClaim
   }
 
   def resource(%{group: "apps", version: "v1", kind: "Deployment"} = c, _) do
@@ -36,6 +38,10 @@ defmodule Console.AI.Evidence.Component.Resource do
   end
   def resource(%{group: "cert-manager.io", version: "v1", kind: "Certificate"} = c, _),
     do: Kube.Client.get_certificate(c.namespace, c.name)
+  def resource(%{group: nil, version: "v1", kind: "PersistentVolumeClaim"} = c, _) do
+    CoreV1.read_namespaced_persistent_volume_claim!(c.namespace, c.name)
+    |> Kube.Utils.run()
+  end
   def resource(%{group: g, version: v, kind: k} = comp, cluster) do
     kind = get_kind(cluster, g, v, k)
     Kube.Client.Base.path(g, v, kind, comp.namespace, comp.name)
@@ -94,6 +100,7 @@ defmodule Console.AI.Evidence.Component.Resource do
   def custom?(%BatchV1.CronJob{}), do: false
   def custom?(%BatchV1.Job{}), do: false
   def custom?(%Kube.Certificate{}), do: false
+  def custom?(%CoreV1.PersistentVolumeClaim{}), do: false
   def custom?(_), do: true
 
   defp do_hydrate(%AppsV1.Deployment{} = dep), do: Deployment.hydrate(dep)
@@ -103,10 +110,12 @@ defmodule Console.AI.Evidence.Component.Resource do
   defp do_hydrate(%BatchV1.CronJob{} = cj), do: CronJob.hydrate(cj)
   defp do_hydrate(%BatchV1.Job{} = cj), do: Job.hydrate(cj)
   defp do_hydrate(%Kube.Certificate{} = cert), do: Certificate.hydrate(cert)
-  # defp do_hydrate(%{"metadata" => _}), do: {:ok, []}
+  defp do_hydrate(%{"metadata" => _} = raw), do: Raw.hydrate(raw)
+  defp do_hydrate(%CoreV1.PersistentVolumeClaim{} = pvc), do: PersistentVolumeClaim.hydrate(pvc)
   defp do_hydrate(_), do: {:ok, []}
 
   defp details(%{metadata: %{uid: uid} = meta}), do: {uid, Map.get(meta, :namespace)}
   defp details(%{"metadata" => %{"uid" => uid} = meta}), do: {uid, meta["namespace"]}
   defp details(%{"metadata" => meta}), do: {meta["uid"], meta["namespace"]}
+  defp details(%{items: []}), do: nil
 end

--- a/lib/console/ai/evidence/component/stateful_set.ex
+++ b/lib/console/ai/evidence/component/stateful_set.ex
@@ -4,29 +4,30 @@ defmodule Console.AI.Evidence.Component.StatefulSet do
   alias Console.AI.Evidence.Context
 
   def hydrate(%AppsV1.StatefulSet{metadata: %{namespace: ns}, spec: %{selector: selector}} = sts) do
-    with {:ok, pod_evidence} <- list_pods(ns, selector) |> default_empty(&pod_messages("statefulset", &1)) do
-      # Start with pod evidence in a Context
-      ctx = Context.new(pod_evidence)
-
-      # Merge in PVC evidence (already accumulated in a Context)
-      final_ctx = case pvc_messages(sts) do
-        %Context{} = pvc_ctx -> Context.merge(ctx, pvc_ctx)
-        _ -> ctx
-      end
-
-      Context.result(final_ctx)
-    else
+    list_pods(ns, selector)
+    |> default_empty(&pod_messages("statefulset", &1))
+    |> case do
+      {:ok, pod_evidence} ->
+        Context.new(pod_evidence)
+        |> maybe_merge_pvcs(pvc_messages(sts))
+        |> Context.result()
       _ -> {:ok, []}
     end
   end
 
   def hydrate(_), do: {:ok, []}
 
+  # we should only care about pvc evidence if there are actually failed pvcs
+  defp maybe_merge_pvcs(ctx, %Context{history: [_ | _]} = pvc_ctx) do
+    pvc_ctx = Context.prompt(pvc_ctx, "this statefulset also has failing pvcs, which i'll describe in the next few messages")
+    Context.merge(ctx, pvc_ctx)
+  end
+  defp maybe_merge_pvcs(ctx, _), do: ctx
+
   defp pvc_messages(%AppsV1.StatefulSet{
-         metadata: %{name: sts_name, namespace: ns},
-         spec: %{replicas: replicas, volume_claim_templates: vcts}
-       })
-       when is_list(vcts) do
+    metadata: %{name: sts_name, namespace: ns},
+    spec: %{replicas: replicas, volume_claim_templates: vcts}
+  }) when is_list(vcts) do
     Enum.reduce(vcts, Context.new([]), fn vct, acc ->
       Enum.reduce(0..(replicas - 1), acc, fn i, acc ->
         case fetch_pvc_evidence(ns, "#{vct.metadata.name}-#{sts_name}-#{i}") do
@@ -36,47 +37,17 @@ defmodule Console.AI.Evidence.Component.StatefulSet do
       end)
     end)
   end
-
-  defp pvc_messages(_), do: Context.new([])
+  defp pvc_messages(_), do: :ignore
 
   defp fetch_pvc_evidence(namespace, pvc_name) do
-    with {:ok, pvc} <- CoreV1.read_namespaced_persistent_volume_claim!(namespace, pvc_name) |> Kube.Utils.run(),
-         {:ok, evidence_messages} <- PersistentVolumeClaim.hydrate(pvc) do
-
-      # Create a Context with both history and evidence
-      now = DateTime.utc_now()
-      ctx = Context.new(evidence_messages)
-
-      # Add evidence for this specific PVC
-      evidence_entry = %{
-        type: :log,
-        logs: %{
-          source: "statefulset-pvc-evidence",
-          pvc_name: pvc_name,
-          lines: create_evidence_lines(evidence_messages, now)
-        }
-      }
-
-      ctx_with_evidence = Context.evidence(ctx, evidence_entry)
-      {:ok, ctx_with_evidence}
-    else
-      _ -> {:error, :not_found}
+    CoreV1.read_namespaced_persistent_volume_claim!(namespace, pvc_name)
+    |> Kube.Utils.run()
+    |> case do
+      {:ok, %CoreV1.PersistentVolumeClaim{status: %CoreV1.PersistentVolumeClaimStatus{phase: p}} = pvc}
+          when p != "Bound" ->
+        PersistentVolumeClaim.hydrate(pvc)
+        |> Context.from_result()
+      _ -> :ignore
     end
-  end
-
-  defp create_evidence_lines(messages, base_timestamp) do
-    messages
-    |> Enum.with_index()
-    |> Enum.map(fn {entry, index} ->
-      log_message = case entry do
-        {_, msg} -> msg
-        msg when is_binary(msg) -> msg
-      end
-
-      %{
-        timestamp: DateTime.add(base_timestamp, index, :second),
-        log: log_message
-      }
-    end)
   end
 end

--- a/lib/console/ai/evidence/component/stateful_set.ex
+++ b/lib/console/ai/evidence/component/stateful_set.ex
@@ -1,9 +1,82 @@
 defmodule Console.AI.Evidence.Component.StatefulSet do
   use Console.AI.Evidence.Base
+  alias Console.AI.Evidence.Component.PersistentVolumeClaim
+  alias Console.AI.Evidence.Context
 
-  def hydrate(%AppsV1.StatefulSet{metadata: %{namespace: ns}, spec: %{selector: selector}}) do
-    list_pods(ns, selector)
-    |> default_empty(&pod_messages("statefulset", &1))
+  def hydrate(%AppsV1.StatefulSet{metadata: %{namespace: ns}, spec: %{selector: selector}} = sts) do
+    with {:ok, pod_evidence} <- list_pods(ns, selector) |> default_empty(&pod_messages("statefulset", &1)) do
+      # Start with pod evidence in a Context
+      ctx = Context.new(pod_evidence)
+
+      # Merge in PVC evidence (already accumulated in a Context)
+      final_ctx = case pvc_messages(sts) do
+        %Context{} = pvc_ctx -> Context.merge(ctx, pvc_ctx)
+        _ -> ctx
+      end
+
+      Context.result(final_ctx)
+    else
+      _ -> {:ok, []}
+    end
   end
+
   def hydrate(_), do: {:ok, []}
+
+  defp pvc_messages(%AppsV1.StatefulSet{
+         metadata: %{name: sts_name, namespace: ns},
+         spec: %{replicas: replicas, volume_claim_templates: vcts}
+       })
+       when is_list(vcts) do
+    Enum.reduce(vcts, Context.new([]), fn vct, acc ->
+      Enum.reduce(0..(replicas - 1), acc, fn i, acc ->
+        case fetch_pvc_evidence(ns, "#{vct.metadata.name}-#{sts_name}-#{i}") do
+          {:ok, pvc_ctx} -> Context.merge(acc, pvc_ctx)
+          _ -> acc
+        end
+      end)
+    end)
+  end
+
+  defp pvc_messages(_), do: Context.new([])
+
+  defp fetch_pvc_evidence(namespace, pvc_name) do
+    with {:ok, pvc} <- CoreV1.read_namespaced_persistent_volume_claim!(namespace, pvc_name) |> Kube.Utils.run(),
+         {:ok, evidence_messages} <- PersistentVolumeClaim.hydrate(pvc) do
+
+      # Create a Context with both history and evidence
+      now = DateTime.utc_now()
+      ctx = Context.new(evidence_messages)
+
+      # Add evidence for this specific PVC
+      evidence_entry = %{
+        type: :log,
+        logs: %{
+          source: "statefulset-pvc-evidence",
+          pvc_name: pvc_name,
+          lines: create_evidence_lines(evidence_messages, now)
+        }
+      }
+
+      ctx_with_evidence = Context.evidence(ctx, evidence_entry)
+      {:ok, ctx_with_evidence}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  defp create_evidence_lines(messages, base_timestamp) do
+    messages
+    |> Enum.with_index()
+    |> Enum.map(fn {entry, index} ->
+      log_message = case entry do
+        {_, msg} -> msg
+        msg when is_binary(msg) -> msg
+      end
+
+      %{
+        timestamp: DateTime.add(base_timestamp, index, :second),
+        log: log_message
+      }
+    end)
+  end
 end

--- a/lib/console/ai/evidence/context.ex
+++ b/lib/console/ai/evidence/context.ex
@@ -21,4 +21,15 @@ defmodule Console.AI.Evidence.Context do
   def reduce(%__MODULE__{} = ctx, enum, fun) when is_function(fun, 2), do: Enum.reduce(enum, ctx, fun)
 
   def result(%__MODULE__{history: history, evidence: evidence}), do: {:ok, history, %{evidence: evidence}}
+
+  def merge(%__MODULE__{history: h1, evidence: e1} = ctx, %__MODULE__{history: h2, evidence: e2}) do
+    %{ctx | history: h1 ++ h2, evidence: e1 ++ e2}
+  end
+  def merge(%__MODULE__{history: hist} = ctx, messages) when is_list(messages) do
+    %{ctx | history: hist ++ messages}
+  end
+  def merge(%__MODULE__{} = ctx, _), do: ctx
+
+  def history(%__MODULE__{history: history}), do: history
+  def history(%__MODULE__{} = ctx), do: ctx.history
 end

--- a/lib/console/ai/evidence/context.ex
+++ b/lib/console/ai/evidence/context.ex
@@ -2,8 +2,16 @@ defmodule Console.AI.Evidence.Context do
   import Console.AI.Evidence.Base, only: [append: 2]
 
   @type t :: %__MODULE__{history: Console.AI.Provider.history}
+  @type result :: {:ok, Console.AI.Provider.history, %{evidence: [map]}} |
+                  {:ok, Console.AI.Provider.history} |
+                  {:error, any}
 
   defstruct [:history, evidence: []]
+
+  def from_result({:ok, history, %{evidence: evidence}}),
+    do: {:ok, %__MODULE__{history: history, evidence: evidence}}
+  def from_result({:ok, history}), do: {:ok, new(history)}
+  def from_result(error), do: error
 
   def new(%__MODULE__{} = ctx), do: ctx
   def new(history), do: %__MODULE__{history: history}
@@ -20,6 +28,7 @@ defmodule Console.AI.Evidence.Context do
 
   def reduce(%__MODULE__{} = ctx, enum, fun) when is_function(fun, 2), do: Enum.reduce(enum, ctx, fun)
 
+  @spec result(t) :: result
   def result(%__MODULE__{history: history, evidence: evidence}), do: {:ok, history, %{evidence: evidence}}
 
   def merge(%__MODULE__{history: h1, evidence: e1} = ctx, %__MODULE__{history: h2, evidence: e2}) do

--- a/lib/console/ai/evidence/logs.ex
+++ b/lib/console/ai/evidence/logs.ex
@@ -24,7 +24,7 @@ defmodule Console.AI.Evidence.Logs do
   @spec with_logging(Provider.history, parent) :: Context.t
   def with_logging(history, parent, opts \\ []) do
     force = Keyword.get(opts, :force, false)
-    args  = Keyword.take(opts, ~w(lines q namespaces)a)
+    args  = Keyword.take(opts, ~w(lines query namespaces)a)
     with %DeploymentSettings{logging: %{enabled: true}} <- Settings.cached(),
          true <- use_logs?(history, force),
          {:ok, query} <- query(parent, args),
@@ -49,7 +49,9 @@ defmodule Console.AI.Evidence.Logs do
     %{cluster: cluster} = Repo.preload(comp, [:cluster])
     build_query(cluster, args ++ @base ++ [cluster_id: cluster.id, namespaces: [comp.namespace]])
   end
-  defp query(%Cluster{} = cluster, args), do: build_query(cluster, args ++ @base ++ [cluster_id: cluster.id])
+  defp query(%Cluster{} = cluster, args) do
+    build_query(cluster, args ++ @base ++ [cluster_id: cluster.id])
+  end
   defp query(_, _), do: {:error, :invalid_parent}
 
   defp build_query(resource, args), do: {:ok, %{Query.new(args) | resource: resource}}

--- a/test/console/ai/cron_test.exs
+++ b/test/console/ai/cron_test.exs
@@ -147,11 +147,10 @@ defmodule Console.AI.CronTest do
       )
       expect(Clusters, :control_plane, 2, fn _ -> %Kazan.Server{} end)
       expect(Clusters, :api_discovery, fn  _ -> %{} end)
-      expect(Kube.Utils, :run, fn _ -> {:ok, es_cluster("ns")} end)
-      expect(Kube.Utils, :run, fn _ -> {:ok, %{items: []}} end)
-      expect(Kube.Utils, :run, fn _ -> {:ok, stateful_set("ns")} end)
-      expect(Kube.Utils, :run, fn _ -> {:ok, %{items: []}} end)
-      expect(Kube.Utils, :run, fn _ -> {:ok, %{items: []}} end)
+      expect(Kube.Utils, :run, 2, fn
+        %Kazan.Request{path: "/apis/elasticsearch.k8s.elastic.com/v1/namespaces/ns/elasticsearches/name"} -> {:ok, es_cluster("ns")}
+        _ -> {:ok, %{items: []}}
+      end)
       expect(Console.AI.OpenAI, :completion, 6, fn _, _, _ -> {:ok, "openai completion"} end)
 
       Cron.services()
@@ -234,6 +233,94 @@ defmodule Console.AI.CronTest do
 
       assert svc.insight.text
       assert svc.insight_id == insight.id
+    end
+
+    test "it will gather evidence from a statefulset and its pvcs" do
+      deployment_settings(
+        logging: %{enabled: true, driver: :elastic, elastic: %{host: "localhost", index: "test"}},
+        ai: %{enabled: true, provider: :openai, openai: %{access_token: "key"}}
+      )
+
+      cluster = insert(:cluster,
+        operational_layout: build(:operational_layout,
+          namespaces: %{ebs_csi_driver: "aws-ebs-csi-driver"}
+        )
+      )
+
+      service = insert(:service, cluster: cluster, status: :failed, errors: [%{source: "manifests", error: "some error"}])
+      insert(:service_component,
+        service: service,
+        state: :pending,
+        group: "apps",
+        version: "v1",
+        kind: "StatefulSet",
+        namespace: "ns",
+        name: "my-sts"
+      )
+
+      vct = volume_claim_template("my-vct", "my-sc")
+      sts = stateful_set("my-sts", "ns", 1, [vct])
+      pvc = persistent_volume_claim("my-vct-my-sts-0", "ns", "my-sc", "my-pv")
+      pv = persistent_volume("my-pv")
+      sc = storage_class("my-sc", "ebs.csi.aws.com")
+
+      expect(Clusters, :control_plane, fn _ -> %Kazan.Server{} end)
+      expect(Kube.Utils, :run, 6, fn
+        %Kazan.Request{path: "/apis/apps/v1/namespaces/ns/statefulsets/my-sts"} -> {:ok, sts}
+        %Kazan.Request{path: "/api/v1/namespaces/ns/persistentvolumeclaims/my-vct-my-sts-0"} -> {:ok, pvc}
+        %Kazan.Request{path: "/api/v1/persistentvolumes/my-pv"} -> {:ok, pv}
+        %Kazan.Request{path: "/apis/storage.k8s.io/v1/storageclasses/my-sc"} -> {:ok, sc}
+        _ -> {:ok, %{items: []}}
+      end)
+
+      expect(Console.Logs.Provider, :query, 1, fn
+        # Updated to expect the specific CSI driver query
+        %Console.Logs.Query{
+          query: "ebs.csi.aws.com",  # <-- Changed from generic error terms
+          namespaces: ["aws-ebs-csi-driver"],
+          cluster_id: _
+        } ->
+          {:ok, [
+            %Console.Logs.Line{
+              log: "2024-01-01 10:00:00 INFO: CSI driver started",
+              timestamp: ~U[2024-01-01 10:00:00Z],
+              facets: []
+            },
+            %Console.Logs.Line{
+              log: "2024-01-01 10:01:00 ERROR: Failed to provision volume",
+              timestamp: ~U[2024-01-01 10:01:00Z],
+              facets: []
+            }
+          ]}
+      end)
+
+      expect(Console.AI.OpenAI, :completion, 4, fn _, _, _ -> {:ok, "openai completion"} end)
+      expect(Console.AI.OpenAI, :tool_call, fn _, _, _ ->
+        {:ok, [%Console.AI.Tool{name: "logging", arguments: %{required: false}}]}
+      end)
+
+      Cron.services()
+
+      %{id: id} = svc = refetch(service) |> Console.Repo.preload([:insight, :components])
+      assert svc.insight.text
+
+      [component] = svc.components
+      component_insight = Repo.get!(Console.Schema.AiInsight, component.insight_id) |> Repo.preload(:evidence)
+      evidence_text = component_insight.evidence
+        |> Stream.filter(&(&1.type == :log))
+        |> Stream.flat_map(&(&1.logs.lines))
+        |> Stream.map(&(&1.log))
+        |> Enum.join("\n")
+
+      assert evidence_text =~ "the persistent volume claim"
+      assert evidence_text =~ "my-vct-my-sts-0"
+      assert evidence_text =~ "the claim is bound to the persistent volume my-pv"
+      assert evidence_text =~ "the storage class my-sc uses the csi provisioner ebs.csi.aws.com"
+      assert evidence_text =~ "analyzing logs for the csi provisioner ebs.csi.aws.com in the aws-ebs-csi-driver namespace"
+      assert evidence_text =~ "CSI driver started"
+      assert evidence_text =~ "Failed to provision volume"
+
+      assert_receive {:event, %PubSub.ServiceInsight{item: {%{id: ^id}, _}}}
     end
   end
 

--- a/test/console/graphql/queries/kubernetes_queries_test.exs
+++ b/test/console/graphql/queries/kubernetes_queries_test.exs
@@ -14,7 +14,7 @@ defmodule Console.GraphQl.KubernetesQueriesTest do
       user = insert(:user)
       svc = insert(:service, namespace: "namespace", read_bindings: [%{user_id: user.id}])
       insert(:service_component, service: svc, group: "apps", version: "v1", kind: "StatefulSet", namespace: "namespace", name: "name")
-      expect(Kazan, :run, fn _, _ -> {:ok, stateful_set("namespace", "name")} end)
+      expect(Kazan, :run, fn _, _ -> {:ok, stateful_set("name", "namespace", 3, [])} end)
       expect(Clusters, :control_plane, fn _ -> %Kazan.Server{} end)
 
       {:ok, %{data: %{"statefulSet" => stateful}}} = run_query("""

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -47,6 +47,7 @@ Mimic.copy(Cloudquery.CloudQuery.Stub)
 Mimic.copy(Console.AI.Graph.Indexer.Sink)
 Mimic.copy(Req)
 Mimic.copy(Oidcc.Token)
+Mimic.copy(Kazan.Client.Imp)
 
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Console.Repo, :manual)


### PR DESCRIPTION
Add PersistentVolume claims as AI evidence generated by the Cron job. The PVCs search CSI log drivers using provisioner and component name as filters.

The PVC module is also integrated into StatefulSet so that PersistentVolume data, if available, is added to the evidence for StatefulSet failures.

Added unit test that makes sure to check evidence string content.

<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
Unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console