### PR TITLE
remove standard scroller from cmd k

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -32,7 +32,7 @@
   "packageManager": "yarn@3.6.0",
   "dependencies": {
     "@absinthe/socket": "0.2.1",
-    "@apollo/client": "3.13.8",
+    "@apollo/client": "3.14.0",
     "@dagrejs/dagre": "1.0.4",
     "@docsearch/js": "3.5.2",
     "@docsearch/react": "3.5.2",

--- a/assets/src/components/ai/chatbot/ChatbotHeader.tsx
+++ b/assets/src/components/ai/chatbot/ChatbotHeader.tsx
@@ -28,7 +28,7 @@ import { ChatbotThreadMoreMenu } from './ChatbotThreadMoreMenu'
 
 export function ChatbotHeader() {
   const { colors } = useTheme()
-  const { setCmdkOpen, setInitialTab } = use(CommandPaletteContext)
+  const { setCmdkOpen } = use(CommandPaletteContext)
   const {
     currentThreadId,
     currentThread,
@@ -96,10 +96,7 @@ export function ChatbotHeader() {
             icon={<HistoryIcon />}
             type="tertiary"
             tooltip="View chat history"
-            onClick={() => {
-              setCmdkOpen(true)
-              setInitialTab(CommandPaletteTab.History)
-            }}
+            onClick={() => setCmdkOpen(true, CommandPaletteTab.History)}
           />
           <ChatbotThreadMoreMenu />
           <IconFrame

--- a/assets/src/components/ai/chatbot/ChatbotThreadMoreMenu.tsx
+++ b/assets/src/components/ai/chatbot/ChatbotThreadMoreMenu.tsx
@@ -40,7 +40,7 @@ export function ChatbotThreadMoreMenu() {
     mutationLoading: forkLoading,
     currentThread,
   } = useChatbot()
-  const { setCmdkOpen, setInitialTab } = use(CommandPaletteContext)
+  const { setCmdkOpen } = use(CommandPaletteContext)
   const [menuKey, setMenuKey] = useState<MenuItemKey | ''>('')
   const [isOpen, setIsOpen] = useState(false)
 
@@ -75,8 +75,7 @@ export function ChatbotThreadMoreMenu() {
         break
       case MenuItemKey.History:
         closeMenu()
-        setCmdkOpen(true)
-        setInitialTab(CommandPaletteTab.History)
+        setCmdkOpen(true, CommandPaletteTab.History)
         break
       default:
         blockClose.current = false

--- a/assets/src/components/ai/chatbot/input/ChatInput.tsx
+++ b/assets/src/components/ai/chatbot/input/ChatInput.tsx
@@ -17,7 +17,7 @@ import {
 } from 'generated/graphql.ts'
 import { isEmpty, truncate } from 'lodash'
 import {
-  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
   Dispatch,
   FormEvent,
   SetStateAction,
@@ -32,8 +32,10 @@ import { useCurrentPageChatContext } from '../useCurrentPageChatContext.tsx'
 import { ChatInputCloudSelect } from './ChatInputCloudSelect.tsx'
 import { ChatInputClusterSelect } from './ChatInputClusterSelect.tsx'
 import { ChatInputIconFrame } from './ChatInputIconFrame.tsx'
+import { mergeRefs } from 'react-merge-refs'
 
 export function ChatInput({
+  ref,
   currentThread,
   sendMessage,
   serverNames,
@@ -54,7 +56,7 @@ export function ChatInput({
   placeholder?: string
   onValueChange?: Dispatch<string>
   stateless?: boolean
-} & ComponentPropsWithoutRef<'div'>) {
+} & Partial<ComponentPropsWithRef<typeof EditableDiv>>) {
   const { selectedAgent, mcpPanelOpen, setMcpPanelOpen } = useChatbot()
 
   const { sourceId, source } = useCurrentPageChatContext()
@@ -146,7 +148,7 @@ export function ChatInput({
           onEnter={() => formRef.current?.requestSubmit()}
           css={{ maxHeight: 130 }}
           {...props}
-          ref={contentEditableRef}
+          ref={mergeRefs([contentEditableRef, ref])}
         />
         <Flex justifyContent="space-between">
           <Flex

--- a/assets/src/components/ai/chatbot/input/ChatInput.tsx
+++ b/assets/src/components/ai/chatbot/input/ChatInput.tsx
@@ -11,7 +11,10 @@ import {
 import usePersistedSessionState from 'components/hooks/usePersistedSessionState.tsx'
 import { GqlError } from 'components/utils/Alert.tsx'
 import { EditableDiv } from 'components/utils/EditableDiv.tsx'
-import { useAddChatContextMutation } from 'generated/graphql.ts'
+import {
+  ChatThreadDetailsFragment,
+  useAddChatContextMutation,
+} from 'generated/graphql.ts'
 import { isEmpty, truncate } from 'lodash'
 import {
   ComponentPropsWithoutRef,
@@ -31,6 +34,7 @@ import { ChatInputClusterSelect } from './ChatInputClusterSelect.tsx'
 import { ChatInputIconFrame } from './ChatInputIconFrame.tsx'
 
 export function ChatInput({
+  currentThread,
   sendMessage,
   serverNames,
   enableExamplePrompts = true,
@@ -41,6 +45,7 @@ export function ChatInput({
   stateless = false,
   ...props
 }: {
+  currentThread?: Nullable<ChatThreadDetailsFragment>
   sendMessage: (newMessage: string) => void
   serverNames?: string[]
   enableExamplePrompts?: boolean
@@ -50,8 +55,7 @@ export function ChatInput({
   onValueChange?: Dispatch<string>
   stateless?: boolean
 } & ComponentPropsWithoutRef<'div'>) {
-  const { selectedAgent, mcpPanelOpen, setMcpPanelOpen, currentThread } =
-    useChatbot()
+  const { selectedAgent, mcpPanelOpen, setMcpPanelOpen } = useChatbot()
 
   const { sourceId, source } = useCurrentPageChatContext()
   const showContextBtn = !!source && !!sourceId

--- a/assets/src/components/commandpalette/CommandPalette.tsx
+++ b/assets/src/components/commandpalette/CommandPalette.tsx
@@ -13,7 +13,6 @@ import {
   use,
   useCallback,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import { useTheme } from 'styled-components'
@@ -24,7 +23,6 @@ import { AITableActions } from '../ai/AITableActions.tsx'
 import { AIEntryLabel, getThreadOrPinTimestamp } from '../ai/AITableEntry.tsx'
 import { ChatInput } from '../ai/chatbot/input/ChatInput.tsx'
 import { useAIEnabled } from '../contexts/DeploymentSettingsContext.tsx'
-import usePersistedSessionState from '../hooks/usePersistedSessionState.tsx'
 import { ButtonGroup } from '../utils/ButtonGroup.tsx'
 import { Body1BoldP, Body2P, CaptionP } from '../utils/typography/Text.tsx'
 import {
@@ -278,18 +276,13 @@ function CommandAdvancedInput({
   onCmdKClose?: () => void
 }) {
   const { createNewThread } = useChatbot()
-  const { setMessage: setPendingMessage } = useCommandPaletteMessage()
 
   const sendMessage = useCallback(
     (message: string) => {
-      createNewThread({
-        summary: 'New Chat with Plural AI',
-      }).then(() => {
-        setPendingMessage(message)
-        onCmdKClose?.()
-      })
+      createNewThread({ summary: 'New Chat with Plural AI' }, message)
+      onCmdKClose?.()
     },
-    [createNewThread, setPendingMessage, onCmdKClose]
+    [createNewThread, onCmdKClose]
   )
 
   return curTab === CommandPaletteTab.History ? (
@@ -335,26 +328,6 @@ function HistoryItem({ thread }: { thread: ChatThreadTinyFragment }) {
       <AITableActions thread={thread} />
     </Flex>
   )
-}
-
-export const useCommandPaletteMessage = () => {
-  const [message, setMessage] = usePersistedSessionState(
-    'commandPalettePendingChatMessage',
-    ''
-  )
-  const processedRef = useRef<string>('')
-
-  const readValue = useCallback(() => {
-    if (!message || processedRef.current === message) {
-      return ''
-    }
-
-    processedRef.current = message
-    setMessage('')
-    return message
-  }, [message, setMessage])
-
-  return { readValue, setMessage }
 }
 
 const CommandEmptyState = ({ value }: { value: string }) => {

--- a/assets/src/components/commandpalette/CommandPaletteContext.tsx
+++ b/assets/src/components/commandpalette/CommandPaletteContext.tsx
@@ -1,11 +1,4 @@
-import {
-  Dispatch,
-  SetStateAction,
-  ReactNode,
-  useState,
-  useMemo,
-  createContext,
-} from 'react'
+import { createContext, ReactNode, useMemo, useState } from 'react'
 
 export enum CommandPaletteTab {
   History = 'History',
@@ -14,16 +7,14 @@ export enum CommandPaletteTab {
 
 type CommandPaletteContextType = {
   cmdkOpen: boolean
-  setCmdkOpen: Dispatch<SetStateAction<boolean>>
+  setCmdkOpen: (open: boolean, initialTab?: CommandPaletteTab) => void
   initialTab: CommandPaletteTab
-  setInitialTab: Dispatch<SetStateAction<CommandPaletteTab>>
 }
 
 export const CommandPaletteContext = createContext<CommandPaletteContextType>({
   cmdkOpen: false,
   setCmdkOpen: () => {},
   initialTab: CommandPaletteTab.Commands,
-  setInitialTab: () => {},
 })
 
 export function CommandPaletteProvider({ children }: { children: ReactNode }) {
@@ -34,9 +25,11 @@ export function CommandPaletteProvider({ children }: { children: ReactNode }) {
   const ctx = useMemo(
     () => ({
       cmdkOpen,
+      setCmdkOpen: (open, initialTab) => {
+        setCmdkOpen(open)
+        setInitialTab(initialTab ?? CommandPaletteTab.Commands)
+      },
       initialTab,
-      setCmdkOpen,
-      setInitialTab,
     }),
     [cmdkOpen, initialTab]
   )

--- a/assets/src/components/commandpalette/CommandPaletteDialog.tsx
+++ b/assets/src/components/commandpalette/CommandPaletteDialog.tsx
@@ -144,7 +144,7 @@ export function CommandPaletteDialog() {
       onOpenChange={(open) => setCmdkOpen(open)}
       title="Command Palette"
     >
-      <Command>
+      <Command shouldFilter={false}>
         <CommandPalette />
       </Command>
     </WrapperModal>

--- a/assets/src/components/commandpalette/CommandPaletteDialog.tsx
+++ b/assets/src/components/commandpalette/CommandPaletteDialog.tsx
@@ -17,6 +17,7 @@ export const WrapperModal = styled(ModalWrapper)(({ theme }) => ({
     flexDirection: 'column',
     width: 840,
     maxHeight: '100%',
+    background: theme.colors['fill-zero'],
 
     '.plrl-chat-input-form': {
       padding: 0,
@@ -58,11 +59,6 @@ export const WrapperModal = styled(ModalWrapper)(({ theme }) => ({
       overflow: 'auto',
       padding: theme.spacing.small,
       transition: 'height 100ms ease',
-
-      '&.cmdk-history': {
-        height: 500,
-        padding: 0,
-      },
 
       '[cmdk-item]': {
         alignItems: 'center',
@@ -106,11 +102,6 @@ export const WrapperModal = styled(ModalWrapper)(({ theme }) => ({
 
         '&:hover': {
           backgroundColor: theme.colors['fill-one-hover'],
-        },
-
-        '&.cmdk-history-item': {
-          padding: `${theme.spacing.small}px ${theme.spacing.medium}px`,
-          margin: `0 ${theme.spacing.small}px`,
         },
       },
 

--- a/assets/src/components/commandpalette/CommandPaletteDialog.tsx
+++ b/assets/src/components/commandpalette/CommandPaletteDialog.tsx
@@ -18,10 +18,9 @@ export const WrapperModal = styled(ModalWrapper)(({ theme }) => ({
     width: 840,
     maxHeight: '100%',
     background: theme.colors['fill-zero'],
+    '&:focus': { outline: 'none' },
 
-    '.plrl-chat-input-form': {
-      padding: 0,
-    },
+    '.plrl-chat-input-form': { padding: 0 },
 
     '#cmdk-input-wrapper': {
       display: 'flex',

--- a/assets/src/components/commandpalette/CommandPaletteLauncher.tsx
+++ b/assets/src/components/commandpalette/CommandPaletteLauncher.tsx
@@ -5,7 +5,10 @@ import { usePlatform } from 'components/hooks/usePlatform'
 import { Body2BoldP } from 'components/utils/typography/Text'
 import { use } from 'react'
 import CommandHotkeys from './CommandHotkeys'
-import { CommandPaletteContext } from './CommandPaletteContext.tsx'
+import {
+  CommandPaletteContext,
+  CommandPaletteTab,
+} from './CommandPaletteContext.tsx'
 import { CommandPaletteDialog } from './CommandPaletteDialog'
 import { useCommandsWithHotkeys } from './commands.ts'
 
@@ -14,14 +17,16 @@ export default function CommandPaletteLauncher() {
   const commands = useCommandsWithHotkeys()
   const { setCmdkOpen } = use(CommandPaletteContext)
 
-  useHotkeys(['cmd K', 'ctrl K'], () => setCmdkOpen(true))
+  useHotkeys(['cmd K', 'ctrl K'], () =>
+    setCmdkOpen(true, CommandPaletteTab.Commands)
+  )
 
   return (
     <>
       <Chip
         clickable
         inactive
-        onClick={() => setCmdkOpen(true)}
+        onClick={() => setCmdkOpen(true, CommandPaletteTab.Commands)}
         size="small"
         userSelect="none"
         whiteSpace="nowrap"

--- a/assets/src/components/commandpalette/commands.ts
+++ b/assets/src/components/commandpalette/commands.ts
@@ -429,5 +429,10 @@ export function useHistory({
     } as Command
   })
 
-  return { loading, history: [{ commands: history }], fetchNextPage, pageInfo }
+  return {
+    loading: loading && !data,
+    history: [{ commands: history }],
+    fetchNextPage,
+    pageInfo,
+  }
 }

--- a/assets/src/components/commandpalette/commands.ts
+++ b/assets/src/components/commandpalette/commands.ts
@@ -73,6 +73,9 @@ export type CommandGroup = {
 }
 
 export type Command = {
+  // Command unique id.
+  id: string
+
   // Command label.
   label: string
 
@@ -161,6 +164,7 @@ export function useCommands({
           ...(!featureFlags.Edge
             ? [
                 {
+                  id: 'enable-edge',
                   label: 'Enable Edge',
                   icon: EdgeComputeIcon,
                   callback: () => setFeatureFlag('Edge', true),
@@ -179,6 +183,7 @@ export function useCommands({
       {
         commands: [
           {
+            id: 'home',
             label: 'Home',
             icon: HomeIcon,
             callback: () => navigate('/'),
@@ -187,6 +192,7 @@ export function useCommands({
             autoFocus: true,
           },
           {
+            id: 'cd',
             label: 'Continuous deployment (CD)',
             icon: GitPullIcon,
             callback: () => navigate(CD_ABS_PATH),
@@ -194,6 +200,7 @@ export function useCommands({
             hotkeys: ['shift C'],
           },
           {
+            id: 'stacks',
             label: 'Stacks',
             icon: StackIcon,
             callback: () => navigate(STACKS_ROOT_PATH),
@@ -201,6 +208,7 @@ export function useCommands({
             hotkeys: ['shift S'],
           },
           {
+            id: 'service-catalog',
             label: 'Service catalog',
             icon: CatalogIcon,
             callback: () => navigate(CATALOGS_ABS_PATH),
@@ -208,6 +216,7 @@ export function useCommands({
             hotkeys: ['shift S+C'],
           },
           {
+            id: 'kubernetes-dashboard',
             label: 'Kubernetes Dashboard',
             icon: KubernetesAltIcon,
             callback: () => navigate(KUBERNETES_ROOT_PATH),
@@ -215,6 +224,7 @@ export function useCommands({
             hotkeys: ['shift K'],
           },
           {
+            id: 'plural-ai',
             label: 'Plural AI',
             icon: AiSparkleOutlineIcon,
             callback: () => navigate(AI_ABS_PATH),
@@ -223,6 +233,7 @@ export function useCommands({
           },
 
           {
+            id: 'flows',
             label: 'Flows',
             icon: FlowIcon,
             callback: () => navigate(FLOWS_ABS_PATH),
@@ -232,6 +243,7 @@ export function useCommands({
           ...(featureFlags.Edge
             ? [
                 {
+                  id: 'edge',
                   label: 'Edge',
                   icon: EdgeComputeIcon,
                   callback: () => navigate(EDGE_ABS_PATH),
@@ -241,6 +253,7 @@ export function useCommands({
               ]
             : []),
           {
+            id: 'pull-requests',
             label: "Pull requests (PR's)",
             icon: PrOpenIcon,
             callback: () => navigate(PR_ABS_PATH),
@@ -248,12 +261,14 @@ export function useCommands({
             hotkeys: ['shift P+R'],
           },
           {
+            id: 'security',
             label: 'Security',
             icon: WarningShieldIcon,
             callback: () => navigate(SECURITY_ABS_PATH),
             deps: [navigate],
           },
           {
+            id: 'cost-management',
             label: 'Cost Management',
             icon: CostManagementIcon,
             callback: () => navigate(COST_MANAGEMENT_ABS_PATH),
@@ -261,6 +276,7 @@ export function useCommands({
             hotkeys: ['shift C+M'],
           },
           {
+            id: 'settings',
             label: 'Settings',
             icon: GearTrainIcon,
             callback: () => navigate(SETTINGS_ABS_PATH),
@@ -271,6 +287,7 @@ export function useCommands({
       {
         commands: [
           {
+            id: 'clusters',
             prefix: 'CD >',
             label: 'Clusters',
             icon: ClusterIcon,
@@ -279,6 +296,7 @@ export function useCommands({
             hotkeys: ['G then C'],
           },
           {
+            id: 'pods',
             prefix: 'CD > Clusters >',
             label: 'Pods',
             icon: PodContainerIcon,
@@ -295,6 +313,7 @@ export function useCommands({
             hotkeys: ['G then P'],
           },
           {
+            id: 'services',
             prefix: 'CD >',
             label: 'Services',
             icon: ToolsIcon,
@@ -303,6 +322,7 @@ export function useCommands({
             hotkeys: ['G then S'],
           },
           {
+            id: 'pr-automations',
             prefix: "PR's >",
             label: 'PR automations',
             icon: PrQueueIcon,
@@ -311,6 +331,7 @@ export function useCommands({
             hotkeys: ['G then A'],
           },
           {
+            id: 'user-management',
             prefix: 'Settings >',
             label: 'User management',
             icon: PeopleIcon,
@@ -323,6 +344,7 @@ export function useCommands({
       {
         commands: [
           {
+            id: 'open-docs',
             label: 'Open docs',
             icon: DocumentIcon,
             rightIcon: ArrowTopRightIcon,
@@ -335,6 +357,7 @@ export function useCommands({
       {
         commands: [
           {
+            id: 'share-secret',
             label: 'Share secret',
             icon: EyeIcon,
             callback: open,
@@ -342,6 +365,7 @@ export function useCommands({
             hotkeys: ['C then S'],
           },
           {
+            id: 'switch-mode',
             label: `Switch to ${mode === 'dark' ? 'light' : 'dark'} mode`,
             icon: SprayIcon,
             callback: () =>
@@ -418,7 +442,8 @@ export function useHistory({
 
   const history = threads.map((thread) => {
     return {
-      label: thread?.summary ?? 'Untitled',
+      id: thread.id,
+      label: thread.summary,
       icon: ChatOutlineIcon,
       callback: () => {
         if (thread?.id) goToThread(thread.id)

--- a/assets/src/components/stacks/state/StackStateGraph.tsx
+++ b/assets/src/components/stacks/state/StackStateGraph.tsx
@@ -1,6 +1,6 @@
 import { type Edge, type Node } from '@xyflow/react'
 import { StackState } from 'generated/graphql'
-import { useMemo, useState } from 'react'
+import { useDeferredValue, useMemo, useState } from 'react'
 
 import { isNonNullable } from '../../../utils/isNonNullable'
 import { NodeType } from '../../cd/pipelines/utils/getNodesAndEdges'
@@ -18,13 +18,8 @@ const nodeTypes = {
 }
 
 const searchOptions = {
-  keys: [
-    'name',
-    {
-      name: 'configuration',
-      getFn: (r) => JSON.stringify(r?.configuration ?? {}),
-    },
-  ],
+  keys: [{ name: 'all', getFn: (r) => JSON.stringify(r ?? {}) }],
+  ignoreLocation: true,
   threshold: 0.25,
 }
 
@@ -80,10 +75,11 @@ function getNodesAndEdges(state: StackState, query: string) {
 
 export function StackStateGraph({ state }: { state: StackState }) {
   const [query, setQuery] = useState('')
+  const deferredQuery = useDeferredValue(query)
 
   const { nodes: baseNodes, edges: baseEdges } = useMemo(
-    () => getNodesAndEdges(state, query),
-    [state, query]
+    () => getNodesAndEdges(state, deferredQuery),
+    [state, deferredQuery]
   )
 
   return (

--- a/assets/src/components/stacks/state/StackStateGraph.tsx
+++ b/assets/src/components/stacks/state/StackStateGraph.tsx
@@ -1,17 +1,25 @@
 import { type Edge, type Node } from '@xyflow/react'
 import { StackState } from 'generated/graphql'
-import { useDeferredValue, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { isNonNullable } from '../../../utils/isNonNullable'
 import { NodeType } from '../../cd/pipelines/utils/getNodesAndEdges'
 import { EdgeType } from '../../utils/reactflow/edges'
 import { ReactFlowGraph } from '../../utils/reactflow/ReactFlowGraph'
 
+import {
+  Card,
+  EmptyState,
+  Flex,
+  Input,
+  SearchIcon,
+} from '@pluralsh/design-system'
 import { LayoutOptions } from 'elkjs'
-import { StackStateGraphNode } from './StackStateGraphNode'
-import { Flex, Input, SearchIcon } from '@pluralsh/design-system'
 import Fuse from 'fuse.js'
 import { isEmpty } from 'lodash'
+import { useTheme } from 'styled-components'
+import { useDebounce } from 'usehooks-ts'
+import { StackStateGraphNode } from './StackStateGraphNode'
 
 const nodeTypes = {
   [NodeType.Stage]: StackStateGraphNode,
@@ -74,12 +82,13 @@ function getNodesAndEdges(state: StackState, query: string) {
 }
 
 export function StackStateGraph({ state }: { state: StackState }) {
+  const { colors } = useTheme()
   const [query, setQuery] = useState('')
-  const deferredQuery = useDeferredValue(query)
+  const debouncedQuery = useDebounce(query, 250)
 
   const { nodes: baseNodes, edges: baseEdges } = useMemo(
-    () => getNodesAndEdges(state, deferredQuery),
-    [state, deferredQuery]
+    () => getNodesAndEdges(state, debouncedQuery),
+    [state, debouncedQuery]
   )
 
   return (
@@ -94,16 +103,22 @@ export function StackStateGraph({ state }: { state: StackState }) {
         placeholder="Search resources"
         startIcon={<SearchIcon color="icon-light" />}
       />
-      <div css={{ height: '100%' }}>
-        <ReactFlowGraph
-          allowFullscreen
-          baseNodes={baseNodes}
-          baseEdges={baseEdges}
-          elkOptions={options}
-          nodeTypes={nodeTypes}
-          minZoom={0.05}
-        />
-      </div>
+      {isEmpty(baseNodes) ? (
+        <Card css={{ height: '100%', background: colors['fill-accent'] }}>
+          <EmptyState message="No resources found, try a different search query." />
+        </Card>
+      ) : (
+        <div css={{ height: '100%' }}>
+          <ReactFlowGraph
+            allowFullscreen
+            baseNodes={baseNodes}
+            baseEdges={baseEdges}
+            elkOptions={options}
+            nodeTypes={nodeTypes}
+            minZoom={0.05}
+          />
+        </div>
+      )}
     </Flex>
   )
 }

--- a/assets/src/components/utils/EditableDiv.tsx
+++ b/assets/src/components/utils/EditableDiv.tsx
@@ -15,6 +15,7 @@ export function EditableDiv({
   initialValue,
   setValue,
   onEnter,
+  onKeyDown: onKeyDownProp,
   placeholder,
   ...props
 }: {
@@ -49,6 +50,7 @@ export function EditableDiv({
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent<HTMLDivElement>) => {
+      onKeyDownProp?.(e)
       // for handling enter key when onEnter callback is defined
       // if any modifier key is pressed, just allow default behavior (which is adding a new line usually)
       if (e.key === 'Enter' && onEnter) {
@@ -57,7 +59,7 @@ export function EditableDiv({
         onEnter?.()
       }
     },
-    [onEnter]
+    [onEnter, onKeyDownProp]
   )
 
   const onPaste = useCallback(

--- a/assets/src/components/utils/SkeletonLoaders.tsx
+++ b/assets/src/components/utils/SkeletonLoaders.tsx
@@ -58,7 +58,7 @@ export function TableSkeleton({
       <svg
         width={width + theme.spacing.large * numColumns}
         height={height}
-        viewBox={`0 0 ${width + theme.spacing.large * numColumns} ${height}`}
+        viewBox={`0 0 ${width + theme.spacing.large * (numColumns - 1)} ${height}`}
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -245,9 +245,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:3.13.8":
-  version: 3.13.8
-  resolution: "@apollo/client@npm:3.13.8"
+"@apollo/client@npm:3.14.0":
+  version: 3.14.0
+  resolution: "@apollo/client@npm:3.14.0"
   dependencies:
     "@graphql-typed-document-node/core": ^3.1.1
     "@wry/caches": ^1.0.0
@@ -277,7 +277,7 @@ __metadata:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: 39f058c2681aaa1f95275d8e856976fb1e15f30bdac33758d3cf3c8dc08f111c1cdfa3a30a777ad1088b950cb94336197a81d136a43faa7470cbf2c9746f53ce
+  checksum: 682a8c8103c80940ee89e0f5d6a5dba3d47dd6915b7016f4d19bcebabbe8c6d0d52ca9ff9598d50d4bc0711f8ef66b4f9b8e832494244bcdf3b91377e489e293
   languageName: node
   linkType: hard
 
@@ -10188,7 +10188,7 @@ __metadata:
   resolution: "console@workspace:."
   dependencies:
     "@absinthe/socket": 0.2.1
-    "@apollo/client": 3.13.8
+    "@apollo/client": 3.14.0
     "@apollo/sandbox": 2.7.0
     "@cypress/webpack-preprocessor": 5.17.1
     "@dagrejs/dagre": 1.0.4


### PR DESCRIPTION
had some ui quirks and doesn't really play nice with the cmdk library, plus we probably don't need to virtualize here because it takes a ton of threads (500+) to really have perf effects. if it becomes a problem we can also use VList under the hood which should be more reliable

also:
* more cleanly separates the logic for AI vs Command views to fix some bugs there (like inadvertently starting a new chat when hitting enter on command selection)
* adds the ability to queue a message for a specific thread, making it much more straightforward to send an initial message when a new thread is created (also allows us to remove auto thread creation entirely)
* updates search on stack state graphs to be much broader (closes PROD-3880)

Plural Flow: console