### PR TITLE
whitelist workspace field for mm

### DIFF
--- a/lib/console/logs/provider/elastic.ex
+++ b/lib/console/logs/provider/elastic.ex
@@ -157,7 +157,7 @@ defmodule Console.Logs.Provider.Elastic do
 
     put_in(resp, ~w(kubernetes node labels), nil)
     |> put_in(~w(kubernetes labels), nil)
-    |> Map.take(~w(kubernetes cloud container cluster))
+    |> Map.take(~w(kubernetes cloud container cluster workspace))
     |> Line.flat_map()
     |> Line.facets()
   end

--- a/lib/console/logs/provider/elastic.ex
+++ b/lib/console/logs/provider/elastic.ex
@@ -157,7 +157,7 @@ defmodule Console.Logs.Provider.Elastic do
 
     put_in(resp, ~w(kubernetes node labels), nil)
     |> put_in(~w(kubernetes labels), nil)
-    |> Map.take(~w(kubernetes cloud container cluster workspace))
+    |> Map.take(~w(kubernetes cloud container cluster custom))
     |> Line.flat_map()
     |> Line.facets()
   end

--- a/lib/console/logs/provider/opensearch.ex
+++ b/lib/console/logs/provider/opensearch.ex
@@ -197,7 +197,7 @@ defmodule Console.Logs.Provider.Opensearch do
 
     put_in(resp, ~w(kubernetes node labels), nil)
     |> put_in(~w(kubernetes labels), nil)
-    |>  Map.take(~w(kubernetes cloud container cluster))
+    |>  Map.take(~w(kubernetes cloud container cluster custom))
     |> Line.flat_map()
     |> Line.facets()
   end


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->
I'm able to query recent MM logs on the uks-dev cluster with the workspace facet and seeing workspace.workload values using this query:

`curl -s -u "$ES_USER:$ES_PASS" 'https://elastic.management.moata.com/plrl-logs-2026.04.21/_search' -H 'Content-Type: application/json' -d '{
  "size": 0,
  "query": {
    "bool": {
      "must": [
        { "exists": { "field": "workspace.workload" } },
        { "range": { "@timestamp": { "gte": "now-10m" } } }
      ]
    }
  },
  "aggs": {
    "workloads": {
      "terms": { "field": "workspace.workload.keyword", "size": 20 }
    }
  }
}'`

So the logstash tuning worked. This should make the facet available in the UI dropdown.

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->


## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console