### PR TITLE
Fix webhook status inference

### DIFF
--- a/lib/console/deployments/issues/webhook/jira.ex
+++ b/lib/console/deployments/issues/webhook/jira.ex
@@ -30,16 +30,18 @@ defmodule Console.Deployments.Issues.Webhook.Jira do
   def status(_), do: :open
 
   defp map_status(status) when is_binary(status) do
-    case String.downcase(status) do
-      "in progress" -> :in_progress
+    String.downcase(status)
+    |> String.replace(~r/[^a-z]/, "")
+    |> case do
+      "inprogress" -> :in_progress
       "done" -> :completed
       "closed" -> :completed
       "resolved" -> :completed
       "cancelled" -> :cancelled
       "canceled" -> :cancelled
       "rejected" -> :cancelled
-      "won't do" -> :cancelled
-      "won't fix" -> :cancelled
+      "wontdo" -> :cancelled
+      "wontfix" -> :cancelled
       _ -> :open
     end
   end

--- a/lib/console/deployments/issues/webhook/linear.ex
+++ b/lib/console/deployments/issues/webhook/linear.ex
@@ -14,7 +14,8 @@ defmodule Console.Deployments.Issues.Webhook.Linear do
   def url(_), do: nil
 
   def status(%{"state" => %{"name" => "In Progress"}}), do: :in_progress
-  def status(%{"state" => %{"name" => "In Review"}}), do: :open
+  def status(%{"state" => %{"name" => "In Review"}}), do: :in_progress
+  def status(%{"state" => %{"name" => "Canceled"}}), do: :cancelled
   def status(%{"state" => %{"name" => "Cancelled"}}), do: :cancelled
   def status(%{"state" => %{"name" => "Done"}}), do: :completed
   def status(_), do: :open


### PR DESCRIPTION
Need to map these correctly (in particular linear open vs in progress states)

## Test Plan
n/a


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console