### PR TITLE
Add arbitrary multi-source support and custom render pipelines for se…

### DIFF
--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -3096,8 +3096,11 @@ export type GitRef = {
 };
 
 export type GitRefAttributes = {
+  /** the files to include in the tarball */
   files?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** the subdirectory in the git repository to use */
   folder: Scalars['String']['input'];
+  /** the git reference to use */
   ref: Scalars['String']['input'];
 };
 
@@ -3380,6 +3383,25 @@ export type HelmConfigAttributes = {
 
 export type HelmGcpAuthAttributes = {
   applicationCredentials?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type HelmMinimal = {
+  __typename?: 'HelmMinimal';
+  /** the helm release name to use when rendering this helm chart */
+  release?: Maybe<Scalars['String']['output']>;
+  /** a helm values file to use when rendering this helm chart */
+  values?: Maybe<Scalars['String']['output']>;
+  /** a list of relative paths to values files to use for helm chart templating */
+  valuesFiles?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+};
+
+export type HelmMinimalAttributes = {
+  /** the helm release name to use when rendering this helm chart */
+  release?: InputMaybe<Scalars['String']['input']>;
+  /** a helm values file to use when rendering this helm chart */
+  values?: InputMaybe<Scalars['String']['input']>;
+  /** a list of relative paths to values files to use for helm chart templating */
+  valuesFiles?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 /** A direct Plural representation of a Helm repository */
@@ -6183,6 +6205,26 @@ export type RegexReplacementAttributes = {
   /** whether you want to apply liquid templating on the regex before compiling */
   templated?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
+export type Renderer = {
+  __typename?: 'Renderer';
+  helm?: Maybe<HelmMinimal>;
+  path: Scalars['String']['output'];
+  type: RendererType;
+};
+
+export type RendererAttributes = {
+  helm?: InputMaybe<HelmMinimalAttributes>;
+  path: Scalars['String']['input'];
+  type: RendererType;
+};
+
+export enum RendererType {
+  Auto = 'AUTO',
+  Helm = 'HELM',
+  Kustomize = 'KUSTOMIZE',
+  Raw = 'RAW'
+}
 
 export type ReplicaSet = {
   __typename?: 'ReplicaSet';
@@ -9405,6 +9447,8 @@ export type ServiceDeployment = {
   rawResource?: Maybe<KubernetesUnstructured>;
   /** read policy for this service */
   readBindings?: Maybe<Array<Maybe<PolicyBinding>>>;
+  /** the renderers of this service */
+  renderers?: Maybe<Array<Maybe<Renderer>>>;
   /** the git repo of this service */
   repository?: Maybe<GitRepository>;
   /** the current revision of this service */
@@ -9414,6 +9458,8 @@ export type ServiceDeployment = {
   scalingRecommendations?: Maybe<Array<Maybe<ClusterScalingRecommendation>>>;
   /** latest git sha we pulled from */
   sha?: Maybe<Scalars['String']['output']>;
+  /** the sources of this service */
+  sources?: Maybe<Array<Maybe<ServiceSource>>>;
   /** A summary status enum for the health of this service */
   status: ServiceDeploymentStatus;
   /** settings for advanced tuning of the sync process */
@@ -9504,6 +9550,7 @@ export type ServiceDeploymentAttributes = {
   protect?: InputMaybe<Scalars['Boolean']['input']>;
   readBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
   repositoryId?: InputMaybe<Scalars['ID']['input']>;
+  sources?: InputMaybe<Array<InputMaybe<ServiceSourceAttributes>>>;
   syncConfig?: InputMaybe<SyncConfigAttributes>;
   /** if you should apply liquid templating to raw yaml files, defaults to true */
   templated?: InputMaybe<Scalars['Boolean']['input']>;
@@ -9579,6 +9626,25 @@ export enum ServicePromotion {
   Proceed = 'PROCEED',
   Rollback = 'ROLLBACK'
 }
+
+export type ServiceSource = {
+  __typename?: 'ServiceSource';
+  /** the git reference to use */
+  git?: Maybe<GitRef>;
+  /** the subdirectory in the git repository to use */
+  path?: Maybe<Scalars['String']['output']>;
+  /** the id of the git repository to source from */
+  repositoryId?: Maybe<Scalars['ID']['output']>;
+};
+
+export type ServiceSourceAttributes = {
+  /** the location in git to use */
+  git?: InputMaybe<GitRefAttributes>;
+  /** the subdirectory this source will live in the final tarball */
+  path?: InputMaybe<Scalars['String']['input']>;
+  /** the id of the git repository to source from */
+  repositoryId?: InputMaybe<Scalars['ID']['input']>;
+};
 
 export type ServiceSpec = {
   __typename?: 'ServiceSpec';
@@ -9668,6 +9734,8 @@ export type ServiceUpdateAttributes = {
   parentId?: InputMaybe<Scalars['ID']['input']>;
   protect?: InputMaybe<Scalars['Boolean']['input']>;
   readBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
+  renderers?: InputMaybe<Array<InputMaybe<RendererAttributes>>>;
+  sources?: InputMaybe<Array<InputMaybe<ServiceSourceAttributes>>>;
   syncConfig?: InputMaybe<SyncConfigAttributes>;
   /** if you should apply liquid templating to raw yaml files, defaults to true */
   templated?: InputMaybe<Scalars['Boolean']['input']>;

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -2506,9 +2506,12 @@ type GitRef struct {
 }
 
 type GitRefAttributes struct {
-	Ref    string   `json:"ref"`
-	Folder string   `json:"folder"`
-	Files  []string `json:"files,omitempty"`
+	// the git reference to use
+	Ref string `json:"ref"`
+	// the subdirectory in the git repository to use
+	Folder string `json:"folder"`
+	// the files to include in the tarball
+	Files []string `json:"files,omitempty"`
 }
 
 // a git repository available for deployments
@@ -2751,6 +2754,24 @@ type HelmConfigAttributes struct {
 
 type HelmGCPAuthAttributes struct {
 	ApplicationCredentials *string `json:"applicationCredentials,omitempty"`
+}
+
+type HelmMinimal struct {
+	// a helm values file to use when rendering this helm chart
+	Values *string `json:"values,omitempty"`
+	// a list of relative paths to values files to use for helm chart templating
+	ValuesFiles []*string `json:"valuesFiles,omitempty"`
+	// the helm release name to use when rendering this helm chart
+	Release *string `json:"release,omitempty"`
+}
+
+type HelmMinimalAttributes struct {
+	// a helm values file to use when rendering this helm chart
+	Values *string `json:"values,omitempty"`
+	// a list of relative paths to values files to use for helm chart templating
+	ValuesFiles []*string `json:"valuesFiles,omitempty"`
+	// the helm release name to use when rendering this helm chart
+	Release *string `json:"release,omitempty"`
 }
 
 // A direct Plural representation of a Helm repository
@@ -5117,6 +5138,18 @@ type RegexReplacementAttributes struct {
 	Templated *bool `json:"templated,omitempty"`
 }
 
+type Renderer struct {
+	Path string       `json:"path"`
+	Type RendererType `json:"type"`
+	Helm *HelmMinimal `json:"helm,omitempty"`
+}
+
+type RendererAttributes struct {
+	Path string                 `json:"path"`
+	Type RendererType           `json:"type"`
+	Helm *HelmMinimalAttributes `json:"helm,omitempty"`
+}
+
 type ReplicaSet struct {
 	Metadata Metadata         `json:"metadata"`
 	Spec     ReplicaSetSpec   `json:"spec"`
@@ -5610,6 +5643,10 @@ type ServiceDeployment struct {
 	DeletedAt *string `json:"deletedAt,omitempty"`
 	// whether this service should not actively reconcile state and instead simply report pending changes
 	DryRun *bool `json:"dryRun,omitempty"`
+	// the sources of this service
+	Sources []*ServiceSource `json:"sources,omitempty"`
+	// the renderers of this service
+	Renderers []*Renderer `json:"renderers,omitempty"`
 	// fetches the /docs directory within this services git tree.  This is a heavy operation and should NOT be used in list queries
 	Docs []*GitFile `json:"docs,omitempty"`
 	// the git repo of this service
@@ -5689,6 +5726,7 @@ type ServiceDeploymentAttributes struct {
 	WriteBindings   []*PolicyBindingAttributes     `json:"writeBindings,omitempty"`
 	ContextBindings []*ContextBindingAttributes    `json:"contextBindings,omitempty"`
 	Imports         []*ServiceImportAttributes     `json:"imports,omitempty"`
+	Sources         []*ServiceSourceAttributes     `json:"sources,omitempty"`
 }
 
 type ServiceDeploymentConnection struct {
@@ -5732,6 +5770,24 @@ type ServicePort struct {
 	Protocol   *string `json:"protocol,omitempty"`
 	Port       *int64  `json:"port,omitempty"`
 	TargetPort *string `json:"targetPort,omitempty"`
+}
+
+type ServiceSource struct {
+	// the subdirectory in the git repository to use
+	Path *string `json:"path,omitempty"`
+	// the id of the git repository to source from
+	RepositoryID *string `json:"repositoryId,omitempty"`
+	// the git reference to use
+	Git *GitRef `json:"git,omitempty"`
+}
+
+type ServiceSourceAttributes struct {
+	// the subdirectory this source will live in the final tarball
+	Path *string `json:"path,omitempty"`
+	// the id of the git repository to source from
+	RepositoryID *string `json:"repositoryId,omitempty"`
+	// the location in git to use
+	Git *GitRefAttributes `json:"git,omitempty"`
 }
 
 type ServiceSpec struct {
@@ -5823,6 +5879,8 @@ type ServiceUpdateAttributes struct {
 	WriteBindings   []*PolicyBindingAttributes     `json:"writeBindings,omitempty"`
 	ContextBindings []*ContextBindingAttributes    `json:"contextBindings,omitempty"`
 	Imports         []*ServiceImportAttributes     `json:"imports,omitempty"`
+	Sources         []*ServiceSourceAttributes     `json:"sources,omitempty"`
+	Renderers       []*RendererAttributes          `json:"renderers,omitempty"`
 }
 
 type ServiceVuln struct {
@@ -9016,6 +9074,51 @@ func (e *ReadType) UnmarshalGQL(v any) error {
 }
 
 func (e ReadType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type RendererType string
+
+const (
+	RendererTypeAuto      RendererType = "AUTO"
+	RendererTypeRaw       RendererType = "RAW"
+	RendererTypeHelm      RendererType = "HELM"
+	RendererTypeKustomize RendererType = "KUSTOMIZE"
+)
+
+var AllRendererType = []RendererType{
+	RendererTypeAuto,
+	RendererTypeRaw,
+	RendererTypeHelm,
+	RendererTypeKustomize,
+}
+
+func (e RendererType) IsValid() bool {
+	switch e {
+	case RendererTypeAuto, RendererTypeRaw, RendererTypeHelm, RendererTypeKustomize:
+		return true
+	}
+	return false
+}
+
+func (e RendererType) String() string {
+	return string(e)
+}
+
+func (e *RendererType) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = RendererType(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid RendererType", str)
+	}
+	return nil
+}
+
+func (e RendererType) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/lib/console/ai/evidence/component/raw.ex
+++ b/lib/console/ai/evidence/component/raw.ex
@@ -30,7 +30,7 @@ defmodule Console.AI.Evidence.Component.Raw do
     PrometheusRule
   ) # ignore crds which we know don't cascade to other resources, mostly our own
 
-  def hydrate(%{"kind" => k, "metadata" => %{"namespace" => ns, "uid" => uid}} = resource)
+  def hydrate(%{"kind" => k, "metadata" => %{"namespace" => ns}} = resource)
       when is_binary(ns) and k not in @kind_blacklist do
     Resource.generate(resource)
   end

--- a/lib/console/deployments/git.ex
+++ b/lib/console/deployments/git.ex
@@ -53,6 +53,12 @@ defmodule Console.Deployments.Git do
   def get_scm_connection(id), do: Repo.get(ScmConnection, id)
   def get_scm_connection!(id), do: Repo.get!(ScmConnection, id)
 
+  def get_repositories(ids) do
+    GitRepository.for_ids(ids)
+    |> Repo.all()
+    |> Map.new(fn %GitRepository{id: id} = git -> {id, git} end)
+  end
+
   def default_scm_connection() do
     ScmConnection.default()
     |> Repo.one()

--- a/lib/console/schema/service.ex
+++ b/lib/console/schema/service.ex
@@ -29,6 +29,7 @@ defmodule Console.Schema.Service do
 
   defenum Promotion, ignore: 0, proceed: 1, rollback: 2
   defenum Status, stale: 0, synced: 1, healthy: 2, failed: 3, paused: 4
+  defenum RendererType, auto: 0, raw: 1, helm: 2, kustomize: 3
 
   defmodule Git do
     use Piazza.Ecto.Schema
@@ -137,6 +138,24 @@ defmodule Console.Schema.Service do
       field :enable_helm, :boolean, default: false
     end
 
+    embeds_many :sources, Source, on_replace: :delete do
+      field :path,          :string
+      field :repository_id, :binary_id
+
+      embeds_one :git,      Git, on_replace: :update
+    end
+
+    embeds_many :renderers, Renderer, on_replace: :delete do
+      field :path, :string
+      field :type, RendererType
+
+      embeds_one :helm, HelmMinimal, on_replace: :update do
+        field :values,       :map
+        field :values_files, :map
+        field :release,      :string
+      end
+    end
+
     belongs_to :revision,   Revision
     belongs_to :cluster,    Cluster
     belongs_to :repository, GitRepository
@@ -151,21 +170,21 @@ defmodule Console.Schema.Service do
     has_one :namespace_instance, NamespaceInstance
     has_one :preview_instance,   PreviewEnvironmentInstance
 
-    has_many :vulns,   ServiceVuln
-    has_many :imports, ServiceImport, on_replace: :delete
-    has_many :errors, ServiceError, on_replace: :delete
-    has_many :components, ServiceComponent, on_replace: :delete
+    has_many :vulns,            ServiceVuln
+    has_many :imports,          ServiceImport, on_replace: :delete
+    has_many :errors,           ServiceError, on_replace: :delete
+    has_many :components,       ServiceComponent, on_replace: :delete
     has_many :context_bindings, ServiceContextBinding, on_replace: :delete
     has_many :configuration, through: [:revision, :configuration]
-    has_many :preview_templates, PreviewEnvironmentTemplate, foreign_key: :reference_service_id
+    has_many :preview_templates,       PreviewEnvironmentTemplate, foreign_key: :reference_service_id
     has_many :scaling_recommendations, ClusterScalingRecommendation, foreign_key: :service_id
-    has_many :dependencies, ServiceDependency,
+    has_many :dependencies,            ServiceDependency,
       foreign_key: :service_id,
       on_replace: :delete
     has_many :api_deprecations, through: [:components, :api_deprecations]
     has_many :contexts, through: [:context_bindings, :context]
     has_many :stage_services, StageService
-    has_many :read_bindings, PolicyBinding,
+    has_many :read_bindings,  PolicyBinding,
       on_replace: :delete,
       foreign_key: :policy_id,
       references: :read_policy_id
@@ -335,6 +354,8 @@ defmodule Console.Schema.Service do
     |> cast_embed(:helm)
     |> cast_embed(:sync_config, with: &sync_config_changeset/2)
     |> cast_embed(:kustomize, with: &kustomize_changeset/2)
+    |> cast_embed(:sources, with: &sources_changeset/2)
+    |> cast_embed(:renderers, with: &renderers_changeset/2)
     |> cast_assoc(:components)
     |> cast_assoc(:errors)
     |> cast_assoc(:read_bindings)
@@ -392,5 +413,23 @@ defmodule Console.Schema.Service do
     model
     |> cast(attrs, ~w(path enable_helm)a)
     |> validate_required(~w(path)a)
+  end
+
+  defp sources_changeset(model, attrs) do
+    model
+    |> cast(attrs, ~w(path repository_id)a)
+    |> cast_embed(:git)
+    |> validate_required(~w(repository_id git)a)
+  end
+
+  defp renderers_changeset(model, attrs) do
+    model
+    |> cast(attrs, ~w(path type)a)
+    |> cast_embed(:helm, with: &helm_minimal_changeset/2)
+  end
+
+  defp helm_minimal_changeset(model, attrs) do
+    model
+    |> cast(attrs, ~w(values values_files release)a)
   end
 end

--- a/priv/repo/migrations/20250615175950_add_service_sources.exs
+++ b/priv/repo/migrations/20250615175950_add_service_sources.exs
@@ -1,0 +1,10 @@
+defmodule Console.Repo.Migrations.AddServiceSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:services) do
+      add :sources,   :map
+      add :renderers, :map
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -4446,6 +4446,13 @@ enum ServicePromotion {
   ROLLBACK
 }
 
+enum RendererType {
+  AUTO
+  RAW
+  HELM
+  KUSTOMIZE
+}
+
 input ServiceDeploymentAttributes {
   name: String!
 
@@ -4489,6 +4496,8 @@ input ServiceDeploymentAttributes {
   contextBindings: [ContextBindingAttributes]
 
   imports: [ServiceImportAttributes]
+
+  sources: [ServiceSourceAttributes]
 }
 
 input ServiceImportAttributes {
@@ -4578,6 +4587,38 @@ input ServiceUpdateAttributes {
   contextBindings: [ContextBindingAttributes]
 
   imports: [ServiceImportAttributes]
+
+  sources: [ServiceSourceAttributes]
+
+  renderers: [RendererAttributes]
+}
+
+input ServiceSourceAttributes {
+  "the subdirectory this source will live in the final tarball"
+  path: String
+
+  "the id of the git repository to source from"
+  repositoryId: ID
+
+  "the location in git to use"
+  git: GitRefAttributes
+}
+
+input RendererAttributes {
+  path: String!
+  type: RendererType!
+  helm: HelmMinimalAttributes
+}
+
+input HelmMinimalAttributes {
+  "a helm values file to use when rendering this helm chart"
+  values: String
+
+  "a list of relative paths to values files to use for helm chart templating"
+  valuesFiles: [String]
+
+  "the helm release name to use when rendering this helm chart"
+  release: String
 }
 
 input ServiceCloneAttributes {
@@ -4587,8 +4628,13 @@ input ServiceCloneAttributes {
 }
 
 input GitRefAttributes {
+  "the git reference to use"
   ref: String!
+
+  "the subdirectory in the git repository to use"
   folder: String!
+
+  "the files to include in the tarball"
   files: [String!]
 }
 
@@ -4720,6 +4766,12 @@ type ServiceDeployment {
 
   "whether this service should not actively reconcile state and instead simply report pending changes"
   dryRun: Boolean
+
+  "the sources of this service"
+  sources: [ServiceSource]
+
+  "the renderers of this service"
+  renderers: [Renderer]
 
   "fetches the \/docs directory within this services git tree.  This is a heavy operation and should NOT be used in list queries"
   docs: [GitFile]
@@ -4903,6 +4955,34 @@ type ServiceConfiguration {
 type HelmValue {
   name: String!
   value: String!
+}
+
+type ServiceSource {
+  "the subdirectory in the git repository to use"
+  path: String
+
+  "the id of the git repository to source from"
+  repositoryId: ID
+
+  "the git reference to use"
+  git: GitRef
+}
+
+type Renderer {
+  path: String!
+  type: RendererType!
+  helm: HelmMinimal
+}
+
+type HelmMinimal {
+  "a helm values file to use when rendering this helm chart"
+  values: String
+
+  "a list of relative paths to values files to use for helm chart templating"
+  valuesFiles: [String]
+
+  "the helm release name to use when rendering this helm chart"
+  release: String
 }
 
 "metadata needed for configuring kustomize"

--- a/test/console/compliance/clusters_test.exs
+++ b/test/console/compliance/clusters_test.exs
@@ -6,7 +6,7 @@ defmodule Console.Compliance.Datasource.ClustersTest do
     user2 = insert(:user, email: "user2@example.com")
     group = insert(:group, name: "compliance-group")
 
-    cluster = insert(:cluster, read_bindings: [%{user_id: user1.id}, %{group_id: group.id}], write_bindings: [%{user_id: user2.id}])
+    insert(:cluster, read_bindings: [%{user_id: user1.id}, %{group_id: group.id}], write_bindings: [%{user_id: user2.id}])
 
     clusters_content = Console.Compliance.Datasource.Clusters.stream()
     |> CSV.encode(headers: true)


### PR DESCRIPTION
…rvices

These support two main usecases:

* adding the ability to source values files + charts from > 2 repos, useful in some unusual but realistic scenarios
* adding the ability to amend basic rendering with custom resources, eg adding a test job to a helm chart or creating a custom namespace policy in before a helm chart

## Test Plan
unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console