### PR TITLE
fix some workbench side panel jankiness

### DIFF
--- a/assets/src/components/ai/chatbot/SidePanelShared.tsx
+++ b/assets/src/components/ai/chatbot/SidePanelShared.tsx
@@ -20,6 +20,7 @@ const SidePanelWrapperSC = styled.div(({ theme }) => ({
   flexDirection: 'column',
   height: '100%',
   width: 'var(--side-panel-width)',
+  transition: 'width calc((1 - var(--is-dragging)) * 0.2s) ease-in-out',
   borderLeft: theme.borders.default,
   background: theme.colors['fill-accent'],
 }))
@@ -54,25 +55,24 @@ export const ResizeGripSC = styled.div(({ theme }) => ({
   },
 }))
 
-export const DragHandleSC = styled.div<{ $isDragging: boolean }>(
-  ({ theme, $isDragging }) => ({
-    position: 'absolute',
-    zIndex: theme.zIndexes.modal,
-    left: -HANDLE_THICKNESS / 2,
-    top: 0,
-    width: HANDLE_THICKNESS,
-    height: '100%',
-    cursor: 'ew-resize',
-    background: 'transparent',
-    display: 'flex',
-    justifyContent: 'center',
-    '&:focus-visible': { outline: theme.borders['outline-focused'] },
-    '&::before': {
-      content: '""',
-      pointerEvents: 'none',
-      width: HANDLE_THICKNESS / 4,
-      background: $isDragging ? theme.colors['icon-primary'] : 'transparent',
-      transition: 'background 0.2s ease-in-out',
-    },
-  })
-)
+export const DragHandleSC = styled.div(({ theme }) => ({
+  position: 'absolute',
+  zIndex: theme.zIndexes.modal,
+  left: -HANDLE_THICKNESS / 2,
+  top: 0,
+  width: HANDLE_THICKNESS,
+  height: '100%',
+  cursor: 'ew-resize',
+  background: 'transparent',
+  display: 'flex',
+  justifyContent: 'center',
+  '&:focus-visible': { outline: theme.borders['outline-focused'] },
+  '&::before': {
+    content: '""',
+    pointerEvents: 'none',
+    width: HANDLE_THICKNESS / 4,
+    background: theme.colors['icon-primary'],
+    opacity: 'var(--is-dragging)',
+    transition: 'opacity 0.2s ease-in-out',
+  },
+}))

--- a/assets/src/components/ai/chatbot/useResizeableChatPane.tsx
+++ b/assets/src/components/ai/chatbot/useResizeableChatPane.tsx
@@ -1,7 +1,7 @@
 import { useResizeObserver } from '@pluralsh/design-system'
 import usePersistedState from 'components/hooks/usePersistedState'
 import { clamp, isNil } from 'lodash'
-import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 const STORAGE_KEY = 'chatbot-panel-width'
 
@@ -29,16 +29,19 @@ export function useResizablePane(
     setPanelWidth(calculatedPanelWidth)
   )
 
-  const prevWidth = useRef<number>(calculatedPanelWidth)
-  const jumpToWidth = useEffectEvent((width: number) => {
-    prevWidth.current = calculatedPanelWidth
-    setPanelWidth(width)
-  })
   // snap to initial when provided, otherwise return to previous width before initial was set
-  useEffect(() => {
-    if (!isNil(initialWidthVw)) jumpToWidth(vwToPx(initialWidthVw))
-    else setPanelWidth(prevWidth.current)
-  }, [initialWidthVw, setPanelWidth])
+  const [prevInitialWidthVw, setPrevInitialWidthVw] =
+    useState<Nullable<number>>(null)
+  const [prevWidth, setPrevWidth] = useState<number>(calculatedPanelWidth)
+  if (initialWidthVw !== prevInitialWidthVw) {
+    setPrevInitialWidthVw(initialWidthVw)
+    if (!isNil(initialWidthVw)) {
+      setPrevWidth(calculatedPanelWidth)
+      setPanelWidth(vwToPx(initialWidthVw))
+    } else {
+      setPanelWidth(prevWidth)
+    }
+  }
 
   const handlePointerDown = (e: React.PointerEvent) => {
     e.preventDefault()

--- a/assets/src/components/layout/TopLevelSidePanel.tsx
+++ b/assets/src/components/layout/TopLevelSidePanel.tsx
@@ -99,13 +99,15 @@ export function TopLevelSidePanel() {
       >
         <div
           css={{ position: 'relative', height: '100%' }}
-          style={{ '--side-panel-width': `${calculatedPanelWidth}px` }}
+          style={{
+            '--side-panel-width': `${calculatedPanelWidth}px`,
+            '--is-dragging': isDragging ? '1' : '0',
+          }}
         >
           <TopLevelSidePanelContent sidePanel={sidePanel} />
           <DragHandleSC
             tabIndex={0}
             {...dragHandleProps}
-            $isDragging={isDragging}
           />
         </div>
       </AccordionItem>

--- a/assets/src/components/workbenches/workbench/job/WorkbenchJob.tsx
+++ b/assets/src/components/workbenches/workbench/job/WorkbenchJob.tsx
@@ -8,6 +8,7 @@ import {
 } from '@pluralsh/design-system'
 import { RunStatusChip } from 'components/ai/infra-research/details/InfraResearch'
 import { POLL_INTERVAL } from 'components/cd/ContinuousDeployment'
+import { useSidePanelWidth } from 'components/layout/TopLevelSidePanel'
 import { GqlError } from 'components/utils/Alert'
 import { Confirm } from 'components/utils/Confirm'
 import { useSimpleToast } from 'components/utils/SimpleToastContext'
@@ -19,7 +20,7 @@ import {
   WorkbenchJobStatus,
 } from 'generated/graphql'
 import { isEmpty, truncate } from 'lodash'
-import { useEffect, useEffectEvent, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import {
   getWorkbenchAbsPath,
@@ -33,6 +34,7 @@ import { isNonNullable } from 'utils/isNonNullable'
 import { WorkbenchToolIcon } from '../../tools/workbenchToolsUtils'
 import { SaveWorkbenchPromptButton } from '../SaveWorkbenchPromptButton'
 import { WorkbenchJobActivities } from './WorkbenchJobActivities'
+import { isJobRunning } from './WorkbenchJobActivity'
 import { useWorkbenchJobPanel } from './WorkbenchJobPanel'
 
 const MAX_VISIBLE_JOB_TOOLS = 3
@@ -41,13 +43,7 @@ export function WorkbenchJob() {
   const theme = useTheme()
   const { [WORKBENCH_JOBS_PARAM_JOB]: jobId = '' } = useParams()
   const { popToast } = useSimpleToast()
-  const { isOpen, setOpen } = useWorkbenchJobPanel()
   const [cancelModalOpen, setCancelModalOpen] = useState(false)
-
-  const onMount = useEffectEvent(() => setOpen(true))
-  useEffect(() => {
-    onMount()
-  }, [])
 
   const {
     data,
@@ -62,6 +58,15 @@ export function WorkbenchJob() {
 
   const job = data?.workbenchJob
   const isLoading = loading && !job
+
+  const { isOpen, setOpen } = useWorkbenchJobPanel(!!job?.id)
+  useSidePanelWidth({
+    maxWidthVw: 60,
+    initialWidthVw:
+      Boolean(job?.result?.conclusion) && !isJobRunning(job?.status)
+        ? 60
+        : undefined,
+  })
 
   const workbenchId = job?.workbench?.id ?? ''
   const workbenchName = job?.workbench?.name ?? 'workbench'

--- a/assets/src/components/workbenches/workbench/job/WorkbenchJobPanel.tsx
+++ b/assets/src/components/workbenches/workbench/job/WorkbenchJobPanel.tsx
@@ -13,14 +13,18 @@ import {
   SidePanelContent,
 } from 'components/ai/chatbot/SidePanelShared'
 import {
-  DEFAULT_MAX_WIDTH_VW,
   SidePanel,
-  useSidePanelWidth,
   useTopLevelSidePanel,
 } from 'components/layout/TopLevelSidePanel'
 import { useWorkbenchJobQuery, WorkbenchJobFragment } from 'generated/graphql'
-import { isEmpty } from 'lodash'
-import { ReactElement, useRef, useState } from 'react'
+import { isEmpty, isNil } from 'lodash'
+import {
+  ReactElement,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from 'react'
 import { matchPath, useLocation } from 'react-router-dom'
 import {
   WORKBENCH_JOB_ABS_PATH,
@@ -58,13 +62,6 @@ export function WorkbenchJobPanelContent() {
   })
   const job = data?.workbenchJob
   const isLoading = loading && !job
-
-  const hasConclusionWhileSettled =
-    Boolean(job?.result?.conclusion) && !isJobRunning(job?.status)
-  useSidePanelWidth({
-    maxWidthVw: 60,
-    initialWidthVw: hasConclusionWhileSettled ? 60 : DEFAULT_MAX_WIDTH_VW,
-  })
 
   const tabs = getPanelTabs(job)
 
@@ -131,13 +128,21 @@ export function WorkbenchJobPanelContent() {
   )
 }
 
-export function useWorkbenchJobPanel() {
+export function useWorkbenchJobPanel(autoOpen?: Nullable<boolean>) {
   const { sidePanel, setSidePanel } = useTopLevelSidePanel()
   const isOpen = sidePanel === SIDE_PANEL_TYPE
-  return {
-    isOpen,
-    setOpen: (open: boolean) => setSidePanel(open ? SIDE_PANEL_TYPE : null),
-  }
+  const setOpen = (open: boolean) => setSidePanel(open ? SIDE_PANEL_TYPE : null)
+
+  const onAutoOpen = useEffectEvent(() => setOpen(true))
+  const onUnmount = useEffectEvent(() => setOpen(false))
+  useEffect(() => {
+    if (!!autoOpen) onAutoOpen()
+    return () => {
+      if (!isNil(autoOpen)) onUnmount()
+    }
+  }, [autoOpen])
+
+  return { isOpen, setOpen }
 }
 
 const ContentWrapperSC = styled.div(() => ({


### PR DESCRIPTION
a few fixes here:
* adds an animation for when the side panel width changes while it's already open
* moves width update logic into the main job view instead of within the side panel content, and also waits until job data is loaded before opening, in both cases to ensure it initially opens to the correct width instead of flickering
* simplifies the logic for handling changes to initialWidthVw to fix a race condition the effect was causing

Plural Flow: console