### PR TITLE
ensure InsightComponents serializes as empty list in ClusterPing

### DIFF
--- a/go/client/.gqlgenc.yml
+++ b/go/client/.gqlgenc.yml
@@ -21,6 +21,11 @@ models:
     model: github.com/99designs/gqlgen/graphql.String
   UploadOrUrl:
     model: github.com/99designs/gqlgen/graphql.String
+
+  # Custom type mapping for ClusterPing
+  ClusterPing:
+    model: github.com/pluralsh/console/go/client.ClusterPing
+
 schema:
   - "../../schema/*.graphql"
 query:

--- a/go/client/models_custom.go
+++ b/go/client/models_custom.go
@@ -1,0 +1,69 @@
+package client
+
+import "encoding/json"
+
+type ClusterPing struct {
+	CurrentVersion   string         `json:"currentVersion"`
+	KubeletVersion   *string        `json:"kubeletVersion,omitempty"`
+	Distro           *ClusterDistro `json:"distro,omitempty"`
+	HealthScore      *int64         `json:"healthScore,omitempty"`
+	OpenshiftVersion *string        `json:"openshiftVersion,omitempty"`
+	NodeCount        *int64         `json:"nodeCount,omitempty"`
+	PodCount         *int64         `json:"podCount,omitempty"`
+	NamespaceCount   *int64         `json:"namespaceCount,omitempty"`
+	CPUTotal         *float64       `json:"cpuTotal,omitempty"`
+	MemoryTotal      *float64       `json:"memoryTotal,omitempty"`
+	CPUUtil          *float64       `json:"cpuUtil,omitempty"`
+	MemoryUtil       *float64       `json:"memoryUtil,omitempty"`
+	// the interval in seconds between pings to the cluster
+	PingInterval      *int64    `json:"pingInterval,omitempty"`
+	AvailabilityZones []*string `json:"availabilityZones,omitempty"`
+	// scraped k8s objects to use for cluster insights, don't send at all if not w/in the last scrape interval
+	InsightComponents []*ClusterInsightComponentAttributes `json:"insightComponents"`
+	NodeStatistics    []*NodeStatisticAttributes           `json:"nodeStatistics"`
+}
+
+// Optional: enforce non-nil empty slice during marshalling
+func (c ClusterPing) MarshalJSON() ([]byte, error) {
+	if c.InsightComponents == nil {
+		c.InsightComponents = []*ClusterInsightComponentAttributes{}
+	}
+	if c.NodeStatistics == nil {
+		c.NodeStatistics = []*NodeStatisticAttributes{}
+	}
+	return json.Marshal(struct {
+		CurrentVersion    string                               `json:"currentVersion"`
+		KubeletVersion    *string                              `json:"kubeletVersion,omitempty"`
+		Distro            *ClusterDistro                       `json:"distro,omitempty"`
+		HealthScore       *int64                               `json:"healthScore,omitempty"`
+		OpenshiftVersion  *string                              `json:"openshiftVersion,omitempty"`
+		NodeCount         *int64                               `json:"nodeCount,omitempty"`
+		PodCount          *int64                               `json:"podCount,omitempty"`
+		NamespaceCount    *int64                               `json:"namespaceCount,omitempty"`
+		CPUTotal          *float64                             `json:"cpuTotal,omitempty"`
+		MemoryTotal       *float64                             `json:"memoryTotal,omitempty"`
+		CPUUtil           *float64                             `json:"cpuUtil,omitempty"`
+		MemoryUtil        *float64                             `json:"memoryUtil,omitempty"`
+		PingInterval      *int64                               `json:"pingInterval,omitempty"`
+		InsightComponents []*ClusterInsightComponentAttributes `json:"insightComponents"`
+		AvailabilityZones []*string                            `json:"availabilityZones,omitempty"`
+		NodeStatistics    []*NodeStatisticAttributes           `json:"nodeStatistics"`
+	}{
+		CurrentVersion:    c.CurrentVersion,
+		KubeletVersion:    c.KubeletVersion,
+		Distro:            c.Distro,
+		HealthScore:       c.HealthScore,
+		OpenshiftVersion:  c.OpenshiftVersion,
+		NodeCount:         c.NodeCount,
+		PodCount:          c.PodCount,
+		NamespaceCount:    c.NamespaceCount,
+		CPUTotal:          c.CPUTotal,
+		MemoryTotal:       c.MemoryTotal,
+		CPUUtil:           c.CPUUtil,
+		MemoryUtil:        c.MemoryUtil,
+		PingInterval:      c.PingInterval,
+		InsightComponents: c.InsightComponents,
+		AvailabilityZones: c.AvailabilityZones,
+		NodeStatistics:    c.NodeStatistics,
+	})
+}

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -1794,27 +1794,6 @@ type ClusterNodeMetrics struct {
 	MemoryUsage []*MetricResponse `json:"memoryUsage,omitempty"`
 }
 
-type ClusterPing struct {
-	CurrentVersion   string         `json:"currentVersion"`
-	KubeletVersion   *string        `json:"kubeletVersion,omitempty"`
-	Distro           *ClusterDistro `json:"distro,omitempty"`
-	HealthScore      *int64         `json:"healthScore,omitempty"`
-	OpenshiftVersion *string        `json:"openshiftVersion,omitempty"`
-	NodeCount        *int64         `json:"nodeCount,omitempty"`
-	PodCount         *int64         `json:"podCount,omitempty"`
-	NamespaceCount   *int64         `json:"namespaceCount,omitempty"`
-	CPUTotal         *float64       `json:"cpuTotal,omitempty"`
-	MemoryTotal      *float64       `json:"memoryTotal,omitempty"`
-	CPUUtil          *float64       `json:"cpuUtil,omitempty"`
-	MemoryUtil       *float64       `json:"memoryUtil,omitempty"`
-	// the interval in seconds between pings to the cluster
-	PingInterval      *int64    `json:"pingInterval,omitempty"`
-	AvailabilityZones []*string `json:"availabilityZones,omitempty"`
-	// scraped k8s objects to use for cluster insights, don't send at all if not w/in the last scrape interval
-	InsightComponents []*ClusterInsightComponentAttributes `json:"insightComponents,omitempty"`
-	NodeStatistics    []*NodeStatisticAttributes           `json:"nodeStatistics,omitempty"`
-}
-
 // a CAPI provider for a cluster, cloud is inferred from name if not provided manually
 type ClusterProvider struct {
 	// the id of this provider


### PR DESCRIPTION
Previously, empty `ClusterPing.InsightComponents `slices were serialized as `nil ` due to
the `omitempty` tag in the generated gqlgenc struct and the custom clientv2 marshaller.

This PR introduces a custom struct ClusterPing, which overrides InsightComponents to remove `omitempty`.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console