### PR TITLE
add logs bucketing for elastic and opensearch

### DIFF
--- a/assets/src/generated/graphql-plural.ts
+++ b/assets/src/generated/graphql-plural.ts
@@ -36,6 +36,7 @@ export type Account = {
   billingAddress?: Maybe<Address>;
   billingCustomerId?: Maybe<Scalars['String']['output']>;
   clusterCount?: Maybe<Scalars['String']['output']>;
+  consumerEmailDomains?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   delinquentAt?: Maybe<Scalars['DateTime']['output']>;
   domainMappings?: Maybe<Array<Maybe<DomainMapping>>>;
   grandfatheredUntil?: Maybe<Scalars['DateTime']['output']>;

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -4312,6 +4312,16 @@ export type LoadBalancerStatus = {
   ingress?: Maybe<Array<Maybe<LoadBalancerIngressStatus>>>;
 };
 
+export type LogAggregationBucket = {
+  __typename?: 'LogAggregationBucket';
+  count?: Maybe<Scalars['Int']['output']>;
+  timestamp?: Maybe<Scalars['DateTime']['output']>;
+};
+
+export type LogAggregationInput = {
+  bucketSize?: InputMaybe<Scalars['String']['input']>;
+};
+
 export enum LogDriver {
   Elastic = 'ELASTIC',
   Opensearch = 'OPENSEARCH',
@@ -8545,6 +8555,7 @@ export type RootQueryType = {
   job?: Maybe<Job>;
   kubernetesVersionInfo?: Maybe<Array<Maybe<KubernetesVersionInfo>>>;
   logAggregation?: Maybe<Array<Maybe<LogLine>>>;
+  logAggregationBuckets?: Maybe<Array<Maybe<LogAggregationBucket>>>;
   loginInfo?: Maybe<LoginInfo>;
   logs?: Maybe<Array<Maybe<LogStream>>>;
   managedNamespace?: Maybe<ManagedNamespace>;
@@ -9202,6 +9213,16 @@ export type RootQueryTypeLogAggregationArgs = {
   clusterId?: InputMaybe<Scalars['ID']['input']>;
   facets?: InputMaybe<Array<InputMaybe<LogFacetInput>>>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
+  serviceId?: InputMaybe<Scalars['ID']['input']>;
+  time?: InputMaybe<LogTimeRange>;
+};
+
+
+export type RootQueryTypeLogAggregationBucketsArgs = {
+  aggregation?: InputMaybe<LogAggregationInput>;
+  clusterId?: InputMaybe<Scalars['ID']['input']>;
+  facets?: InputMaybe<Array<InputMaybe<LogFacetInput>>>;
   query?: InputMaybe<Scalars['String']['input']>;
   serviceId?: InputMaybe<Scalars['ID']['input']>;
   time?: InputMaybe<LogTimeRange>;

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -3501,6 +3501,15 @@ type LoadBalancerStatus struct {
 	Ingress []*LoadBalancerIngressStatus `json:"ingress,omitempty"`
 }
 
+type LogAggregationBucket struct {
+	Timestamp *string `json:"timestamp,omitempty"`
+	Count     *int64  `json:"count,omitempty"`
+}
+
+type LogAggregationInput struct {
+	BucketSize *string `json:"bucketSize,omitempty"`
+}
+
 type LogFacet struct {
 	Key   string  `json:"key"`
 	Value *string `json:"value,omitempty"`

--- a/lib/console/graphql/resolvers/observability.ex
+++ b/lib/console/graphql/resolvers/observability.ex
@@ -31,6 +31,13 @@ defmodule Console.GraphQl.Resolvers.Observability do
     Observability.get_logs(query, end_ts, start, limit)
   end
 
+  def list_log_aggregations(args, %{context: %{current_user: user}}) do
+    args = Map.merge(args, args[:aggregation] || %{})
+    query = Query.new(args)
+    with {:ok, query} <- Provider.accessible(query, user),
+      do: Provider.aggregate(query)
+  end
+
   def resolve_metric(%{query: query} = args, _) do
     now   = Timex.now()
     start = Timex.shift(now, seconds: -Map.get(args, :offset, @default_offset))

--- a/lib/console/logs/aggregation_bucket.ex
+++ b/lib/console/logs/aggregation_bucket.ex
@@ -1,0 +1,6 @@
+defmodule Console.Logs.AggregationBucket do
+  defstruct [:timestamp, :count]
+
+  @type t :: %__MODULE__{timestamp: DateTime.t(), count: non_neg_integer()}
+
+end

--- a/lib/console/logs/provider.ex
+++ b/lib/console/logs/provider.ex
@@ -6,11 +6,18 @@ defmodule Console.Logs.Provider do
   @type error :: Console.error
 
   @callback query(struct, Query.t) :: {:ok, [Line.t]} | error
+  @callback aggregate(struct, Query.t) :: {:ok, [map()]} | error
 
   @spec query(Query.t) :: {:ok, [Line.t]} | error
   def query(%Query{} = q) do
     with {:ok, %{__struct__: provider} = prov} <- client(),
       do: provider.query(prov, q)
+  end
+
+  @spec aggregate(Query.t) :: {:ok, [map()]} | error
+  def aggregate(%Query{} = q) do
+    with {:ok, %{__struct__: provider} = prov} <- client(),
+      do: provider.aggregate(prov, q)
   end
 
   @spec accessible(Query.t, User.t) :: {:ok, Query.t} | error

--- a/lib/console/logs/provider/opensearch.ex
+++ b/lib/console/logs/provider/opensearch.ex
@@ -4,7 +4,7 @@ defmodule Console.Logs.Provider.Opensearch do
   """
   @behaviour Console.Logs.Provider
   alias Console.Schema.{Cluster, Service, DeploymentSettings.Opensearch}
-  alias Console.Logs.{Query, Line, Time}
+  alias Console.Logs.{Query, Line, Time, AggregationBucket}
 
   @type t :: %__MODULE__{}
   @headers [{"Content-Type", "application/json"}]
@@ -20,6 +20,14 @@ defmodule Console.Logs.Provider.Opensearch do
     case search(connection, build_query(q)) do
       {:ok, hits} -> {:ok, format_hits(hits)}
       {:error, err} -> {:error, "failed to query elasticsearch: #{inspect(err)}"}
+    end
+  end
+
+  @spec aggregate(t(), Query.t) :: {:ok, [map()]} | Console.error
+  def aggregate(%__MODULE__{connection: connection}, %Query{} = q) do
+    case search(connection, build_aggregation_query(q)) do
+      {:ok, response} -> {:ok, format_aggregation_response(response)}
+      {:error, err} -> {:error, "failed to query elasticsearch aggregations: #{inspect(err)}"}
     end
   end
 
@@ -52,6 +60,26 @@ defmodule Console.Logs.Provider.Opensearch do
     |> Enum.filter(& &1.log)
   end
   defp format_hits(_), do: []
+
+  defp format_aggregation_response(%Snap.SearchResponse{aggregations: %{"logs_over_time" => %Snap.Aggregation{buckets: buckets}}}) do
+    Enum.map(buckets, fn bucket ->
+      %AggregationBucket{
+        timestamp: parse_bucket_timestamp(bucket["key_as_string"] || bucket["key"]),
+        count: bucket["doc_count"]
+      }
+    end)
+  end
+  defp format_aggregation_response(_), do: []
+
+  defp parse_bucket_timestamp(timestamp) when is_integer(timestamp) do
+    DateTime.from_unix!(timestamp, :millisecond)
+  end
+  defp parse_bucket_timestamp(timestamp) when is_binary(timestamp) do
+    case DateTime.from_iso8601(timestamp) do
+      {:ok, dt, _} -> dt
+      _ -> DateTime.utc_now()
+    end
+  end
 
   defp build_query(%Query{query: str} = q) do
     %{
@@ -179,4 +207,28 @@ defmodule Console.Logs.Provider.Opensearch do
 
   defp sort(%Query{time: %Time{reverse: true}}), do: [%{"@timestamp": %{order: "asc"}}]
   defp sort(_), do: [%{"@timestamp": %{order: "desc"}}]
+
+
+  defp build_aggregation_query(%Query{query: str} = q) do
+    %{
+      query: maybe_query(str)
+             |> add_terms(q)
+             |> add_range(q)
+             |> add_namespaces(q)
+             |> add_facets(q),
+      aggs: build_aggregations(q),
+      size: 0
+    }
+  end
+
+  defp build_aggregations(%Query{bucket_size: bucket_size}) do
+    %{
+      logs_over_time: %{
+        date_histogram: %{
+          field: "@timestamp",
+          fixed_interval: bucket_size || "1m"
+        }
+      }
+    }
+  end
 end

--- a/lib/console/logs/provider/victoria.ex
+++ b/lib/console/logs/provider/victoria.ex
@@ -25,6 +25,12 @@ defmodule Console.Logs.Provider.Victoria do
   end
   def query(_, _), do: {:error, "no victoria metrics host specified"}
 
+  # Empty since victoria metrics doesn't support aggregations
+  def aggregate(%__MODULE__{connection: %Connection{host: host}}, %Query{}) when is_binary(host) do
+    {:ok, []}
+  end
+  def aggregate(_, _), do: {:error, "no victoria metrics host specified"}
+
   defp build_query(%Query{query: query} = q) do
     add_resource([query], q)
     |> add_time(q)

--- a/lib/console/logs/query.ex
+++ b/lib/console/logs/query.ex
@@ -9,7 +9,11 @@ defmodule Console.Logs.Query do
   @type t :: %__MODULE__{time: Time.t}
   @type direction :: :gte | :lte | :gt | :lt
 
-  defstruct [:project_id, :cluster_id, :service_id, :query, :limit, :resource, :time, :facets, :namespaces]
+  defstruct [
+    :project_id, :cluster_id, :service_id, :query, :limit,
+    :resource, :time, :facets, :namespaces,
+    :bucket_size, :group_by_fields
+  ]
 
   def new(args) do
     %__MODULE__{
@@ -20,7 +24,9 @@ defmodule Console.Logs.Query do
       limit: args[:limit],
       time: Time.new(args[:time]),
       facets: args[:facets],
-      namespaces: args[:namespaces]
+      namespaces: args[:namespaces],
+      bucket_size: args[:bucket_size],
+      group_by_fields: args[:group_by_fields]
     }
   end
 

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -53,6 +53,10 @@ type RootQueryType {
 
   logAggregation(serviceId: ID, clusterId: ID, query: String, time: LogTimeRange, limit: Int, facets: [LogFacetInput]): [LogLine]
 
+  logAggregationBuckets(
+    serviceId: ID, clusterId: ID, query: String, time: LogTimeRange, aggregation: LogAggregationInput, facets: [LogFacetInput]
+  ): [LogAggregationBucket]
+
   logs(query: String!, start: Long, end: Long, limit: Int!, clusterId: ID): [LogStream]
 
   scalingRecommendation(kind: AutoscalingTarget!, namespace: String!, name: String!): VerticalPodAutoscaler
@@ -9328,6 +9332,10 @@ input LogFacetInput {
   value: String!
 }
 
+input LogAggregationInput {
+  bucketSize: String
+}
+
 type Dashboard {
   id: String!
   spec: DashboardSpec!
@@ -9377,6 +9385,11 @@ type LogLine {
 type LogFacet {
   key: String!
   value: String
+}
+
+type LogAggregationBucket {
+  timestamp: DateTime
+  count: Int
 }
 
 type Metadata {


### PR DESCRIPTION
Add log bucketing for elastic and opensearch.
To my knowledge Victoria does not offer this feature so leave it stubbed for that provider.

## Test Plan
unit tests

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console