### PR TITLE
fix: Project deletion improvements

### DIFF
--- a/go/controller/config/samples/project.yaml
+++ b/go/controller/config/samples/project.yaml
@@ -5,6 +5,3 @@ metadata:
 spec:
   name: marcin-test
   description: Sample project
-
-
-

--- a/go/controller/config/samples/project.yaml
+++ b/go/controller/config/samples/project.yaml
@@ -1,0 +1,10 @@
+apiVersion: deployments.plural.sh/v1alpha1
+kind: Project
+metadata:
+  name: test
+spec:
+  name: marcin-test
+  description: Sample project
+
+
+

--- a/go/controller/internal/client/console.go
+++ b/go/controller/internal/client/console.go
@@ -126,7 +126,7 @@ type ConsoleClient interface {
 	CreateProject(ctx context.Context, attributes console.ProjectAttributes) (*console.ProjectFragment, error)
 	GetProject(ctx context.Context, id, name *string) (*console.ProjectFragment, error)
 	UpdateProject(ctx context.Context, id string, attributes console.ProjectAttributes) (*console.ProjectFragment, error)
-	IsProjectExists(ctx context.Context, name string) (bool, error)
+	IsProjectExists(ctx context.Context, id, name *string) (bool, error)
 	UpsertHelmRepository(ctx context.Context, url string, attributes *console.HelmRepositoryAttributes) (*console.HelmRepositoryFragment, error)
 	GetHelmRepository(ctx context.Context, url string) (*console.HelmRepositoryFragment, error)
 	IsHelmRepositoryExists(ctx context.Context, url string) (bool, error)

--- a/go/controller/internal/client/project.go
+++ b/go/controller/internal/client/project.go
@@ -61,8 +61,8 @@ func (c *client) DeleteProject(ctx context.Context, id string) error {
 	return err
 }
 
-func (c *client) IsProjectExists(ctx context.Context, name string) (bool, error) {
-	scm, err := c.GetProject(ctx, nil, &name)
+func (c *client) IsProjectExists(ctx context.Context, id, name *string) (bool, error) {
+	scm, err := c.GetProject(ctx, id, name)
 	if errors.IsNotFound(err) {
 		return false, nil
 	}

--- a/go/controller/internal/controller/project_controller.go
+++ b/go/controller/internal/controller/project_controller.go
@@ -136,7 +136,7 @@ func (in *ProjectReconciler) addOrRemoveFinalizer(ctx context.Context, project *
 			return &requeue
 		}
 
-		// Remove service from Console API if it exists.
+		// Remove project from Console API if it exists.
 		if exists {
 			if err = in.ConsoleClient.DeleteProject(ctx, project.Status.GetID()); err != nil {
 				// If it fails to delete the external dependency here, return with the error

--- a/go/controller/internal/controller/project_controller_test.go
+++ b/go/controller/internal/controller/project_controller_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pluralsh/console/go/controller/internal/test/mocks"
 )
 
-var _ = Describe("NotificationSink Project Controller", Ordered, func() {
+var _ = Describe("Project Controller", Ordered, func() {
 	Context("When reconciling a resource", func() {
 		const (
 			projectName = "test"
@@ -97,7 +97,7 @@ var _ = Describe("NotificationSink Project Controller", Ordered, func() {
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
-			fakeConsoleClient.On("IsProjectExists", mock.Anything, mock.Anything).Return(false, nil)
+			fakeConsoleClient.On("IsProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
 			fakeConsoleClient.On("CreateProject", mock.Anything, mock.Anything).Return(test.projectFragment, nil)
 
 			nr := &controller.ProjectReconciler{
@@ -166,7 +166,7 @@ var _ = Describe("NotificationSink Project Controller", Ordered, func() {
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
-			fakeConsoleClient.On("IsProjectExists", mock.Anything, mock.Anything).Return(true, nil)
+			fakeConsoleClient.On("IsProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, &clientv2.ErrorResponse{
 				GqlErrors: &gqlerror.List{gqlerror.Errorf("%s", "could not find resource")},
 			})
@@ -207,7 +207,7 @@ var _ = Describe("NotificationSink Project Controller", Ordered, func() {
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
-			fakeConsoleClient.On("IsProjectExists", mock.Anything, mock.Anything).Return(true, nil)
+			fakeConsoleClient.On("IsProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 			fakeConsoleClient.On("DeleteProject", mock.Anything, mock.Anything).Return(nil)
 
 			nsReconciler := &controller.ProjectReconciler{

--- a/go/controller/internal/test/mocks/ConsoleClient_mock.go
+++ b/go/controller/internal/test/mocks/ConsoleClient_mock.go
@@ -5800,9 +5800,9 @@ func (_c *ConsoleClientMock_IsPrAutomationExistsByName_Call) RunAndReturn(run fu
 	return _c
 }
 
-// IsProjectExists provides a mock function with given fields: ctx, name
-func (_m *ConsoleClientMock) IsProjectExists(ctx context.Context, name string) (bool, error) {
-	ret := _m.Called(ctx, name)
+// IsProjectExists provides a mock function with given fields: ctx, id, name
+func (_m *ConsoleClientMock) IsProjectExists(ctx context.Context, id *string, name *string) (bool, error) {
+	ret := _m.Called(ctx, id, name)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IsProjectExists")
@@ -5810,17 +5810,17 @@ func (_m *ConsoleClientMock) IsProjectExists(ctx context.Context, name string) (
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
-		return rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, *string, *string) (bool, error)); ok {
+		return rf(ctx, id, name)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
-		r0 = rf(ctx, name)
+	if rf, ok := ret.Get(0).(func(context.Context, *string, *string) bool); ok {
+		r0 = rf(ctx, id, name)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, name)
+	if rf, ok := ret.Get(1).(func(context.Context, *string, *string) error); ok {
+		r1 = rf(ctx, id, name)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -5835,14 +5835,15 @@ type ConsoleClientMock_IsProjectExists_Call struct {
 
 // IsProjectExists is a helper method to define mock.On call
 //   - ctx context.Context
-//   - name string
-func (_e *ConsoleClientMock_Expecter) IsProjectExists(ctx interface{}, name interface{}) *ConsoleClientMock_IsProjectExists_Call {
-	return &ConsoleClientMock_IsProjectExists_Call{Call: _e.mock.On("IsProjectExists", ctx, name)}
+//   - id *string
+//   - name *string
+func (_e *ConsoleClientMock_Expecter) IsProjectExists(ctx interface{}, id interface{}, name interface{}) *ConsoleClientMock_IsProjectExists_Call {
+	return &ConsoleClientMock_IsProjectExists_Call{Call: _e.mock.On("IsProjectExists", ctx, id, name)}
 }
 
-func (_c *ConsoleClientMock_IsProjectExists_Call) Run(run func(ctx context.Context, name string)) *ConsoleClientMock_IsProjectExists_Call {
+func (_c *ConsoleClientMock_IsProjectExists_Call) Run(run func(ctx context.Context, id *string, name *string)) *ConsoleClientMock_IsProjectExists_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context), args[1].(*string), args[2].(*string))
 	})
 	return _c
 }
@@ -5852,7 +5853,7 @@ func (_c *ConsoleClientMock_IsProjectExists_Call) Return(_a0 bool, _a1 error) *C
 	return _c
 }
 
-func (_c *ConsoleClientMock_IsProjectExists_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *ConsoleClientMock_IsProjectExists_Call {
+func (_c *ConsoleClientMock_IsProjectExists_Call) RunAndReturn(run func(context.Context, *string, *string) (bool, error)) *ConsoleClientMock_IsProjectExists_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
It brings two improvements:
- finalizer will not be applied to read-only projects (this probably should be replicated for all other resources)
- projects ID is used to check if exists instead of its name (deletion is based on ID) 