### PR TITLE
fix: ltree extension issues on multiple aws connections

### DIFF
--- a/go/cloud-query/Makefile
+++ b/go/cloud-query/Makefile
@@ -90,6 +90,6 @@ update-dependencies: ## update dependencies
 
 .PHONY: --download-extensions
 --download-extensions: ## INTERNAL: download postgres extensions
-	@./hack/postgres.sh -p aws -d $(DIST_DIR) -v 1.16.1
-	@./hack/postgres.sh -p gcp -d $(DIST_DIR) -v 1.8.0
+	@./hack/postgres.sh -p aws -d $(DIST_DIR) -v 1.20.0
+	@./hack/postgres.sh -p gcp -d $(DIST_DIR) -v 1.10.0
 	@./hack/postgres.sh -p azure -d $(DIST_DIR) -v 1.4.0

--- a/go/cloud-query/api/proto/cloudquery.proto
+++ b/go/cloud-query/api/proto/cloudquery.proto
@@ -9,6 +9,7 @@ option go_package = "internal/proto/cloudquery";
 message AwsCredentials {
   string access_key_id = 1;
   string secret_access_key = 2;
+  optional string region = 3;
 }
 
 message AzureCredentials {

--- a/go/cloud-query/db.Dockerfile
+++ b/go/cloud-query/db.Dockerfile
@@ -5,9 +5,9 @@ FROM golang:1.24.2 AS libraries
 
 # Configure versions for Steampipe extensions
 # Do not use latest versions here, as they may not be compatible
-ARG AWS_VERSION=1.14.1
+ARG AWS_VERSION=1.20.0
 ARG AZURE_VERSION=1.4.0
-ARG GCP_VERSION=1.8.0
+ARG GCP_VERSION=1.10.0
 
 WORKDIR /workspace
 

--- a/go/cloud-query/hack/init.sql
+++ b/go/cloud-query/hack/init.sql
@@ -1,3 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS steampipe_postgres_aws;
 CREATE EXTENSION IF NOT EXISTS steampipe_postgres_azure;
 CREATE EXTENSION IF NOT EXISTS steampipe_postgres_gcp;
+CREATE SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS ltree WITH SCHEMA extensions;

--- a/go/cloud-query/internal/config/aws.go
+++ b/go/cloud-query/internal/config/aws.go
@@ -11,6 +11,7 @@ import (
 type AWSConfiguration struct {
 	accessKeyId     *string
 	secretAccessKey *string
+	region          *string
 }
 
 func (c *AWSConfiguration) Query(connectionName string) (string, error) {
@@ -24,6 +25,7 @@ func (c *AWSConfiguration) Query(connectionName string) (string, error) {
 			config '
 				access_key=%[3]s
 				secret_key=%[4]s
+				regions=[%[5]s]
 		');
 		IMPORT FOREIGN SCHEMA %[1]s FROM SERVER %[2]s INTO %[1]s;
 	`,
@@ -31,16 +33,23 @@ func (c *AWSConfiguration) Query(connectionName string) (string, error) {
 		pq.QuoteIdentifier("steampipe_"+connectionName),
 		pq.QuoteIdentifier(lo.FromPtr(c.accessKeyId)),
 		pq.QuoteIdentifier(lo.FromPtr(c.secretAccessKey)),
+		pq.QuoteIdentifier(c.getRegion()),
 	), nil
+}
+
+func (c *AWSConfiguration) getRegion() string {
+	return lo.Ternary(c == nil || c.region == nil || len(*c.region) == 0, "us-east-1", *c.region)
 }
 
 func (c *AWSConfiguration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
 		AccessKeyId     *string `json:"accessKeyId,omitempty"`
 		SecretAccessKey *string `json:"secretAccessKey,omitempty"`
+		Region          *string `json:"region,omitempty"`
 	}{
 		AccessKeyId:     c.accessKeyId,
 		SecretAccessKey: c.secretAccessKey,
+		Region:          c.region,
 	})
 }
 
@@ -53,5 +62,11 @@ func WithAWSAccessKeyId(accessKeyId string) func(*Configuration) {
 func WithAWSSecretAccessKey(secretAccessKey string) func(*Configuration) {
 	return func(c *Configuration) {
 		c.aws.secretAccessKey = &secretAccessKey
+	}
+}
+
+func WithAWSRegion(region string) func(*Configuration) {
+	return func(c *Configuration) {
+		c.aws.region = &region
 	}
 }

--- a/go/cloud-query/internal/pool/pool.go
+++ b/go/cloud-query/internal/pool/pool.go
@@ -3,6 +3,7 @@ package pool
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -19,10 +20,12 @@ import (
 )
 
 type ConnectionPool struct {
-	admin connection.Connection
-	pool  cmap.ConcurrentMap[string, entry]
-	ttl   time.Duration
-	mux   sync.Mutex
+	admin         connection.Connection
+	pool          cmap.ConcurrentMap[string, entry]
+	ttl           time.Duration
+	mux           sync.Mutex
+	isCleaningUp  atomic.Bool
+	isBulkCleanup atomic.Bool
 }
 
 func NewConnectionPool(ttl time.Duration) (*ConnectionPool, error) {
@@ -47,6 +50,7 @@ func (c *ConnectionPool) cleanupRoutine() {
 	defer ticker.Stop()
 
 	for range ticker.C {
+		c.isBulkCleanup.Store(true)
 		for item := range c.pool.IterBuffered() {
 			if !item.Val.alive(c.ttl) {
 				err := c.Remove(item)
@@ -55,6 +59,7 @@ func (c *ConnectionPool) cleanupRoutine() {
 				}
 			}
 		}
+		c.isBulkCleanup.Store(false)
 	}
 }
 
@@ -107,10 +112,25 @@ func (c *ConnectionPool) cleanup(connection string) error {
 	)
 
 	_, err := c.admin.Exec(query)
+	if err != nil {
+		klog.ErrorS(err, "failed to cleanup connection", "connection", connection)
+		return fmt.Errorf("failed to cleanup connection '%s': %w", connection, err)
+	}
+
+	klog.V(log.LogLevelExtended).InfoS("cleaned up connection", "connection", connection)
 	return err
 }
 
 func (c *ConnectionPool) Connect(config config.Configuration) (connection.Connection, error) {
+	for c.isCleaningUp.Load() || c.isBulkCleanup.Load() {
+		klog.V(log.LogLevelVerbose).InfoS("waiting for cleanup to finish before connecting")
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return c.connect(config)
+}
+
+func (c *ConnectionPool) connect(config config.Configuration) (connection.Connection, error) {
 	sha, err := config.SHA()
 	if err != nil {
 		return nil, err
@@ -131,6 +151,12 @@ func (c *ConnectionPool) Connect(config config.Configuration) (connection.Connec
 		}
 
 		connectionName := fmt.Sprintf("%x", id)
+		defer func() {
+			if err != nil {
+				_ = c.cleanup(connectionName)
+			}
+		}()
+
 		klog.V(log.LogLevelVerbose).InfoS("creating new connection", "connection", connectionName)
 		if err = c.setup(connectionName, string(config.Provider())); err != nil {
 			return nil, fmt.Errorf("setup failed: %w", err)
@@ -144,8 +170,7 @@ func (c *ConnectionPool) Connect(config config.Configuration) (connection.Connec
 			return nil, err
 		}
 
-		if err := conn.Configure(config); err != nil {
-			_ = c.cleanup(connectionName)
+		if err = conn.Configure(config); err != nil {
 			_ = conn.Close()
 			return nil, err
 		}
@@ -168,13 +193,17 @@ func (c *ConnectionPool) Remove(t cmap.Tuple[string, entry]) error {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
+	c.isCleaningUp.Store(true)
+	defer func() {
+		c.isCleaningUp.Store(false)
+	}()
+
 	if !c.pool.Has(t.Key) {
 		return nil
 	}
 
 	err := c.cleanup(t.Val.uuid)
 	if err != nil {
-		klog.ErrorS(err, "failed to cleanup connection", "connection", t.Val.uuid)
 		return err
 	}
 

--- a/go/cloud-query/internal/proto/cloudquery/cloudquery.pb.go
+++ b/go/cloud-query/internal/proto/cloudquery/cloudquery.pb.go
@@ -27,6 +27,7 @@ type AwsCredentials struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	AccessKeyId     string                 `protobuf:"bytes,1,opt,name=access_key_id,json=accessKeyId,proto3" json:"access_key_id,omitempty"`
 	SecretAccessKey string                 `protobuf:"bytes,2,opt,name=secret_access_key,json=secretAccessKey,proto3" json:"secret_access_key,omitempty"`
+	Region          *string                `protobuf:"bytes,3,opt,name=region,proto3,oneof" json:"region,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -71,6 +72,13 @@ func (x *AwsCredentials) GetAccessKeyId() string {
 func (x *AwsCredentials) GetSecretAccessKey() string {
 	if x != nil {
 		return x.SecretAccessKey
+	}
+	return ""
+}
+
+func (x *AwsCredentials) GetRegion() string {
+	if x != nil && x.Region != nil {
+		return *x.Region
 	}
 	return ""
 }
@@ -714,10 +722,12 @@ var File_cloudquery_proto protoreflect.FileDescriptor
 const file_cloudquery_proto_rawDesc = "" +
 	"\n" +
 	"\x10cloudquery.proto\x12\n" +
-	"cloudquery\"`\n" +
+	"cloudquery\"\x88\x01\n" +
 	"\x0eAwsCredentials\x12\"\n" +
 	"\raccess_key_id\x18\x01 \x01(\tR\vaccessKeyId\x12*\n" +
-	"\x11secret_access_key\x18\x02 \x01(\tR\x0fsecretAccessKey\"\x9a\x01\n" +
+	"\x11secret_access_key\x18\x02 \x01(\tR\x0fsecretAccessKey\x12\x1b\n" +
+	"\x06region\x18\x03 \x01(\tH\x00R\x06region\x88\x01\x01B\t\n" +
+	"\a_region\"\x9a\x01\n" +
 	"\x10AzureCredentials\x12'\n" +
 	"\x0fsubscription_id\x18\x01 \x01(\tR\x0esubscriptionId\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12\x1b\n" +
@@ -824,6 +834,7 @@ func file_cloudquery_proto_init() {
 	if File_cloudquery_proto != nil {
 		return
 	}
+	file_cloudquery_proto_msgTypes[0].OneofWrappers = []any{}
 	file_cloudquery_proto_msgTypes[3].OneofWrappers = []any{
 		(*Connection_Aws)(nil),
 		(*Connection_Azure)(nil),

--- a/go/cloud-query/internal/service/cloudquery.go
+++ b/go/cloud-query/internal/service/cloudquery.go
@@ -77,6 +77,7 @@ func (in *CloudQueryService) toConnectionConfiguration(provider config.Provider,
 		return config.NewAWSConfiguration(
 			config.WithAWSAccessKeyId(connection.GetAws().GetAccessKeyId()),
 			config.WithAWSSecretAccessKey(connection.GetAws().GetSecretAccessKey()),
+			config.WithAWSRegion(connection.GetAws().GetRegion()),
 		), nil
 	case config.ProviderAzure:
 		return config.NewAzureConfiguration(


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
- use shared `extensions` schema to load shared extensions and grant all schemas access to it
- bump provider extension versions
- add support for `region` arg to AWS provider
- when any pool connection cleanup is in progress do not allow to create new connections

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console