### PR TITLE
fix(stacks): prevent rendering of VirtualList when stacks are empty

### DIFF
--- a/assets/src/components/stacks/Stacks.tsx
+++ b/assets/src/components/stacks/Stacks.tsx
@@ -309,7 +309,7 @@ export function Stacks() {
             }}
           />
         )}
-        {!isEmpty(stacks) && (
+        {(!isEmpty(stacks) || (!data && loading)) && (
           <VirtualList
             data={stacks}
             loading={!data && loading}

--- a/assets/src/components/stacks/Stacks.tsx
+++ b/assets/src/components/stacks/Stacks.tsx
@@ -309,22 +309,24 @@ export function Stacks() {
             }}
           />
         )}
-        <VirtualList
-          data={stacks}
-          loading={!data && loading}
-          skeletonProps={{ gap: 'xsmall', height: 80 }}
-          onVirtualSliceChange={setVirtualSlice}
-          hasNextPage={pageInfo?.hasNextPage}
-          isLoadingNextPage={loading}
-          loadNextPage={() => pageInfo?.hasNextPage && fetchNextPage()}
-          renderer={({ rowData, index }) => (
-            <StackEntry
-              stack={rowData}
-              active={rowData.id === stackId}
-              first={index === 0}
-            />
-          )}
-        />
+        {!isEmpty(stacks) && (
+          <VirtualList
+            data={stacks}
+            loading={!data && loading}
+            skeletonProps={{ gap: 'xsmall', height: 80 }}
+            onVirtualSliceChange={setVirtualSlice}
+            hasNextPage={pageInfo?.hasNextPage}
+            isLoadingNextPage={loading}
+            loadNextPage={() => pageInfo?.hasNextPage && fetchNextPage()}
+            renderer={({ rowData, index }) => (
+              <StackEntry
+                stack={rowData}
+                active={rowData.id === stackId}
+                first={index === 0}
+              />
+            )}
+          />
+        )}
         {isEmpty(stacks) &&
           !(isEmpty(debouncedSearchString) && isEmpty(searchTags)) && (
             <EmptyState message="No stacks match your query.">


### PR DESCRIPTION
This pull request makes a small update to the `Stacks` component to ensure that the `VirtualList` is only rendered when there are stacks to display. This prevents unnecessary rendering and improves the component's conditional logic. It also fixed an issue where some stacks were missing from the list after using search input and clearing it.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Locally

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.

Plural Flow: console