### PR TITLE
fix: set Content-Length in  the new PersistedQueryInterceptor

### DIFF
--- a/go/client/utils.go
+++ b/go/client/utils.go
@@ -41,6 +41,7 @@ func PersistedQueryInterceptor(ctx context.Context, req *http.Request, gqlInfo *
 		return err
 	}
 	req.Body = io.NopCloser(bytes.NewBuffer(newBodyBytes))
+	req.ContentLength = int64(len(newBodyBytes))
 
 	return next(ctx, req, gqlInfo, res)
 }


### PR DESCRIPTION
This PR fixes go-client error: `request failed: Post http2: request body larger than specified content length`

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console