### PR TITLE
prevent sending empty stack ID to the API

### DIFF
--- a/go/controller/internal/client/stack.go
+++ b/go/controller/internal/client/stack.go
@@ -13,6 +13,11 @@ import (
 )
 
 func (c *client) GetStack(ctx context.Context, id string) (*console.InfrastructureStackFragment, error) {
+	// we assume that an empty id means the stack does not exist
+	// this is to avoid making a call to the backend with an empty id
+	if id == "" {
+		return nil, errors.NewNotFound(schema.GroupResource{}, "")
+	}
 	response, err := c.consoleClient.GetInfrastructureStack(ctx, lo.ToPtr(id), nil)
 	if internalerror.IsNotFound(err) {
 		return nil, errors.NewNotFound(schema.GroupResource{}, id)
@@ -28,6 +33,9 @@ func (c *client) GetStack(ctx context.Context, id string) (*console.Infrastructu
 }
 
 func (c *client) GetStackById(ctx context.Context, id string) (*console.InfrastructureStackIDFragment, error) {
+	if id == "" {
+		return nil, errors.NewNotFound(schema.GroupResource{}, "")
+	}
 	response, err := c.consoleClient.GetInfrastructureStackID(ctx, lo.ToPtr(id), nil)
 	if internalerror.IsNotFound(err) {
 		return nil, errors.NewNotFound(schema.GroupResource{}, id)
@@ -43,6 +51,9 @@ func (c *client) GetStackById(ctx context.Context, id string) (*console.Infrastr
 }
 
 func (c *client) GetStackStatus(ctx context.Context, id string) (*console.InfrastructureStackStatusFragment, error) {
+	if id == "" {
+		return nil, errors.NewNotFound(schema.GroupResource{}, "")
+	}
 	response, err := c.consoleClient.GetInfrastructureStackStatus(ctx, lo.ToPtr(id), nil)
 	if internalerror.IsNotFound(err) {
 		return nil, errors.NewNotFound(schema.GroupResource{}, id)
@@ -58,11 +69,17 @@ func (c *client) GetStackStatus(ctx context.Context, id string) (*console.Infras
 }
 
 func (c *client) DeleteStack(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.NewNotFound(schema.GroupResource{}, "")
+	}
 	_, err := c.consoleClient.DeleteStack(ctx, id)
 	return err
 }
 
 func (c *client) DetachStack(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.NewNotFound(schema.GroupResource{}, "")
+	}
 	_, err := c.consoleClient.DetachStack(ctx, id)
 	return err
 }


### PR DESCRIPTION
The InfrastructureStack reconciler is querying for stacks with empty IDs. We should assume an empty ID implies the stack doesn't exist, and not fetch from the API

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console