### PR TITLE
enhancement: Reduce stack poll intervals

### DIFF
--- a/assets/src/components/stacks/Stacks.tsx
+++ b/assets/src/components/stacks/Stacks.tsx
@@ -103,8 +103,6 @@ enum MenuItemKey {
   Delete = 'delete',
 }
 
-const pollInterval = 5 * 1000
-
 const getDirectory = (stack: Nullable<StackFragment>, aiEnabled: boolean) => [
   { path: STACK_RUNS_REL_PATH, label: 'Runs', enabled: true },
   { path: STACK_PRS_REL_PATH, label: 'PRs', enabled: true },
@@ -189,7 +187,7 @@ export default function Stacks() {
     variables: { id: stackId },
     fetchPolicy: 'cache-and-network',
     errorPolicy: 'all',
-    pollInterval,
+    pollInterval: 3_000,
   })
 
   const fullStack = useMemo(() => stackData?.infrastructureStack, [stackData])

--- a/assets/src/components/stacks/prs/PrStackRunsAccordion.tsx
+++ b/assets/src/components/stacks/prs/PrStackRunsAccordion.tsx
@@ -23,8 +23,6 @@ import { PrStatusChip } from 'components/self-service/pr/queue/PrQueueColumns'
 
 import { StackRunsScroller } from '../runs/StackRunsScroller'
 
-const pollInterval = 5 * 1000
-
 // can't really make this dynamic with the current scroller component
 const ACCORDION_TABLE_HEIGHT = '300px'
 
@@ -43,7 +41,7 @@ export function PrStackRunsAccordion({
   const queryResult = useStackRunsQuery({
     variables: { id: stackId, pullRequestId: pr.id },
     fetchPolicy: 'cache-and-network',
-    pollInterval,
+    pollInterval: 5_000,
     skip: !isOpen,
   })
 

--- a/assets/src/components/stacks/run/job/RunJob.tsx
+++ b/assets/src/components/stacks/run/job/RunJob.tsx
@@ -23,7 +23,6 @@ import { ResponsiveLayoutSidenavContainer } from 'components/utils/layout/Respon
 import { SideNavEntries } from 'components/layout/SideNavEntries'
 import { useTheme } from 'styled-components'
 import { Subtitle2H1 } from 'components/utils/typography/Text'
-import { POLL_INTERVAL } from 'components/cd/ContinuousDeployment'
 import { getStackRunsAbsPath } from 'routes/stacksRoutesConsts'
 
 import { TRUNCATE } from '../../../utils/truncate'
@@ -71,7 +70,7 @@ export default function RunJob() {
 
   const { data, error, refetch } = useStackRunJobQuery({
     variables: { id: runId || '' },
-    pollInterval: POLL_INTERVAL,
+    pollInterval: 5_000,
   })
 
   const outletContext: OutletContextT = useMemo(

--- a/assets/src/components/stacks/runs/StackRuns.tsx
+++ b/assets/src/components/stacks/runs/StackRuns.tsx
@@ -10,8 +10,6 @@ import { StackOutletContextT, getBreadcrumbs } from '../Stacks'
 
 import { StackRunsScroller } from './StackRunsScroller'
 
-const pollInterval = 5 * 1000
-
 export default function StackRuns() {
   const { stack } = useOutletContext() as StackOutletContextT
 
@@ -25,7 +23,7 @@ export default function StackRuns() {
   const queryResult = useStackRunsQuery({
     variables: { id: stack?.id ?? '' },
     fetchPolicy: 'cache-and-network',
-    pollInterval,
+    pollInterval: 2_000,
   })
 
   if (!queryResult.data) {


### PR DESCRIPTION
Sets following poll intervals:
- 3s for stacks
- 2s for stack runs
- 5s for stack pull requests and stack run job

Kept policy as `cache-and-network`.