### PR TITLE
finish getting rid of old loading spinners in cd cluster drilldowns

### DIFF
--- a/assets/src/components/cd/cluster/Cluster.tsx
+++ b/assets/src/components/cd/cluster/Cluster.tsx
@@ -259,13 +259,13 @@ export function Cluster() {
       }
       headingContent={
         <>
-          <div css={{ width: 320, height: '100%' }}>
+          <div css={{ width: 320, height: '100%', flexShrink: 0 }}>
             <ClusterSelector
               clusterId={clusterId}
               allowDeselect={false}
               showUpgrades={tab === 'addons'}
               onClusterChange={(c) => {
-                if (c?.id) {
+                if (c?.id && c.id !== clusterId) {
                   navigate(
                     `/cd/clusters/${c.id}/${tab}/${tab === 'addons' ? CLUSTER_ALL_ADDONS_REL_PATH : tab === 'details' ? `${detailsTab}` : ''}`
                   )

--- a/assets/src/components/cd/cluster/ClusterAddOns.tsx
+++ b/assets/src/components/cd/cluster/ClusterAddOns.tsx
@@ -1,5 +1,4 @@
-import { Tab, TabList } from '@pluralsh/design-system'
-import LoadingIndicator from 'components/utils/LoadingIndicator'
+import { Flex, Tab, TabList } from '@pluralsh/design-system'
 import {
   CloudAddonFragment,
   ClusterDistro,
@@ -8,7 +7,7 @@ import {
   useRuntimeServicesQuery,
 } from 'generated/graphql'
 import { isEmpty } from 'lodash'
-import { useEffect, useMemo, useRef } from 'react'
+import { useLayoutEffect, useMemo, useRef } from 'react'
 import {
   Outlet,
   useMatch,
@@ -36,8 +35,9 @@ import { useClusterContext } from './Cluster.tsx'
 import ClusterAddOnsEntry from './ClusterAddOnsEntry'
 
 export type AddonContextType = {
-  cluster: ClusterFragment
+  cluster: Nullable<ClusterFragment>
   cloudAddon?: CloudAddonFragment
+  loading?: boolean
 }
 
 export function useAddonsContext() {
@@ -52,8 +52,8 @@ const directory = [
 export default function ClusterAddOns() {
   const theme = useTheme()
   const navigate = useNavigate()
-  const { cluster } = useClusterContext()
-  const kubeVersion = getClusterKubeVersion(cluster)
+  const { cluster, clusterLoading } = useClusterContext()
+  const kubeVersion = getClusterKubeVersion(cluster) ?? ''
   const tabStateRef = useRef<any>(null)
   const params = useParams()
   const addOnId = params[CLUSTER_ADDONS_PARAM_ID] as string
@@ -67,11 +67,13 @@ export default function ClusterAddOns() {
   const currentTab = directory.find(({ path }) => path === tab)
   const isCloudAddon = currentTab?.path == CLUSTER_CLOUD_ADDONS_REL_PATH
 
-  const { data, error } = useRuntimeServicesQuery({
+  const { data, loading, error } = useRuntimeServicesQuery({
     variables: { kubeVersion, hasKubeVersion: !!kubeVersion, id: clusterId },
+    skip: !kubeVersion,
     fetchPolicy: 'cache-and-network',
     pollInterval: POLL_INTERVAL,
   })
+  const isLoading = (!data && loading) || (!cluster && clusterLoading)
 
   const addOns: RuntimeServiceFragment[] | CloudAddonFragment[] = useMemo(
     () =>
@@ -86,47 +88,41 @@ export default function ClusterAddOns() {
     [addOnId, addOns]
   )
 
-  const hasAddons = !isEmpty(addOns)
-
   const supportsCloudAddons = cluster?.distro === ClusterDistro.Eks
 
-  useEffect(() => {
-    if (hasAddons && !addOnId)
+  useLayoutEffect(() => {
+    if (!isEmpty(addOns) && !addOnId)
       navigate(
         getClusterAddOnDetailsPath({
           clusterId,
           addOnId: addOns[0].id,
           isCloudAddon,
-        })
+        }),
+        { replace: true }
       )
-  }, [addOns, addOnId, navigate, clusterId, hasAddons, isCloudAddon])
+  }, [addOns, addOnId, navigate, clusterId, isCloudAddon])
 
   const context = useMemo(
-    () =>
-      ({
-        cluster,
-        cloudAddon: isCloudAddon ? addOn : undefined, // Update once there is a separate query to get a single cloud addon.
-      }) as AddonContextType,
-    [addOn, cluster, isCloudAddon]
+    () => ({
+      cluster,
+      cloudAddon: isCloudAddon ? addOn : undefined, // Update once there is a separate query to get a single cloud addon.
+      loading: isLoading,
+    }),
+    [addOn, cluster, isCloudAddon, isLoading]
   )
 
   if (error) return <GqlError error={error} />
 
-  if (!data) return <LoadingIndicator />
-
   return (
-    <div
-      css={{
-        display: 'flex',
-        height: '100%',
-        width: '100%',
-        overflow: 'hidden',
-      }}
+    <Flex
+      height="100%"
+      width="100%"
+      overflow="hidden"
+      gap="medium"
     >
       <div
         css={{
           height: '100%',
-          marginRight: theme.spacing.medium,
           maxWidth: 320,
           minWidth: 320,
           overflow: 'hidden',
@@ -164,7 +160,7 @@ export default function ClusterAddOns() {
             height: '100%',
           }}
         >
-          {hasAddons ? (
+          {!isEmpty(addOns) ? (
             addOns.map((addon: RuntimeServiceFragment | CloudAddonFragment) => (
               <ClusterAddOnsEntry
                 key={addon.id}
@@ -184,6 +180,18 @@ export default function ClusterAddOns() {
                 }
                 active={addon.id === addOnId}
                 cloudAddon={addon.__typename === 'CloudAddon'}
+                loading={loading}
+              />
+            ))
+          ) : isLoading ? (
+            Array.from({ length: 5 }).map((_, index) => (
+              <ClusterAddOnsEntry
+                loading
+                key={index}
+                id={`x`.repeat(index)}
+                name=""
+                active={index === 0}
+                cloudAddon={isCloudAddon}
               />
             ))
           ) : (
@@ -198,7 +206,7 @@ export default function ClusterAddOns() {
           )}
         </div>
       </div>
-      {addOn && <Outlet context={context} />}
-    </div>
+      <Outlet context={context} />
+    </Flex>
   )
 }

--- a/assets/src/components/cd/cluster/ClusterAddOnsEntry.tsx
+++ b/assets/src/components/cd/cluster/ClusterAddOnsEntry.tsx
@@ -4,9 +4,10 @@ import { useTheme } from 'styled-components'
 import {
   CLUSTER_PARAM_ID,
   getClusterAddOnDetailsPath,
-} from '../../../routes/cdRoutesConsts'
+} from 'routes/cdRoutesConsts'
 
-import { TRUNCATE } from '../../utils/truncate'
+import { TRUNCATE } from 'components/utils/truncate'
+import { RectangleSkeleton } from 'components/utils/SkeletonLoaders'
 
 export default function ClusterAddOnsEntry({
   id,
@@ -15,6 +16,7 @@ export default function ClusterAddOnsEntry({
   blocking,
   active,
   cloudAddon,
+  loading,
 }: {
   id: string
   name: string
@@ -22,6 +24,7 @@ export default function ClusterAddOnsEntry({
   blocking?: boolean | null
   active: boolean
   cloudAddon: boolean
+  loading?: boolean
 }) {
   const theme = useTheme()
   const navigate = useNavigate()
@@ -31,7 +34,7 @@ export default function ClusterAddOnsEntry({
   return (
     <div
       onClick={() => {
-        if (!active)
+        if (!active && !loading)
           navigate(
             getClusterAddOnDetailsPath({
               clusterId,
@@ -68,9 +71,9 @@ export default function ClusterAddOnsEntry({
           gap: theme.spacing.small,
         }}
       >
-        {icon ? (
+        {icon || loading ? (
           <AppIcon
-            url={icon}
+            url={icon || ''}
             size="xxsmall"
             css={{
               backgroundColor: active
@@ -94,7 +97,14 @@ export default function ClusterAddOnsEntry({
             flexGrow: 1,
           }}
         >
-          {name}
+          {loading ? (
+            <RectangleSkeleton
+              $height="medium"
+              $width={`${90 - ((id.length % 2) + 1) * 8}%`}
+            />
+          ) : (
+            name
+          )}
         </div>
         {blocking && (
           <Chip

--- a/assets/src/components/cd/cluster/ClusterAddon.tsx
+++ b/assets/src/components/cd/cluster/ClusterAddon.tsx
@@ -1,5 +1,4 @@
-import { Chip, SubTab, TabList } from '@pluralsh/design-system'
-import LoadingIndicator from 'components/utils/LoadingIndicator'
+import { Chip, Flex, SubTab, TabList } from '@pluralsh/design-system'
 import {
   RuntimeServiceDetailsFragment,
   useRuntimeServiceQuery,
@@ -9,8 +8,8 @@ import { Outlet, useMatch, useParams } from 'react-router-dom'
 import { useTheme } from 'styled-components'
 import {
   CLUSTER_ADDONS_COMPATIBILITY_PATH,
-  CLUSTER_ADDONS_RELEASES_PATH,
   CLUSTER_ADDONS_PARAM_ID,
+  CLUSTER_ADDONS_RELEASES_PATH,
   CLUSTER_PARAM_ID,
   getClusterAddOnDetailsPath,
 } from '../../../routes/cdRoutesConsts'
@@ -20,6 +19,8 @@ import PropCard from '../../utils/PropCard.tsx'
 import { LinkTabWrap } from '../../utils/Tabs'
 import { getClusterKubeVersion } from '../clusters/runtime/RuntimeServices'
 
+import { RectangleSkeleton } from 'components/utils/SkeletonLoaders.tsx'
+import { StretchedFlex } from 'components/utils/StretchedFlex.tsx'
 import { useSetPageHeaderContent } from '../ContinuousDeployment'
 import { useAddonsContext } from './ClusterAddOns.tsx'
 
@@ -33,13 +34,12 @@ export const versionPlaceholder = '_VSN_PLACEHOLDER_'
 const directory = [
   { path: CLUSTER_ADDONS_COMPATIBILITY_PATH, label: 'Compatibility' },
   { path: CLUSTER_ADDONS_RELEASES_PATH, label: 'Releases' },
-  // { path: 'readme', label: 'README' },
 ]
 
 export default function ClusterAddon() {
-  const theme = useTheme()
-  const { cluster } = useAddonsContext()
-  const kubeVersion = getClusterKubeVersion(cluster)
+  const { spacing } = useTheme()
+  const { cluster, loading } = useAddonsContext()
+  const kubeVersion = getClusterKubeVersion(cluster) ?? ''
   const tabStateRef = useRef<any>(null)
   const params = useParams()
   const addOnId = params[CLUSTER_ADDONS_PARAM_ID] as string
@@ -54,8 +54,12 @@ export default function ClusterAddon() {
   const tab = pathMatch?.params?.tab || ''
   const currentTab = directory.find(({ path }) => path === tab)
 
-  const { data: addOnData, error: addOnError } = useRuntimeServiceQuery({
-    skip: !addOnId,
+  const {
+    data: addOnData,
+    loading: addOnLoading,
+    error: addOnError,
+  } = useRuntimeServiceQuery({
+    skip: !addOnId || !cluster,
     variables: {
       id: addOnId,
       version: versionPlaceholder,
@@ -64,17 +68,11 @@ export default function ClusterAddon() {
     },
   })
 
-  const addOn = useMemo(
-    () => addOnData?.runtimeService,
-    [addOnData?.runtimeService]
-  )
+  const addOn = addOnData?.runtimeService
+  const isLoading = !addOn && (addOnLoading || loading)
 
-  const context = useMemo(
-    () =>
-      ({
-        addOn,
-        kubeVersion,
-      }) as ClusterAddOnOutletContextT,
+  const context: ClusterAddOnOutletContextT = useMemo(
+    () => ({ addOn, kubeVersion }),
     [addOn, kubeVersion]
   )
 
@@ -82,95 +80,87 @@ export default function ClusterAddon() {
     useMemo(
       () =>
         addOnId ? (
-          <div
-            css={{
-              display: 'flex',
-              justifyContent: 'end',
-              gap: theme.spacing.small,
+          <TabList
+            stateRef={tabStateRef}
+            stateProps={{
+              orientation: 'horizontal',
+              selectedKey: currentTab?.path,
             }}
           >
-            <TabList
-              stateRef={tabStateRef}
-              stateProps={{
-                orientation: 'horizontal',
-                selectedKey: currentTab?.path,
-              }}
-            >
-              {directory.map(({ label, path }) => (
-                <LinkTabWrap
-                  subTab
+            {directory.map(({ label, path }) => (
+              <LinkTabWrap
+                subTab
+                key={path}
+                textValue={label}
+                to={`${pathPrefix}/${path}`}
+              >
+                <SubTab
                   key={path}
                   textValue={label}
-                  to={`${pathPrefix}/${path}`}
                 >
-                  <SubTab
-                    key={path}
-                    textValue={label}
-                  >
-                    {label}
-                  </SubTab>
-                </LinkTabWrap>
-              ))}
-            </TabList>
-          </div>
+                  {label}
+                </SubTab>
+              </LinkTabWrap>
+            ))}
+          </TabList>
         ) : undefined,
-      [addOnId, currentTab?.path, pathPrefix, theme.spacing.small]
+      [addOnId, currentTab?.path, pathPrefix]
     )
   )
 
-  if (addOnError) return <GqlError error={addOnError} />
-
-  if (!addOn) return <LoadingIndicator />
+  if (!addOn && !isLoading) return null
 
   return (
-    <div
-      css={{
-        display: 'flex',
-        height: '100%',
-        overflow: 'hidden',
-        width: '100%',
-      }}
+    <Flex
+      direction="column"
+      gap="medium"
+      overflow="hidden"
+      height="100%"
+      width="100%"
     >
+      {addOnError && <GqlError error={addOnError} />}
       <div
         css={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: theme.spacing.medium,
-          overflow: 'hidden',
-          width: '100%',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gridAutoRows: 'min-content',
+          gridGap: spacing.small,
         }}
       >
-        <div
-          css={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(3, 1fr)',
-            gridAutoRows: 'min-content',
-            gridGap: theme.spacing.small,
-          }}
+        <PropCard
+          title="Add-on"
+          loading={isLoading}
         >
-          <PropCard title="Add-on">{addOn?.name}</PropCard>
-          <PropCard title="Add-on version">
-            <div
-              css={{
-                alignItems: 'center',
-                display: 'flex',
-                justifyContent: 'space-between',
-              }}
+          {addOn?.name}
+        </PropCard>
+        <PropCard
+          title="Add-on version"
+          loading={isLoading}
+        >
+          <StretchedFlex>
+            {toNiceVersion(addOn?.addonVersion?.version)}
+            <Chip
+              severity={addOn?.addonVersion?.blocking ? 'danger' : 'success'}
             >
-              {toNiceVersion(addOn?.addonVersion?.version)}
-              <Chip
-                severity={addOn?.addonVersion?.blocking ? 'danger' : 'success'}
-              >
-                {addOn?.addonVersion?.blocking ? 'Blocking' : 'Not blocking'}
-              </Chip>
-            </div>
-          </PropCard>
-          <PropCard title="Kubernetes version">
-            {toNiceVersion(kubeVersion)}
-          </PropCard>
-        </div>
-        <Outlet context={context} />
+              {addOn?.addonVersion?.blocking ? 'Blocking' : 'Not blocking'}
+            </Chip>
+          </StretchedFlex>
+        </PropCard>
+        <PropCard
+          title="Kubernetes version"
+          loading={isLoading}
+        >
+          {toNiceVersion(kubeVersion)}
+        </PropCard>
       </div>
-    </div>
+      {isLoading ? (
+        <RectangleSkeleton
+          $width="100%"
+          $height="100%"
+        />
+      ) : (
+        <Outlet context={context} />
+      )}
+    </Flex>
   )
 }

--- a/assets/src/components/cd/cluster/ClusterAddon.tsx
+++ b/assets/src/components/cd/cluster/ClusterAddon.tsx
@@ -108,7 +108,13 @@ export default function ClusterAddon() {
     )
   )
 
-  if (!addOn && !isLoading) return null
+  if (!addOn && !isLoading)
+    return addOnError ? (
+      <GqlError
+        error={addOnError}
+        css={{ height: 'fit-content', width: '100%' }}
+      />
+    ) : null
 
   return (
     <Flex
@@ -118,7 +124,6 @@ export default function ClusterAddon() {
       height="100%"
       width="100%"
     >
-      {addOnError && <GqlError error={addOnError} />}
       <div
         css={{
           display: 'grid',

--- a/assets/src/components/cd/cluster/ClusterMetrics.tsx
+++ b/assets/src/components/cd/cluster/ClusterMetrics.tsx
@@ -7,7 +7,10 @@ import {
   ListBoxItem,
   Select,
 } from '@pluralsh/design-system'
-import { useMetricsEnabled } from 'components/contexts/DeploymentSettingsContext'
+import {
+  useLoadingDeploymentSettings,
+  useMetricsEnabled,
+} from 'components/contexts/DeploymentSettingsContext'
 import {
   ClusterWithMetricsFragment,
   HeatMapFlavor,
@@ -19,9 +22,9 @@ import { capitalize, isEmpty, isNull } from 'lodash'
 import styled, { useTheme } from 'styled-components'
 
 import { Prometheus } from '../../../utils/prometheus'
-import LoadingIndicator from '../../utils/LoadingIndicator'
 
 import { GqlError } from 'components/utils/Alert'
+import { RectangleSkeleton } from 'components/utils/SkeletonLoaders'
 import { CaptionP, Subtitle2H1 } from 'components/utils/typography/Text'
 import { UtilizationHeatmap } from 'components/utils/UtilizationHeatmap'
 import { useMemo, useState } from 'react'
@@ -43,13 +46,14 @@ export function ClusterMetrics() {
   const { spacing } = useTheme()
   const { clusterId } = useParams()
   const metricsEnabled = useMetricsEnabled()
+  const deploymentSettingsLoading = useLoadingDeploymentSettings()
 
   const [heatMapFlavor, setHeatMapFlavor] = useState<HeatMapFlavor>(
     HeatMapFlavor.Node
   )
 
   const {
-    utilLoading: loading,
+    utilLoading,
     utilError: error,
     utilCpuHeatMap,
     utilMemoryHeatMap,
@@ -58,10 +62,11 @@ export function ClusterMetrics() {
     fetchUtilization: true,
     utilizationFlavor: heatMapFlavor,
   })
+  const loading = utilLoading || deploymentSettingsLoading
 
   const {
     data: metricsData,
-    loading: metricsLoading,
+    loading: metricsQueryLoading,
     error: metricsError,
   } = useClusterMetricsQuery({
     variables: { clusterId: clusterId ?? '' },
@@ -69,13 +74,15 @@ export function ClusterMetrics() {
     fetchPolicy: 'cache-and-network',
     pollInterval: 60_000,
   })
+  const metricsLoading = metricsQueryLoading || deploymentSettingsLoading
 
   const { cpuMetrics, memMetrics, podsMetrics } = useMemo(
     () => processClusterMetrics(metricsData?.cluster),
     [metricsData?.cluster]
   )
 
-  if (!metricsEnabled) return <MetricsEmptyState />
+  if (!(metricsEnabled || deploymentSettingsLoading))
+    return <MetricsEmptyState />
 
   const hasMetrics =
     !isNull(cpuMetrics.total) &&
@@ -90,12 +97,15 @@ export function ClusterMetrics() {
         gap="small"
       >
         <Subtitle2H1>Metrics</Subtitle2H1>
-        <Card css={{ padding: spacing.xlarge }}>
+        <Card style={{ padding: hasMetrics ? spacing.xlarge : 0 }}>
           {!hasMetrics ? (
             metricsError ? (
               <GqlError error={metricsError} />
             ) : metricsLoading ? (
-              <LoadingIndicator />
+              <RectangleSkeleton
+                $height={306}
+                $width="100%"
+              />
             ) : (
               <EmptyState message="No metrics available." />
             )
@@ -148,15 +158,13 @@ export function ClusterMetrics() {
             </Select>
           </Flex>
         </Flex>
-        {!hasHeatmapData ? (
+        {!(hasHeatmapData || loading) ? (
           <Card css={{ padding: spacing.xlarge, flex: 1 }}>
             {error ? (
               <GqlError
                 css={{ width: '100%' }}
                 error={error}
               />
-            ) : loading ? (
-              <LoadingIndicator />
             ) : (
               <EmptyState message="Utilization heatmaps not available." />
             )}

--- a/assets/src/components/cd/cluster/ClusterNetwork.tsx
+++ b/assets/src/components/cd/cluster/ClusterNetwork.tsx
@@ -1,4 +1,7 @@
-import { useMetricsEnabled } from 'components/contexts/DeploymentSettingsContext'
+import {
+  useLoadingDeploymentSettings,
+  useMetricsEnabled,
+} from 'components/contexts/DeploymentSettingsContext'
 import { GqlError } from 'components/utils/Alert'
 import { NetworkGraph } from 'components/utils/network-graph/NetworkGraph'
 import { useClusterNetworkGraphQuery } from 'generated/graphql'
@@ -9,6 +12,7 @@ import { MetricsEmptyState } from './ClusterMetrics'
 export function ClusterNetwork() {
   const { clusterId = '' } = useParams()
   const metricsEnabled = useMetricsEnabled()
+  const deploymentSettingsLoading = useLoadingDeploymentSettings()
   const [timestamp, setTimestamp] = useState<string | undefined>(undefined)
 
   const {
@@ -21,13 +25,14 @@ export function ClusterNetwork() {
   })
   const data = newData || previousData
 
-  if (!metricsEnabled) return <MetricsEmptyState />
+  if (!(metricsEnabled || deploymentSettingsLoading))
+    return <MetricsEmptyState />
   if (error) return <GqlError error={error} />
 
   return (
     <NetworkGraph
       networkData={data?.cluster?.networkGraph ?? []}
-      loading={!data && loading}
+      loading={deploymentSettingsLoading || (!data && loading)}
       setTimestamp={setTimestamp}
       isTimestampSet={!!timestamp}
     />

--- a/assets/src/components/cd/cluster/ClusterServices.tsx
+++ b/assets/src/components/cd/cluster/ClusterServices.tsx
@@ -84,7 +84,9 @@ export default function ClusterServices() {
       setRefetch,
       clusterId,
       q,
-      setQ: (newQ: string) => setSearchParams({ ...(newQ && { q: newQ }) }),
+      setQ: (newQ: string) =>
+        (newQ || null) !== q &&
+        setSearchParams({ ...(newQ && { q: newQ }) }, { replace: true }),
     }),
     [setRefetch, clusterId, q, setSearchParams]
   )

--- a/assets/src/components/cd/cluster/upgrade-plan/ClusterUpgradePlan.tsx
+++ b/assets/src/components/cd/cluster/upgrade-plan/ClusterUpgradePlan.tsx
@@ -121,7 +121,7 @@ export function ClusterUpgradePlan() {
     fetchPolicy: 'cache-and-network',
   })
   const clusterBasic = basicData?.cluster
-  const kubeVersion = getClusterKubeVersion(clusterBasic)
+  const kubeVersion = getClusterKubeVersion(clusterBasic) ?? ''
   const parsedKubeVersion =
     semver.coerce(kubeVersion) ?? semver.coerce('1.21.0')
   const nextKubeVersion = `${parsedKubeVersion.major}.${parsedKubeVersion.minor + 1}`
@@ -133,7 +133,7 @@ export function ClusterUpgradePlan() {
       nextKubeVersion,
       hasKubeVersion: true,
     },
-    skip: !clusterBasic?.id,
+    skip: !clusterBasic?.id || !kubeVersion,
     fetchPolicy: 'cache-and-network',
     pollInterval: POLL_INTERVAL,
   })

--- a/assets/src/components/cd/clusters/info-flyover/ClusterInfoFlyover.tsx
+++ b/assets/src/components/cd/clusters/info-flyover/ClusterInfoFlyover.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  EmptyState,
   FillLevelProvider,
   Flex,
   Flyover,
@@ -9,16 +10,16 @@ import {
   useClusterOverviewDetailsQuery,
 } from 'generated/graphql'
 
-import semver from 'semver'
 import { POLL_INTERVAL } from 'components/cd/ContinuousDeployment.tsx'
 import { GqlError } from 'components/utils/Alert.tsx'
 import { ButtonGroup } from 'components/utils/ButtonGroup.tsx'
 import { DistroProviderIconFrame } from 'components/utils/ClusterDistro.tsx'
-import LoadingIndicator from 'components/utils/LoadingIndicator.tsx'
+import { RectangleSkeleton } from 'components/utils/SkeletonLoaders.tsx'
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { getClusterDetailsPath } from 'routes/cdRoutesConsts.tsx'
 import { getKubernetesAbsPath } from 'routes/kubernetesRoutesConsts.tsx'
+import semver from 'semver'
 import { getClusterKubeVersion } from '../runtime/RuntimeServices.tsx'
 import { HealthScoreTab } from './health/HealthScoreTab.tsx'
 import { OverviewTab } from './overview/OverviewTab.tsx'
@@ -103,7 +104,7 @@ function ClusterInfoFlyoverContent({
 }) {
   const [tab, setTab] = useState(initialTab)
 
-  const kubeVersion = getClusterKubeVersion(clusterBasic)
+  const kubeVersion = getClusterKubeVersion(clusterBasic) ?? ''
   const parsedKubeVersion =
     semver.coerce(kubeVersion) ?? semver.coerce('1.21.0')
   const nextKubeVersion = `${parsedKubeVersion.major}.${parsedKubeVersion.minor + 1}`
@@ -115,13 +116,12 @@ function ClusterInfoFlyoverContent({
       hasKubeVersion: true,
       id: clusterBasic?.id ?? '',
     },
+    skip: !clusterBasic?.id || !kubeVersion,
     fetchPolicy: 'cache-and-network',
     pollInterval: POLL_INTERVAL,
   })
-
   const cluster = data?.cluster
 
-  if (!cluster) return loading ? <LoadingIndicator /> : null
   if (error) return <GqlError error={error} />
 
   return (
@@ -140,14 +140,25 @@ function ClusterInfoFlyoverContent({
           tab={tab}
           onClick={(path) => setTab(path as ClusterInfoFlyoverTab)}
         />
-        {tab === ClusterInfoFlyoverTab.Overview && (
-          <OverviewTab
-            cluster={cluster}
-            setTab={setTab}
+        {cluster ? (
+          <>
+            {tab === ClusterInfoFlyoverTab.Overview && (
+              <OverviewTab
+                cluster={cluster}
+                setTab={setTab}
+              />
+            )}
+            {tab === ClusterInfoFlyoverTab.HealthScore && (
+              <HealthScoreTab cluster={cluster} />
+            )}
+          </>
+        ) : loading ? (
+          <RectangleSkeleton
+            $width="100%"
+            $height="100%"
           />
-        )}
-        {tab === ClusterInfoFlyoverTab.HealthScore && (
-          <HealthScoreTab cluster={cluster} />
+        ) : (
+          <EmptyState message="Cluster not found." />
         )}
       </Flex>
     </FillLevelProvider>

--- a/assets/src/components/cd/clusters/runtime/RuntimeServices.tsx
+++ b/assets/src/components/cd/clusters/runtime/RuntimeServices.tsx
@@ -16,7 +16,7 @@ import { RuntimeService, runtimeColumns } from './columns'
 export function getClusterKubeVersion(
   cluster: Nullable<Pick<ClustersRowFragment, 'currentVersion' | 'version'>>
 ) {
-  return cluster?.currentVersion || cluster?.version || '1.20.0'
+  return cluster?.currentVersion || cluster?.version
 }
 
 export function RuntimeServices({

--- a/assets/src/components/cd/services/Services.tsx
+++ b/assets/src/components/cd/services/Services.tsx
@@ -132,13 +132,21 @@ export default function Services() {
       clusterId,
       // we want empty strings omitted from the new params objects
       setClusterId: (newId: string) =>
-        setParams({ ...(q && { q }), ...(newId && { clusterId: newId }) }),
+        (newId || null) !== clusterId &&
+        setParams(
+          { ...(q && { q }), ...(newId && { clusterId: newId }) },
+          { replace: true }
+        ),
       q,
       setQ: (newQ: string) =>
-        setParams({
-          ...(clusterId && { clusterId }),
-          ...(newQ && { q: newQ }),
-        }),
+        (newQ || null) !== q &&
+        setParams(
+          {
+            ...(clusterId && { clusterId }),
+            ...(newQ && { q: newQ }),
+          },
+          { replace: true }
+        ),
     }
   }, [setRefetch, params, setParams])
 

--- a/assets/src/components/cd/services/service/ServiceNetwork.tsx
+++ b/assets/src/components/cd/services/service/ServiceNetwork.tsx
@@ -1,5 +1,8 @@
 import { MetricsEmptyState } from 'components/cd/cluster/ClusterMetrics'
-import { useMetricsEnabled } from 'components/contexts/DeploymentSettingsContext'
+import {
+  useLoadingDeploymentSettings,
+  useMetricsEnabled,
+} from 'components/contexts/DeploymentSettingsContext'
 import { GqlError } from 'components/utils/Alert'
 import { NetworkGraph } from 'components/utils/network-graph/NetworkGraph'
 import { useServiceNetworkGraphQuery } from 'generated/graphql'
@@ -9,6 +12,7 @@ import { useParams } from 'react-router-dom'
 export function ServiceNetwork() {
   const { serviceId = '' } = useParams()
   const metricsEnabled = useMetricsEnabled()
+  const deploymentSettingsLoading = useLoadingDeploymentSettings()
   const [timestamp, setTimestamp] = useState<string | undefined>(undefined)
 
   const {
@@ -21,13 +25,14 @@ export function ServiceNetwork() {
   })
   const data = newData || previousData
 
-  if (!metricsEnabled) return <MetricsEmptyState />
+  if (!(metricsEnabled || deploymentSettingsLoading))
+    return <MetricsEmptyState />
   if (error) return <GqlError error={error} />
 
   return (
     <NetworkGraph
       networkData={data?.serviceDeployment?.networkGraph ?? []}
-      loading={!data && loading}
+      loading={deploymentSettingsLoading || (!data && loading)}
       setTimestamp={setTimestamp}
       isTimestampSet={!!timestamp}
       enableNamespaceFilter={false}

--- a/assets/src/components/utils/PropCard.tsx
+++ b/assets/src/components/utils/PropCard.tsx
@@ -1,14 +1,17 @@
 import { Card, CardProps } from '@pluralsh/design-system'
-import { ReactElement } from 'react'
+import { ReactNode } from 'react'
 import { useTheme } from 'styled-components'
+import { RectangleSkeleton } from './SkeletonLoaders.tsx'
+import { StretchedFlex } from './StretchedFlex.tsx'
 import { OverlineH1 } from './typography/Text.tsx'
 
 export default function PropCard({
   title,
   titleContent,
   children,
+  loading,
   ...props
-}: { title: string; titleContent?: ReactElement<any> } & CardProps) {
+}: { title: string; titleContent?: ReactNode; loading?: boolean } & CardProps) {
   const theme = useTheme()
 
   return (
@@ -16,13 +19,7 @@ export default function PropCard({
       {...props}
       css={{ ...theme.partials.text.body2Bold, padding: theme.spacing.medium }}
     >
-      <div
-        css={{
-          alignItems: 'baseline',
-          display: 'flex',
-          justifyContent: 'space-between',
-        }}
-      >
+      <StretchedFlex align="baseline">
         <OverlineH1
           as="h3"
           css={{
@@ -33,8 +30,15 @@ export default function PropCard({
           {title}
         </OverlineH1>
         {titleContent}
-      </div>
-      {children}
+      </StretchedFlex>
+      {loading ? (
+        <RectangleSkeleton
+          $bright
+          $height="large"
+        />
+      ) : (
+        children
+      )}
     </Card>
   )
 }

--- a/assets/src/components/utils/network-graph/NetworkGraph.tsx
+++ b/assets/src/components/utils/network-graph/NetworkGraph.tsx
@@ -24,9 +24,9 @@ import { ComponentProps, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import styled, { useTheme } from 'styled-components'
 import { isNonNullable } from 'utils/isNonNullable'
-import LoadingIndicator from '../LoadingIndicator'
 import { Edge, EdgeType } from '../reactflow/edges'
 import { ReactFlowGraph } from '../reactflow/ReactFlowGraph'
+import { RectangleSkeleton } from '../SkeletonLoaders'
 import { TimestampSliderButton } from '../TimestampSlider'
 import { MeshWorkloadNode } from './NetworkGraphNodes'
 import { NetworkGraphStatistics } from './NetworkGraphStatistics'
@@ -163,7 +163,10 @@ function NetworkGraphInternal({
       <Card flex={1}>
         {isEmpty(networkData) ? (
           loading ? (
-            <LoadingIndicator />
+            <RectangleSkeleton
+              $height="100%"
+              $width="100%"
+            />
           ) : (
             <EmptyState message="No network data found." />
           )


### PR DESCRIPTION
finishes remaining cluster views not covered in https://github.com/pluralsh/console/pull/3253, specifically add-ons, metrics, and network
also removes several instances of back button navigation getting broken on a couple views (generally auditing this, part of PROD-4683)
Plural Flow: console