### PR TITLE
fix(cloud-query): icrease default db connection TTL and improve cleanup logic

### DIFF
--- a/charts/console-rapid/Chart.yaml
+++ b/charts/console-rapid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: console-rapid
 description: rapid channel chart for the plural console (used for testing)
 appVersion: 0.11.29
-version: 0.3.134
+version: 0.3.135
 dependencies:
   - name: kas
     version: 0.3.0

--- a/go/cloud-query/cmd/args/args.go
+++ b/go/cloud-query/cmd/args/args.go
@@ -34,7 +34,7 @@ const (
 	defaultDatabasePassword       = "postgres"
 	defaultDatabaseHost           = "localhost"
 	defaultDatabasePort           = "5432"
-	defaultDatabaseConnectionTTL  = 15 * time.Minute
+	defaultDatabaseConnectionTTL  = 3 * time.Hour
 	defaultServerAddress          = ":9192"
 	defaultServerEnableReflection = false
 )
@@ -125,7 +125,7 @@ func DatabaseConnectionTTL() time.Duration {
 		return defaultDatabaseConnectionTTL
 	}
 
-	if *argDatabaseConnectionTTL < 1*time.Minute {
+	if *argDatabaseConnectionTTL < 10*time.Minute {
 		klog.Warningf("Connection TTL is set to a very low value (%s), this may lead to performance issues", *argDatabaseConnectionTTL)
 	}
 

--- a/go/cloud-query/docker-compose.yml
+++ b/go/cloud-query/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - "--database-user=cloudquery"
       - "--database-password=cloudquery"
       - "--database-name=cloudquery"
+      - "--v=4"
     ports:
       - "9192:9192"
     depends_on:


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- Fix connection cleanup logic
- Lock remove method to avoid a situation where cleanup timer collides with get and remove.
- Improve error handling and error logging
- Increase db connection TTL to 3h by default

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console