### PR TITLE
fix: name override in controllers

### DIFF
--- a/go/controller/api/v1alpha1/oidcprovider_types.go
+++ b/go/controller/api/v1alpha1/oidcprovider_types.go
@@ -34,7 +34,7 @@ type OIDCProvider struct {
 	Status Status           `json:"status,omitempty"`
 }
 
-func (in *OIDCProvider) GetName() string {
+func (in *OIDCProvider) ConsoleName() string {
 	if in.Spec.Name != nil && len(*in.Spec.Name) > 0 {
 		return *in.Spec.Name
 	}
@@ -57,7 +57,7 @@ func (in *OIDCProvider) Diff(hasher Hasher) (changed bool, sha string, err error
 
 func (in *OIDCProvider) Attributes() console.OidcProviderAttributes {
 	result := console.OidcProviderAttributes{
-		Name:         in.GetName(),
+		Name:         in.ConsoleName(),
 		Description:  in.Spec.Description,
 		RedirectUris: lo.ToSlicePtr(in.Spec.RedirectUris),
 	}

--- a/go/controller/api/v1alpha1/previewenvironmenttemplate_types.go
+++ b/go/controller/api/v1alpha1/previewenvironmenttemplate_types.go
@@ -60,7 +60,7 @@ func init() {
 	SchemeBuilder.Register(&PreviewEnvironmentTemplate{}, &PreviewEnvironmentTemplateList{})
 }
 
-func (in *PreviewEnvironmentTemplate) GetName() string {
+func (in *PreviewEnvironmentTemplate) ConsoleName() string {
 	if in.Spec.Name != nil && len(*in.Spec.Name) > 0 {
 		return *in.Spec.Name
 	}

--- a/go/controller/api/v1alpha1/servicecontext_types.go
+++ b/go/controller/api/v1alpha1/servicecontext_types.go
@@ -55,7 +55,7 @@ func (s *ServiceContext) ConsoleID() *string {
 	return s.Status.ID
 }
 
-func (s *ServiceContext) GetName() string {
+func (s *ServiceContext) ConsoleName() string {
 	if s.Spec.Name != nil && len(*s.Spec.Name) > 0 {
 		return *s.Spec.Name
 	}

--- a/go/controller/internal/controller/previewenvironmenttemplate_controller.go
+++ b/go/controller/internal/controller/previewenvironmenttemplate_controller.go
@@ -154,7 +154,7 @@ func (r *PreviewEnvironmentTemplateReconciler) addOrRemoveFinalizer(ctx context.
 
 func getAttributes(ctx context.Context, kubeClient client.Client, previewEnvTmpl v1alpha1.PreviewEnvironmentTemplate) (*console.PreviewEnvironmentTemplateAttributes, *ctrl.Result, error) {
 	attr := &console.PreviewEnvironmentTemplateAttributes{
-		Name:            previewEnvTmpl.GetName(),
+		Name:            previewEnvTmpl.ConsoleName(),
 		CommentTemplate: previewEnvTmpl.Spec.CommentTemplate,
 	}
 	sta, err := genServiceTemplate(ctx, kubeClient, previewEnvTmpl.Namespace, &previewEnvTmpl.Spec.Template, nil)

--- a/go/controller/internal/controller/servicecontext_controller.go
+++ b/go/controller/internal/controller/servicecontext_controller.go
@@ -125,7 +125,7 @@ func (r *ServiceContextReconciler) sync(sc *v1alpha1.ServiceContext, project *v1
 		attributes.ProjectID = project.Status.ID
 	}
 
-	return r.ConsoleClient.SaveServiceContext(sc.GetName(), attributes)
+	return r.ConsoleClient.SaveServiceContext(sc.ConsoleName(), attributes)
 }
 
 func (r *ServiceContextReconciler) handleExisting(sc *v1alpha1.ServiceContext) (reconcile.Result, error) {


### PR DESCRIPTION
Specifying GetName() for the controller overrides the ObjectMeta.Name defined in the CRD.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console