### PR TITLE
fix(cloud-query): use forked steampipe plugin versions to fix critical vulnerabilities

### DIFF
--- a/go/cloud-query/db.Dockerfile
+++ b/go/cloud-query/db.Dockerfile
@@ -5,9 +5,9 @@ FROM golang:1.26.2 AS libraries
 
 # Configure versions for Steampipe extensions
 # Do not use latest versions here, as they may not be compatible
-ARG AWS_VERSION=1.30.5
-ARG AZURE_VERSION=1.12.1
-ARG GCP_VERSION=1.13.2
+ARG AWS_VERSION=1.30.6
+ARG AZURE_VERSION=1.12.2
+ARG GCP_VERSION=1.13.3
 
 WORKDIR /workspace
 

--- a/go/cloud-query/db.Dockerfile
+++ b/go/cloud-query/db.Dockerfile
@@ -5,9 +5,9 @@ FROM golang:1.26.2 AS libraries
 
 # Configure versions for Steampipe extensions
 # Do not use latest versions here, as they may not be compatible
-ARG AWS_VERSION=1.30.6
-ARG AZURE_VERSION=1.12.2
-ARG GCP_VERSION=1.13.3
+ARG AWS_VERSION=1.30.7
+ARG AZURE_VERSION=1.12.3
+ARG GCP_VERSION=1.13.4
 
 WORKDIR /workspace
 

--- a/go/cloud-query/db.Dockerfile
+++ b/go/cloud-query/db.Dockerfile
@@ -5,9 +5,9 @@ FROM golang:1.26.2 AS libraries
 
 # Configure versions for Steampipe extensions
 # Do not use latest versions here, as they may not be compatible
-ARG AWS_VERSION=1.30.2
-ARG AZURE_VERSION=1.12.0
-ARG GCP_VERSION=1.13.0
+ARG AWS_VERSION=1.30.5
+ARG AZURE_VERSION=1.12.1
+ARG GCP_VERSION=1.13.2
 
 WORKDIR /workspace
 

--- a/go/cloud-query/hack/postgres.sh
+++ b/go/cloud-query/hack/postgres.sh
@@ -87,7 +87,7 @@ download_plugin() {
     return 0
   fi
 
-  local base_url="https://github.com/turbot/steampipe-plugin-${provider}"
+  local base_url="https://github.com/pluralsh/steampipe-plugin-${provider}"
   local temp_dir=$(mktemp -d)
   local download_url
 


### PR DESCRIPTION
This pull request updates the Steampipe extension versions and changes the plugin download source to use the Pluralsh GitHub organization.

Dependency updates:
* Updated Steampipe extension versions for AWS, Azure, and GCP to `1.30.7`, `1.12.3`, and `1.13.4` respectively in `go/cloud-query/db.Dockerfile`.

Source alignment:
* Changed the plugin download URL in `go/cloud-query/hack/postgres.sh` to use the `pluralsh` GitHub organization instead of `turbot`.

### Vulnerability Report

Before
<img width="1617" height="884" alt="image" src="https://github.com/user-attachments/assets/2f882c2f-a580-4b92-818e-d221851ad165" />


After
<img width="1596" height="973" alt="image" src="https://github.com/user-attachments/assets/2d41af6b-76de-42fc-ba08-82ecaa7ab4ed" />


## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
PR image on dev env

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console