### PR TITLE
fix: prevent stale ready status after stack update

### DIFF
--- a/go/controller/internal/common/reconciliation.go
+++ b/go/controller/internal/common/reconciliation.go
@@ -27,8 +27,12 @@ func HandleRequeue(result *ctrl.Result, err error, setCondition func(condition m
 		result = lo.ToPtr(Wait())
 	}
 
+	conditionReason := v1alpha1.SynchronizedConditionReason
+	if err != nil {
+		conditionReason = v1alpha1.SynchronizedConditionReasonError
+	}
 	utils.MarkCondition(setCondition, v1alpha1.SynchronizedConditionType, metav1.ConditionFalse,
-		v1alpha1.SynchronizedConditionReasonError, defaultErrMessage(err, ""))
+		conditionReason, defaultErrMessage(err, ""))
 	return lo.FromPtr(result), lo.Ternary(result != nil, nil, err)
 }
 

--- a/go/controller/internal/controller/infrastructurestack_controller.go
+++ b/go/controller/internal/controller/infrastructurestack_controller.go
@@ -211,7 +211,6 @@ func (r *InfrastructureStackReconciler) Process(ctx context.Context, req ctrl.Re
 	if result != nil || err != nil {
 		return common.HandleRequeue(result, err, stack.SetCondition)
 	}
-
 	utils.MarkCondition(stack.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionTrue, v1alpha1.SynchronizedConditionReason, "")
 
 	return ctrl.Result{RequeueAfter: requeueAfterInfrastructureStack}, nil
@@ -254,7 +253,7 @@ func (r *InfrastructureStackReconciler) setReadyCondition(ctx context.Context, s
 // SetupWithManager sets up the controller with the Manager.
 func (r *InfrastructureStackReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).                                                                 // Requirement for credentials implementation.
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}). // Requirement for credentials implementation.
 		Watches(&v1alpha1.NamespaceCredentials{}, credentials.OnCredentialsChange(r.Client, new(v1alpha1.InfrastructureStackList))). // Reconcile objects on credentials change.
 		Watches(&corev1.ConfigMap{}, utils.OwnerRefAnnotationEventHandler(r.Client, new(v1alpha1.InfrastructureStack))).
 		Watches(&corev1.Secret{}, utils.OwnerRefAnnotationEventHandler(r.Client, new(v1alpha1.InfrastructureStack))).

--- a/go/controller/internal/controller/infrastructurestack_controller.go
+++ b/go/controller/internal/controller/infrastructurestack_controller.go
@@ -254,7 +254,7 @@ func (r *InfrastructureStackReconciler) setReadyCondition(ctx context.Context, s
 // SetupWithManager sets up the controller with the Manager.
 func (r *InfrastructureStackReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}). // Requirement for credentials implementation.
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).                                                                 // Requirement for credentials implementation.
 		Watches(&v1alpha1.NamespaceCredentials{}, credentials.OnCredentialsChange(r.Client, new(v1alpha1.InfrastructureStackList))). // Reconcile objects on credentials change.
 		Watches(&corev1.ConfigMap{}, utils.OwnerRefAnnotationEventHandler(r.Client, new(v1alpha1.InfrastructureStack))).
 		Watches(&corev1.Secret{}, utils.OwnerRefAnnotationEventHandler(r.Client, new(v1alpha1.InfrastructureStack))).

--- a/go/controller/internal/controller/infrastructurestack_controller.go
+++ b/go/controller/internal/controller/infrastructurestack_controller.go
@@ -119,43 +119,9 @@ func (r *InfrastructureStackReconciler) Process(ctx context.Context, req ctrl.Re
 		return common.HandleRequeue(result, err, stack.SetCondition)
 	}
 
-	clusterID, result, err := r.handleClusterRef(ctx, stack)
+	attributes, result, err := r.getDynamicAttributes(ctx, stack)
 	if result != nil || err != nil {
 		return common.HandleRequeue(result, err, stack.SetCondition)
-	}
-
-	repositoryID, result, err := r.handleRepositoryRef(ctx, stack)
-	if result != nil || err != nil {
-		return common.HandleRequeue(result, err, stack.SetCondition)
-	}
-
-	policyEngineRepositoryID, result, err := r.handlePolicyEngineRepositoryRef(ctx, stack)
-	if result != nil || err != nil {
-		return common.HandleRequeue(result, err, stack.SetCondition)
-	}
-
-	project, result, err := common.Project(ctx, r.Client, r.Scheme, stack)
-	if result != nil || err != nil {
-		return common.HandleRequeue(result, err, stack.SetCondition)
-	}
-
-	stackDefinitionID, result, err := r.handleStackDefinitionRef(ctx, stack)
-	if result != nil || err != nil {
-		return common.HandleRequeue(result, err, stack.SetCondition)
-	}
-
-	metrics, result, err := r.handleObservableMetrics(ctx, stack)
-	if result != nil || err != nil {
-		return lo.FromPtr(result), err
-	}
-
-	attributes := dynamicAttributes{
-		clusterID:                clusterID,
-		repositoryID:             repositoryID,
-		policyEngineRepositoryID: policyEngineRepositoryID,
-		projectID:                project.Status.ID,
-		definitionID:             stackDefinitionID,
-		observableMetrics:        metrics,
 	}
 
 	// Check if resource already exists in the API and only sync the ID
@@ -216,6 +182,47 @@ func (r *InfrastructureStackReconciler) Process(ctx context.Context, req ctrl.Re
 	return ctrl.Result{RequeueAfter: requeueAfterInfrastructureStack}, nil
 }
 
+func (r *InfrastructureStackReconciler) getDynamicAttributes(ctx context.Context, stack *v1alpha1.InfrastructureStack) (*dynamicAttributes, *ctrl.Result, error) {
+	clusterID, result, err := r.handleClusterRef(ctx, stack)
+	if result != nil || err != nil {
+		return nil, result, err
+	}
+
+	repositoryID, result, err := r.handleRepositoryRef(ctx, stack)
+	if result != nil || err != nil {
+		return nil, result, err
+	}
+
+	policyEngineRepositoryID, result, err := r.handlePolicyEngineRepositoryRef(ctx, stack)
+	if result != nil || err != nil {
+		return nil, result, err
+	}
+
+	project, result, err := common.Project(ctx, r.Client, r.Scheme, stack)
+	if result != nil || err != nil {
+		return nil, result, err
+	}
+
+	stackDefinitionID, result, err := r.handleStackDefinitionRef(ctx, stack)
+	if result != nil || err != nil {
+		return nil, result, err
+	}
+
+	metrics, result, err := r.handleObservableMetrics(ctx, stack)
+	if result != nil || err != nil {
+		return nil, result, err
+	}
+
+	return &dynamicAttributes{
+		clusterID:                clusterID,
+		repositoryID:             repositoryID,
+		policyEngineRepositoryID: policyEngineRepositoryID,
+		projectID:                project.Status.ID,
+		definitionID:             stackDefinitionID,
+		observableMetrics:        metrics,
+	}, nil, nil
+}
+
 func (r *InfrastructureStackReconciler) handleExistingResource(ctx context.Context, stack *v1alpha1.InfrastructureStack, apiStack *console.InfrastructureStackIDFragment) (ctrl.Result, error) {
 	stack.Status.ID = apiStack.ID
 
@@ -253,7 +260,7 @@ func (r *InfrastructureStackReconciler) setReadyCondition(ctx context.Context, s
 // SetupWithManager sets up the controller with the Manager.
 func (r *InfrastructureStackReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}). // Requirement for credentials implementation.
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).                                                                 // Requirement for credentials implementation.
 		Watches(&v1alpha1.NamespaceCredentials{}, credentials.OnCredentialsChange(r.Client, new(v1alpha1.InfrastructureStackList))). // Reconcile objects on credentials change.
 		Watches(&corev1.ConfigMap{}, utils.OwnerRefAnnotationEventHandler(r.Client, new(v1alpha1.InfrastructureStack))).
 		Watches(&corev1.Secret{}, utils.OwnerRefAnnotationEventHandler(r.Client, new(v1alpha1.InfrastructureStack))).
@@ -327,7 +334,7 @@ type dynamicAttributes struct {
 func (r *InfrastructureStackReconciler) getStackAttributes(
 	ctx context.Context,
 	stack *v1alpha1.InfrastructureStack,
-	attributes dynamicAttributes,
+	attributes *dynamicAttributes,
 ) (*console.StackAttributes, error) {
 	attr := &console.StackAttributes{
 		Name:              stack.StackName(),
@@ -681,7 +688,7 @@ func (r *InfrastructureStackReconciler) handleObservableMetrics(
 		if !obsProvider.Status.HasID() {
 			logger.Info("ObservabilityProvider not ready", "provider", key)
 			utils.MarkCondition(stack.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReason, "stack definition is not ready")
-			return nil, lo.ToPtr(stack.Spec.Reconciliation.Requeue()), nil
+			return nil, lo.ToPtr(common.WaitForResources()), nil
 		}
 
 		metrics = append(metrics, console.ObservableMetricAttributes{

--- a/go/controller/internal/controller/infrastructurestack_controller.go
+++ b/go/controller/internal/controller/infrastructurestack_controller.go
@@ -194,7 +194,9 @@ func (r *InfrastructureStackReconciler) Process(ctx context.Context, req ctrl.Re
 		stack.Status.SHA = lo.ToPtr(sha)
 	}
 
+	changed := false
 	if !stack.Status.IsSHAEqual(sha) {
+		changed = true
 		_, err = r.ConsoleClient.UpdateStack(ctx, stack.Status.GetID(), *attr)
 		if err != nil {
 			utils.MarkCondition(stack.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
@@ -205,9 +207,11 @@ func (r *InfrastructureStackReconciler) Process(ctx context.Context, req ctrl.Re
 		stack.Status.SHA = lo.ToPtr(sha)
 	}
 
-	if err := r.setReadyCondition(ctx, stack, existing != nil); err != nil {
-		return ctrl.Result{}, err
+	result, err = r.setReadyCondition(ctx, stack, existing != nil, changed)
+	if result != nil || err != nil {
+		return common.HandleRequeue(result, err, stack.SetCondition)
 	}
+
 	utils.MarkCondition(stack.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionTrue, v1alpha1.SynchronizedConditionReason, "")
 
 	return ctrl.Result{RequeueAfter: requeueAfterInfrastructureStack}, nil
@@ -216,33 +220,41 @@ func (r *InfrastructureStackReconciler) Process(ctx context.Context, req ctrl.Re
 func (r *InfrastructureStackReconciler) handleExistingResource(ctx context.Context, stack *v1alpha1.InfrastructureStack, apiStack *console.InfrastructureStackIDFragment) (ctrl.Result, error) {
 	stack.Status.ID = apiStack.ID
 
-	if err := r.setReadyCondition(ctx, stack, apiStack != nil); err != nil {
-		return ctrl.Result{}, err
+	result, err := r.setReadyCondition(ctx, stack, apiStack != nil, false)
+	if result != nil || err != nil {
+		return common.HandleRequeue(result, err, stack.SetCondition)
 	}
 
 	utils.MarkCondition(stack.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionTrue, v1alpha1.SynchronizedConditionReason, "")
-	return stack.Spec.Reconciliation.Requeue(), nil
+	return ctrl.Result{RequeueAfter: requeueAfterInfrastructureStack}, nil
 }
 
-func (r *InfrastructureStackReconciler) setReadyCondition(ctx context.Context, stack *v1alpha1.InfrastructureStack, exists bool) error {
+func (r *InfrastructureStackReconciler) setReadyCondition(ctx context.Context, stack *v1alpha1.InfrastructureStack, exists, changed bool) (*ctrl.Result, error) {
 	if !exists {
-		return nil
+		return lo.ToPtr(common.WaitForResources()), nil
+	}
+
+	// wait a little bit before marking the stack as ready to give the console some time to process the updated stack
+	if changed {
+		return lo.ToPtr(ctrl.Result{RequeueAfter: v1alpha1.Jitter(5 * time.Second)}), nil
 	}
 	utils.MarkCondition(stack.SetCondition, v1alpha1.ReadyConditionType, v1.ConditionFalse, v1alpha1.ReadyConditionReason, "")
 	status, err := r.ConsoleClient.GetStackStatus(ctx, *stack.Status.ID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if status.Status == console.StackStatusSuccessful {
 		utils.MarkCondition(stack.SetCondition, v1alpha1.ReadyConditionType, v1.ConditionTrue, v1alpha1.ReadyConditionReason, "")
+		return nil, nil
 	}
-	return nil
+
+	return lo.ToPtr(common.WaitForResources()), nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *InfrastructureStackReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).                                                                 // Requirement for credentials implementation.
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}). // Requirement for credentials implementation.
 		Watches(&v1alpha1.NamespaceCredentials{}, credentials.OnCredentialsChange(r.Client, new(v1alpha1.InfrastructureStackList))). // Reconcile objects on credentials change.
 		Watches(&corev1.ConfigMap{}, utils.OwnerRefAnnotationEventHandler(r.Client, new(v1alpha1.InfrastructureStack))).
 		Watches(&corev1.Secret{}, utils.OwnerRefAnnotationEventHandler(r.Client, new(v1alpha1.InfrastructureStack))).

--- a/go/controller/internal/controller/infrastructurestack_controller_test.go
+++ b/go/controller/internal/controller/infrastructurestack_controller_test.go
@@ -382,7 +382,7 @@ var _ = Describe("Infrastructure Stack Controller", Ordered, func() {
 						},
 						{
 							Type:   v1alpha1.SynchronizedConditionType.String(),
-							Status: metav1.ConditionTrue,
+							Status: metav1.ConditionFalse,
 							Reason: v1alpha1.SynchronizedConditionReason.String(),
 						},
 					},
@@ -435,12 +435,12 @@ var _ = Describe("Infrastructure Stack Controller", Ordered, func() {
 						},
 						{
 							Type:   v1alpha1.ReadyConditionType.String(),
-							Status: metav1.ConditionTrue,
+							Status: metav1.ConditionFalse,
 							Reason: v1alpha1.ReadyConditionReason.String(),
 						},
 						{
 							Type:   v1alpha1.SynchronizedConditionType.String(),
-							Status: metav1.ConditionTrue,
+							Status: metav1.ConditionFalse,
 							Reason: v1alpha1.SynchronizedConditionReason.String(),
 						},
 					},


### PR DESCRIPTION
When a stack was updated, the controller immediately queried the Console API for the status. This could incorrectly return Successful from the previous run.

This PR reduces the requeue interval to provide more responsive status updates.

It also fixes requeue behavior in read-only mode to ensure the actual status is retrieved.

The `stack.Spec.Reconciliation.Requeue()` replaced with `ctrl.Result{RequeueAfter: requeueAfterInfrastructureStack}`

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.your-env.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
