### PR TITLE
fix k8s dashboard filter logic

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -13,6 +13,7 @@ The page will reload if you make edits.<br />
 You will also see any lint errors in the console.
 
 #### Environment variables
+
 - BASE_URL - `optional` - used to override the default `https://console.kubeflow-aws.com` used for proxying the API requests. Configuration can be found in `src/setupProxy.js` file.
 
 ### `yarn build`
@@ -34,15 +35,3 @@ Lints the app.
 ### `yarn fix`
 
 Fixes linting issues that can be fixed automatically.
-
-### E2E Tests
-
-In order to run e2e tests use `yarn e2e:run` target. It will run a silent version of tests without the UI.
-
-For the development use `yarn e2e:open` to open a cypress UI and be able to see and debug running tests.
-
-#### Environment variables
-- CYPRESS_EMAIL - `required` - used to log in
-- CYPRESS_PASSWORD - `required` - used to log in
-- CYPRESS_BASE_URL - `optional` - allows to override default url that should be used to access the application under test.
-

--- a/assets/src/components/kubernetes/Cluster.tsx
+++ b/assets/src/components/kubernetes/Cluster.tsx
@@ -20,6 +20,7 @@ import { GqlError } from '../utils/Alert'
 import LoadingIndicator from '../utils/LoadingIndicator'
 
 import { LAST_SELECTED_CLUSTER_KEY } from './Navigation'
+import { DataSelectProvider } from './common/DataSelect'
 
 type ClusterContextT = {
   clusters: KubernetesClusterFragment[]
@@ -184,8 +185,10 @@ export default function Cluster() {
   if (!cluster) return <EmptyState message="No clusters found." />
 
   return (
-    <ClusterContext.Provider value={context}>
-      <Outlet />
-    </ClusterContext.Provider>
+    <ClusterContext value={context}>
+      <DataSelectProvider>
+        <Outlet />
+      </DataSelectProvider>
+    </ClusterContext>
   )
 }

--- a/assets/src/components/kubernetes/Navigation.tsx
+++ b/assets/src/components/kubernetes/Navigation.tsx
@@ -1,13 +1,6 @@
-import {
-  Outlet,
-  useLocation,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from 'react-router-dom'
-import { useTheme } from 'styled-components'
 import { ReactNode, useLayoutEffect, useMemo, useState } from 'react'
-import { isEmpty } from 'lodash'
+import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useTheme } from 'styled-components'
 
 import {
   AUDIT_REL_PATH,
@@ -20,18 +13,15 @@ import {
   STORAGE_REL_PATH,
   WORKLOADS_REL_PATH,
 } from '../../routes/kubernetesRoutesConsts'
+import { PageHeaderContext } from '../cd/ContinuousDeployment'
+import { ClusterSelect } from '../cd/utils/ClusterSelect'
+import { Directory, SideNavEntries } from '../layout/SideNavEntries'
 import { ResponsiveLayoutPage } from '../utils/layout/ResponsiveLayoutPage'
 import { ResponsiveLayoutSidenavContainer } from '../utils/layout/ResponsiveLayoutSidenavContainer'
-import { Directory, SideNavEntries } from '../layout/SideNavEntries'
-import { ClusterSelect } from '../cd/utils/ClusterSelect'
-import { PageHeaderContext } from '../cd/ContinuousDeployment'
 
+import { Flex } from '@pluralsh/design-system'
 import { useClusters } from './Cluster'
-import {
-  DataSelect,
-  DataSelectInputs,
-  useDataSelect,
-} from './common/DataSelect'
+import { DataSelectInputs, useDataSelect } from './common/DataSelect'
 
 export const NAMESPACE_PARAM = 'namespace'
 export const FILTER_PARAM = 'filter'
@@ -54,15 +44,11 @@ export default function Navigation() {
   const { pathname, search } = useLocation()
   const { clusterId = '' } = useParams()
   const clusters = useClusters()
-  const [params, setParams] = useSearchParams()
   const [headerContent, setHeaderContent] = useState<ReactNode>()
   const [headerAction, setHeaderAction] = useState<ReactNode>()
   const pathPrefix = getKubernetesAbsPath(clusterId)
 
-  const dataSelect = useDataSelect({
-    namespace: params.get(NAMESPACE_PARAM) ?? '',
-    filter: params.get(FILTER_PARAM) ?? '',
-  })
+  const dataSelect = useDataSelect()
 
   const pageHeaderContext = useMemo(
     () => ({ setHeaderContent, setHeaderAction }),
@@ -70,22 +56,8 @@ export default function Navigation() {
   )
 
   useLayoutEffect(() => {
-    dataSelect.setEnabled(true)
-
     if (clusterId) sessionStorage.setItem(LAST_SELECTED_CLUSTER_KEY, clusterId)
-
-    const newParams = new URLSearchParams()
-
-    if (!isEmpty(dataSelect.filter))
-      newParams.set(FILTER_PARAM, dataSelect.filter)
-
-    if (!isEmpty(dataSelect.namespace))
-      newParams.set(NAMESPACE_PARAM, dataSelect.namespace)
-
-    if (newParams.toString() !== params.toString()) setParams(newParams)
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataSelect, pathname, clusterId])
+  }, [pathname, clusterId])
 
   return (
     <ResponsiveLayoutPage>
@@ -104,45 +76,38 @@ export default function Navigation() {
             selectedKey={clusterId}
             onSelectionChange={(id) => {
               dataSelect.setNamespace('')
-              navigate(pathname.replace(clusterId, id as string) + search)
+              navigate(pathname.replace(clusterId, `${id}`) + search)
             }}
             withoutTitleContent
           />
           <SideNavEntries
             directory={directory}
-            pathname={pathname}
+            pathname={`${pathname}?${search}`}
             pathPrefix={pathPrefix}
           />
         </div>
       </ResponsiveLayoutSidenavContainer>
-      <div
-        css={{
-          display: 'flex',
-          flexDirection: 'column',
-          flexGrow: 1,
-          flexShrink: 1,
-          height: '100%',
-          width: '100%',
-          minWidth: 0,
-        }}
+      <Flex
+        direction="column"
+        flex={1}
+        height="100%"
+        width="100%"
+        minWidth={0}
       >
-        <div
-          css={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            gap: theme.spacing.small,
-          }}
-        >
-          <div css={{ flex: 1, overflow: 'hidden' }}>{headerContent}</div>
-          <div>{headerAction}</div>
-          {dataSelect.enabled && <DataSelectInputs dataSelect={dataSelect} />}
-        </div>
+        {!pathname.includes(AUDIT_REL_PATH) && (
+          <Flex
+            justify="space-between"
+            gap="small"
+          >
+            <div css={{ flex: 1, overflow: 'hidden' }}>{headerContent}</div>
+            <div>{headerAction}</div>
+            <DataSelectInputs />
+          </Flex>
+        )}
         <PageHeaderContext.Provider value={pageHeaderContext}>
-          <DataSelect.Provider value={dataSelect}>
-            <Outlet />
-          </DataSelect.Provider>
+          <Outlet />
         </PageHeaderContext.Provider>
-      </div>
+      </Flex>
     </ResponsiveLayoutPage>
   )
 }

--- a/assets/src/components/kubernetes/Navigation.tsx
+++ b/assets/src/components/kubernetes/Navigation.tsx
@@ -21,7 +21,7 @@ import { ResponsiveLayoutSidenavContainer } from '../utils/layout/ResponsiveLayo
 
 import { Flex } from '@pluralsh/design-system'
 import { useClusters } from './Cluster'
-import { DataSelectInputs, useDataSelect } from './common/DataSelect'
+import { DataSelectInputs } from './common/DataSelect'
 
 export const NAMESPACE_PARAM = 'namespace'
 export const FILTER_PARAM = 'filter'
@@ -41,14 +41,12 @@ const directory: Directory = [
 export default function Navigation() {
   const theme = useTheme()
   const navigate = useNavigate()
-  const { pathname, search } = useLocation()
+  const { pathname } = useLocation()
   const { clusterId = '' } = useParams()
   const clusters = useClusters()
   const [headerContent, setHeaderContent] = useState<ReactNode>()
   const [headerAction, setHeaderAction] = useState<ReactNode>()
   const pathPrefix = getKubernetesAbsPath(clusterId)
-
-  const dataSelect = useDataSelect()
 
   const pageHeaderContext = useMemo(
     () => ({ setHeaderContent, setHeaderAction }),
@@ -74,15 +72,14 @@ export default function Navigation() {
           <ClusterSelect
             clusters={clusters}
             selectedKey={clusterId}
-            onSelectionChange={(id) => {
-              dataSelect.setNamespace('')
-              navigate(pathname.replace(clusterId, `${id}`) + search)
-            }}
+            onSelectionChange={(id) =>
+              navigate(pathname.replace(clusterId, `${id}`))
+            }
             withoutTitleContent
           />
           <SideNavEntries
             directory={directory}
-            pathname={`${pathname}?${search}`}
+            pathname={pathname}
             pathPrefix={pathPrefix}
           />
         </div>

--- a/assets/src/components/kubernetes/common/DataSelect.tsx
+++ b/assets/src/components/kubernetes/common/DataSelect.tsx
@@ -1,14 +1,19 @@
 import {
-  Dispatch,
-  SetStateAction,
   createContext,
-  useContext,
-  useEffect,
+  ReactNode,
+  use,
+  useCallback,
+  useLayoutEffect,
   useMemo,
   useState,
 } from 'react'
 
-import { FiltersIcon, Flex, SearchIcon } from '@pluralsh/design-system'
+import {
+  FiltersIcon,
+  Flex,
+  SearchIcon,
+  usePrevious,
+} from '@pluralsh/design-system'
 
 import { ExpandedInput, IconExpander } from 'components/utils/IconExpander'
 
@@ -16,107 +21,129 @@ import { useDebounce } from 'usehooks-ts'
 
 import { useNamespaces } from '../Cluster'
 
+import {
+  SetURLSearchParams,
+  useLocation,
+  useSearchParams,
+} from 'react-router-dom'
+import { FILTER_PARAM, NAMESPACE_PARAM } from '../Navigation'
 import { NamespaceFilter } from './NamespaceFilter'
 
-export type DataSelectT = {
-  namespace: string
-  filter: string
-}
-
-export type DataSelectContextT = {
-  enabled: boolean
-  setEnabled: Dispatch<SetStateAction<boolean>>
+type DataSelectContextT = {
   namespaced: boolean
-  setNamespaced: Dispatch<SetStateAction<boolean>>
+  setNamespaced: (namespaced: boolean) => void
   namespace: string
-  setNamespace: Dispatch<SetStateAction<string>>
+  setNamespace: (namespace: string) => void
   filter: string
-  setFilter: Dispatch<SetStateAction<string>>
+  setFilter: (filter: string) => void
+  setParams: SetURLSearchParams
 }
 
-export const DataSelect = createContext<DataSelectContextT | undefined>(
+export const DataSelectContext = createContext<DataSelectContextT | undefined>(
   undefined
 )
 
-export function useDataSelect(defaults?: DataSelectT) {
-  const context = useContext(DataSelect)
+export function DataSelectProvider({ children }: { children: ReactNode }) {
+  const [params, setParams] = useSearchParams()
   const [namespaced, setNamespaced] = useState<boolean>(true)
-  const [namespace, setNamespace] = useState(defaults?.namespace ?? '')
-  const [filter, setFilter] = useState(defaults?.filter ?? '')
-  const [enabled, setEnabled] = useState<boolean>(true)
 
-  return useMemo(
-    () =>
-      context ?? {
-        enabled,
-        setEnabled,
-        namespaced,
-        setNamespaced,
-        namespace,
-        setNamespace,
-        filter,
-        setFilter,
-      },
-    [
-      enabled,
-      setEnabled,
-      context,
+  const setParam = useCallback(
+    (key: string, value: string) => {
+      const newParams = new URLSearchParams(params)
+      if (value) newParams.set(key, value)
+      else newParams.delete(key)
+      setParams(newParams, { replace: true })
+    },
+    [params, setParams]
+  )
+
+  const ctx = useMemo(
+    () => ({
       namespaced,
       setNamespaced,
-      namespace,
-      setNamespace,
-      filter,
-      setFilter,
-    ]
+      namespace: params.get(NAMESPACE_PARAM) ?? '',
+      setNamespace: (namespace: string) => setParam(NAMESPACE_PARAM, namespace),
+      filter: params.get(FILTER_PARAM) ?? '',
+      setFilter: (filter: string) => setParam(FILTER_PARAM, filter),
+      setParams,
+    }),
+    [namespaced, params, setParam, setParams]
   )
+  return <DataSelectContext value={ctx}>{children}</DataSelectContext>
 }
 
-export function DataSelectInputs({
-  dataSelect,
-}: {
-  dataSelect: DataSelectContextT
-}) {
+export function useDataSelect() {
+  const ctx = use(DataSelectContext)
+  if (!ctx)
+    throw new Error('useDataSelect must be used within a DataSelectProvider')
+  return ctx
+}
+
+export function DataSelectInputs() {
   const namespaces = useNamespaces()
-  const {
-    namespaced,
-    namespace,
+  const { pathname } = useLocation()
+  const { namespaced, namespace, setNamespace, filter, setFilter, setParams } =
+    useDataSelect()
+
+  const [nsState, setNsState] = useState(namespace)
+  const [filterState, setFilterState] = useState(filter)
+  const debFilterState = useDebounce(filterState, 200)
+
+  // this kind of logic is generally brittle and bad practice, but likely necessary here
+  // need internal filter state for debouncing and performance
+  // need internal namespace state so we can persist it across route changes that occur while the component still exists
+  // the custom setParams is needed to avoid a race condition when simultaneously calling setFilter and setNamespace
+  const routeHasChanged = usePrevious(pathname) !== pathname
+  useLayoutEffect(() => {
+    if (routeHasChanged) setFilterState('')
+    else {
+      setParams(
+        new URLSearchParams({
+          ...(nsState && { [NAMESPACE_PARAM]: nsState }),
+          ...(debFilterState && { [FILTER_PARAM]: debFilterState }),
+        }),
+        { replace: true }
+      )
+    }
+  }, [
+    debFilterState,
+    nsState,
+    routeHasChanged,
+    setFilter,
     setNamespace,
-    filter: contextFilter,
-    setFilter: setContextFilter,
-  } = dataSelect
-
-  const [filter, setFilter] = useState(contextFilter)
-  const debouncedFilter = useDebounce(filter, 200)
-
-  useEffect(
-    () => setContextFilter(debouncedFilter),
-    [debouncedFilter, setContextFilter]
-  )
+    setParams,
+  ])
 
   return (
     <Flex gap="medium">
       <IconExpander
         showIndicator
         icon={<SearchIcon />}
-        active={!!filter}
-        onClear={() => setFilter('')}
+        active={!!filterState}
+        onClear={() => {
+          setFilterState('')
+          setFilter('')
+        }}
       >
         <ExpandedInput
-          inputValue={filter}
-          onChange={setFilter}
+          inputValue={filterState}
+          onChange={setFilterState}
         />
       </IconExpander>
       {namespaced && (
         <IconExpander
           showIndicator
           icon={<FiltersIcon />}
-          active={!!namespace}
-          onClear={() => setNamespace('')}
+          active={!!nsState}
+          onClear={() => {
+            setNsState('')
+            setNamespace('')
+          }}
         >
           <NamespaceFilter
             namespaces={namespaces}
-            namespace={namespace}
-            onChange={setNamespace}
+            namespace={nsState}
+            onChange={setNsState}
           />
         </IconExpander>
       )}

--- a/assets/src/components/kubernetes/customresources/CustomResourceDefinition.tsx
+++ b/assets/src/components/kubernetes/customresources/CustomResourceDefinition.tsx
@@ -6,20 +6,15 @@ import {
 import { createColumnHelper } from '@tanstack/react-table'
 import { isEmpty } from 'lodash'
 import { ReactElement, useEffect, useMemo } from 'react'
-import {
-  Outlet,
-  useOutletContext,
-  useParams,
-  useSearchParams,
-} from 'react-router-dom'
+import { Outlet, useOutletContext, useParams } from 'react-router-dom'
 import {
   CustomResourceDefinitionQueryVariables,
+  Types_CustomResourceDefinitionDetail as CustomResourceDefinitionT,
+  Types_CustomResourceObjectList as CustomResourceListT,
   CustomResourcesDocument,
   CustomResourcesQuery,
   CustomResourcesQueryVariables,
-  Types_CustomResourceDefinitionDetail as CustomResourceDefinitionT,
   Types_CustomResourceObjectDetail as CustomResourceT,
-  Types_CustomResourceObjectList as CustomResourceListT,
   useCustomResourceDefinitionQuery,
 } from '../../../generated/graphql-kubernetes'
 import { KubernetesClient } from '../../../helpers/kubernetes.client'
@@ -35,7 +30,6 @@ import { ResourceList } from '../common/ResourceList'
 import { Kind } from '../common/types'
 
 import { MetadataSidecar, useDefaultColumns } from '../common/utils'
-import { NAMESPACE_PARAM } from '../Navigation'
 
 import { getBreadcrumbs } from './CustomResourceDefinitions'
 import { CRDEstablishedChip } from './utils'
@@ -109,12 +103,11 @@ export default function CustomResourceDefinition(): ReactElement<any> {
 
 const columnHelper = createColumnHelper<CustomResourceT>()
 
-export function CustomResourceDefinitionObjects(): ReactElement<any> {
+export function CustomResourceDefinitionObjects() {
   const crd = useOutletContext() as CustomResourceDefinitionT
   const namespaced = crd?.scope.toLowerCase() === 'namespaced'
   const dataSelect = useDataSelect()
   const { name } = useParams()
-  const [params, setParams] = useSearchParams()
   const { colAction, colName, colNamespace, colLabels, colCreationTimestamp } =
     useDefaultColumns(columnHelper)
   const columns = useMemo(
@@ -135,26 +128,11 @@ export function CustomResourceDefinitionObjects(): ReactElement<any> {
     ]
   )
 
-  useEffect(
-    () => {
-      dataSelect.setNamespaced(namespaced)
-      dataSelect.setNamespace(params.get(NAMESPACE_PARAM) ?? '')
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  )
-
   useEffect(() => {
-    if (isEmpty(dataSelect.namespace)) params.delete(NAMESPACE_PARAM)
-    else params.set(NAMESPACE_PARAM, dataSelect.namespace)
+    dataSelect.setNamespaced(namespaced)
+  }, [namespaced, dataSelect])
 
-    setParams(params)
-  }, [dataSelect.namespace, params, setParams])
-
-  const headerContent = useMemo(
-    () => <DataSelectInputs dataSelect={dataSelect} />,
-    [dataSelect]
-  )
+  const headerContent = useMemo(() => <DataSelectInputs />, [])
 
   useSetPageHeaderContent(headerContent)
 

--- a/assets/src/components/kubernetes/customresources/PinnedCustomResourceDefinitions.tsx
+++ b/assets/src/components/kubernetes/customresources/PinnedCustomResourceDefinitions.tsx
@@ -62,6 +62,7 @@ export default function PinnedCustomResourceDefinitions({
         .filter((pr): pr is PinnedCustomResourceFragment => !!pr)
         .map(({ id, name, displayName }) => (
           <LinkButton
+            key={id}
             tertiary
             onClick={() =>
               navigate(

--- a/assets/waitOnConfig.json
+++ b/assets/waitOnConfig.json
@@ -1,5 +1,0 @@
-{
-  "headers": {
-    "accept": "text/html"
-  }
-}


### PR DESCRIPTION
having to keep context, state, and search queries all in sync was making this unnecessarily brittle (and breaking the namespace selector on custom resource lists)
also fixes a couple styling bugs

Plural Flow: console