### PR TITLE
fix: Improve bindings error handling

### DIFF
--- a/go/controller/config/samples/catalog.yaml
+++ b/go/controller/config/samples/catalog.yaml
@@ -50,3 +50,20 @@ metadata:
 spec:
   author: Plural
   description: The new open-source standard to sync data from applications, APIs & databases. One click deploys for data scientists and developers.
+---
+apiVersion: deployments.plural.sh/v1alpha1
+kind: Catalog
+metadata:
+  labels:
+    app.kubernetes.io/name: catalog-invalid-binding
+    app.kubernetes.io/instance: catalog-sample
+    app.kubernetes.io/part-of: controller
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: controller
+  name: catalog-invalid-binding
+spec:
+  author: Plural
+  description: Catalog with an invalid binding.
+  bindings:
+    create:
+      - userEmail: invalid@email.com

--- a/go/controller/internal/client/common.go
+++ b/go/controller/internal/client/common.go
@@ -10,10 +10,10 @@ import (
 func (c *client) GetUser(email string) (*console.UserFragment, error) {
 	response, err := c.consoleClient.GetUser(c.ctx, email)
 	if internalerror.IsNotFound(err) {
-		return nil, errors.NewNotFound(schema.GroupResource{}, email)
+		return nil, errors.NewNotFound(schema.GroupResource{Resource: "user"}, email)
 	}
 	if err == nil && (response == nil || response.User == nil) {
-		return nil, errors.NewNotFound(schema.GroupResource{}, email)
+		return nil, errors.NewNotFound(schema.GroupResource{Resource: "user"}, email)
 	}
 	if response == nil {
 		return nil, err
@@ -25,10 +25,10 @@ func (c *client) GetUser(email string) (*console.UserFragment, error) {
 func (c *client) GetGroup(name string) (*console.GroupFragment, error) {
 	response, err := c.consoleClient.GetGroup(c.ctx, name)
 	if internalerror.IsNotFound(err) {
-		return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		return nil, errors.NewNotFound(schema.GroupResource{Resource: "group"}, name)
 	}
 	if err == nil && (response == nil || response.Group == nil) {
-		return nil, errors.NewNotFound(schema.GroupResource{}, name)
+		return nil, errors.NewNotFound(schema.GroupResource{Resource: "group"}, name)
 	}
 	if response == nil {
 		return nil, err

--- a/go/controller/internal/client/common.go
+++ b/go/controller/internal/client/common.go
@@ -2,22 +2,37 @@ package client
 
 import (
 	console "github.com/pluralsh/console/go/client"
+	internalerror "github.com/pluralsh/console/go/controller/internal/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func (c *client) GetUser(email string) (*console.UserFragment, error) {
-	getUser, err := c.consoleClient.GetUser(c.ctx, email)
-	if err != nil {
+	response, err := c.consoleClient.GetUser(c.ctx, email)
+	if internalerror.IsNotFound(err) {
+		return nil, errors.NewNotFound(schema.GroupResource{}, email)
+	}
+	if err == nil && (response == nil || response.User == nil) {
+		return nil, errors.NewNotFound(schema.GroupResource{}, email)
+	}
+	if response == nil {
 		return nil, err
 	}
 
-	return getUser.User, nil
+	return response.User, nil
 }
 
 func (c *client) GetGroup(name string) (*console.GroupFragment, error) {
-	getGroup, err := c.consoleClient.GetGroup(c.ctx, name)
-	if err != nil {
+	response, err := c.consoleClient.GetGroup(c.ctx, name)
+	if internalerror.IsNotFound(err) {
+		return nil, errors.NewNotFound(schema.GroupResource{}, name)
+	}
+	if err == nil && (response == nil || response.Group == nil) {
+		return nil, errors.NewNotFound(schema.GroupResource{}, name)
+	}
+	if response == nil {
 		return nil, err
 	}
 
-	return getGroup.Group, nil
+	return response.Group, nil
 }

--- a/go/controller/internal/controller/catalog_controller_test.go
+++ b/go/controller/internal/controller/catalog_controller_test.go
@@ -3,12 +3,9 @@ package controller_test
 import (
 	"context"
 
-	"github.com/Yamashou/gqlgenc/clientv2"
-	"github.com/pluralsh/console/go/controller/internal/cache"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pluralsh/console/go/controller/internal/cache"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -194,9 +191,7 @@ var _ = Describe("Catalog Controller", Ordered, func() {
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("GetCatalog", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
-			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, &clientv2.ErrorResponse{
-				GqlErrors: &gqlerror.List{gqlerror.Errorf("%s", "could not find resource")},
-			})
+			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, "user"))
 
 			nr := &controller.CatalogReconciler{
 				Client:         k8sClient,

--- a/go/controller/internal/controller/cloudconnection_controller.go
+++ b/go/controller/internal/controller/cloudconnection_controller.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -143,15 +142,12 @@ func (r *CloudConnectionReconciler) ensure(connection *v1alpha1.CloudConnection)
 	if connection.Spec.ReadBindings == nil {
 		return nil
 	}
-	bindings, req, err := ensureBindings(connection.Spec.ReadBindings, r.UserGroupCache)
+
+	bindings, err := ensureBindings(connection.Spec.ReadBindings, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	connection.Spec.ReadBindings = bindings
-
-	if req {
-		return errors.NewNotFound(schema.GroupResource{}, "bindings")
-	}
 
 	return nil
 }

--- a/go/controller/internal/controller/cluster_controller_test.go
+++ b/go/controller/internal/controller/cluster_controller_test.go
@@ -4,12 +4,9 @@ import (
 	"context"
 	"sort"
 
-	"github.com/Yamashou/gqlgenc/clientv2"
-	"github.com/pluralsh/console/go/controller/internal/cache"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pluralsh/console/go/controller/internal/cache"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
@@ -621,9 +618,7 @@ var _ = Describe("Cluster Controller", Ordered, func() {
 				ID:             byokReadonlyClusterConsoleID,
 				CurrentVersion: lo.ToPtr("1.24.11"),
 			}, nil)
-			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, &clientv2.ErrorResponse{
-				GqlErrors: &gqlerror.List{gqlerror.Errorf("%s", "could not find resource")},
-			})
+			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, "user"))
 
 			controllerReconciler := &controller.ClusterReconciler{
 				Client:           k8sClient,

--- a/go/controller/internal/controller/common.go
+++ b/go/controller/internal/controller/common.go
@@ -92,7 +92,7 @@ func ensureBindings(bindings []v1alpha1.Binding, userGroupCache cache.UserGroupC
 
 func ensureBinding(binding v1alpha1.Binding, userGroupCache cache.UserGroupCache) (v1alpha1.Binding, error) {
 	if binding.GroupName == nil && binding.UserEmail == nil {
-		return binding, apierrors.NewNotFound(schema.GroupResource{}, "")
+		return binding, apierrors.NewNotFound(schema.GroupResource{Resource: "group/user"}, "nil")
 	}
 
 	if binding.GroupName != nil {

--- a/go/controller/internal/controller/compliancereportgenerator_controller.go
+++ b/go/controller/internal/controller/compliancereportgenerator_controller.go
@@ -11,7 +11,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -125,15 +124,12 @@ func (r *ComplianceReportGeneratorReconciler) ensure(server *v1alpha1.Compliance
 	if server.Spec.ReadBindings == nil {
 		return nil
 	}
-	bindings, req, err := ensureBindings(server.Spec.ReadBindings, r.UserGroupCache)
+
+	bindings, err := ensureBindings(server.Spec.ReadBindings, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	server.Spec.ReadBindings = bindings
-
-	if req {
-		return apierrors.NewNotFound(schema.GroupResource{}, "bindings")
-	}
 
 	return nil
 }

--- a/go/controller/internal/controller/deploymentsettings_controller.go
+++ b/go/controller/internal/controller/deploymentsettings_controller.go
@@ -21,10 +21,8 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
-	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -217,6 +215,7 @@ func (r *DeploymentSettingsReconciler) genDeploymentSettingsAttr(ctx context.Con
 		if err := r.ensure(settings); err != nil {
 			return nil, err
 		}
+
 		attr.ReadBindings = policyBindings(settings.Spec.Bindings.Read)
 		attr.WriteBindings = policyBindings(settings.Spec.Bindings.Write)
 		attr.CreateBindings = policyBindings(settings.Spec.Bindings.Create)
@@ -249,33 +248,29 @@ func (r *DeploymentSettingsReconciler) ensure(settings *v1alpha1.DeploymentSetti
 		return nil
 	}
 
-	bindings, req, err := ensureBindings(settings.Spec.Bindings.Read, r.UserGroupCache)
+	bindings, err := ensureBindings(settings.Spec.Bindings.Read, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	settings.Spec.Bindings.Read = bindings
 
-	bindings, req2, err := ensureBindings(settings.Spec.Bindings.Write, r.UserGroupCache)
+	bindings, err = ensureBindings(settings.Spec.Bindings.Write, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	settings.Spec.Bindings.Write = bindings
 
-	bindings, req3, err := ensureBindings(settings.Spec.Bindings.Create, r.UserGroupCache)
+	bindings, err = ensureBindings(settings.Spec.Bindings.Create, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	settings.Spec.Bindings.Create = bindings
 
-	bindings, req4, err := ensureBindings(settings.Spec.Bindings.Git, r.UserGroupCache)
+	bindings, err = ensureBindings(settings.Spec.Bindings.Git, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	settings.Spec.Bindings.Git = bindings
-
-	if req || req2 || req3 || req4 {
-		return errors.NewNotFound(schema.GroupResource{}, "bindings")
-	}
 
 	return nil
 }

--- a/go/controller/internal/controller/flow_controller.go
+++ b/go/controller/internal/controller/flow_controller.go
@@ -14,7 +14,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -168,21 +167,17 @@ func (r *FlowReconciler) ensure(flow *v1alpha1.Flow) error {
 	if flow.Spec.Bindings == nil {
 		return nil
 	}
-	bindings, req, err := ensureBindings(flow.Spec.Bindings.Read, r.UserGroupCache)
+	bindings, err := ensureBindings(flow.Spec.Bindings.Read, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	flow.Spec.Bindings.Read = bindings
 
-	bindings, req2, err := ensureBindings(flow.Spec.Bindings.Write, r.UserGroupCache)
+	bindings, err = ensureBindings(flow.Spec.Bindings.Write, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	flow.Spec.Bindings.Write = bindings
-
-	if req || req2 {
-		return apierrors.NewNotFound(schema.GroupResource{}, "bindings")
-	}
 
 	return nil
 }

--- a/go/controller/internal/controller/flow_controller_test.go
+++ b/go/controller/internal/controller/flow_controller_test.go
@@ -3,12 +3,9 @@ package controller_test
 import (
 	"context"
 
-	"github.com/Yamashou/gqlgenc/clientv2"
-	"github.com/pluralsh/console/go/controller/internal/cache"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pluralsh/console/go/controller/internal/cache"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -139,9 +136,7 @@ var _ = Describe("Flow Controller", Ordered, func() {
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
 			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
-			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, &clientv2.ErrorResponse{
-				GqlErrors: &gqlerror.List{gqlerror.Errorf("%s", "could not find resource")},
-			})
+			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, "user@example.com"))
 
 			fr := &controller.FlowReconciler{
 				Client:         k8sClient,

--- a/go/controller/internal/controller/mcpserver_controller.go
+++ b/go/controller/internal/controller/mcpserver_controller.go
@@ -11,7 +11,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -125,21 +124,17 @@ func (r *MCPServerReconciler) ensure(server *v1alpha1.MCPServer) error {
 	if server.Spec.Bindings == nil {
 		return nil
 	}
-	bindings, req, err := ensureBindings(server.Spec.Bindings.Read, r.UserGroupCache)
+	bindings, err := ensureBindings(server.Spec.Bindings.Read, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	server.Spec.Bindings.Read = bindings
 
-	bindings, req2, err := ensureBindings(server.Spec.Bindings.Write, r.UserGroupCache)
+	bindings, err = ensureBindings(server.Spec.Bindings.Write, r.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	server.Spec.Bindings.Write = bindings
-
-	if req || req2 {
-		return apierrors.NewNotFound(schema.GroupResource{}, "bindings")
-	}
 
 	return nil
 }

--- a/go/controller/internal/controller/persona_controller.go
+++ b/go/controller/internal/controller/persona_controller.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 
 	"github.com/pluralsh/console/go/controller/internal/credentials"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -183,15 +181,11 @@ func (in *PersonaReconciler) ensure(persona *v1alpha1.Persona) error {
 		return nil
 	}
 
-	bindings, req, err := ensureBindings(persona.Spec.Bindings, in.UserGroupCache)
+	bindings, err := ensureBindings(persona.Spec.Bindings, in.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	persona.Spec.Bindings = bindings
-
-	if req {
-		return errors.NewNotFound(schema.GroupResource{}, "bindings")
-	}
 
 	return nil
 }

--- a/go/controller/internal/controller/persona_controller_test.go
+++ b/go/controller/internal/controller/persona_controller_test.go
@@ -3,9 +3,8 @@ package controller_test
 import (
 	"context"
 
-	"github.com/Yamashou/gqlgenc/clientv2"
 	"github.com/pluralsh/console/go/controller/internal/cache"
-	"github.com/vektah/gqlparser/v2/gqlerror"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -136,9 +135,7 @@ var _ = Describe("Persona Controller", Ordered, func() {
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
 			fakeConsoleClient.On("IsPersonaExists", mock.Anything, mock.Anything).Return(false, nil)
-			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, &clientv2.ErrorResponse{
-				GqlErrors: &gqlerror.List{gqlerror.Errorf("%s", "could not find resource")},
-			})
+			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, "user@example.com"))
 
 			pr := &controller.PersonaReconciler{
 				Client:         k8sClient,

--- a/go/controller/internal/controller/project_controller.go
+++ b/go/controller/internal/controller/project_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/samber/lo"
@@ -242,21 +241,17 @@ func (in *ProjectReconciler) ensure(project *v1alpha1.Project) error {
 		return nil
 	}
 
-	bindings, req, err := ensureBindings(project.Spec.Bindings.Read, in.UserGroupCache)
+	bindings, err := ensureBindings(project.Spec.Bindings.Read, in.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	project.Spec.Bindings.Read = bindings
 
-	bindings, req2, err := ensureBindings(project.Spec.Bindings.Write, in.UserGroupCache)
+	bindings, err = ensureBindings(project.Spec.Bindings.Write, in.UserGroupCache)
 	if err != nil {
 		return err
 	}
 	project.Spec.Bindings.Write = bindings
-
-	if req || req2 {
-		return errors.NewNotFound(schema.GroupResource{}, "bindings")
-	}
 
 	return nil
 }

--- a/go/controller/internal/controller/project_controller_test.go
+++ b/go/controller/internal/controller/project_controller_test.go
@@ -3,12 +3,9 @@ package controller_test
 import (
 	"context"
 
-	"github.com/Yamashou/gqlgenc/clientv2"
-	"github.com/pluralsh/console/go/controller/internal/cache"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pluralsh/console/go/controller/internal/cache"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -145,7 +142,7 @@ var _ = Describe("Project Controller", Ordered, func() {
 							Type:    v1alpha1.SynchronizedConditionType.String(),
 							Status:  metav1.ConditionFalse,
 							Reason:  v1alpha1.SynchronizedConditionReasonError.String(),
-							Message: " \"bindings\" not found",
+							Message: " \"test@plural.sh\" not found",
 						},
 					},
 				},
@@ -167,9 +164,7 @@ var _ = Describe("Project Controller", Ordered, func() {
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("GetProject", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
 			fakeConsoleClient.On("IsProjectExists", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
-			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, &clientv2.ErrorResponse{
-				GqlErrors: &gqlerror.List{gqlerror.Errorf("%s", "could not find resource")},
-			})
+			fakeConsoleClient.On("GetUser", mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, "test@plural.sh"))
 			userGroupCache := cache.NewUserGroupCache(fakeConsoleClient)
 
 			nsReconciler := &controller.ProjectReconciler{

--- a/go/controller/internal/errors/base.go
+++ b/go/controller/internal/errors/base.go
@@ -19,7 +19,6 @@ func (k KnownError) Error() string {
 const (
 	ErrorNotFound             KnownError = "could not find resource"
 	ErrorNotFoundOIDCProvider KnownError = "the resource you requested was not found"
-	ErrRetriable              KnownError = "still waiting on read/write bindings, requeueing until they're available"
 	ErrDeleteRepository                  = "could not delete repository"
 )
 


### PR DESCRIPTION
Removes `ErrRetriable` and uses original errors coming from the `ensureBinding` function.Errors can then be handled in the `handleRequeue` that detects not found errors and sets conditions and `requeueAfter` accordingly.

Deployed to https://console.plrl-dev-aws.onplural.sh.

Tested on local kind cluster connected to plrl-dev-aws. 

<img width="502" height="666" alt="Zrzut ekranu 2025-08-11 o 16 06 49" src="https://github.com/user-attachments/assets/96581521-a4e3-4a82-8ace-e001967899a5" />

Resource with invalid binding was immediately created after fixing user email.