### PR TITLE
CloudQuery support in workbenches

### DIFF
--- a/assets/src/components/workbenches/WorkbenchesConfiguredToolMetadata.tsx
+++ b/assets/src/components/workbenches/WorkbenchesConfiguredToolMetadata.tsx
@@ -32,6 +32,7 @@ const metadataExtractors: Record<WorkbenchToolType, MetadataExtractor> = {
   [WorkbenchToolType.Dynatrace]: extractDynatraceMetadata,
   [WorkbenchToolType.Cloudwatch]: extractCloudwatchMetadata,
   [WorkbenchToolType.Azure]: extractAzureMetadata,
+  [WorkbenchToolType.Cloud]: () => [],
 }
 
 export function WorkbenchesConfiguredToolMetadata({

--- a/assets/src/components/workbenches/tools/workbenchToolsUtils.tsx
+++ b/assets/src/components/workbenches/tools/workbenchToolsUtils.tsx
@@ -89,6 +89,7 @@ export const TOOL_TYPE_TO_LABEL: Record<WorkbenchToolType, string> = {
   [WorkbenchToolType.Dynatrace]: 'Dynatrace',
   [WorkbenchToolType.Cloudwatch]: 'Cloudwatch',
   [WorkbenchToolType.Azure]: 'Azure',
+  [WorkbenchToolType.Cloud]: 'Cloud',
 }
 
 export const TOOL_TYPE_TO_CATEGORIES: Record<
@@ -122,6 +123,7 @@ export const TOOL_TYPE_TO_CATEGORIES: Record<
     WorkbenchToolCategory.Metrics,
     WorkbenchToolCategory.Logs,
   ],
+  [WorkbenchToolType.Cloud]: [WorkbenchToolCategory.Infrastructure],
 }
 
 /** Descriptions for configurable tool types (create cards). Single source for supported types + copy. */
@@ -157,6 +159,7 @@ export const categoryToLabel: Record<WorkbenchToolCategory, string> = {
   [WorkbenchToolCategory.Ticketing]: 'Ticketing',
   [WorkbenchToolCategory.Integration]: 'Integration',
   [WorkbenchToolCategory.ErrorTracking]: 'Error tracking',
+  [WorkbenchToolCategory.Infrastructure]: 'Infrastructure',
 }
 
 export const TOOL_TYPE_CARDS: {

--- a/assets/src/components/workbenches/workbench/create-edit/WorkbenchCreateOrEdit.tsx
+++ b/assets/src/components/workbenches/workbench/create-edit/WorkbenchCreateOrEdit.tsx
@@ -43,7 +43,7 @@ import {
 // use FormBinding[] so BindingInput can show chips (user email / group name).
 export type WorkbenchFormState = Omit<
   Required<WorkbenchAttributes>,
-  'readBindings' | 'writeBindings' | 'projectId'
+  'readBindings' | 'writeBindings' | 'projectId' | 'workbenchSkills'
 > & {
   readBindings: PolicyBindingFragment[]
   writeBindings: PolicyBindingFragment[]

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -1331,6 +1331,8 @@ export type AwsCloudAttributes = {
 
 export type AwsCloudConnectionAttributes = {
   accessKeyId: Scalars['String']['input'];
+  /** optional IAM role ARN for the console to assume when using this connection */
+  assumeRoleArn?: InputMaybe<Scalars['String']['input']>;
   region?: InputMaybe<Scalars['String']['input']>;
   regions?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   secretAccessKey: Scalars['String']['input'];
@@ -1347,6 +1349,8 @@ export type AwsConnectionAttributes = {
   __typename?: 'AwsConnectionAttributes';
   /** the access key id for aws */
   accessKeyId: Scalars['String']['output'];
+  /** IAM role ARN for the console to assume when using this connection */
+  assumeRoleArn?: Maybe<Scalars['String']['output']>;
   /** the region for aws */
   region?: Maybe<Scalars['String']['output']>;
   /** the regions for aws */
@@ -14870,6 +14874,8 @@ export type WorkbenchAttributes = {
   systemPrompt?: InputMaybe<Scalars['String']['input']>;
   /** tool ids to associate with this workbench */
   toolAssociations?: InputMaybe<Array<InputMaybe<WorkbenchToolAssociationAttributes>>>;
+  /** skills to include with this workbench */
+  workbenchSkills?: InputMaybe<Array<InputMaybe<WorkbenchSkillAttributes>>>;
   /** users who can modify this workbench */
   writeBindings?: InputMaybe<Array<InputMaybe<PolicyBindingAttributes>>>;
 };
@@ -15356,6 +15362,8 @@ export type WorkbenchTool = {
   __typename?: 'WorkbenchTool';
   /** categories for the tool */
   categories?: Maybe<Array<Maybe<WorkbenchToolCategory>>>;
+  /** the cloud connection bound to this tool */
+  cloudConnection?: Maybe<CloudConnection>;
   /** tool configuration */
   configuration?: Maybe<WorkbenchToolConfiguration>;
   /** the id of the tool */
@@ -15397,6 +15405,8 @@ export type WorkbenchToolAtlassianConnectionAttributes = {
 export type WorkbenchToolAttributes = {
   /** categories for the tool */
   categories?: InputMaybe<Array<InputMaybe<WorkbenchToolCategory>>>;
+  /** the cloud connection for this tool (e.g. infrastructure cloud tools) */
+  cloudConnectionId?: InputMaybe<Scalars['ID']['input']>;
   /** tool configuration (e.g. http) */
   configuration?: InputMaybe<WorkbenchToolConfigurationAttributes>;
   /** the mcp server for this tool */
@@ -15432,6 +15442,7 @@ export type WorkbenchToolAzureConnectionAttributes = {
 
 export enum WorkbenchToolCategory {
   ErrorTracking = 'ERROR_TRACKING',
+  Infrastructure = 'INFRASTRUCTURE',
   Integration = 'INTEGRATION',
   Logs = 'LOGS',
   Metrics = 'METRICS',
@@ -15742,6 +15753,7 @@ export type WorkbenchToolTempoConnectionAttributes = {
 export enum WorkbenchToolType {
   Atlassian = 'ATLASSIAN',
   Azure = 'AZURE',
+  Cloud = 'CLOUD',
   Cloudwatch = 'CLOUDWATCH',
   Datadog = 'DATADOG',
   Dynatrace = 'DYNATRACE',

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -1040,6 +1040,8 @@ type AWSCloudConnectionAttributes struct {
 	SecretAccessKey string    `json:"secretAccessKey"`
 	Region          *string   `json:"region,omitempty"`
 	Regions         []*string `json:"regions,omitempty"`
+	// optional IAM role ARN for the console to assume when using this connection
+	AssumeRoleArn *string `json:"assumeRoleArn,omitempty"`
 }
 
 // aws specific cloud configuration
@@ -1057,6 +1059,8 @@ type AWSConnectionAttributes struct {
 	Region *string `json:"region,omitempty"`
 	// the regions for aws
 	Regions []*string `json:"regions,omitempty"`
+	// IAM role ARN for the console to assume when using this connection
+	AssumeRoleArn *string `json:"assumeRoleArn,omitempty"`
 }
 
 type AWSNodeCloudAttributes struct {
@@ -9500,6 +9504,8 @@ type WorkbenchAttributes struct {
 	WriteBindings []*PolicyBindingAttributes `json:"writeBindings,omitempty"`
 	// tool ids to associate with this workbench
 	ToolAssociations []*WorkbenchToolAssociationAttributes `json:"toolAssociations,omitempty"`
+	// skills to include with this workbench
+	WorkbenchSkills []*WorkbenchSkillAttributes `json:"workbenchSkills,omitempty"`
 }
 
 type WorkbenchCoding struct {
@@ -9915,9 +9921,11 @@ type WorkbenchTool struct {
 	// tool configuration
 	Configuration *WorkbenchToolConfiguration `json:"configuration,omitempty"`
 	// the mcp server for this tool
-	McpServer  *McpServer `json:"mcpServer,omitempty"`
-	InsertedAt *string    `json:"insertedAt,omitempty"`
-	UpdatedAt  *string    `json:"updatedAt,omitempty"`
+	McpServer *McpServer `json:"mcpServer,omitempty"`
+	// the cloud connection bound to this tool
+	CloudConnection *CloudConnection `json:"cloudConnection,omitempty"`
+	InsertedAt      *string          `json:"insertedAt,omitempty"`
+	UpdatedAt       *string          `json:"updatedAt,omitempty"`
 }
 
 type WorkbenchToolAssociationAttributes struct {
@@ -9952,6 +9960,8 @@ type WorkbenchToolAttributes struct {
 	ProjectID *string `json:"projectId,omitempty"`
 	// the mcp server for this tool
 	McpServerID *string `json:"mcpServerId,omitempty"`
+	// the cloud connection for this tool (e.g. infrastructure cloud tools)
+	CloudConnectionID *string `json:"cloudConnectionId,omitempty"`
 	// tool configuration (e.g. http)
 	Configuration *WorkbenchToolConfigurationAttributes `json:"configuration,omitempty"`
 }
@@ -16288,12 +16298,13 @@ func (e WorkbenchJobStatus) MarshalJSON() ([]byte, error) {
 type WorkbenchToolCategory string
 
 const (
-	WorkbenchToolCategoryMetrics       WorkbenchToolCategory = "METRICS"
-	WorkbenchToolCategoryLogs          WorkbenchToolCategory = "LOGS"
-	WorkbenchToolCategoryIntegration   WorkbenchToolCategory = "INTEGRATION"
-	WorkbenchToolCategoryTicketing     WorkbenchToolCategory = "TICKETING"
-	WorkbenchToolCategoryTraces        WorkbenchToolCategory = "TRACES"
-	WorkbenchToolCategoryErrorTracking WorkbenchToolCategory = "ERROR_TRACKING"
+	WorkbenchToolCategoryMetrics        WorkbenchToolCategory = "METRICS"
+	WorkbenchToolCategoryLogs           WorkbenchToolCategory = "LOGS"
+	WorkbenchToolCategoryIntegration    WorkbenchToolCategory = "INTEGRATION"
+	WorkbenchToolCategoryTicketing      WorkbenchToolCategory = "TICKETING"
+	WorkbenchToolCategoryTraces         WorkbenchToolCategory = "TRACES"
+	WorkbenchToolCategoryErrorTracking  WorkbenchToolCategory = "ERROR_TRACKING"
+	WorkbenchToolCategoryInfrastructure WorkbenchToolCategory = "INFRASTRUCTURE"
 )
 
 var AllWorkbenchToolCategory = []WorkbenchToolCategory{
@@ -16303,11 +16314,12 @@ var AllWorkbenchToolCategory = []WorkbenchToolCategory{
 	WorkbenchToolCategoryTicketing,
 	WorkbenchToolCategoryTraces,
 	WorkbenchToolCategoryErrorTracking,
+	WorkbenchToolCategoryInfrastructure,
 }
 
 func (e WorkbenchToolCategory) IsValid() bool {
 	switch e {
-	case WorkbenchToolCategoryMetrics, WorkbenchToolCategoryLogs, WorkbenchToolCategoryIntegration, WorkbenchToolCategoryTicketing, WorkbenchToolCategoryTraces, WorkbenchToolCategoryErrorTracking:
+	case WorkbenchToolCategoryMetrics, WorkbenchToolCategoryLogs, WorkbenchToolCategoryIntegration, WorkbenchToolCategoryTicketing, WorkbenchToolCategoryTraces, WorkbenchToolCategoryErrorTracking, WorkbenchToolCategoryInfrastructure:
 		return true
 	}
 	return false
@@ -16426,6 +16438,7 @@ const (
 	WorkbenchToolTypeDynatrace  WorkbenchToolType = "DYNATRACE"
 	WorkbenchToolTypeCloudwatch WorkbenchToolType = "CLOUDWATCH"
 	WorkbenchToolTypeAzure      WorkbenchToolType = "AZURE"
+	WorkbenchToolTypeCloud      WorkbenchToolType = "CLOUD"
 )
 
 var AllWorkbenchToolType = []WorkbenchToolType{
@@ -16443,11 +16456,12 @@ var AllWorkbenchToolType = []WorkbenchToolType{
 	WorkbenchToolTypeDynatrace,
 	WorkbenchToolTypeCloudwatch,
 	WorkbenchToolTypeAzure,
+	WorkbenchToolTypeCloud,
 }
 
 func (e WorkbenchToolType) IsValid() bool {
 	switch e {
-	case WorkbenchToolTypeHTTP, WorkbenchToolTypeElastic, WorkbenchToolTypeDatadog, WorkbenchToolTypePrometheus, WorkbenchToolTypeLoki, WorkbenchToolTypeTempo, WorkbenchToolTypeSentry, WorkbenchToolTypeMcp, WorkbenchToolTypeLinear, WorkbenchToolTypeAtlassian, WorkbenchToolTypeSplunk, WorkbenchToolTypeDynatrace, WorkbenchToolTypeCloudwatch, WorkbenchToolTypeAzure:
+	case WorkbenchToolTypeHTTP, WorkbenchToolTypeElastic, WorkbenchToolTypeDatadog, WorkbenchToolTypePrometheus, WorkbenchToolTypeLoki, WorkbenchToolTypeTempo, WorkbenchToolTypeSentry, WorkbenchToolTypeMcp, WorkbenchToolTypeLinear, WorkbenchToolTypeAtlassian, WorkbenchToolTypeSplunk, WorkbenchToolTypeDynatrace, WorkbenchToolTypeCloudwatch, WorkbenchToolTypeAzure, WorkbenchToolTypeCloud:
 		return true
 	}
 	return false

--- a/go/cloud-query/api/proto/cloudquery.proto
+++ b/go/cloud-query/api/proto/cloudquery.proto
@@ -7,9 +7,11 @@ package cloudquery;
 option go_package = "internal/proto/cloudquery";
 
 message AwsCredentials {
-  string access_key_id = 1;
-  string secret_access_key = 2;
+  optional string access_key_id = 1;
+  optional string secret_access_key = 2;
   optional string region = 3;
+  repeated string regions = 4;
+  optional string assume_role_arn = 5;
 }
 
 message AzureCredentials {

--- a/go/cloud-query/internal/proto/cloudquery/cloudquery.pb.go
+++ b/go/cloud-query/internal/proto/cloudquery/cloudquery.pb.go
@@ -25,9 +25,11 @@ const (
 
 type AwsCredentials struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
-	AccessKeyId     string                 `protobuf:"bytes,1,opt,name=access_key_id,json=accessKeyId,proto3" json:"access_key_id,omitempty"`
-	SecretAccessKey string                 `protobuf:"bytes,2,opt,name=secret_access_key,json=secretAccessKey,proto3" json:"secret_access_key,omitempty"`
+	AccessKeyId     *string                `protobuf:"bytes,1,opt,name=access_key_id,json=accessKeyId,proto3,oneof" json:"access_key_id,omitempty"`
+	SecretAccessKey *string                `protobuf:"bytes,2,opt,name=secret_access_key,json=secretAccessKey,proto3,oneof" json:"secret_access_key,omitempty"`
 	Region          *string                `protobuf:"bytes,3,opt,name=region,proto3,oneof" json:"region,omitempty"`
+	Regions         []string               `protobuf:"bytes,4,rep,name=regions,proto3" json:"regions,omitempty"`
+	AssumeRoleArn   *string                `protobuf:"bytes,5,opt,name=assume_role_arn,json=assumeRoleArn,proto3,oneof" json:"assume_role_arn,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -63,15 +65,15 @@ func (*AwsCredentials) Descriptor() ([]byte, []int) {
 }
 
 func (x *AwsCredentials) GetAccessKeyId() string {
-	if x != nil {
-		return x.AccessKeyId
+	if x != nil && x.AccessKeyId != nil {
+		return *x.AccessKeyId
 	}
 	return ""
 }
 
 func (x *AwsCredentials) GetSecretAccessKey() string {
-	if x != nil {
-		return x.SecretAccessKey
+	if x != nil && x.SecretAccessKey != nil {
+		return *x.SecretAccessKey
 	}
 	return ""
 }
@@ -79,6 +81,20 @@ func (x *AwsCredentials) GetSecretAccessKey() string {
 func (x *AwsCredentials) GetRegion() string {
 	if x != nil && x.Region != nil {
 		return *x.Region
+	}
+	return ""
+}
+
+func (x *AwsCredentials) GetRegions() []string {
+	if x != nil {
+		return x.Regions
+	}
+	return nil
+}
+
+func (x *AwsCredentials) GetAssumeRoleArn() string {
+	if x != nil && x.AssumeRoleArn != nil {
+		return *x.AssumeRoleArn
 	}
 	return ""
 }
@@ -722,12 +738,17 @@ var File_cloudquery_proto protoreflect.FileDescriptor
 const file_cloudquery_proto_rawDesc = "" +
 	"\n" +
 	"\x10cloudquery.proto\x12\n" +
-	"cloudquery\"\x88\x01\n" +
-	"\x0eAwsCredentials\x12\"\n" +
-	"\raccess_key_id\x18\x01 \x01(\tR\vaccessKeyId\x12*\n" +
-	"\x11secret_access_key\x18\x02 \x01(\tR\x0fsecretAccessKey\x12\x1b\n" +
-	"\x06region\x18\x03 \x01(\tH\x00R\x06region\x88\x01\x01B\t\n" +
-	"\a_region\"\x9a\x01\n" +
+	"cloudquery\"\x95\x02\n" +
+	"\x0eAwsCredentials\x12'\n" +
+	"\raccess_key_id\x18\x01 \x01(\tH\x00R\vaccessKeyId\x88\x01\x01\x12/\n" +
+	"\x11secret_access_key\x18\x02 \x01(\tH\x01R\x0fsecretAccessKey\x88\x01\x01\x12\x1b\n" +
+	"\x06region\x18\x03 \x01(\tH\x02R\x06region\x88\x01\x01\x12\x18\n" +
+	"\aregions\x18\x04 \x03(\tR\aregions\x12+\n" +
+	"\x0fassume_role_arn\x18\x05 \x01(\tH\x03R\rassumeRoleArn\x88\x01\x01B\x10\n" +
+	"\x0e_access_key_idB\x14\n" +
+	"\x12_secret_access_keyB\t\n" +
+	"\a_regionB\x12\n" +
+	"\x10_assume_role_arn\"\x9a\x01\n" +
 	"\x10AzureCredentials\x12'\n" +
 	"\x0fsubscription_id\x18\x01 \x01(\tR\x0esubscriptionId\x12\x1b\n" +
 	"\ttenant_id\x18\x02 \x01(\tR\btenantId\x12\x1b\n" +

--- a/lib/cloud_query/cloudquery.pb.ex
+++ b/lib/cloud_query/cloudquery.pb.ex
@@ -3,9 +3,11 @@ defmodule Cloudquery.AwsCredentials do
 
   use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto3
 
-  field :access_key_id, 1, type: :string, json_name: "accessKeyId"
-  field :secret_access_key, 2, type: :string, json_name: "secretAccessKey"
+  field :access_key_id, 1, proto3_optional: true, type: :string, json_name: "accessKeyId"
+  field :secret_access_key, 2, proto3_optional: true, type: :string, json_name: "secretAccessKey"
   field :region, 3, proto3_optional: true, type: :string
+  field :regions, 4, repeated: true, type: :string
+  field :assume_role_arn, 5, proto3_optional: true, type: :string, json_name: "assumeRoleArn"
 end
 
 defmodule Cloudquery.AzureCredentials do

--- a/lib/console/ai/tools/agent/base.ex
+++ b/lib/console/ai/tools/agent/base.ex
@@ -86,7 +86,9 @@ defmodule Console.AI.Tools.Agent.Base do
     %AwsCredentials{
       access_key_id:     aws.access_key_id,
       secret_access_key: aws.secret_access_key,
-      region:            aws.region
+      region:            aws.region,
+      regions:           aws.regions,
+      assume_role_arn:   aws.assume_role_arn
     }
   end
 

--- a/lib/console/ai/tools/workbench/infrastructure/cloud_query.ex
+++ b/lib/console/ai/tools/workbench/infrastructure/cloud_query.ex
@@ -1,0 +1,33 @@
+defmodule Console.AI.Tools.Workbench.Infrastructure.CloudQuery do
+  use Console.AI.Tools.Agent.Base
+  alias Console.Schema.{CloudConnection, WorkbenchTool}
+  alias Cloudquery.QueryInput
+
+  embedded_schema do
+    field :tool,  :map, virtual: true
+    field :query, :string
+  end
+
+  @valid ~w(query)a
+
+  def changeset(model, attrs) do
+    model
+    |> cast(attrs, @valid)
+    |> validate_required([:query])
+  end
+
+  @json_schema Console.priv_file!("tools/workbench/infrastructure/cloud_query.json") |> Jason.decode!()
+
+  def json_schema(_), do: @json_schema
+  def name(%__MODULE__{tool: %WorkbenchTool{name: name}}), do: "cloud_query_#{name}"
+  def description(%__MODULE__{tool: %WorkbenchTool{cloud_connection: %CloudConnection{provider: provider}}}),
+    do: "Performs a postgresql-compatible sql query against the #{provider} cloud account.  You *must* use the cloud schema tool to discover the schema of the sql database first before calling this so it uses the proper tables and columns."
+
+  def implement(%__MODULE__{query: query, tool: %WorkbenchTool{cloud_connection: %CloudConnection{} = connection}}) do
+    with {:ok, client} <- Client.connect(),
+         input = %QueryInput{query: query, connection: to_pb(connection)},
+         {:ok, result} <- Stub.query(client, input) do
+      Protobuf.JSON.encode(result)
+    end
+  end
+end

--- a/lib/console/ai/tools/workbench/infrastructure/cloud_schema.ex
+++ b/lib/console/ai/tools/workbench/infrastructure/cloud_schema.ex
@@ -1,0 +1,32 @@
+defmodule Console.AI.Tools.Workbench.Infrastructure.CloudSchema do
+  use Console.AI.Tools.Agent.Base
+  alias Console.Schema.{CloudConnection, WorkbenchTool}
+  alias Cloudquery.SchemaInput
+
+  embedded_schema do
+    field :tool, :map, virtual: true
+    field :table, :string
+  end
+
+  @valid ~w(table)a
+
+  def changeset(model, attrs) do
+    model
+    |> cast(attrs, @valid)
+  end
+
+  @json_schema Console.priv_file!("tools/workbench/infrastructure/cloud_schema.json") |> Jason.decode!()
+
+  def json_schema(_), do: @json_schema
+  def name(%__MODULE__{tool: %{name: name}}), do: "cloud_schema_#{name}"
+  def description(%__MODULE__{tool: %WorkbenchTool{cloud_connection: %CloudConnection{provider: provider}}}),
+    do: "Shows the schema for querying a #{provider} cloud account using sql. Can also search for certain datatypes using the table parameter to save tokens."
+
+  def implement(%__MODULE__{tool: %WorkbenchTool{cloud_connection: %CloudConnection{} = connection}, table: table}) do
+    with {:ok, client} <- Client.connect(),
+         input = %SchemaInput{connection: to_pb(connection), table: table},
+         {:ok, output} <- Stub.schema(client, input) do
+      Protobuf.JSON.encode(output)
+    end
+  end
+end

--- a/lib/console/ai/workbench/engine.ex
+++ b/lib/console/ai/workbench/engine.ex
@@ -38,7 +38,7 @@ defmodule Console.AI.Workbench.Engine do
 
   def new(%WorkbenchJob{} = job) do
     %{user: user, workbench: workbench} = job =
-      Repo.preload(job, [user: [:groups], workbench: [:workbench_skills, :repository, :agent_runtime, [tools: :mcp_server]]])
+      Repo.preload(job, [user: [:groups], workbench: [:workbench_skills, :repository, :agent_runtime, [tools: [:mcp_server, :cloud_connection]]]])
 
     user = Console.Services.Rbac.preload(user)
     with {:ok, _} <- Heartbeat.start_link(job),

--- a/lib/console/ai/workbench/subagents/infrastructure.ex
+++ b/lib/console/ai/workbench/subagents/infrastructure.ex
@@ -1,6 +1,6 @@
 defmodule Console.AI.Workbench.Subagents.Infrastructure do
   use Console.AI.Workbench.Subagents.Base
-  alias Console.Schema.{WorkbenchJob, WorkbenchJobActivity, Workbench, User}
+  alias Console.Schema.{WorkbenchJob, WorkbenchTool, WorkbenchJobActivity, Workbench, User}
   alias Console.AI.Tools.Workbench.{
     SummarizeComponent,
     Result,
@@ -15,7 +15,9 @@ defmodule Console.AI.Workbench.Subagents.Infrastructure do
     Infrastructure.ClusterServices,
     Infrastructure.ServiceInspect,
     Infrastructure.StackList,
-    Infrastructure.StackInspect
+    Infrastructure.StackInspect,
+    Infrastructure.CloudSchema,
+    Infrastructure.CloudQuery
   }
   alias Console.AI.Tools.Agent.{ServiceComponent, Stack}
   alias Console.AI.Workbench.Environment
@@ -23,8 +25,9 @@ defmodule Console.AI.Workbench.Subagents.Infrastructure do
   require EEx
 
   def run(%WorkbenchJobActivity{prompt: prompt} = activity, %WorkbenchJob{prompt: jprompt} = job, %Environment{} = environment) do
+    system_prompt = String.trim(system_prompt(prompt: jprompt, cloud_tools: has_cloud_tools?(environment.tools)))
     tools(job, environment)
-    |> MemoryEngine.new(50, system_prompt: String.trim(system_prompt(prompt: jprompt)), acc: %{}, callback: &callback(activity, &1))
+    |> MemoryEngine.new(50, system_prompt: system_prompt, acc: %{}, callback: &callback(activity, &1))
     |> MemoryEngine.reduce([{:user, prompt}], &reducer/2)
     |> case do
       {:ok, attrs} -> attrs
@@ -42,15 +45,30 @@ defmodule Console.AI.Workbench.Subagents.Infrastructure do
     end
   end
 
-  defp tools(%WorkbenchJob{workbench: bench, user: user}, %Environment{skills: skills}) do
+  defp tools(%WorkbenchJob{workbench: bench, user: user}, %Environment{skills: skills} = environment) do
     svc_tools(bench, user)
     |> Enum.concat(stack_tools(bench, user))
     |> Enum.concat(k8s_tools(bench, user))
+    |> Enum.concat(cloud_tools(environment))
     |> Enum.concat([
       %Skills{skills: skills},
       %Skill{skills: skills},
       Result
     ])
+  end
+
+  defp cloud_tools(%Environment{tools: tools}) do
+    Enum.flat_map(tools, fn
+      {_, %WorkbenchTool{tool: :cloud} = tool} -> [%CloudSchema{tool: tool}, %CloudQuery{tool: tool}]
+      _ -> []
+    end)
+  end
+
+  defp has_cloud_tools?(tools) do
+    Enum.any?(tools, fn
+      {_, %WorkbenchTool{tool: :cloud}} -> true
+      _ -> false
+    end)
   end
 
   defp svc_tools(%Workbench{configuration: %{infrastructure: %{services: true}}}, user) do

--- a/lib/console/deployments/pr/utils.ex
+++ b/lib/console/deployments/pr/utils.ex
@@ -10,13 +10,13 @@ defmodule Console.Deployments.Pr.Utils do
 
   @ansi_code ~r/\x1b\[[0-9;]*m/
 
-  @stack_regex [~r/plrl\/stacks?\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(stacks?:([[:alnum:]_\-]*)\)/, ~r/Plural [sS]tacks?:\s+([[:alnum:]_\-]+)/]
-  @svc_regex [~r/plrl\/svcs?\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(services?:([[:alnum:]_\-\/]*)\)/, ~r/Plural [sS]ervices?:\s+([[:alnum:]_\/\-]+)/]
-  @cluster_regex [~r/plrl\/clusters?\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(clusters?:([[:alnum:]_\-]*)\)/, ~r/Plural [cC]lusters?:\s+([[:alnum:]_\-]+)/]
-  @flow_regex [~r/plrl\/flow\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(flow:([[:alnum:]_\-]*)\)/, ~r/Plural [fF]low:\s+([[:alnum:]_\-]+)/]
-  @preview_regex [~r/plrl\/preview\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(preview:([[:alnum:]_\-]*)\)/, ~r/Plural [pP]review:\s+([[:alnum:]_\-]+)/]
-  @merge_cron_regex [~r/[Pp]lural [Mm]erge [Cc]ron:\s+([0-9,\-*\/]+\s[0-9,\-*\/]+\s[0-9,\-*\/]+\s[0-9,\-*\/]+\s[0-9,\-*\/]+)/]
-  @governance_regex [~r/[Pp]lural [Gg]overnance:\s+([[:alnum:]_\-]+)/]
+  @stack_regex [~r/plrl\/stacks?\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(stacks?:([[:alnum:]_\-]*)\)/, ~r/\**Plural [sS]tacks?:\**\s+([[:alnum:]_\-]+)/]
+  @svc_regex [~r/plrl\/svcs?\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(services?:([[:alnum:]_\-\/]*)\)/, ~r/\**Plural [sS]ervices?:\**\s+([[:alnum:]_\/\-]+)/]
+  @cluster_regex [~r/plrl\/clusters?\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(clusters?:([[:alnum:]_\-]*)\)/, ~r/\**Plural [cC]lusters?:\**\s+([[:alnum:]_\-]+)/]
+  @flow_regex [~r/plrl\/flow\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(flow:([[:alnum:]_\-]*)\)/, ~r/\**Plural [fF]low:\**\s+([[:alnum:]_\-]+)/]
+  @preview_regex [~r/plrl\/preview\/([[:alnum:]_\-]+)\/?/, ~r/plrl\(preview:([[:alnum:]_\-]*)\)/, ~r/\**Plural [pP]review:\**\s+([[:alnum:]_\-]+)/]
+  @merge_cron_regex [~r/\**Plural [Mm]erge [Cc]ron:\**\s+([0-9,\-*\/]+\s[0-9,\-*\/]+\s[0-9,\-*\/]+\s[0-9,\-*\/]+\s[0-9,\-*\/]+)/]
+  @governance_regex [~r/\**Plural [Gg]overnance:\**\s+([[:alnum:]_\-]+)/]
 
   @solid_opts [strict_variables: true, strict_filters: true]
 

--- a/lib/console/deployments/workbenches.ex
+++ b/lib/console/deployments/workbenches.ex
@@ -79,7 +79,7 @@ defmodule Console.Deployments.Workbenches do
   @spec update_workbench(map, binary, User.t()) :: workbench_resp
   def update_workbench(attrs, id, %User{} = user) do
     get_workbench!(id)
-    |> Repo.preload([:tool_associations, :read_bindings, :write_bindings])
+    |> Repo.preload([:tool_associations, :read_bindings, :write_bindings, :workbench_skills])
     |> allow(user, :write)
     |> when_ok(&Workbench.changeset(&1, override_bot_user(attrs, user)))
     |> when_ok(:update)

--- a/lib/console/graphql/deployments/settings.ex
+++ b/lib/console/graphql/deployments/settings.ex
@@ -219,6 +219,7 @@ defmodule Console.GraphQl.Deployments.Settings do
     field :secret_access_key, non_null(:string)
     field :region,            :string
     field :regions,           list_of(:string)
+    field :assume_role_arn,   :string, description: "optional IAM role ARN for the console to assume when using this connection"
   end
 
   input_object :gcp_cloud_connection_attributes do
@@ -456,6 +457,7 @@ defmodule Console.GraphQl.Deployments.Settings do
     field :secret_access_key, non_null(:string), description: "the secret access key for aws"
     field :region,            :string, description: "the region for aws"
     field :regions,           list_of(:string), description: "the regions for aws"
+    field :assume_role_arn,   :string, description: "IAM role ARN for the console to assume when using this connection"
   end
 
   @desc "The configuration for a cloud provider"

--- a/lib/console/graphql/deployments/workbench.ex
+++ b/lib/console/graphql/deployments/workbench.ex
@@ -36,6 +36,7 @@ defmodule Console.GraphQl.Deployments.Workbench do
     field :read_bindings,     list_of(:policy_binding_attributes), description: "users who can read and execute this workbench"
     field :write_bindings,    list_of(:policy_binding_attributes), description: "users who can modify this workbench"
     field :tool_associations, list_of(:workbench_tool_association_attributes), description: "tool ids to associate with this workbench"
+    field :workbench_skills,  list_of(:workbench_skill_attributes), description: "skills to include with this workbench"
   end
 
   input_object :workbench_configuration_attributes do
@@ -100,12 +101,13 @@ defmodule Console.GraphQl.Deployments.Workbench do
   end
 
   input_object :workbench_tool_attributes do
-    field :name,          non_null(:string), description: "the name of the tool (a-z, 0-9, underscores)"
-    field :tool,          non_null(:workbench_tool_type), description: "the type of tool"
-    field :categories,    list_of(:workbench_tool_category), description: "categories for the tool"
-    field :project_id,    :id, description: "the project for this tool"
-    field :mcp_server_id, :id, description: "the mcp server for this tool"
-    field :configuration, :workbench_tool_configuration_attributes, description: "tool configuration (e.g. http)"
+    field :name,                 non_null(:string), description: "the name of the tool (a-z, 0-9, underscores)"
+    field :tool,                 non_null(:workbench_tool_type), description: "the type of tool"
+    field :categories,           list_of(:workbench_tool_category), description: "categories for the tool"
+    field :project_id,           :id, description: "the project for this tool"
+    field :mcp_server_id,        :id, description: "the mcp server for this tool"
+    field :cloud_connection_id,  :id, description: "the cloud connection for this tool (e.g. infrastructure cloud tools)"
+    field :configuration,        :workbench_tool_configuration_attributes, description: "tool configuration (e.g. http)"
   end
 
   input_object :workbench_tool_configuration_attributes do
@@ -472,13 +474,14 @@ defmodule Console.GraphQl.Deployments.Workbench do
   end
 
   object :workbench_tool do
-    field :id,            non_null(:string), description: "the id of the tool"
-    field :name,          non_null(:string), description: "the name of the tool"
-    field :tool,          non_null(:workbench_tool_type), description: "the type of tool"
-    field :categories,    list_of(:workbench_tool_category), description: "categories for the tool"
-    field :project,       :project, resolve: dataloader(Deployments), description: "the project of this tool"
-    field :configuration, :workbench_tool_configuration, description: "tool configuration"
-    field :mcp_server,    :mcp_server, resolve: dataloader(Deployments), description: "the mcp server for this tool"
+    field :id,               non_null(:string), description: "the id of the tool"
+    field :name,             non_null(:string), description: "the name of the tool"
+    field :tool,             non_null(:workbench_tool_type), description: "the type of tool"
+    field :categories,       list_of(:workbench_tool_category), description: "categories for the tool"
+    field :project,          :project, resolve: dataloader(Deployments), description: "the project of this tool"
+    field :configuration,    :workbench_tool_configuration, description: "tool configuration"
+    field :mcp_server,       :mcp_server, resolve: dataloader(Deployments), description: "the mcp server for this tool"
+    field :cloud_connection, :cloud_connection, resolve: dataloader(Deployments), description: "the cloud connection bound to this tool"
 
     timestamps()
   end

--- a/lib/console/schema/cloud_connection.ex
+++ b/lib/console/schema/cloud_connection.ex
@@ -16,6 +16,7 @@ defmodule Console.Schema.CloudConnection do
         field :region,            :string
         field :regions,           {:array, :string}
         field :access_key_id,     :string
+        field :assume_role_arn,   :string
         field :secret_access_key, EncryptedString
       end
 
@@ -78,7 +79,7 @@ defmodule Console.Schema.CloudConnection do
 
   defp aws_changeset(model, attrs) do
     model
-    |> cast(attrs, [:region, :regions, :access_key_id, :secret_access_key])
+    |> cast(attrs, [:region, :regions, :access_key_id, :secret_access_key, :assume_role_arn])
     |> validate_required([:access_key_id, :secret_access_key])
   end
 

--- a/lib/console/schema/workbench.ex
+++ b/lib/console/schema/workbench.ex
@@ -112,6 +112,7 @@ defmodule Console.Schema.Workbench do
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, @valid)
+    |> cast_assoc(:workbench_skills)
     |> cast_assoc(:read_bindings)
     |> cast_assoc(:write_bindings)
     |> cast_assoc(:tool_associations)

--- a/lib/console/schema/workbench_tool.ex
+++ b/lib/console/schema/workbench_tool.ex
@@ -1,11 +1,11 @@
 defmodule Console.Schema.WorkbenchTool do
   use Console.Schema.Base
-  alias Console.Schema.{Project, PolicyBinding, User, McpServer}
+  alias Console.Schema.{Project, PolicyBinding, User, McpServer, CloudConnection}
   alias Console.Deployments.Policies.Rbac
   alias Piazza.Ecto.EncryptedString
 
-  defenum Tool, http: 0, elastic: 1, datadog: 2, prometheus: 3, loki: 4, tempo: 5, sentry: 6, mcp: 7, linear: 8, atlassian: 9, splunk: 10, dynatrace: 11, cloudwatch: 12, azure: 13
-  defenum Category, metrics: 0, logs: 1, integration: 2, ticketing: 3, traces: 4, error_tracking: 5
+  defenum Tool, http: 0, elastic: 1, datadog: 2, prometheus: 3, loki: 4, tempo: 5, sentry: 6, mcp: 7, linear: 8, atlassian: 9, splunk: 10, dynatrace: 11, cloudwatch: 12, azure: 13, cloud: 14
+  defenum Category, metrics: 0, logs: 1, integration: 2, ticketing: 3, traces: 4, error_tracking: 5, infrastructure: 6
   defenum HttpMethod, get: 0, post: 1, put: 2, delete: 3, patch: 4
 
   schema "workbench_tools" do
@@ -123,8 +123,9 @@ defmodule Console.Schema.WorkbenchTool do
       foreign_key: :policy_id,
       references: :write_policy_id
 
-    belongs_to :project,    Project
-    belongs_to :mcp_server, McpServer
+    belongs_to :project,          Project
+    belongs_to :mcp_server,       McpServer
+    belongs_to :cloud_connection, CloudConnection
 
     timestamps()
   end
@@ -153,7 +154,7 @@ defmodule Console.Schema.WorkbenchTool do
     end)
   end
 
-  @valid ~w(tool categories name project_id mcp_server_id)a
+  @valid ~w(tool categories name project_id cloud_connection_id mcp_server_id)a
 
   def changeset(model, attrs \\ %{}) do
     model
@@ -163,6 +164,8 @@ defmodule Console.Schema.WorkbenchTool do
     |> cast_assoc(:write_bindings)
     |> then(fn cs -> cast_embed(cs, :configuration, with: &configuration_changeset(&1, &2, get_field(cs, :tool))) end)
     |> foreign_key_constraint(:project_id)
+    |> foreign_key_constraint(:cloud_connection_id)
+    |> foreign_key_constraint(:mcp_server_id)
     |> validate_format(:name, ~r/^[a-z0-9]([\._a-z0-9]*[a-z0-9])?$/, message: "must be a valid name for OpenAI or equivalent tool calls (only a-z, 0-9, .,  and underscores allowed)")
     |> put_new_change(:read_policy_id, &Ecto.UUID.generate/0)
     |> put_new_change(:write_policy_id, &Ecto.UUID.generate/0)
@@ -209,7 +212,10 @@ defmodule Console.Schema.WorkbenchTool do
   defp categories(:sentry), do: [:error_tracking]
   defp categories(:linear), do: [:ticketing]
   defp categories(:atlassian), do: [:ticketing]
+  defp categories(:cloud), do: [:infrastructure]
   defp categories(_), do: [:integration]
+
+  @noconfig [:mcp, :cloud]
 
   defp configuration_changeset(model, attrs, tool) do
     model
@@ -227,7 +233,7 @@ defmodule Console.Schema.WorkbenchTool do
     |> cast_embed(:sentry, with: &sentry_configuration_changeset/2)
     |> cast_embed(:linear, with: &linear_configuration_changeset/2)
     |> cast_embed(:atlassian, with: &atlassian_configuration_changeset/2)
-    |> validate_required(if tool == :mcp, do: [], else: [tool])
+    |> validate_required(if tool in @noconfig, do: [], else: [tool])
   end
 
   defp http_configuration_changeset(model, attrs) do

--- a/priv/prompts/workbench/infrastructure.md.eex
+++ b/priv/prompts/workbench/infrastructure.md.eex
@@ -48,6 +48,19 @@ You are producing output for a human user, and should expect them to want to rea
 3. We can offer the ability to directly query kubernetes, but you need to be precise with your inputs and *always* include a Plural cluster handle to make it work.  It's also possible user RBAC policies block your query.
 4. If you're searching for a kubernetes resource and don't know exactly the namespace/name it might have, you can mix `service_search` with standard k8s tool calls since it has the ability to probe kubernetes objects just with a finely crafted prompt.  Both are useful tools in the toolkit.
 
+<%= if @cloud_tools do %>
+We also have added a set of tools to query live cloud infrastructure configuration using sql.  These are meant to be used within the following constraints:
+
+1. If you can discover the same cloud infrastructure using Plural stack state, always prefer that.  It provides direct linkage to IaC and is often more useful info for determining a fix.
+2. It can be useful for generating aggregate analysis of cloud infrastructure, for instance to build cost analyses or inventory reports.
+3. It can be useful also to determine drift against IaC or discover hidden or resources created manually outside of a best-practice infrastructure deployment process.
+
+The way to use these tools is relatively simple:
+
+1. You have a `cloud_schema_*` tool to get the schema of the sql tables for that account.  You should use the `table` argument to filter this schema since it can be query large and pollute context.
+2. You have a `cloud_query_*` tool to perform a broad sql query against the cloud account. You should always confirm the tables you are using in this query exist in the schema first before calling it, as a plain guess can be an expensive mistake.
+<% end %>
+
 ## Ideal Output
 
 Beyond simply answering all the questions you were asked, a few things to keep in mind:

--- a/priv/repo/migrations/20260419015458_add_workbench_tool_cloud_connection.exs
+++ b/priv/repo/migrations/20260419015458_add_workbench_tool_cloud_connection.exs
@@ -1,0 +1,11 @@
+defmodule Console.Repo.Migrations.AddWorkbenchToolCloudConnection do
+  use Ecto.Migration
+
+  def change do
+    alter table(:workbench_tools) do
+      add :cloud_connection_id, references(:cloud_connections, type: :uuid, on_delete: :delete_all)
+    end
+
+    create index(:workbench_tools, [:cloud_connection_id])
+  end
+end

--- a/priv/tools/workbench/infrastructure/cloud_query.json
+++ b/priv/tools/workbench/infrastructure/cloud_query.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": "A valid postgresql-compatible SQL query using the schema from the cloud_schema tool to perform some query or analysis on the cloud accounts configuration data"
+        }
+    },
+    "required": ["query"]
+}

--- a/priv/tools/workbench/infrastructure/cloud_schema.json
+++ b/priv/tools/workbench/infrastructure/cloud_schema.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "properties": {
+        "table": {
+            "type": "string",
+            "description": "Query for tables containing this substring. Searches for all tables if not provided."
+        }
+    },
+    "required": []
+}

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -2234,6 +2234,7 @@ enum WorkbenchToolType {
   DYNATRACE
   CLOUDWATCH
   AZURE
+  CLOUD
 }
 
 enum WorkbenchToolCategory {
@@ -2243,6 +2244,7 @@ enum WorkbenchToolCategory {
   TICKETING
   TRACES
   ERROR_TRACKING
+  INFRASTRUCTURE
 }
 
 enum WorkbenchToolHttpMethod {
@@ -2333,6 +2335,9 @@ input WorkbenchAttributes {
 
   "tool ids to associate with this workbench"
   toolAssociations: [WorkbenchToolAssociationAttributes]
+
+  "skills to include with this workbench"
+  workbenchSkills: [WorkbenchSkillAttributes]
 }
 
 input WorkbenchConfigurationAttributes {
@@ -2456,6 +2461,9 @@ input WorkbenchToolAttributes {
 
   "the mcp server for this tool"
   mcpServerId: ID
+
+  "the cloud connection for this tool (e.g. infrastructure cloud tools)"
+  cloudConnectionId: ID
 
   "tool configuration (e.g. http)"
   configuration: WorkbenchToolConfigurationAttributes
@@ -3135,6 +3143,9 @@ type WorkbenchTool {
 
   "the mcp server for this tool"
   mcpServer: McpServer
+
+  "the cloud connection bound to this tool"
+  cloudConnection: CloudConnection
 
   insertedAt: DateTime
 
@@ -4709,9 +4720,15 @@ input CloudConnectionConfigurationAttributes {
 
 input AwsCloudConnectionAttributes {
   accessKeyId: String!
+
   secretAccessKey: String!
+
   region: String
+
   regions: [String]
+
+  "optional IAM role ARN for the console to assume when using this connection"
+  assumeRoleArn: String
 }
 
 input GcpCloudConnectionAttributes {
@@ -5115,6 +5132,9 @@ type AwsConnectionAttributes {
 
   "the regions for aws"
   regions: [String]
+
+  "IAM role ARN for the console to assume when using this connection"
+  assumeRoleArn: String
 }
 
 "The configuration for a cloud provider"


### PR DESCRIPTION
This is still enormously useful, and feel like workbenches is a great surface to leverage it since users can tweak it/opt out as they chose. Does a few things:

1. Adds a cloud type of tool, with a cloud connection association
2. Wires up infrastructure subagent to use it
3. Slightly tweak aws cloudquery protobuf to help it leverage best practices better.

## Test Plan
unit test

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console