### PR TITLE
make expanded sidebar persist

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -125,7 +125,7 @@
     "yaml": "2.3.3"
   },
   "devDependencies": {
-    "@apollo/sandbox": "2.7.0",
+    "@apollo/sandbox": "2.7.2",
     "@cypress/webpack-preprocessor": "5.17.1",
     "@eslint/compat": "1.1.1",
     "@graphql-codegen/add": "5.0.0",

--- a/assets/src/components/ai/AIContext.tsx
+++ b/assets/src/components/ai/AIContext.tsx
@@ -25,6 +25,7 @@ import {
 } from 'react'
 import { useTheme } from 'styled-components'
 import usePersistedState from '../hooks/usePersistedState.tsx'
+import { SidebarContext } from 'components/layout/Sidebar.tsx'
 
 export enum AIVerbosityLevel {
   High = 'High',
@@ -108,7 +109,8 @@ export function AIContextProvider({ children }: { children: ReactNode }) {
 
 function ChatbotContextProvider({ children }: { children: ReactNode }) {
   const { spacing } = useTheme()
-  const [open, setOpen] = usePersistedState('plural-ai-chat-open', false)
+  const { setIsExpanded: setSidebarExpanded } = use(SidebarContext)
+  const [open, setOpenState] = usePersistedState('plural-ai-chat-open', false)
   const [actionsPanelOpen, setActionsPanelOpen] = useState<boolean>(false)
   const [mcpPanelOpen, setMcpPanelOpen] = useState<boolean>(false)
   const [currentThreadId, setCurrentThreadId] = usePersistedState<
@@ -154,7 +156,10 @@ function ChatbotContextProvider({ children }: { children: ReactNode }) {
     <ChatbotContext
       value={{
         open,
-        setOpen,
+        setOpen: (open) => {
+          setOpenState(open)
+          if (open) setSidebarExpanded(false)
+        },
         currentThread,
         currentThreadLoading,
         currentThreadId,

--- a/assets/src/components/help/HelpLauncherBtn.tsx
+++ b/assets/src/components/help/HelpLauncherBtn.tsx
@@ -3,12 +3,13 @@ import {
   CaretLeftIcon,
   IconFrame,
   IconFrameProps,
-  useSidebar,
 } from '@pluralsh/design-system'
 
 import { useTheme } from 'styled-components'
 
 import { CountBadge } from '../utils/CountBadge'
+import { use } from 'react'
+import { SidebarContext } from 'components/layout/Sidebar'
 
 export function HelpLauncherBtn({
   variant,
@@ -19,7 +20,7 @@ export function HelpLauncherBtn({
   { variant: 'help' | 'minimize'; count?: number }
 >) {
   const theme = useTheme()
-  const { isExpanded } = useSidebar()
+  const { isExpanded } = use(SidebarContext)
 
   const translate = count > 10 ? -7 : -6
 

--- a/assets/src/components/layout/Console.tsx
+++ b/assets/src/components/layout/Console.tsx
@@ -29,7 +29,7 @@ import { useNativeDomEvent } from 'components/hooks/useNativeDomEvent'
 import { CloudConsoleWelcomeModal } from '../cloud-setup/CloudConsoleWelcomeModal'
 import { ApplicationUpdateToast } from './ApplicationUpdateToast'
 import Header from './Header'
-import Sidebar from './Sidebar'
+import { Sidebar, SidebarProvider } from './Sidebar'
 import Subheader from './Subheader'
 import { SentryInitializer } from '../SentryInitializer'
 
@@ -46,13 +46,15 @@ export default function Console() {
                     <TerminalThemeProvider>
                       <ShareSecretProvider>
                         <DeploymentSettingsProvider>
-                          <AIContextProvider>
-                            <FeatureFlagProvider>
-                              <CommandPaletteProvider>
-                                <ConsoleContent />
-                              </CommandPaletteProvider>
-                            </FeatureFlagProvider>
-                          </AIContextProvider>
+                          <SidebarProvider>
+                            <AIContextProvider>
+                              <FeatureFlagProvider>
+                                <CommandPaletteProvider>
+                                  <ConsoleContent />
+                                </CommandPaletteProvider>
+                              </FeatureFlagProvider>
+                            </AIContextProvider>
+                          </SidebarProvider>
                         </DeploymentSettingsProvider>
                       </ShareSecretProvider>
                     </TerminalThemeProvider>
@@ -92,7 +94,6 @@ function ConsoleContent() {
         overflow="hidden"
         flexDirection="column"
         flexGrow={1}
-        container="console / inline-size"
         zIndex={0} // needed so chatbot flyovers render over main console content
       >
         {isProduction && <ApplicationUpdateToast />}
@@ -111,6 +112,7 @@ function ConsoleContent() {
             flexGrow={1}
             overflowX="hidden"
             position="relative"
+            container="console / inline-size"
           >
             <Subheader />
             <Suspense fallback={<LoadingIndicator />}>

--- a/assets/src/components/layout/Sidebar.tsx
+++ b/assets/src/components/layout/Sidebar.tsx
@@ -4,13 +4,14 @@ import {
   Avatar,
   CatalogIcon,
   CostManagementIcon,
-  Sidebar as DSSidebar,
   EdgeComputeIcon,
   Flex,
   FlowIcon,
   GearTrainIcon,
   GitHubLogoIcon,
   GitPullIcon,
+  HamburgerMenuCollapsedIcon,
+  HamburgerMenuCollapseIcon,
   HomeIcon,
   KubernetesAltIcon,
   LogoutIcon,
@@ -18,19 +19,18 @@ import {
   MenuItem,
   PersonIcon,
   ScrollIcon,
-  SidebarExpandButton,
-  SidebarExpandWrapper,
-  SidebarItem,
-  SidebarSection,
   StackIcon,
   Tooltip,
-  useSidebar,
   WarningShieldIcon,
   WrapWithIf,
 } from '@pluralsh/design-system'
 
 import {
+  createContext,
+  Dispatch,
   ReactElement,
+  ReactNode,
+  SetStateAction,
   use,
   useCallback,
   useMemo,
@@ -49,23 +49,29 @@ import { SECURITY_ABS_PATH } from 'routes/securityRoutesConsts'
 import { SETTINGS_ABS_PATH } from 'routes/settingsRoutesConst'
 import { AI_ABS_PATH } from '../../routes/aiRoutesConsts.tsx'
 
-import { KUBERNETES_ROOT_PATH } from '../../routes/kubernetesRoutesConsts'
-import { getStacksAbsPath } from '../../routes/stacksRoutesConsts'
-import { useLogin } from '../contexts'
+import { KUBERNETES_ROOT_PATH } from '../../routes/kubernetesRoutesConsts.tsx'
+import { getStacksAbsPath } from '../../routes/stacksRoutesConsts.tsx'
+import { useLogin } from '../contexts.tsx'
 
-import HelpLauncher from '../help/HelpLauncher'
+import HelpLauncher from '../help/HelpLauncher.tsx'
 
 import {
   FeatureFlagContext,
   FeatureFlags,
 } from 'components/flows/FeatureFlagContext.tsx'
 import { useOutsideClick } from 'components/hooks/useOutsideClick.tsx'
+import usePersistedState from 'components/hooks/usePersistedState.tsx'
+import { SidebarItem } from 'components/utils/sidebar/SidebarItem.tsx'
+import { SidebarSection } from 'components/utils/sidebar/SidebarSection.tsx'
 import { TRUNCATE } from 'components/utils/truncate.ts'
 import { FLOWS_ABS_PATH } from 'routes/flowRoutesConsts.tsx'
 import { SELF_SERVICE_ABS_PATH } from 'routes/selfServiceRoutesConsts.tsx'
 import { GITHUB_LINK } from 'utils/constants.ts'
 import { EDGE_ABS_PATH } from '../../routes/edgeRoutes.tsx'
 import CommandPaletteShortcuts from '../commandpalette/CommandPaletteShortcuts.tsx'
+
+const SIDEBAR_WIDTH = 64
+const SIDEBAR_EXPANDED_WIDTH = 180
 
 type MenuItem = {
   text: string
@@ -76,6 +82,26 @@ type MenuItem = {
   hotkeys?: string[]
   enabled?: boolean
   expandedLabel: string
+}
+
+type SidebarContextT = {
+  isExpanded: boolean
+  setIsExpanded: Dispatch<SetStateAction<boolean>>
+}
+export const SidebarContext = createContext<SidebarContextT>({
+  isExpanded: false,
+  setIsExpanded: () => {},
+})
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [isExpanded, setIsExpanded] = usePersistedState<boolean>(
+    'sidebar-expanded',
+    false
+  )
+  const ctx = useMemo(
+    () => ({ isExpanded, setIsExpanded }),
+    [isExpanded, setIsExpanded]
+  )
+  return <SidebarContext value={ctx}>{children}</SidebarContext>
 }
 
 // Keep hotkeys in sync with assets/src/components/commandpalette/commands.ts.
@@ -169,16 +195,6 @@ function getMenuItems({
       path: '/cost-management',
       hotkeys: ['shift C+M'],
     },
-    // {
-    //   text: 'Backups',
-    //   expandedLabel: 'Backups',
-    //   icon: <HistoryIcon />,
-    //   path: '/backups',
-    //   enabled:
-    //     isCDEnabled &&
-    //     !!(personaConfig?.all || personaConfig?.sidebar?.backups),
-    //   hotkeys: ['shift B', '9'],
-    // },
     {
       text: 'Settings',
       expandedLabel: 'Settings',
@@ -191,41 +207,29 @@ function getMenuItems({
   ].filter((item) => item.enabled !== false)
 }
 
+type MenuItemPath = Pick<MenuItem, 'path' | 'pathRegexp' | 'ignoreRegexp'>
 function isActiveMenuItem(
-  {
-    path,
-    pathRegexp,
-    ignoreRegexp,
-  }: Pick<MenuItem, 'path' | 'pathRegexp' | 'ignoreRegexp'>,
-  currentPath
+  { path, pathRegexp, ignoreRegexp }: MenuItemPath,
+  currentPath: string
 ) {
   return (
     (path === '/' ? currentPath === path : currentPath.startsWith(path)) ||
-    (pathRegexp &&
-      (currentPath.match(pathRegexp)?.length ?? 0 > 0) &&
+    (!!pathRegexp &&
+      (currentPath.match(pathRegexp)?.length ?? 0) > 0 &&
       (!ignoreRegexp || (currentPath.match(ignoreRegexp)?.length ?? 0) === 0))
   )
 }
 
-const SidebarSC = styled(DSSidebar).attrs(({ variant }) => ({
-  variant,
-}))((_) => ({
-  flexGrow: 1,
-  minHeight: 0,
-  height: 'auto',
-  overflow: 'visible',
-}))
-
-export default function Sidebar() {
-  const menuItemRef = useRef<HTMLDivElement>(null)
+export function Sidebar() {
+  const menuItemRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  const { isExpanded, setIsExpanded } = use(SidebarContext)
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false)
   const { me, configuration, personaConfiguration } = useLogin()
   const { featureFlags } = use(FeatureFlagContext)
   const { pathname } = useLocation()
   const isActive = useCallback(
-    (menuItem: Parameters<typeof isActiveMenuItem>[0]) =>
-      isActiveMenuItem(menuItem, pathname),
+    (menuItem: MenuItemPath) => isActiveMenuItem(menuItem, pathname),
     [pathname]
   )
   const isCDEnabled = useCDEnabled({ redirect: false })
@@ -266,111 +270,112 @@ export default function Sidebar() {
   if (!me) return null
 
   return (
-    <SidebarSC variant="console">
-      <SidebarExpandWrapper pathname={pathname}>
-        <SidebarSection flex={1}>
-          {menuItems.map((item, i) => (
-            <Tooltip
-              key={i}
-              label={
-                <div
-                  css={{
-                    alignItems: 'center',
-                    display: 'flex',
-                    gap: theme.spacing.small,
-                  }}
-                >
-                  {item.expandedLabel}
-                  <CommandPaletteShortcuts shortcuts={item.hotkeys} />
-                </div>
-              }
-            >
-              <SidebarItem
-                clickable
-                className={`sidebar-${item.text}`}
-                active={isActive(item)}
-                as={Link}
-                to={item.path}
-                expandedLabel={item.expandedLabel}
-              >
-                {item.icon}
-              </SidebarItem>
-            </Tooltip>
-          ))}
-          <Flex flex={1} />
-          <SidebarExpandButton />
-          <HelpLauncher />
+    <SidebarSC $isExpanded={isExpanded}>
+      <SidebarSection flex={1}>
+        {menuItems.map((item, i) => (
           <SidebarItem
-            ref={menuItemRef}
-            className="sidebar-menu"
-            active={isMenuOpen}
-            clickable
-            onClick={(e) => {
-              e.stopPropagation()
-              setIsMenuOpen((x) => !x)
-            }}
-            expandedLabel="Menu"
-            css={{ paddingLeft: theme.spacing.xxsmall }}
+            key={i}
+            asLink
+            to={item.path}
+            active={isActive(item)}
+            expandedLabel={item.expandedLabel}
+            tooltip={
+              <Flex
+                gap="small"
+                align="center"
+              >
+                {item.expandedLabel}
+                <CommandPaletteShortcuts shortcuts={item.hotkeys} />
+              </Flex>
+            }
           >
-            <Avatar
-              name={me.name}
-              src={me.profile}
-              size={32}
-            />
+            {item.icon}
           </SidebarItem>
-          {configuration?.consoleVersion && (
-            <ConsoleVersion version={configuration.consoleVersion} />
+        ))}
+        <Flex flex={1} />
+        <SidebarItem
+          tooltip="Expand"
+          expandedLabel="Collapse"
+          onClick={(e) => {
+            e.stopPropagation()
+            setIsExpanded((x: boolean) => !x)
+          }}
+        >
+          {isExpanded ? (
+            <HamburgerMenuCollapseIcon />
+          ) : (
+            <HamburgerMenuCollapsedIcon />
           )}
-        </SidebarSection>
-        {isMenuOpen && (
-          <ProfileMenuSC ref={menuRef}>
-            <MenuItem
-              as={Link}
-              to="/profile"
-              onClick={() => setIsMenuOpen(false)}
-            >
-              <PersonIcon marginRight="xsmall" />
-              My profile
-            </MenuItem>
-            <MenuItem
-              as="a"
-              href="https://docs.plural.sh"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setIsMenuOpen(false)}
-            >
-              <ScrollIcon marginRight="xsmall" />
-              <span css={{ flex: 1 }}>Docs</span>
-              <ArrowTopRightIcon />
-            </MenuItem>
-            <MenuItem
-              as="a"
-              href={`${GITHUB_LINK}/plural`}
-              target="_blank"
-              rel="noopener noreferrer"
-              expandedLabel="GitHub"
-            >
-              <GitHubLogoIcon marginRight="xsmall" />
-              <span css={{ flex: 1 }}>GitHub</span>
-              <ArrowTopRightIcon />
-            </MenuItem>
-            <MenuItem
-              as="a"
-              style={{ color: theme.colors['icon-danger'] }}
-              onClick={handleLogout}
-            >
-              <LogoutIcon marginRight="xsmall" />
-              Logout
-            </MenuItem>
-          </ProfileMenuSC>
+        </SidebarItem>
+        <HelpLauncher />
+        <SidebarItem
+          ref={menuItemRef}
+          active={isMenuOpen}
+          onClick={(e) => {
+            e.stopPropagation()
+            setIsMenuOpen((x) => !x)
+          }}
+          expandedLabel="Menu"
+          css={{ paddingLeft: theme.spacing.xxsmall }}
+        >
+          <Avatar
+            name={me.name}
+            src={me.profile}
+            size={32}
+          />
+        </SidebarItem>
+        {configuration?.consoleVersion && (
+          <ConsoleVersion version={configuration.consoleVersion} />
         )}
-      </SidebarExpandWrapper>
+      </SidebarSection>
+      {isMenuOpen && (
+        <ProfileMenuSC ref={menuRef}>
+          <MenuItem
+            as={Link}
+            to="/profile"
+            onClick={() => setIsMenuOpen(false)}
+          >
+            <PersonIcon marginRight="xsmall" />
+            My profile
+          </MenuItem>
+          <MenuItem
+            as="a"
+            href="https://docs.plural.sh"
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => setIsMenuOpen(false)}
+          >
+            <ScrollIcon marginRight="xsmall" />
+            <span css={{ flex: 1 }}>Docs</span>
+            <ArrowTopRightIcon />
+          </MenuItem>
+          <MenuItem
+            as="a"
+            href={`${GITHUB_LINK}/plural`}
+            target="_blank"
+            rel="noopener noreferrer"
+            expandedLabel="GitHub"
+          >
+            <GitHubLogoIcon marginRight="xsmall" />
+            <span css={{ flex: 1 }}>GitHub</span>
+            <ArrowTopRightIcon />
+          </MenuItem>
+          <MenuItem
+            as="a"
+            style={{ color: theme.colors['icon-danger'] }}
+            onClick={handleLogout}
+          >
+            <LogoutIcon marginRight="xsmall" />
+            Logout
+          </MenuItem>
+        </ProfileMenuSC>
+      )}
     </SidebarSC>
   )
 }
 
 function ConsoleVersion({ version }: { version: string }) {
-  const { isExpanded } = useSidebar()
+  const { isExpanded } = use(SidebarContext)
   return (
     <WrapWithIf
       condition={!isExpanded}
@@ -398,9 +403,25 @@ const ConsoleVersionSC = styled.span<{ $isExpanded?: boolean }>(
 const ProfileMenuSC = styled(Menu)(({ theme }) => ({
   zIndex: 999,
   position: 'absolute',
-  bottom: 8,
+  bottom: theme.spacing.medium,
   minWidth: '175px',
   left: 'calc(100% + 10px)',
   '& a': { color: theme.colors.text, textDecoration: 'none' },
   '& *:hover': { background: theme.colors['fill-two-hover'] },
+}))
+
+const SidebarSC = styled.div<{
+  $isExpanded: boolean
+}>(({ theme, $isExpanded }) => ({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
+  justifyContent: 'flex-start',
+  height: '100%',
+  transition: 'max-width 0.2s ease-in-out',
+  width: '100%',
+  maxWidth: $isExpanded ? SIDEBAR_EXPANDED_WIDTH : SIDEBAR_WIDTH,
+  backgroundColor: theme.colors['fill-accent'],
+  borderRight: theme.borders.default,
 }))

--- a/assets/src/components/utils/sidebar/SidebarItem.tsx
+++ b/assets/src/components/utils/sidebar/SidebarItem.tsx
@@ -1,0 +1,77 @@
+import { ComponentPropsWithRef, ReactNode, use } from 'react'
+import styled from 'styled-components'
+
+import { Tooltip, WrapWithIf } from '@pluralsh/design-system'
+import { SidebarContext } from 'components/layout/Sidebar'
+import { Link, LinkProps } from 'react-router-dom'
+
+type SidebarItemProps = ComponentPropsWithRef<'button'> & {
+  tooltip?: ReactNode
+  expandedLabel?: string
+  active?: boolean
+} & ({ asLink?: never } | ({ asLink: true } & LinkProps))
+
+export function SidebarItem({
+  asLink,
+  tooltip,
+  expandedLabel,
+  active,
+  children,
+  ...props
+}: SidebarItemProps) {
+  const { isExpanded } = use(SidebarContext)
+  if (expandedLabel?.toLowerCase() === 'home')
+    console.log(expandedLabel, active)
+  return (
+    <WrapWithIf
+      condition={!!tooltip && !isExpanded}
+      wrapper={
+        <Tooltip
+          label={tooltip}
+          placement="right"
+          css={{ whiteSpace: 'nowrap' }}
+        />
+      }
+    >
+      <ItemSC
+        as={asLink ? Link : 'button'}
+        {...props}
+        $active={!!active}
+      >
+        {children}
+        {isExpanded && expandedLabel ? expandedLabel : null}
+      </ItemSC>
+    </WrapWithIf>
+  )
+}
+
+const ItemSC = styled.button<{
+  $active: boolean
+}>(({ theme, $active }) => ({
+  ...theme.partials.reset.button,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+  gap: theme.spacing.xsmall,
+  textDecoration: 'none',
+  whiteSpace: 'nowrap',
+  width: '100%',
+  height: 39,
+  flexGrow: 0,
+  padding: theme.spacing.small,
+  borderRadius: '3px',
+  overflow: 'hidden',
+  color: theme.colors['icon-light'],
+  background: $active
+    ? theme.mode === 'light'
+      ? theme.colors['fill-one-selected']
+      : theme.colors['fill-zero-selected']
+    : 'transparent',
+  cursor: 'pointer',
+  '&:hover': {
+    background: !$active ? theme.colors['fill-zero-hover'] : undefined,
+  },
+  '&:focus-visible': {
+    outline: theme.borders['outline-focused'],
+  },
+}))

--- a/assets/src/components/utils/sidebar/SidebarSection.tsx
+++ b/assets/src/components/utils/sidebar/SidebarSection.tsx
@@ -1,0 +1,19 @@
+import { Flex, FlexProps } from '@pluralsh/design-system'
+import { useTheme } from 'styled-components'
+
+export function SidebarSection({ grow = 0, ...props }: FlexProps) {
+  const { borders } = useTheme()
+  return (
+    <Flex
+      direction="column"
+      grow={grow}
+      align="center"
+      borderBottom={borders.default}
+      gap="xxsmall"
+      padding="small"
+      width="100%"
+      {...{ '&:last-of-type': { border: 'none' } }}
+      {...props}
+    />
+  )
+}

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -313,9 +313,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/sandbox@npm:2.7.0":
-  version: 2.7.0
-  resolution: "@apollo/sandbox@npm:2.7.0"
+"@apollo/sandbox@npm:2.7.2":
+  version: 2.7.2
+  resolution: "@apollo/sandbox@npm:2.7.2"
   dependencies:
     "@types/whatwg-mimetype": ^3.0.0
     eventemitter3: 3.1.0
@@ -331,7 +331,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 5ff663a13537999520652500a617831e67fc8e41ec6cda0bc397cad87bdf0fdcf7bbe1b3083f3c4f1414d3aab7ed45f21ae3d1eb633eaaf9d56c21e4dc3f29ed
+  checksum: bcf1d1c7ce2253547d93b057f3e3c8fa5822f358682f73c6bcb7f201f1abe8f22f6b6fe6a0168838010787243252ba73298a562b69f0b4ab47908468e63c0ee6
   languageName: node
   linkType: hard
 
@@ -10426,7 +10426,7 @@ __metadata:
   dependencies:
     "@absinthe/socket": 0.2.1
     "@apollo/client": 3.14.0
-    "@apollo/sandbox": 2.7.0
+    "@apollo/sandbox": 2.7.2
     "@cypress/webpack-preprocessor": 5.17.1
     "@dagrejs/dagre": 1.0.4
     "@docsearch/js": 3.5.2


### PR DESCRIPTION
moves the sidebar component out of the DS, strips out the extra functionality we never use, makes it so that the expanded sidebar pushes content instead of overlaying, and makes the user's expansion choice persist in local storage (defaults closed,  and also automatically closes when the chatbot is opens so the main content isn't squeezed too much)

https://github.com/user-attachments/assets/a4c5df41-60e0-4011-948f-14b36faa2208


also bumps vulnerable apollo sandbox version

Plural Flow: console