### PR TITLE
fix(cluster-addons): update isCloudAddon logic to use correct path

### DIFF
--- a/assets/src/components/cd/cluster/ClusterAddOns.tsx
+++ b/assets/src/components/cd/cluster/ClusterAddOns.tsx
@@ -32,8 +32,8 @@ import { LinkTabWrap } from '../../utils/Tabs'
 import { getClusterKubeVersion } from '../clusters/runtime/RuntimeServices'
 
 import { POLL_INTERVAL } from '../ContinuousDeployment'
-import ClusterAddOnsEntry from './ClusterAddOnsEntry'
 import { useClusterContext } from './Cluster.tsx'
+import ClusterAddOnsEntry from './ClusterAddOnsEntry'
 
 export type AddonContextType = {
   cluster: ClusterFragment
@@ -65,7 +65,7 @@ export default function ClusterAddOns() {
   )
   const tab = pathMatch?.params?.tab || ''
   const currentTab = directory.find(({ path }) => path === tab)
-  const isCloudAddon = currentTab?.path !== CLUSTER_ALL_ADDONS_REL_PATH
+  const isCloudAddon = currentTab?.path == CLUSTER_CLOUD_ADDONS_REL_PATH
 
   const { data, error } = useRuntimeServicesQuery({
     variables: { kubeVersion, hasKubeVersion: !!kubeVersion, id: clusterId },


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
This didn't work since path routing does not redirect to `all` tab and stays on the root `addons` path. In this case cloud addon check should check for exact tab match.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console