### PR TITLE
fix: Small styling improvements

### DIFF
--- a/assets/src/components/ai/chatbot/AgentSelect.tsx
+++ b/assets/src/components/ai/chatbot/AgentSelect.tsx
@@ -95,7 +95,7 @@ export function AgentSelect() {
         <>
           <ListBoxFooter
             css={{
-              borderBottom: theme.borders.input,
+              borderBottom: selectedAgent ? theme.borders.input : undefined,
             }}
             onClick={() => {
               navigate(AI_AGENT_ABS_PATH)

--- a/assets/src/components/ai/chatbot/ChatbotPanelThread.tsx
+++ b/assets/src/components/ai/chatbot/ChatbotPanelThread.tsx
@@ -341,6 +341,31 @@ export const ChatbotMessagesWrapperSC = styled.div(({ theme }) => ({
   flex: 1,
   scrollbarWidth: 'none',
   overflowY: 'auto',
-  padding: theme.spacing.medium,
+  padding: `0 ${theme.spacing.medium}px 0 ${theme.spacing.medium}px`,
+  position: 'relative',
   height: '100%',
+
+  '&:after': {
+    content: '""',
+    pointerEvents: 'none',
+    position: 'absolute',
+    height: 32,
+    inset: 0,
+    zIndex: 1,
+    background: `linear-gradient(180deg, #0E1015 20.97%, rgba(14, 16, 21, 0) 67.74%)`,
+    filter: 'drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))',
+  },
+
+  '&:before': {
+    content: '""',
+    pointerEvents: 'none',
+    position: 'absolute',
+    height: 32,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 1,
+    background: `linear-gradient(0deg, #0E1015 20.97%, rgba(14, 16, 21, 0) 67.74%)`,
+    filter: 'drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))',
+  },
 }))


### PR DESCRIPTION
Brings back shadow effect in the chat panel:
<img width="502" height="238" alt="Zrzut ekranu 2025-08-13 o 11 37 35" src="https://github.com/user-attachments/assets/a817828d-9707-4ef2-a813-3e532fcb8d97" />

Removes double border in agent select panel.