### PR TITLE
fix: update downloadServiceManifests tool definition

### DIFF
--- a/go/deployment-operator/dockerfiles/agent-harness/system/babysit.md.tmpl
+++ b/go/deployment-operator/dockerfiles/agent-harness/system/babysit.md.tmpl
@@ -37,6 +37,19 @@ Docker-in-Docker is enabled. You can use `docker` and `docker-compose` for testi
 ---
 {{ end }}
 
+## Plural MCP tool hints
+
+### `downloadServiceManifests`
+
+Use this tool whenever you need to inspect the actual Kubernetes manifests Plural is applying for a **ServiceDeployment** or a **GlobalService** CR (each GlobalService creates one child ServiceDeployment per targeted cluster).
+
+- **`cluster`** — the cluster *handle* (`.spec.handle` on the Cluster CR, e.g. `mgmt`, `prod-eu-1`), not `metadata.name`.
+- **`service`** — the `ServiceDeployment` name (`.metadata.name`). For a GlobalService, locate the per-cluster child ServiceDeployment and use its name.
+- After the tool returns, use Read/Glob/Grep on the directory it reports to inspect Helm chart sources, kustomize bases, raw YAML, or Plural liquid templates.
+- **InfrastructureStack CRs are not supported** — use `kubectl` or Bash to inspect stack state instead.
+
+---
+
 ## 2. Workflow (strict order)
 
 1. **Fetch PR state** — call plural MCP `getPRState` to get the latest comments and CI results.

--- a/go/deployment-operator/dockerfiles/agent-harness/system/write.md.tmpl
+++ b/go/deployment-operator/dockerfiles/agent-harness/system/write.md.tmpl
@@ -121,6 +121,19 @@ Each failure → **one** cycle updating only the relevant todo’s `description`
 
 ---
 
+## Plural MCP tool hints
+
+### `downloadServiceManifests`
+
+Use this tool whenever you need to inspect the actual Kubernetes manifests Plural is applying for a **ServiceDeployment** or a **GlobalService** CR (each GlobalService creates one child ServiceDeployment per targeted cluster).
+
+- **`cluster`** — the cluster *handle* (`.spec.handle` on the Cluster CR, e.g. `mgmt`, `prod-eu-1`), not `metadata.name`.
+- **`service`** — the `ServiceDeployment` name (`.metadata.name`). For a GlobalService, locate the per-cluster child ServiceDeployment and use its name.
+- After the tool returns, use Read/Glob/Grep on the directory it reports to inspect Helm chart sources, kustomize bases, raw YAML, or Plural liquid templates.
+- **InfrastructureStack CRs are not supported** — use `kubectl` or Bash to inspect stack state instead.
+
+---
+
 ## 3. Workflow (high‑level order)
 
 Your **high‑level** order is:

--- a/go/deployment-operator/internal/mcpserver/agent/tool/downloadmanifests.go
+++ b/go/deployment-operator/internal/mcpserver/agent/tool/downloadmanifests.go
@@ -31,14 +31,18 @@ func (in *DownloadManifests) Install(s *server.MCPServer) {
 		mcp.NewTool(
 			in.id.String(),
 			mcp.WithDescription(in.description),
-			mcp.WithString("cluster",
-				mcp.Required(),
-				mcp.Description("Handle of the Plural cluster the service is deployed to (e.g. 'mgmt' or 'prod-eu-1')"),
-			),
-			mcp.WithString("service",
-				mcp.Required(),
-				mcp.Description("Name of the Plural service whose rendered manifests should be downloaded"),
-			),
+		mcp.WithString("cluster",
+			mcp.Required(),
+			mcp.Description("Handle of the Plural cluster the service is deployed to. "+
+				"This is the `.spec.handle` field on the Cluster CR, not its metadata.name. "+
+				"Examples: 'mgmt', 'prod-eu-1'."),
+		),
+		mcp.WithString("service",
+			mcp.Required(),
+			mcp.Description("Name of the ServiceDeployment whose rendered manifests should be downloaded. "+
+				"Use `.metadata.name` from the ServiceDeployment CR. "+
+				"For a GlobalService, this is the name of the per-cluster child ServiceDeployment it created."),
+		),
 		),
 		in.handler,
 	)
@@ -182,13 +186,18 @@ func NewDownloadManifests(client console.Client) Tool {
 	return &DownloadManifests{
 		ConsoleTool: ConsoleTool{
 			id: DownloadManifestsTool,
-			description: "Downloads a Plural service's gitops bundle - the exact set of files " +
-				"Plural ships to the cluster-side agent before apply (Helm chart sources, kustomize " +
-				"bases, raw YAML, or Plural liquid templates, depending on how the service is " +
-				"configured). Files are written to a dedicated '<handle>-<name>' subdirectory under " +
-				"'" + manifestsSubdir + "/' next to the cloned repository. Use this to inspect " +
-				"Plural's gitops layout - including external Helm charts - instead of guessing via " +
-				"web searches. After it returns, inspect the listed directory with Read/Glob/Grep.",
+			description: "Downloads the rendered Kubernetes manifests for a Plural ServiceDeployment " +
+				"(or a per-cluster instance created by a GlobalService). " +
+				"Pass the cluster *handle* (the value of `.spec.handle` on the Cluster CR, " +
+				"e.g. 'mgmt', 'prod-eu-1') as 'cluster', " +
+				"and the ServiceDeployment name (`.metadata.name` on the ServiceDeployment CR) as 'service'. " +
+				"For a GlobalService CR, first identify which per-cluster child ServiceDeployment you want to inspect " +
+				"(the GlobalService creates one per targeted cluster), then pass that cluster's handle and the child service name. " +
+				"NOTE: InfrastructureStack CRs are not supported by this tool — use kubectl or Bash to inspect stack state instead. " +
+				"Files are written to a '<handle>-<name>/' subdirectory under '" + manifestsSubdir + "/' next to the cloned repository " +
+				"(Helm chart sources, kustomize bases, raw YAML, or Plural liquid templates, depending on how the service is configured). " +
+				"Use this to inspect Plural's gitops layout — including external Helm charts — instead of guessing via web searches. " +
+				"After it returns, inspect the listed directory with Read/Glob/Grep.",
 			client: client,
 		},
 	}

--- a/go/deployment-operator/internal/mcpserver/agent/tool/downloadmanifests.go
+++ b/go/deployment-operator/internal/mcpserver/agent/tool/downloadmanifests.go
@@ -31,18 +31,18 @@ func (in *DownloadManifests) Install(s *server.MCPServer) {
 		mcp.NewTool(
 			in.id.String(),
 			mcp.WithDescription(in.description),
-		mcp.WithString("cluster",
-			mcp.Required(),
-			mcp.Description("Handle of the Plural cluster the service is deployed to. "+
-				"This is the `.spec.handle` field on the Cluster CR, not its metadata.name. "+
-				"Examples: 'mgmt', 'prod-eu-1'."),
-		),
-		mcp.WithString("service",
-			mcp.Required(),
-			mcp.Description("Name of the ServiceDeployment whose rendered manifests should be downloaded. "+
-				"Use `.metadata.name` from the ServiceDeployment CR. "+
-				"For a GlobalService, this is the name of the per-cluster child ServiceDeployment it created."),
-		),
+			mcp.WithString("cluster",
+				mcp.Required(),
+				mcp.Description("Handle of the Plural cluster the service is deployed to. "+
+					"This is the `.spec.handle` field on the Cluster CR, not its metadata.name. "+
+					"Examples: 'mgmt', 'prod-eu-1'."),
+			),
+			mcp.WithString("service",
+				mcp.Required(),
+				mcp.Description("Name of the ServiceDeployment whose rendered manifests should be downloaded. "+
+					"Use `.metadata.name` from the ServiceDeployment CR. "+
+					"For a GlobalService, this is the name of the per-cluster child ServiceDeployment it created."),
+			),
 		),
 		in.handler,
 	)


### PR DESCRIPTION
I have checked the agent's access to `downloadServiceManifests`, and it works fine for all providers.
I've updated the tool description and extended the system prompt.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.your-env.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
