### PR TITLE
feat(chart): add check for existing chart version before OCI push

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -44,9 +44,24 @@ jobs:
         with:
           msg: ${{ steps.release.outputs.changed_charts }}
           separator: ","
+      - name: Chart | Check
+        id: chart_exists
+        env:
+          REGISTRY_PASSWORD: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+        run: |
+          helm registry login registry-1.docker.io -u mjgpluralsh --password-stdin <<< $REGISTRY_PASSWORD
+          
+          if helm pull oci://registry-1.docker.io/pluralsh/helm-charts/console --version ${{ steps.console_vsn.outputs.result }} --destination /tmp 2>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Chart version ${{ steps.console_vsn.outputs.result }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Chart version ${{ steps.console_vsn.outputs.result }} does not exist"
+          fi
+        continue-on-error: true
       - name: Chart | OCI Push
         uses: appany/helm-oci-chart-releaser@v0.5.0
-        if: ${{ contains(steps.split.outputs, 'console') }}
+        if: ${{ steps.chart_exists.outputs.exists == 'false' }}
         with:
           name: console
           repository: pluralsh/helm-charts


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
Added a step to first pull the target version from OCI before trying to push it. Tested it on a separate repo for a public image.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test repo: https://github.com/floreks/actions/actions/workflows/oci-test.yaml.yml

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console