### PR TITLE
fix: use hardened postgres image

### DIFF
--- a/go/cloud-query/db.Dockerfile
+++ b/go/cloud-query/db.Dockerfile
@@ -16,6 +16,13 @@ COPY hack/ hack/
 ARG TARGETOS
 ARG TARGETARCH
 
+# Install dependencies required by the installer script
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        bash \
+        curl \
+        ca-certificates
+
 # Set gcloud CLI download URL based on architecture
 RUN case ${TARGETARCH} in \
             amd64) GCLOUD_ARCH=x86_64 ;; \
@@ -26,13 +33,6 @@ RUN case ${TARGETARCH} in \
     mv google-cloud-sdk /opt/google-cloud-sdk && \
     /opt/google-cloud-sdk/install.sh --quiet
 
-# Install dependencies required by the installer script
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        bash \
-        curl \
-        ca-certificates
-
 # Run installer script and install
 # provider extensions for AWS, Azure, and GCP
 RUN mkdir -p /workspace/lib && \
@@ -40,27 +40,18 @@ RUN mkdir -p /workspace/lib && \
     /workspace/hack/postgres.sh -p azure -v ${AZURE_VERSION} -d /workspace/lib/ && \
     /workspace/hack/postgres.sh -p gcp -v ${GCP_VERSION} -d /workspace/lib/
 
-FROM postgres:${POSTGRES_VERSION}
+FROM dhi.io/postgres:${POSTGRES_VERSION}
 
 ARG POSTGRES_MAJOR_VERSION
 
-# Install CA certificates and upgrade packages to fix CVEs:
-# - openssl/libssl3t64: PKCS#12 NULL pointer dereference DoS (CVE in PKCS12_item_decrypt_d2i_ex)
-# - gpg: GnuPG out-of-bounds write (CVE in armor_filter, fixed in 2.4.7-21+deb13u1)
-# - libxml2: Uncontrolled recursion in XPath evaluation (CVE in xmlXPathRunEval, fixed in 2.12.7+dfsg+really2.9.14-2.1+deb13u2)
-# - libpcre2-8-0: PCRE2 heap-buffer-overflow read in match_ref (CVE in SCS verb handling, fixed in 10.46-1~deb13u1)
-RUN apt-get update && apt-get install -y ca-certificates openssl libssl3t64 gpg libxml2 libpcre2-8-0 && rm -rf /var/lib/apt/lists/* \
-    && update-ca-certificates
-
-COPY hack/init.sh /usr/local/bin/startup.sh
-RUN chmod +x /usr/local/bin/startup.sh
+COPY --chmod=755 hack/init.sh /usr/local/bin/startup.sh
 
 # Copy extension libraries
-COPY --from=libraries /workspace/lib/steampipe_postgres_*.so /usr/lib/postgresql/${POSTGRES_MAJOR_VERSION}/lib/
+COPY --from=libraries /workspace/lib/steampipe_postgres_*.so /opt/postgresql/${POSTGRES_MAJOR_VERSION}/lib/
 
 # Copy extension SQL and control files
-COPY --from=libraries /workspace/lib//steampipe_postgres_*.sql /usr/share/postgresql/${POSTGRES_MAJOR_VERSION}/extension/
-COPY --from=libraries /workspace/lib//steampipe_postgres_*.control /usr/share/postgresql/${POSTGRES_MAJOR_VERSION}/extension/
+COPY --from=libraries /workspace/lib/steampipe_postgres_*.sql /opt/postgresql/${POSTGRES_MAJOR_VERSION}/share/extension/
+COPY --from=libraries /workspace/lib/steampipe_postgres_*.control /opt/postgresql/${POSTGRES_MAJOR_VERSION}/share/extension/
 
 # Copy gcloud CLI
 COPY --from=libraries /opt/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud

--- a/go/cloud-query/hack/init.sh
+++ b/go/cloud-query/hack/init.sh
@@ -13,14 +13,16 @@ configure_pg_hba() {
 
     # Allow container-to-container TCP connections.
     while IFS= read -r line; do
-        case "$line" in
-            "host all all 0.0.0.0/0 scram-sha-256")
-                has_ipv4_rule=true
-                ;;
-            "host all all ::/0 scram-sha-256")
-                has_ipv6_rule=true
-                ;;
-        esac
+        set -- $line
+        if [ "$#" -lt 5 ]; then
+            continue
+        fi
+        if [ "$1" = "host" ] && [ "$2" = "all" ] && [ "$3" = "all" ] && [ "$4" = "0.0.0.0/0" ] && [ "$5" = "scram-sha-256" ]; then
+            has_ipv4_rule=true
+        fi
+        if [ "$1" = "host" ] && [ "$2" = "all" ] && [ "$3" = "all" ] && [ "$4" = "::/0" ] && [ "$5" = "scram-sha-256" ]; then
+            has_ipv6_rule=true
+        fi
     done < "$pg_hba"
 
     if [ "$has_ipv4_rule" = false ]; then
@@ -61,7 +63,15 @@ EOSQL
 fi
 
 # Create database if it doesn't exist (connect to postgres to avoid PGDATABASE override)
-DB_EXISTS=$(psql -U "$POSTGRES_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$POSTGRES_DB'")
+DB_EXISTS=$(
+    psql -v ON_ERROR_STOP=1 \
+      --set=postgres_db="$POSTGRES_DB" \
+      -U "$POSTGRES_USER" \
+      -d postgres \
+      -tA <<-'EOSQL'
+      SELECT 1 FROM pg_database WHERE datname = :'postgres_db';
+EOSQL
+)
 if [ "$DB_EXISTS" != "1" ]; then
   createdb -U "$POSTGRES_USER" "$POSTGRES_DB"
   echo "Database '$POSTGRES_DB' created successfully."

--- a/go/cloud-query/hack/init.sh
+++ b/go/cloud-query/hack/init.sh
@@ -4,12 +4,39 @@ set -e
 # Set default values if not provided
 POSTGRES_USER=${POSTGRES_USER:-postgres}
 POSTGRES_DB=${POSTGRES_DB:-postgres}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-}
+
+configure_pg_hba() {
+    local pg_hba="${PGDATA}/pg_hba.conf"
+    local has_ipv4_rule=false
+    local has_ipv6_rule=false
+
+    # Allow container-to-container TCP connections.
+    while IFS= read -r line; do
+        case "$line" in
+            "host all all 0.0.0.0/0 scram-sha-256")
+                has_ipv4_rule=true
+                ;;
+            "host all all ::/0 scram-sha-256")
+                has_ipv6_rule=true
+                ;;
+        esac
+    done < "$pg_hba"
+
+    if [ "$has_ipv4_rule" = false ]; then
+        echo "host all all 0.0.0.0/0 scram-sha-256" >> "$pg_hba"
+    fi
+    if [ "$has_ipv6_rule" = false ]; then
+        echo "host all all ::/0 scram-sha-256" >> "$pg_hba"
+    fi
+}
 
 # Initialize database if not already done (PGDATA is set by the base image)
 if [ ! -s "${PGDATA}/PG_VERSION" ]; then
     echo "ENTRYPOINT: Initializing database..."
     initdb --username="$POSTGRES_USER"
 fi
+configure_pg_hba
 
 # Start PostgreSQL in background (uses PGDATA from env)
 postgres &
@@ -23,9 +50,24 @@ done
 
 echo "PostgreSQL is ready. Creating extensions..."
 
+if [ -n "$POSTGRES_PASSWORD" ]; then
+    psql -v ON_ERROR_STOP=1 \
+      --set=postgres_user="$POSTGRES_USER" \
+      --set=postgres_password="$POSTGRES_PASSWORD" \
+      --username "$POSTGRES_USER" \
+      --dbname postgres <<-'EOSQL'
+      SELECT format('ALTER USER %I WITH PASSWORD %L', :'postgres_user', :'postgres_password') \gexec
+EOSQL
+fi
+
 # Create database if it doesn't exist (connect to postgres to avoid PGDATABASE override)
 DB_EXISTS=$(psql -U "$POSTGRES_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$POSTGRES_DB'")
-[ "$DB_EXISTS" != "1" ] && createdb -U "$POSTGRES_USER" "$POSTGRES_DB"
+if [ "$DB_EXISTS" != "1" ]; then
+  createdb -U "$POSTGRES_USER" "$POSTGRES_DB"
+  echo "Database '$POSTGRES_DB' created successfully."
+else
+  echo "Database '$POSTGRES_DB' already exists."
+fi
 
 if psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
   CREATE EXTENSION IF NOT EXISTS steampipe_postgres_aws;

--- a/go/cloud-query/hack/init.sh
+++ b/go/cloud-query/hack/init.sh
@@ -5,8 +5,14 @@ set -e
 POSTGRES_USER=${POSTGRES_USER:-postgres}
 POSTGRES_DB=${POSTGRES_DB:-postgres}
 
-# Start PostgreSQL in background
-/usr/local/bin/docker-entrypoint.sh "$@" &
+# Initialize database if not already done (PGDATA is set by the base image)
+if [ ! -s "${PGDATA}/PG_VERSION" ]; then
+    echo "ENTRYPOINT: Initializing database..."
+    initdb --username="$POSTGRES_USER"
+fi
+
+# Start PostgreSQL in background (uses PGDATA from env)
+postgres &
 PG_PID=$!
 
 # Wait for PostgreSQL to be ready
@@ -16,6 +22,10 @@ until pg_isready -U "$POSTGRES_USER"; do
 done
 
 echo "PostgreSQL is ready. Creating extensions..."
+
+# Create database if it doesn't exist (connect to postgres to avoid PGDATABASE override)
+DB_EXISTS=$(psql -U "$POSTGRES_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$POSTGRES_DB'")
+[ "$DB_EXISTS" != "1" ] && createdb -U "$POSTGRES_USER" "$POSTGRES_DB"
 
 if psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
   CREATE EXTENSION IF NOT EXISTS steampipe_postgres_aws;
@@ -29,7 +39,6 @@ then
 else
     PSQL_EXIT_CODE=$?
     echo "ERROR: psql failed with exit code $PSQL_EXIT_CODE"
-    # Kill PostgreSQL and exit with error
     kill $PG_PID
     exit $PSQL_EXIT_CODE
 fi


### PR DESCRIPTION
**Dockerfile improvements:**

* Switched the base image from the official `postgres` image to hardened one `dhi.io/postgres`
* Updated extension library and SQL/control file installation paths from `/usr/lib` and `/usr/share` to `/opt/postgresql`, aligning with the new base image's directory structure.
* Improved Dockerfile layering by moving dependency installation for the installer script to an earlier stage and using `--chmod=755` for copying the startup script. 

**Database initialization and configuration enhancements:**

* The `init.sh` script now ensures the `pg_hba.conf` file allows container-to-container TCP connections by adding `scram-sha-256` rules for both IPv4 and IPv6 if not present.
* Database initialization is more robust: it checks for an existing database, sets the `POSTGRES_PASSWORD` if provided, and creates the target database if it doesn't already exist.
* Improved error handling: if extension creation fails, the script kills the background PostgreSQL process and exits with the correct code.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally and w/ dev env

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console