### PR TITLE
Add read permission logic on catalogs

### DIFF
--- a/lib/console/ai/tools/agent/catalogs.ex
+++ b/lib/console/ai/tools/agent/catalogs.ex
@@ -18,6 +18,7 @@ defmodule Console.AI.Tools.Agent.Catalogs do
 
   def implement(_) do
     Catalog.ordered()
+    |> Catalog.for_user(Tool.actor())
     |> Repo.all()
     |> Enum.map(&Map.take(&1, [:id, :name, :description, :category]))
     |> Jason.encode()

--- a/lib/console/graphql/resolvers/deployments/git.ex
+++ b/lib/console/graphql/resolvers/deployments/git.ex
@@ -92,8 +92,9 @@ defmodule Console.GraphQl.Resolvers.Deployments.Git do
     |> paginate(args)
   end
 
-  def list_catalogs(args, _) do
+  def list_catalogs(args, %{context: %{current_user: user}}) do
     Catalog.ordered()
+    |> Catalog.for_user(user)
     |> filter_proj(Catalog, args)
     |> paginate(args)
   end

--- a/test/console/ai/tools/agent/catalogs_test.exs
+++ b/test/console/ai/tools/agent/catalogs_test.exs
@@ -4,12 +4,25 @@ defmodule Console.AI.Tools.Agent.CatalogsTest do
 
   describe "implement/1" do
     test "it can fetch catalogs" do
-      catalogs = insert_list(2, :catalog)
+      user = insert(:user)
+      catalogs = insert_list(2, :catalog, read_bindings: [%{user_id: user.id}])
+
+      Console.AI.Tool.context(%{user: user})
 
       {:ok, result} = Catalogs.implement(%Catalogs{})
       {:ok, decoded} = Jason.decode(result)
 
       assert ids_equal(decoded, catalogs)
+    end
+
+    test "non-readers cannot list" do
+      user = insert(:user)
+      insert_list(2, :catalog)
+
+      Console.AI.Tool.context(%{user: user})
+
+      {:ok, result} = Catalogs.implement(%Catalogs{})
+      {:ok, []} = Jason.decode(result)
     end
   end
 end

--- a/test/console/ai/tools/agent/pr_automations_test.exs
+++ b/test/console/ai/tools/agent/pr_automations_test.exs
@@ -4,9 +4,11 @@ defmodule Console.AI.Tools.Agent.PrAutomationsTest do
 
   describe "implement/1" do
     test "it can fetch catalogs" do
-      catalog = insert(:catalog)
+      user = insert(:user)
+      catalog = insert(:catalog, read_bindings: [%{user_id: user.id}])
       pr_automations = insert_list(2, :pr_automation, catalog: catalog)
 
+      Console.AI.Tool.context(%{user: user})
       {:ok, result} = PrAutomations.implement(%PrAutomations{catalog: catalog.name})
       {:ok, decoded} = Jason.decode(result)
 

--- a/test/console/graphql/queries/deployments/git_queries_test.exs
+++ b/test/console/graphql/queries/deployments/git_queries_test.exs
@@ -216,7 +216,8 @@ defmodule Console.GraphQl.Deployments.GitQueriesTest do
 
   describe "catalogs" do
     test "it can fetch paginated catalogs" do
-      catalogs = insert_list(3, :catalog)
+      user = insert(:user)
+      catalogs = insert_list(3, :catalog, read_bindings: [%{user_id: user.id}])
 
       {:ok, %{data: %{"catalogs" => found}}} = run_query("""
         query {
@@ -224,14 +225,15 @@ defmodule Console.GraphQl.Deployments.GitQueriesTest do
             edges { node { id } }
           }
         }
-      """, %{}, %{current_user: insert(:user)})
+      """, %{}, %{current_user: user})
 
       assert from_connection(found)
              |> ids_equal(catalogs)
     end
 
     test "it can filter by project" do
-      project = insert(:project)
+      user = insert(:user)
+      project = insert(:project, read_bindings: [%{user_id: user.id}])
       catalogs = insert_list(3, :catalog, project: project)
       insert_list(3, :catalog)
 
@@ -241,7 +243,7 @@ defmodule Console.GraphQl.Deployments.GitQueriesTest do
             edges { node { id } }
           }
         }
-      """, %{"id" => project.id}, %{current_user: insert(:user)})
+      """, %{"id" => project.id}, %{current_user: user})
 
       assert from_connection(found)
              |> ids_equal(catalogs)


### PR DESCRIPTION
The original behavior was open to support browsability, but actually think permissioning it can help restrict the provisioning ai in a useful way, so working w/ that now

## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console