### PR TITLE
feat: Add full GitLab, Bitbucket, Azure DevOps SCM support

### DIFF
--- a/go/deployment-operator/go.mod
+++ b/go/deployment-operator/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.30
 	github.com/vmware-tanzu/velero v1.16.2
 	github.com/yuin/gopher-lua v1.1.1
+	gitlab.com/gitlab-org/api/client-go v1.46.0
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/time v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -216,8 +217,10 @@ require (
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter v1.8.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect

--- a/go/deployment-operator/go.mod
+++ b/go/deployment-operator/go.mod
@@ -246,6 +246,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
+	github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0 // indirect
 	github.com/minio/simdjson-go v0.4.5 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect

--- a/go/deployment-operator/go.sum
+++ b/go/deployment-operator/go.sum
@@ -473,6 +473,8 @@ github.com/grafana/pyroscope-go v1.2.7 h1:VWBBlqxjyR0Cwk2W6UrE8CdcdD80GOFNutj0Kb
 github.com/grafana/pyroscope-go v1.2.7/go.mod h1:o/bpSLiJYYP6HQtvcoVKiE9s5RiNgjYTj1DhiddP2Pc=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasnuOY813tbMN8i/a3Og=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
+github.com/graph-gophers/graphql-go v1.9.0 h1:yu0ucKHLc5qGpRwLYKIWtr9bOoxovkWasuBrPQwlHls=
+github.com/graph-gophers/graphql-go v1.9.0/go.mod h1:23olKZ7duEvHlF/2ELEoSZaY1aNPfShjP782SOoNTyM=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -489,8 +491,12 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-getter v1.8.0 h1:GMRdoMBDz12Mim366pWsRVIrrkugJ19rrmykkv0Nhzo=
 github.com/hashicorp/go-getter v1.8.0/go.mod h1:/K0O5zR6R72O3r2x3z2UHadiC0XHMbbzHO9pS8ZeJPA=
+github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
+github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
+github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
@@ -848,6 +854,8 @@ github.com/zclconf/go-cty v1.17.0 h1:seZvECve6XX4tmnvRzWtJNHdscMtYEx5R7bnnVyd/d0
 github.com/zclconf/go-cty v1.17.0/go.mod h1:wqFzcImaLTI6A5HfsRwB0nj5n0MRZFwmey8YoFPPs3U=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+gitlab.com/gitlab-org/api/client-go v1.46.0 h1:YxBWFZIFYKcGESCb9fpkwzouo+apyB9pr/XTWzNoL24=
+gitlab.com/gitlab-org/api/client-go v1.46.0/go.mod h1:FtgyU6g2HS5+fMhw6nLK96GBEEBx5MzntOiJWfIaiN8=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.etcd.io/etcd/api/v3 v3.6.6 h1:mcaMp3+7JawWv69p6QShYWS8cIWUOl32bFLb6qf8pOQ=

--- a/go/deployment-operator/go.sum
+++ b/go/deployment-operator/go.sum
@@ -457,6 +457,7 @@ github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.3.6 h1:GW/XbdyBFQ8Qe+YAmFU9uHLo7OnF5tL52HFAgMmyrf4=
@@ -588,6 +589,8 @@ github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBW
 github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
+github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0 h1:mmJCWLe63QvybxhW1iBmQWEaCKdc4SKgALfTNZ+OphU=
+github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0/go.mod h1:mDunUZ1IUJdJIRHvFb+LPBUtxe3AYB5MI6BMXNg8194=
 github.com/miekg/dns v1.1.68 h1:jsSRkNozw7G/mnmXULynzMNIsgY2dHC8LO6U6Ij2JEA=
 github.com/miekg/dns v1.1.68/go.mod h1:fujopn7TB3Pu3JM69XaawiU0wqjpL9/8xGop5UrTPps=
 github.com/minio/simdjson-go v0.4.5 h1:r4IQwjRGmWCQ2VeMc7fGiilu1z5du0gJ/I/FsKwgo5A=

--- a/go/deployment-operator/pkg/scm/azure_devops.go
+++ b/go/deployment-operator/pkg/scm/azure_devops.go
@@ -307,6 +307,8 @@ func (c *azureDevOpsClient) ReactToComment(_ context.Context, _ string, _ string
 	return nil
 }
 
+const adoBuildStatusCompleted = CICheckStatusCompleted
+
 // adoBranchName strips the "refs/heads/" prefix from an ADO ref name.
 func adoBranchName(ref string) string {
 	return strings.TrimPrefix(ref, "refs/heads/")
@@ -334,24 +336,24 @@ func adoBuildToCheck(status *adobuild.BuildStatus, result *adobuild.BuildResult)
 	switch *status {
 	case adobuild.BuildStatusValues.Completed:
 		if result == nil {
-			return "completed", ""
+			return adoBuildStatusCompleted, ""
 		}
 		switch *result {
 		case adobuild.BuildResultValues.Succeeded:
-			return "completed", "success"
+			return adoBuildStatusCompleted, CICheckConclusionSuccess
 		case adobuild.BuildResultValues.PartiallySucceeded:
-			return "completed", "neutral"
+			return adoBuildStatusCompleted, CICheckConclusionNeutral
 		case adobuild.BuildResultValues.Failed:
-			return "completed", "failure"
+			return adoBuildStatusCompleted, CICheckConclusionFailure
 		case adobuild.BuildResultValues.Canceled:
-			return "completed", "cancelled"
+			return adoBuildStatusCompleted, CICheckConclusionCancelled
 		default:
-			return "completed", ""
+			return adoBuildStatusCompleted, ""
 		}
 	case adobuild.BuildStatusValues.InProgress, adobuild.BuildStatusValues.Cancelling:
-		return "in_progress", ""
+		return CICheckStatusInProgress, ""
 	default: // NotStarted, Postponed
-		return "queued", ""
+		return CICheckStatusQueued, ""
 	}
 }
 
@@ -362,4 +364,3 @@ func adoTime(t *azuredevops.Time) time.Time {
 	}
 	return t.Time
 }
-

--- a/go/deployment-operator/pkg/scm/azure_devops.go
+++ b/go/deployment-operator/pkg/scm/azure_devops.go
@@ -1,0 +1,365 @@
+package scm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	adobuild "github.com/microsoft/azure-devops-go-api/azuredevops/v7/build"
+	adogit "github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+	"github.com/samber/lo"
+)
+
+// https://dev.azure.com/{org}/{project}/_git/{repo}/pullrequest/{id}
+var adoPRPatternDevAzure = regexp.MustCompile(`(?i)dev\.azure\.com/([^/]+)/([^/]+)/_git/([^/?#]+)/pullrequest/(\d+)`)
+
+// https://{org}.visualstudio.com/{project}/_git/{repo}/pullrequest/{id}
+var adoPRPatternVSO = regexp.MustCompile(`(?i)([^/.]+)\.visualstudio\.com/([^/]+)/_git/([^/?#]+)/pullrequest/(\d+)`)
+
+// adoParsedURL holds the fields extracted from an Azure DevOps PR URL.
+type adoParsedURL struct {
+	org     string
+	project string
+	repo    string
+	prID    int
+}
+
+// orgURL returns the organisation-scoped base URL used to create an SDK connection.
+func (p adoParsedURL) orgURL() string {
+	return fmt.Sprintf("https://dev.azure.com/%s", p.org)
+}
+
+// parseADOPRURL extracts org, project, repo and PR ID from both the
+// dev.azure.com and *.visualstudio.com URL formats.
+func parseADOPRURL(prURL string) (adoParsedURL, error) {
+	if m := adoPRPatternDevAzure.FindStringSubmatch(prURL); m != nil {
+		prID, err := strconv.Atoi(m[4])
+		if err != nil {
+			return adoParsedURL{}, fmt.Errorf("invalid PR ID in URL %s: %w", prURL, err)
+		}
+		return adoParsedURL{org: m[1], project: m[2], repo: m[3], prID: prID}, nil
+	}
+	if m := adoPRPatternVSO.FindStringSubmatch(prURL); m != nil {
+		prID, err := strconv.Atoi(m[4])
+		if err != nil {
+			return adoParsedURL{}, fmt.Errorf("invalid PR ID in URL %s: %w", prURL, err)
+		}
+		// visualstudio.com: org is the subdomain, API still lives at dev.azure.com
+		return adoParsedURL{org: m[1], project: m[2], repo: m[3], prID: prID}, nil
+	}
+	return adoParsedURL{}, fmt.Errorf("cannot parse Azure DevOps PR URL: %s", prURL)
+}
+
+// azureDevOpsClient implements the SCM Client interface for Azure DevOps.
+// It uses a PAT (Personal Access Token) for authentication via the official
+// Azure DevOps Go SDK.  If the token is in "username:pat" format the PAT
+// portion (after the colon) is extracted and used; otherwise the whole value
+// is treated as a bare PAT.
+type azureDevOpsClient struct {
+	pat string // bare Personal Access Token
+}
+
+func newAzureDevOpsClient(token string) *azureDevOpsClient {
+	pat := token
+	if idx := strings.Index(token, ":"); idx >= 0 {
+		pat = token[idx+1:]
+	}
+	return &azureDevOpsClient{pat: pat}
+}
+
+// connection creates an SDK connection scoped to the given organisation URL.
+func (c *azureDevOpsClient) connection(orgURL string) *azuredevops.Connection {
+	return azuredevops.NewPatConnection(orgURL, c.pat)
+}
+
+// gitClient returns an SDK Git client for the given organisation.
+func (c *azureDevOpsClient) gitClient(ctx context.Context, orgURL string) (adogit.Client, error) {
+	return adogit.NewClient(ctx, c.connection(orgURL))
+}
+
+// buildClient returns an SDK Build client for the given organisation.
+func (c *azureDevOpsClient) buildClient(ctx context.Context, orgURL string) (adobuild.Client, error) {
+	return adobuild.NewClient(ctx, c.connection(orgURL))
+}
+
+func (c *azureDevOpsClient) GetPRDetails(ctx context.Context, prURL string) (*PRDetails, error) {
+	parsed, err := parseADOPRURL(prURL)
+	if err != nil {
+		return nil, err
+	}
+
+	gc, err := c.gitClient(ctx, parsed.orgURL())
+	if err != nil {
+		return nil, fmt.Errorf("create git client: %w", err)
+	}
+
+	pr, err := gc.GetPullRequest(ctx, adogit.GetPullRequestArgs{
+		RepositoryId:  &parsed.repo,
+		PullRequestId: &parsed.prID,
+		Project:       &parsed.project,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get PR: %w", err)
+	}
+
+	comments, err := c.allComments(ctx, gc, parsed)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceRef := lo.FromPtr(pr.SourceRefName)
+
+	checks, err := c.ciChecks(ctx, parsed, sourceRef)
+	if err != nil {
+		// Build API access is optional — the PAT may not have Build (Read) scope.
+		// Log a warning and continue with empty CI checks rather than failing the whole call.
+		log.Printf("[azure-devops] warning: could not fetch CI checks (missing Build scope?): %v", err)
+		checks = nil
+	}
+
+	return &PRDetails{
+		Title:    lo.FromPtr(pr.Title),
+		Body:     lo.FromPtr(pr.Description),
+		HeadRef:  adoBranchName(sourceRef),
+		State:    adoPRState(pr.Status),
+		Comments: comments,
+		CIChecks: checks,
+	}, nil
+}
+
+func (c *azureDevOpsClient) allComments(ctx context.Context, gc adogit.Client, parsed adoParsedURL) ([]PRComment, error) {
+	threads, err := gc.GetThreads(ctx, adogit.GetThreadsArgs{
+		RepositoryId:  &parsed.repo,
+		PullRequestId: &parsed.prID,
+		Project:       &parsed.project,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get PR threads: %w", err)
+	}
+
+	var all []PRComment
+	for _, thread := range *threads {
+		if thread.IsDeleted != nil && *thread.IsDeleted {
+			continue
+		}
+		inline := thread.ThreadContext != nil
+		if thread.Comments == nil {
+			continue
+		}
+		for _, cm := range *thread.Comments {
+			if cm.IsDeleted != nil && *cm.IsDeleted {
+				continue
+			}
+			if cm.CommentType != nil && *cm.CommentType == adogit.CommentTypeValues.System {
+				continue
+			}
+			cType := PRCommentTypeIssue
+			if inline {
+				cType = PRCommentTypeReview
+			}
+			// Encode both thread ID and comment ID so ReactableID is unique
+			threadID := 0
+			if thread.Id != nil {
+				threadID = *thread.Id
+			}
+			cmID := 0
+			if cm.Id != nil {
+				cmID = *cm.Id
+			}
+			author := ""
+			if cm.Author != nil {
+				author = lo.FromPtr(cm.Author.UniqueName)
+			}
+			createdAt := adoTime(cm.PublishedDate)
+			all = append(all, PRComment{
+				ID:        fmt.Sprintf("%d-%d", threadID, cmID),
+				Type:      cType,
+				Author:    author,
+				Body:      lo.FromPtr(cm.Content),
+				CreatedAt: createdAt,
+			})
+		}
+	}
+	return all, nil
+}
+
+func (c *azureDevOpsClient) ciChecks(ctx context.Context, parsed adoParsedURL, sourceRefName string) ([]CICheck, error) {
+	bc, err := c.buildClient(ctx, parsed.orgURL())
+	if err != nil {
+		return nil, fmt.Errorf("create build client: %w", err)
+	}
+
+	top := 100
+	reason := adobuild.BuildReasonValues.PullRequest
+	args := adobuild.GetBuildsArgs{
+		Project:      &parsed.project,
+		ReasonFilter: &reason,
+		Top:          &top,
+	}
+	if sourceRefName != "" {
+		args.BranchName = &sourceRefName
+	}
+
+	resp, err := bc.GetBuilds(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("list PR builds: %w", err)
+	}
+
+	var all []CICheck
+	for _, b := range resp.Value {
+		status, conclusion := adoBuildToCheck(b.Status, b.Result)
+		name := ""
+		if b.Definition != nil {
+			name = lo.FromPtr(b.Definition.Name)
+		}
+		id := lo.FromPtr(b.Id)
+		all = append(all, CICheck{
+			Name:       name,
+			Status:     status,
+			Conclusion: conclusion,
+			CheckRunID: int64(id),
+		})
+	}
+	return all, nil
+}
+
+// GetCILogs fetches log content for an Azure DevOps build (checkRunID = build ID).
+// It concatenates the last few task logs, capped at 512 KB total.
+func (c *azureDevOpsClient) GetCILogs(ctx context.Context, prURL string, checkRunID int64) (string, error) {
+	parsed, err := parseADOPRURL(prURL)
+	if err != nil {
+		return "", err
+	}
+
+	bc, err := c.buildClient(ctx, parsed.orgURL())
+	if err != nil {
+		return "", fmt.Errorf("create build client: %w", err)
+	}
+
+	buildID := int(checkRunID)
+	logs, err := bc.GetBuildLogs(ctx, adobuild.GetBuildLogsArgs{
+		Project: &parsed.project,
+		BuildId: &buildID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("list build logs for build %d: %w", checkRunID, err)
+	}
+	if logs == nil || len(*logs) == 0 {
+		return "", fmt.Errorf("no logs found for build %d", checkRunID)
+	}
+
+	entries := *logs
+
+	// Fetch the last ≤3 log entries and concatenate, capped at 512 KB.
+	start := len(entries) - 3
+	if start < 0 {
+		start = 0
+	}
+
+	const maxBytes = 512 * 1024
+	var sb strings.Builder
+
+	for i := start; i < len(entries); i++ {
+		if entries[i].Id == nil {
+			continue
+		}
+		logID := *entries[i].Id
+		reader, err := bc.GetBuildLog(ctx, adobuild.GetBuildLogArgs{
+			Project: &parsed.project,
+			BuildId: &buildID,
+			LogId:   &logID,
+		})
+		if err != nil {
+			continue
+		}
+		remaining := maxBytes - sb.Len()
+		if remaining <= 0 {
+			_ = reader.Close()
+			break
+		}
+		raw, readErr := io.ReadAll(io.LimitReader(reader, int64(remaining)))
+		_ = reader.Close()
+		if readErr == nil && len(raw) > 0 {
+			sb.Write(raw)
+			sb.WriteByte('\n')
+		}
+	}
+
+	if sb.Len() > 0 {
+		return sb.String(), nil
+	}
+
+	// Fallback: return the URL of the last log entry.
+	if last := entries[len(entries)-1]; last.Url != nil {
+		return fmt.Sprintf("Logs available at: %s", *last.Url), nil
+	}
+	return "", fmt.Errorf("no logs available for build %d", checkRunID)
+}
+
+// ReactToComment is a no-op for Azure DevOps, there is no comment reaction API.
+func (c *azureDevOpsClient) ReactToComment(_ context.Context, _ string, _ string, _ CommentReactState) error {
+	return nil
+}
+
+// adoBranchName strips the "refs/heads/" prefix from an ADO ref name.
+func adoBranchName(ref string) string {
+	return strings.TrimPrefix(ref, "refs/heads/")
+}
+
+func adoPRState(status *adogit.PullRequestStatus) PRState {
+	if status == nil {
+		return PRStateOpen
+	}
+	switch *status {
+	case adogit.PullRequestStatusValues.Completed:
+		return PRStateMerged
+	case adogit.PullRequestStatusValues.Abandoned:
+		return PRStateClosed
+	default:
+		return PRStateOpen
+	}
+}
+
+// adoBuildToCheck maps Azure DevOps build status/result enums to (status, conclusion).
+func adoBuildToCheck(status *adobuild.BuildStatus, result *adobuild.BuildResult) (string, string) {
+	if status == nil {
+		return "queued", ""
+	}
+	switch *status {
+	case adobuild.BuildStatusValues.Completed:
+		if result == nil {
+			return "completed", ""
+		}
+		switch *result {
+		case adobuild.BuildResultValues.Succeeded:
+			return "completed", "success"
+		case adobuild.BuildResultValues.PartiallySucceeded:
+			return "completed", "neutral"
+		case adobuild.BuildResultValues.Failed:
+			return "completed", "failure"
+		case adobuild.BuildResultValues.Canceled:
+			return "completed", "cancelled"
+		default:
+			return "completed", ""
+		}
+	case adobuild.BuildStatusValues.InProgress, adobuild.BuildStatusValues.Cancelling:
+		return "in_progress", ""
+	default: // NotStarted, Postponed
+		return "queued", ""
+	}
+}
+
+// adoTime safely dereferences an *azuredevops.Time to a time.Time.
+func adoTime(t *azuredevops.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return t.Time
+}
+

--- a/go/deployment-operator/pkg/scm/bitbucket.go
+++ b/go/deployment-operator/pkg/scm/bitbucket.go
@@ -1,0 +1,462 @@
+package scm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const bbCloudAPIBase = "https://api.bitbucket.org/2.0"
+
+// Cloud:  https://bitbucket.org/{workspace}/{repo}/pull-requests/{id}
+var bbCloudPRPattern = regexp.MustCompile(`bitbucket\.org/([^/]+)/([^/]+)/pull-requests?/(\d+)`)
+
+// Data Center / Server:  https://{host}/projects/{PROJECT}/repos/{repo}/pull-requests/{id}
+var bbDCPRPattern = regexp.MustCompile(`/projects/([^/]+)/repos/([^/]+)/pull-requests?/(\d+)`)
+
+// newBitBucketClient returns a Cloud or Data Center client based on the host.
+func newBitBucketClient(token, host string) Client {
+	if host == "bitbucket.org" {
+		return &bitBucketCloudClient{token: token}
+	}
+	return &bitBucketDCClient{
+		token:   token,
+		baseURL: fmt.Sprintf("https://%s/rest", host),
+	}
+}
+
+type bitBucketCloudClient struct {
+	token string
+}
+
+type bbCloudPR struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	State       string `json:"state"` // OPEN, MERGED, DECLINED, SUPERSEDED
+	Source      struct {
+		Branch struct {
+			Name string `json:"name"`
+		} `json:"branch"`
+		Commit struct {
+			Hash string `json:"hash"`
+		} `json:"commit"`
+	} `json:"source"`
+}
+
+type bbCloudComment struct {
+	ID      int64 `json:"id"`
+	Content struct {
+		Raw string `json:"raw"`
+	} `json:"content"`
+	// The API returns the comment author under "user", not "author".
+	User struct {
+		Nickname string `json:"nickname"`
+	} `json:"user"`
+	CreatedOn string `json:"created_on"` // ISO 8601
+	Inline    *struct {
+		Path string `json:"path"`
+	} `json:"inline"` // non-null → inline diff comment
+	Deleted bool `json:"deleted"`
+}
+
+type bbCloudBuildStatus struct {
+	Key   string `json:"key"`
+	Name  string `json:"name"`
+	State string `json:"state"` // INPROGRESS, SUCCESSFUL, FAILED, STOPPED
+	URL   string `json:"url"`
+}
+
+func (c *bitBucketCloudClient) GetPRDetails(ctx context.Context, prURL string) (*PRDetails, error) {
+	workspace, repo, prID, err := parseCloudPRURL(prURL)
+	if err != nil {
+		return nil, err
+	}
+	var pr bbCloudPR
+	if err := c.get(ctx, fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%d", bbCloudAPIBase, workspace, repo, prID), &pr); err != nil {
+		return nil, fmt.Errorf("get PR: %w", err)
+	}
+	comments, err := c.allComments(ctx, workspace, repo, prID)
+	if err != nil {
+		return nil, err
+	}
+	checks, err := c.ciChecks(ctx, workspace, repo, pr.Source.Commit.Hash)
+	if err != nil {
+		return nil, err
+	}
+	return &PRDetails{
+		Title:    pr.Title,
+		Body:     pr.Description,
+		HeadRef:  pr.Source.Branch.Name,
+		State:    bbCloudState(pr.State),
+		Comments: comments,
+		CIChecks: checks,
+	}, nil
+}
+
+func (c *bitBucketCloudClient) allComments(ctx context.Context, workspace, repo string, prID int64) ([]PRComment, error) {
+	u := fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%d/comments?pagelen=100", bbCloudAPIBase, workspace, repo, prID)
+	var all []PRComment
+	for u != "" {
+		var page struct {
+			Values []bbCloudComment `json:"values"`
+			Next   string           `json:"next"`
+		}
+		if err := c.get(ctx, u, &page); err != nil {
+			return nil, fmt.Errorf("list PR comments: %w", err)
+		}
+		for _, cm := range page.Values {
+			if cm.Deleted {
+				continue
+			}
+			cType := PRCommentTypeIssue
+			if cm.Inline != nil {
+				cType = PRCommentTypeReview
+			}
+			all = append(all, PRComment{
+				ID:        strconv.FormatInt(cm.ID, 10),
+				Type:      cType,
+				Author:    cm.User.Nickname,
+				Body:      cm.Content.Raw,
+				CreatedAt: parseBBCloudTime(cm.CreatedOn),
+			})
+		}
+		u = page.Next
+	}
+	return all, nil
+}
+
+func (c *bitBucketCloudClient) ciChecks(ctx context.Context, workspace, repo, sha string) ([]CICheck, error) {
+	u := fmt.Sprintf("%s/repositories/%s/%s/commit/%s/statuses?pagelen=100", bbCloudAPIBase, workspace, repo, sha)
+	var all []CICheck
+	for u != "" {
+		var page struct {
+			Values []bbCloudBuildStatus `json:"values"`
+			Next   string               `json:"next"`
+		}
+		if err := c.get(ctx, u, &page); err != nil {
+			return nil, fmt.Errorf("list build statuses: %w", err)
+		}
+		for _, s := range page.Values {
+			status, conclusion := bbBuildStateToCheck(s.State)
+			all = append(all, CICheck{
+				Name:       s.Name,
+				Status:     status,
+				Conclusion: conclusion,
+				CheckRunID: bbHashKey(s.Key),
+			})
+		}
+		u = page.Next
+	}
+	return all, nil
+}
+
+func (c *bitBucketCloudClient) GetCILogs(ctx context.Context, prURL string, checkRunID int64) (string, error) {
+	workspace, repo, prID, err := parseCloudPRURL(prURL)
+	if err != nil {
+		return "", err
+	}
+	var pr bbCloudPR
+	if err := c.get(ctx, fmt.Sprintf("%s/repositories/%s/%s/pullrequests/%d", bbCloudAPIBase, workspace, repo, prID), &pr); err != nil {
+		return "", fmt.Errorf("get PR: %w", err)
+	}
+	u := fmt.Sprintf("%s/repositories/%s/%s/commit/%s/statuses?pagelen=100", bbCloudAPIBase, workspace, repo, pr.Source.Commit.Hash)
+	for u != "" {
+		var page struct {
+			Values []bbCloudBuildStatus `json:"values"`
+			Next   string               `json:"next"`
+		}
+		if err := c.get(ctx, u, &page); err != nil {
+			return "", fmt.Errorf("list build statuses: %w", err)
+		}
+		for _, s := range page.Values {
+			if bbHashKey(s.Key) == checkRunID && s.URL != "" {
+				return fmt.Sprintf("Logs available at: %s", s.URL), nil
+			}
+		}
+		u = page.Next
+	}
+	return "", fmt.Errorf("no logs found for check run %d", checkRunID)
+}
+
+// ReactToComment is a no-op for Bitbucket Cloud which has no emoji reaction API.
+func (c *bitBucketCloudClient) ReactToComment(_ context.Context, _ string, _ string, _ CommentReactState) error {
+	return nil
+}
+
+func (c *bitBucketCloudClient) get(ctx context.Context, u string, out any) error {
+	return bbGet(ctx, c.token, u, out)
+}
+
+func parseCloudPRURL(prURL string) (workspace, repo string, prID int64, err error) {
+	m := bbCloudPRPattern.FindStringSubmatch(prURL)
+	if m == nil {
+		return "", "", 0, fmt.Errorf("cannot parse Bitbucket Cloud PR URL: %s", prURL)
+	}
+	id, err := strconv.ParseInt(m[3], 10, 64)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid PR ID in URL %s: %w", prURL, err)
+	}
+	return m[1], m[2], id, nil
+}
+
+func bbCloudState(s string) PRState {
+	switch s {
+	case "MERGED":
+		return PRStateMerged
+	case "DECLINED", "SUPERSEDED":
+		return PRStateClosed
+	default:
+		return PRStateOpen
+	}
+}
+
+func parseBBCloudTime(s string) time.Time {
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+type bitBucketDCClient struct {
+	token   string // Bearer token or "email:token"
+	baseURL string // e.g. https://bitbucket.company.com/rest
+}
+
+// bbDCPage is the standard DC paginated response envelope.
+// Pagination uses ?start={nextPageStart} instead of a Next URL.
+type bbDCPage[T any] struct {
+	IsLastPage    bool `json:"isLastPage"`
+	NextPageStart int  `json:"nextPageStart"`
+	Values        []T  `json:"values"`
+}
+
+type bbDCPR struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	State       string `json:"state"` // OPEN, MERGED, DECLINED, SUPERSEDED
+	FromRef     struct {
+		DisplayId    string `json:"displayId"`
+		LatestCommit string `json:"latestCommit"`
+	} `json:"fromRef"`
+}
+
+type bbDCComment struct {
+	ID     int64  `json:"id"`
+	Text   string `json:"text"`
+	Author struct {
+		Slug string `json:"slug"`
+	} `json:"author"`
+	CreatedDate   int64 `json:"createdDate"` // Unix milliseconds
+	CommentAnchor *struct {
+		Path string `json:"path"`
+	} `json:"commentAnchor"` // non-null
+}
+
+type bbDCBuildStatus struct {
+	State string `json:"state"` // INPROGRESS, SUCCESSFUL, FAILED
+	Key   string `json:"key"`
+	Name  string `json:"name"`
+	URL   string `json:"url"`
+}
+
+func (c *bitBucketDCClient) GetPRDetails(ctx context.Context, prURL string) (*PRDetails, error) {
+	project, repo, prID, err := parseDCPRURL(prURL)
+	if err != nil {
+		return nil, err
+	}
+	var pr bbDCPR
+	if err := c.get(ctx, fmt.Sprintf("%s/api/1.0/projects/%s/repos/%s/pull-requests/%d", c.baseURL, project, repo, prID), &pr); err != nil {
+		return nil, fmt.Errorf("get PR: %w", err)
+	}
+	comments, err := c.allComments(ctx, project, repo, prID)
+	if err != nil {
+		return nil, err
+	}
+	checks, err := c.ciChecks(ctx, pr.FromRef.LatestCommit)
+	if err != nil {
+		return nil, err
+	}
+	return &PRDetails{
+		Title:    pr.Title,
+		Body:     pr.Description,
+		HeadRef:  pr.FromRef.DisplayId,
+		State:    bbDCState(pr.State),
+		Comments: comments,
+		CIChecks: checks,
+	}, nil
+}
+
+func (c *bitBucketDCClient) allComments(ctx context.Context, project, repo string, prID int64) ([]PRComment, error) {
+	var all []PRComment
+	start := 0
+	for {
+		u := fmt.Sprintf("%s/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments?limit=100&start=%d",
+			c.baseURL, project, repo, prID, start)
+		var page bbDCPage[bbDCComment]
+		if err := c.get(ctx, u, &page); err != nil {
+			return nil, fmt.Errorf("list PR comments: %w", err)
+		}
+		for _, cm := range page.Values {
+			cType := PRCommentTypeIssue
+			if cm.CommentAnchor != nil {
+				cType = PRCommentTypeReview
+			}
+			all = append(all, PRComment{
+				ID:        strconv.FormatInt(cm.ID, 10),
+				Type:      cType,
+				Author:    cm.Author.Slug,
+				Body:      cm.Text,
+				CreatedAt: time.UnixMilli(cm.CreatedDate).UTC(),
+			})
+		}
+		if page.IsLastPage {
+			break
+		}
+		start = page.NextPageStart
+	}
+	return all, nil
+}
+
+func (c *bitBucketDCClient) ciChecks(ctx context.Context, sha string) ([]CICheck, error) {
+	var all []CICheck
+	start := 0
+	for {
+		u := fmt.Sprintf("%s/build-status/1.0/commits/%s?limit=100&start=%d", c.baseURL, sha, start)
+		var page bbDCPage[bbDCBuildStatus]
+		if err := c.get(ctx, u, &page); err != nil {
+			return nil, fmt.Errorf("list build statuses: %w", err)
+		}
+		for _, s := range page.Values {
+			status, conclusion := bbBuildStateToCheck(s.State)
+			all = append(all, CICheck{
+				Name:       s.Name,
+				Status:     status,
+				Conclusion: conclusion,
+				CheckRunID: bbHashKey(s.Key),
+			})
+		}
+		if page.IsLastPage {
+			break
+		}
+		start = page.NextPageStart
+	}
+	return all, nil
+}
+
+func (c *bitBucketDCClient) GetCILogs(ctx context.Context, prURL string, checkRunID int64) (string, error) {
+	project, repo, prID, err := parseDCPRURL(prURL)
+	if err != nil {
+		return "", err
+	}
+	var pr bbDCPR
+	if err := c.get(ctx, fmt.Sprintf("%s/api/1.0/projects/%s/repos/%s/pull-requests/%d", c.baseURL, project, repo, prID), &pr); err != nil {
+		return "", fmt.Errorf("get PR: %w", err)
+	}
+	start := 0
+	for {
+		u := fmt.Sprintf("%s/build-status/1.0/commits/%s?limit=100&start=%d", c.baseURL, pr.FromRef.LatestCommit, start)
+		var page bbDCPage[bbDCBuildStatus]
+		if err := c.get(ctx, u, &page); err != nil {
+			return "", fmt.Errorf("list build statuses: %w", err)
+		}
+		for _, s := range page.Values {
+			if bbHashKey(s.Key) == checkRunID && s.URL != "" {
+				return fmt.Sprintf("Logs available at: %s", s.URL), nil
+			}
+		}
+		if page.IsLastPage {
+			break
+		}
+		start = page.NextPageStart
+	}
+	return "", fmt.Errorf("no logs found for check run %d", checkRunID)
+}
+
+// ReactToComment is a no-op for Bitbucket DC which has no emoji reaction API.
+func (c *bitBucketDCClient) ReactToComment(_ context.Context, _ string, _ string, _ CommentReactState) error {
+	return nil
+}
+
+func (c *bitBucketDCClient) get(ctx context.Context, u string, out any) error {
+	return bbGet(ctx, c.token, u, out)
+}
+
+func parseDCPRURL(prURL string) (project, repo string, prID int64, err error) {
+	m := bbDCPRPattern.FindStringSubmatch(prURL)
+	if m == nil {
+		return "", "", 0, fmt.Errorf("cannot parse Bitbucket Data Center PR URL: %s", prURL)
+	}
+	id, err := strconv.ParseInt(m[3], 10, 64)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid PR ID in URL %s: %w", prURL, err)
+	}
+	return m[1], m[2], id, nil
+}
+
+func bbDCState(s string) PRState {
+	switch s {
+	case "MERGED":
+		return PRStateMerged
+	case "DECLINED", "SUPERSEDED":
+		return PRStateClosed
+	default:
+		return PRStateOpen
+	}
+}
+
+// bbGet performs an authenticated GET and JSON-decodes the response body.
+// Supports Bearer tokens and "username:password" Basic auth.
+func bbGet(ctx context.Context, token, u string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(token, ":") {
+		parts := strings.SplitN(token, ":", 2)
+		req.SetBasicAuth(parts[0], parts[1])
+	} else {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// bbHashKey maps a Bitbucket build status key to a stable int64 via FNV-64a.
+func bbHashKey(key string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	return int64(h.Sum64())
+}
+
+// bbBuildStateToCheck maps INPROGRESS/SUCCESSFUL/FAILED/STOPPED → (status, conclusion).
+func bbBuildStateToCheck(state string) (status, conclusion string) {
+	switch state {
+	case "SUCCESSFUL":
+		return "completed", "success"
+	case "FAILED":
+		return "completed", "failed"
+	case "STOPPED":
+		return "completed", "canceled"
+	default: // INPROGRESS
+		return "in_progress", ""
+	}
+}

--- a/go/deployment-operator/pkg/scm/bitbucket.go
+++ b/go/deployment-operator/pkg/scm/bitbucket.go
@@ -451,12 +451,12 @@ func bbHashKey(key string) int64 {
 func bbBuildStateToCheck(state string) (status, conclusion string) {
 	switch state {
 	case "SUCCESSFUL":
-		return "completed", "success"
+		return CICheckStatusCompleted, CICheckConclusionSuccess
 	case "FAILED":
-		return "completed", "failed"
+		return CICheckStatusCompleted, "failed"
 	case "STOPPED":
-		return "completed", "canceled"
+		return CICheckStatusCompleted, "canceled"
 	default: // INPROGRESS
-		return "in_progress", ""
+		return CICheckStatusInProgress, ""
 	}
 }

--- a/go/deployment-operator/pkg/scm/gitlab.go
+++ b/go/deployment-operator/pkg/scm/gitlab.go
@@ -3,29 +3,238 @@ package scm
 import (
 	"context"
 	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+
+	gogitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
-// gitLabClient is a stub. Full implementation is pending.
+// gitlabMRPattern matches GitLab MR URLs, e.g.
+// https://gitlab.com/group/subgroup/project/-/merge_requests/123
+var gitlabMRPattern = regexp.MustCompile(`gitlab(?:\.[^/]+)?/(.+?)/-/merge_requests/(\d+)`)
+
 type gitLabClient struct {
-	token   string
-	baseURL string
+	gl *gogitlab.Client
 }
 
 func newGitLabClient(token, host string) *gitLabClient {
-	return &gitLabClient{
-		token:   token,
-		baseURL: fmt.Sprintf("https://%s", host),
+	baseURL := fmt.Sprintf("https://%s/", host)
+	gl, _ := gogitlab.NewClient(token, gogitlab.WithBaseURL(baseURL))
+	return &gitLabClient{gl: gl}
+}
+
+func (c *gitLabClient) GetPRDetails(ctx context.Context, prURL string) (*PRDetails, error) {
+	projectPath, mrIID, err := parseGitLabMRURL(prURL)
+	if err != nil {
+		return nil, err
 	}
+
+	mr, _, err := c.gl.MergeRequests.GetMergeRequest(projectPath, mrIID, nil, gogitlab.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("get MR: %w", err)
+	}
+
+	comments, err := c.allComments(ctx, projectPath, mrIID)
+	if err != nil {
+		return nil, err
+	}
+
+	checks, err := c.ciChecks(ctx, projectPath, mr.SHA)
+	if err != nil {
+		return nil, err
+	}
+
+	state := PRStateOpen
+	if mr.State == "merged" {
+		state = PRStateMerged
+	} else if mr.State == "closed" {
+		state = PRStateClosed
+	}
+
+	return &PRDetails{
+		Title:    mr.Title,
+		Body:     mr.Description,
+		HeadRef:  mr.SourceBranch,
+		State:    state,
+		Comments: comments,
+		CIChecks: checks,
+	}, nil
 }
 
-func (c *gitLabClient) GetPRDetails(_ context.Context, prURL string) (*PRDetails, error) {
-	return nil, fmt.Errorf("GitLab SCM support not yet implemented (PR URL: %s)", prURL)
+func (c *gitLabClient) allComments(ctx context.Context, projectPath string, mrIID int64) ([]PRComment, error) {
+	var all []PRComment
+	noteOpts := &gogitlab.ListMergeRequestNotesOptions{ListOptions: gogitlab.ListOptions{PerPage: 100}}
+	for {
+		notes, resp, err := c.gl.Notes.ListMergeRequestNotes(projectPath, mrIID, noteOpts, gogitlab.WithContext(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("list MR notes: %w", err)
+		}
+		for _, n := range notes {
+			if n.System {
+				continue
+			}
+			all = append(all, PRComment{
+				ID:        strconv.FormatInt(n.ID, 10),
+				Type:      PRCommentTypeIssue,
+				Author:    n.Author.Username,
+				Body:      n.Body,
+				CreatedAt: *n.CreatedAt,
+			})
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		noteOpts.Page = resp.NextPage
+	}
+
+	// Inline review notes from discussions
+	discOpts := &gogitlab.ListMergeRequestDiscussionsOptions{ListOptions: gogitlab.ListOptions{PerPage: 100}}
+	for {
+		discussions, resp, err := c.gl.Discussions.ListMergeRequestDiscussions(projectPath, mrIID, discOpts, gogitlab.WithContext(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("list MR discussions: %w", err)
+		}
+		for _, d := range discussions {
+			for _, n := range d.Notes {
+				if n.System || n.Position == nil {
+					continue // skip system notes and non-inline notes
+				}
+				all = append(all, PRComment{
+					ID:        strconv.FormatInt(n.ID, 10),
+					Type:      PRCommentTypeReview,
+					Author:    n.Author.Username,
+					Body:      n.Body,
+					CreatedAt: *n.CreatedAt,
+				})
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		discOpts.Page = resp.NextPage
+	}
+
+	return all, nil
 }
 
-func (c *gitLabClient) GetCILogs(_ context.Context, prURL string, _ int64) (string, error) {
-	return "", fmt.Errorf("GitLab SCM support not yet implemented (PR URL: %s)", prURL)
+func (c *gitLabClient) ciChecks(ctx context.Context, projectPath, sha string) ([]CICheck, error) {
+	pipelineOpts := &gogitlab.ListProjectPipelinesOptions{
+		SHA:         &sha,
+		ListOptions: gogitlab.ListOptions{PerPage: 10},
+	}
+	pipelines, _, err := c.gl.Pipelines.ListProjectPipelines(projectPath, pipelineOpts, gogitlab.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("list pipelines: %w", err)
+	}
+
+	var all []CICheck
+	for _, p := range pipelines {
+		jobs, _, err := c.gl.Jobs.ListPipelineJobs(projectPath, int64(p.ID), &gogitlab.ListJobsOptions{ListOptions: gogitlab.ListOptions{PerPage: 100}}, gogitlab.WithContext(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("list pipeline jobs for pipeline %d: %w", p.ID, err)
+		}
+		for _, j := range jobs {
+			conclusion := ""
+			switch j.Status {
+			case "success", "failed", "canceled", "skipped":
+				conclusion = j.Status
+			}
+			all = append(all, CICheck{
+				Name:       j.Name,
+				Status:     j.Status,
+				Conclusion: conclusion,
+				CheckRunID: j.ID,
+			})
+		}
+	}
+	return all, nil
 }
 
-func (c *gitLabClient) ReactToComment(_ context.Context, prURL string, _ string, _ CommentReactState) error {
-	return fmt.Errorf("GitLab SCM support not yet implemented (PR URL: %s)", prURL)
+func (c *gitLabClient) GetCILogs(ctx context.Context, prURL string, checkRunID int64) (string, error) {
+	projectPath, _, err := parseGitLabMRURL(prURL)
+	if err != nil {
+		return "", err
+	}
+
+	reader, _, err := c.gl.Jobs.GetTraceFile(projectPath, checkRunID, gogitlab.WithContext(ctx))
+	if err != nil {
+		return "", fmt.Errorf("get job trace for job %d: %w", checkRunID, err)
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(reader, 512*1024))
+	if err != nil {
+		return "", fmt.Errorf("read job trace: %w", err)
+	}
+	return string(raw), nil
+}
+
+// ReactToComment adds a GitLab award emoji to an MR note.
+func (c *gitLabClient) ReactToComment(ctx context.Context, prURL string, reactableID string, state CommentReactState) error {
+	projectPath, mrIID, err := parseGitLabMRURL(prURL)
+	if err != nil {
+		return err
+	}
+
+	parts := strings.SplitN(reactableID, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid reactableID %q: expected format type:numericID", reactableID)
+	}
+	noteID, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid comment ID %q: %w", parts[1], err)
+	}
+
+	if state == CommentReactStateComplete {
+		// Best-effort removal of the "eyes" emoji we previously added.
+		_ = c.deleteAwardEmojiOnNote(ctx, projectPath, mrIID, noteID, "eyes")
+	}
+
+	emoji := "eyes"
+	if state == CommentReactStateComplete {
+		emoji = "thumbsup"
+	}
+
+	_, _, err = c.gl.AwardEmoji.CreateMergeRequestAwardEmojiOnNote(
+		projectPath, mrIID, noteID,
+		&gogitlab.CreateAwardEmojiOptions{Name: emoji},
+		gogitlab.WithContext(ctx),
+	)
+	return err
+}
+
+// deleteAwardEmojiOnNote removes the first matching emoji from an MR note.
+func (c *gitLabClient) deleteAwardEmojiOnNote(ctx context.Context, projectPath string, mrIID, noteID int64, emojiName string) error {
+	emojis, _, err := c.gl.AwardEmoji.ListMergeRequestAwardEmojiOnNote(
+		projectPath, mrIID, noteID,
+		&gogitlab.ListAwardEmojiOptions{},
+		gogitlab.WithContext(ctx),
+	)
+	if err != nil {
+		return err
+	}
+	for _, e := range emojis {
+		if e.Name == emojiName {
+			_, err = c.gl.AwardEmoji.DeleteMergeRequestAwardEmojiOnNote(
+				projectPath, mrIID, noteID, e.ID,
+				gogitlab.WithContext(ctx),
+			)
+			return err
+		}
+	}
+	return nil
+}
+
+// parseGitLabMRURL extracts the project path and MR IID from a GitLab MR URL.
+func parseGitLabMRURL(prURL string) (string, int64, error) {
+	m := gitlabMRPattern.FindStringSubmatch(prURL)
+	if m == nil {
+		return "", 0, fmt.Errorf("cannot parse GitLab MR URL: %s", prURL)
+	}
+	mrIID, err := strconv.ParseInt(m[2], 10, 64)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid MR IID in URL %s: %w", prURL, err)
+	}
+	return m[1], mrIID, nil
 }

--- a/go/deployment-operator/pkg/scm/gitlab.go
+++ b/go/deployment-operator/pkg/scm/gitlab.go
@@ -18,6 +18,9 @@ import (
 const (
 	gitlabJobStatusFailed   = "failed"
 	gitlabJobStatusCanceled = "canceled"
+
+	gitlabMRStateMerged = "merged"
+	gitlabMRStateClosed = "closed"
 )
 
 // gitlabMRPattern matches GitLab MR URLs, e.g.
@@ -56,9 +59,10 @@ func (c *gitLabClient) GetPRDetails(ctx context.Context, prURL string) (*PRDetai
 	}
 
 	state := PRStateOpen
-	if mr.State == "merged" {
+	switch mr.State {
+	case gitlabMRStateMerged:
 		state = PRStateMerged
-	} else if mr.State == "closed" {
+	case gitlabMRStateClosed:
 		state = PRStateClosed
 	}
 

--- a/go/deployment-operator/pkg/scm/gitlab.go
+++ b/go/deployment-operator/pkg/scm/gitlab.go
@@ -12,6 +12,14 @@ import (
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
+// gitlabJobStatusFailed and gitlabJobStatusCanceled are the raw GitLab job
+// status strings for terminal states (distinct from the shared "failure" /
+// "cancelled" conclusion constants which follow the GitHub naming convention).
+const (
+	gitlabJobStatusFailed   = "failed"
+	gitlabJobStatusCanceled = "canceled"
+)
+
 // gitlabMRPattern matches GitLab MR URLs, e.g.
 // https://gitlab.com/group/subgroup/project/-/merge_requests/123
 var gitlabMRPattern = regexp.MustCompile(`gitlab(?:\.[^/]+)?/(.+?)/-/merge_requests/(\d+)`)
@@ -139,7 +147,7 @@ func (c *gitLabClient) ciChecks(ctx context.Context, projectPath, sha string) ([
 		for _, j := range jobs {
 			conclusion := ""
 			switch j.Status {
-			case "success", "failed", "canceled", "skipped":
+			case CICheckConclusionSuccess, gitlabJobStatusFailed, gitlabJobStatusCanceled, CICheckConclusionSkipped:
 				conclusion = j.Status
 			}
 			all = append(all, CICheck{

--- a/go/deployment-operator/pkg/scm/gitlab.go
+++ b/go/deployment-operator/pkg/scm/gitlab.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/samber/lo"
 	gogitlab "gitlab.com/gitlab-org/api/client-go"
 )
 
@@ -72,15 +73,15 @@ func (c *gitLabClient) allComments(ctx context.Context, projectPath string, mrII
 			return nil, fmt.Errorf("list MR notes: %w", err)
 		}
 		for _, n := range notes {
-			if n.System {
-				continue
+			if n.System || n.Position != nil {
+				continue // skip system notes and inline notes
 			}
 			all = append(all, PRComment{
 				ID:        strconv.FormatInt(n.ID, 10),
 				Type:      PRCommentTypeIssue,
 				Author:    n.Author.Username,
 				Body:      n.Body,
-				CreatedAt: *n.CreatedAt,
+				CreatedAt: lo.FromPtr(n.CreatedAt),
 			})
 		}
 		if resp.NextPage == 0 {
@@ -106,7 +107,7 @@ func (c *gitLabClient) allComments(ctx context.Context, projectPath string, mrII
 					Type:      PRCommentTypeReview,
 					Author:    n.Author.Username,
 					Body:      n.Body,
-					CreatedAt: *n.CreatedAt,
+					CreatedAt: lo.FromPtr(n.CreatedAt),
 				})
 			}
 		}
@@ -158,11 +159,13 @@ func (c *gitLabClient) GetCILogs(ctx context.Context, prURL string, checkRunID i
 		return "", err
 	}
 
-	reader, _, err := c.gl.Jobs.GetTraceFile(projectPath, checkRunID, gogitlab.WithContext(ctx))
+	reader, resp, err := c.gl.Jobs.GetTraceFile(projectPath, checkRunID, gogitlab.WithContext(ctx))
 	if err != nil {
 		return "", fmt.Errorf("get job trace for job %d: %w", checkRunID, err)
 	}
-
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	raw, err := io.ReadAll(io.LimitReader(reader, 512*1024))
 	if err != nil {
 		return "", fmt.Errorf("read job trace: %w", err)

--- a/go/deployment-operator/pkg/scm/scm.go
+++ b/go/deployment-operator/pkg/scm/scm.go
@@ -132,8 +132,12 @@ func (d *dispatchClient) clientFor(prURL string) (Client, error) {
 		return newGitHubClient(d.token, host), nil
 	case strings.Contains(host, "gitlab"):
 		return newGitLabClient(d.token, host), nil
+	case strings.Contains(host, "bitbucket"):
+		return newBitBucketClient(d.token, host), nil
+	case host == "dev.azure.com" || strings.HasSuffix(host, ".visualstudio.com"):
+		return newAzureDevOpsClient(d.token), nil
 	default:
-		return nil, fmt.Errorf("unsupported SCM host %q: only GitHub and GitLab are supported", host)
+		return nil, fmt.Errorf("unsupported SCM host %q: only GitHub, GitLab, Bitbucket and Azure DevOps are supported", host)
 	}
 }
 

--- a/go/deployment-operator/pkg/scm/scm.go
+++ b/go/deployment-operator/pkg/scm/scm.go
@@ -57,11 +57,27 @@ func (c PRComment) ReactableID() string {
 	return string(c.Type) + ":" + c.ID
 }
 
+// CICheckStatus values for CICheck.Status.
+const (
+	CICheckStatusQueued     = "queued"
+	CICheckStatusInProgress = "in_progress"
+	CICheckStatusCompleted  = "completed"
+)
+
+// CICheckConclusion values for CICheck.Conclusion.
+const (
+	CICheckConclusionSuccess   = "success"
+	CICheckConclusionFailure   = "failure"
+	CICheckConclusionNeutral   = "neutral"
+	CICheckConclusionCancelled = "cancelled"
+	CICheckConclusionSkipped   = "skipped"
+)
+
 // CICheck is a single CI check run or commit status.
 type CICheck struct {
 	Name       string
-	Status     string // "queued", "in_progress", "completed"
-	Conclusion string // "success", "failure", "neutral", "cancelled", "skipped", "timed_out", ""
+	Status     string // CICheckStatusQueued, CICheckStatusInProgress, CICheckStatusCompleted
+	Conclusion string // CICheckConclusionSuccess, …, or ""
 	// CheckRunID is the provider-specific ID used to fetch logs (GitHub check run ID).
 	CheckRunID int64
 }

--- a/go/deployment-operator/pkg/scm/scm.go
+++ b/go/deployment-operator/pkg/scm/scm.go
@@ -76,8 +76,8 @@ const (
 // CICheck is a single CI check run or commit status.
 type CICheck struct {
 	Name       string
-	Status     string // CICheckStatusQueued, CICheckStatusInProgress, CICheckStatusCompleted
-	Conclusion string // CICheckConclusionSuccess, …, or ""
+	Status     string // "queued", "in_progress", "completed"
+	Conclusion string // "success", "failure", "neutral", "cancelled", "skipped", "timed_out", ""
 	// CheckRunID is the provider-specific ID used to fetch logs (GitHub check run ID).
 	CheckRunID int64
 }


### PR DESCRIPTION
Implements the Client interface for 
 - GitLab
 - Bitbucket Cloud
 - Azure DevOps Repos

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.your-env.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).
  - [ ] Agent starts successfully.
  - [ ] Service creation works without any issues when using raw manifests and Helm templates.
  - [ ] Service creation works when resources contain both CRD and CRD instances.
  - [ ] Service templating works correctly.
  - [ ] Service errors are reported properly and visible in the UI.
  - [ ] Service updates are reflected properly in the cluster.
  - [ ] Service resync triggers immediately and works as expected.
  - [ ] Sync waves annotations are respected.
  - [ ] Sync phases annotations are respected. Phases are executed in the correct order.
  - [ ] Sync hook delete policies are respected. Resources are not recreated once they reach the desired state.
  - [ ] Service deletion works and cleanups resources properly.
  - [ ] Services can be recreated after deletion.
  - [ ] Service detachment works and keeps resources unaffected.
  - [ ] Services can be recreated after detachment.
  - [ ] Service component trees are working as expected.
  - [ ] Cluster health statuses are being updated.
  - [ ] Agent logs do not contain any errors (after running for at least 30 minutes).
  - [ ] There are no visible anomalies in Datadog (after running for at least 30 minutes).

Plural Flow: console
