### PR TITLE
fix null thread handling

### DIFF
--- a/assets/src/components/ai/AIContext.tsx
+++ b/assets/src/components/ai/AIContext.tsx
@@ -66,6 +66,7 @@ type ChatbotContextT = {
   setShowForkToast: (show: boolean) => void
 
   currentThread: Nullable<ChatThreadDetailsFragment>
+  currentThreadLoading: boolean
 
   // this is the selected thread ID, updating it triggers currentThread to populate with its details
   currentThreadId: Nullable<string>
@@ -112,7 +113,11 @@ function ChatbotContextProvider({ children }: { children: ReactNode }) {
     usePersistedState<AutoAgentSessionT>('plural-ai-agent-init-mode', null)
   const [showForkToast, setShowForkToast] = useState(false)
 
-  const { data: threadData, error: threadError } = useChatThreadDetailsQuery({
+  const {
+    data: threadData,
+    loading: currentThreadLoading,
+    error: threadError,
+  } = useChatThreadDetailsQuery({
     skip: !currentThreadId,
     variables: { id: currentThreadId ?? '' },
     fetchPolicy: 'cache-and-network',
@@ -142,6 +147,7 @@ function ChatbotContextProvider({ children }: { children: ReactNode }) {
         open,
         setOpen,
         currentThread,
+        currentThreadLoading,
         currentThreadId,
         setCurrentThreadId,
         selectedAgent,

--- a/assets/src/components/ai/chatbot/ChatbotPanelThread.tsx
+++ b/assets/src/components/ai/chatbot/ChatbotPanelThread.tsx
@@ -12,7 +12,7 @@ import {
 import { produce } from 'immer'
 import { isEmpty, uniq } from 'lodash'
 
-import LoadingIndicator from 'components/utils/LoadingIndicator.tsx'
+import { TableSkeleton } from 'components/utils/SkeletonLoaders.tsx'
 import { VirtualList } from 'components/utils/VirtualList.tsx'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import styled, { useTheme } from 'styled-components'
@@ -44,7 +44,13 @@ export function ChatbotPanelThread({
 }) {
   const theme = useTheme()
   const { readValue } = useCommandPaletteMessage()
-  const { currentThread: curThreadDetails, createNewThread } = useChatbot()
+  const {
+    currentThread: curThreadDetails,
+    currentThreadLoading,
+    createNewThread,
+    mutationLoading,
+  } = useChatbot()
+
   const threadId = curThreadDetails?.id
   const messageListRef = useRef<VListHandle | null>(null)
 
@@ -137,9 +143,16 @@ export function ChatbotPanelThread({
 
   // create a new thread if we're here and one doesn't exist
   useEffect(() => {
-    if (threadId) return
+    if (threadId || currentThreadLoading || mutationLoading || initLoading)
+      return
     createNewThread({ summary: 'New chat with Plural AI' })
-  }, [threadId, createNewThread])
+  }, [
+    createNewThread,
+    currentThreadLoading,
+    initLoading,
+    mutationLoading,
+    threadId,
+  ])
 
   useEffect(() => {
     const commandPalettePendingMessage = readValue()
@@ -147,7 +160,15 @@ export function ChatbotPanelThread({
     sendMessage(commandPalettePendingMessage)
   }, [readValue, sendMessage])
 
-  if (initLoading) return <LoadingIndicator />
+  if (initLoading || currentThreadLoading)
+    return (
+      <TableSkeleton
+        centered
+        numColumns={1}
+        width={500}
+        styles={{ padding: theme.spacing.xlarge }}
+      />
+    )
 
   return (
     <Flex


### PR DESCRIPTION
the logic for creating a new thread when one isn't currently selected wasn't correctly accounting for loading states, so a ton of threads were being created on page load and switching to old threads in the history was totally broken