### PR TITLE
Add metrics-server compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -10370,6 +10370,44 @@ addons:
     chart_version: 1.0.0
     images: ['longhornio/longhorn-manager:v1.0.0', 'longhornio/longhorn-ui:v1.0.0']
   name: longhorn
+- icon: https://avatars.githubusercontent.com/u/36015203?s=400&v=4
+  git_url: https://github.com/kubernetes-sigs/metrics-server
+  release_url: https://github.com/kubernetes-sigs/metrics-server/releases/tag/v{vsn}
+  helm_repository_url: https://kubernetes-sigs.github.io/metrics-server
+  versions:
+  - version: 0.8.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 3.13.0
+    images: ['registry.k8s.io/metrics-server/metrics-server:v0.8.0']
+  - version: 0.7.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 3.12.0
+    images: ['registry.k8s.io/metrics-server/metrics-server:v0.7.0']
+  - version: 0.6.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 3.8.0
+    images: ['k8s.gcr.io/metrics-server/metrics-server:v0.6.0']
+  - version: 0.5.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17', '1.16', '1.15', '1.14', '1.13', '1.12', '1.11', '1.10', '1.9',
+      '1.8']
+    requirements: ['Kubernetes versions lower than v1.16 require --authorization-always-allow-paths=/livez,/readyz.']
+    incompatibilities: []
+    summary: null
+    chart_version: 3.5.0
+    images: ['k8s.gcr.io/metrics-server/metrics-server:v0.5.0']
+  name: metrics-server
 - icon: https://avatars.githubusercontent.com/u/49998002?s=48&v=4
   git_url: https://github.com/open-telemetry/opentelemetry-operator
   release_url: https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v{vsn}

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -22,6 +22,7 @@ names:
 - kyverno
 - linkerd
 - longhorn
+- metrics-server
 - opentelemetry-operator
 - rook
 - strimzi-kafka

--- a/static/compatibilities/metrics-server.yaml
+++ b/static/compatibilities/metrics-server.yaml
@@ -1,0 +1,36 @@
+icon: https://avatars.githubusercontent.com/u/36015203?s=400&v=4
+git_url: https://github.com/kubernetes-sigs/metrics-server
+release_url: https://github.com/kubernetes-sigs/metrics-server/releases/tag/v{vsn}
+helm_repository_url: https://kubernetes-sigs.github.io/metrics-server
+versions:
+- version: 0.8.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.13.0
+  images: ['registry.k8s.io/metrics-server/metrics-server:v0.8.0']
+- version: 0.7.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.12.0
+  images: ['registry.k8s.io/metrics-server/metrics-server:v0.7.0']
+- version: 0.6.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.8.0
+  images: ['k8s.gcr.io/metrics-server/metrics-server:v0.6.0']
+- version: 0.5.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16',
+    '1.15', '1.14', '1.13', '1.12', '1.11', '1.10', '1.9', '1.8']
+  requirements: ['Kubernetes versions lower than v1.16 require --authorization-always-allow-paths=/livez,/readyz.']
+  incompatibilities: []
+  summary: null
+  chart_version: 3.5.0
+  images: ['k8s.gcr.io/metrics-server/metrics-server:v0.5.0']

--- a/utils/compatibility/scrapers/metrics-server.py
+++ b/utils/compatibility/scrapers/metrics-server.py
@@ -55,7 +55,10 @@ def parse_compatibility_matrix(content):
         if set(stripped.replace("|", "").strip()) <= {"-"}:
             continue
 
-        columns = [_clean_cell(column) for column in stripped.split("|")]
+        columns = [
+            _clean_cell(column)
+            for column in stripped.strip("|").split("|")
+        ]
         if len(columns) != 3 or columns[0] == "Metrics Server":
             continue
 
@@ -109,6 +112,9 @@ def scrape():
     compatibility_matrix = parse_compatibility_matrix(page_content)
     chart_versions = get_chart_versions(APP_NAME)
     rows = extract_table_data(compatibility_matrix, chart_versions)
+    if not rows:
+        print_error("No metrics-server versions extracted from compatibility matrix.")
+        return
     update_compatibility_info(
         f"../../static/compatibilities/{APP_NAME}.yaml", rows
     )

--- a/utils/compatibility/scrapers/metrics-server.py
+++ b/utils/compatibility/scrapers/metrics-server.py
@@ -1,0 +1,114 @@
+import re
+from collections import OrderedDict
+
+from packaging.version import Version
+
+from utils import (
+    current_kube_version,
+    expand_kube_versions,
+    fetch_page,
+    get_chart_versions,
+    print_error,
+    update_compatibility_info,
+)
+
+
+APP_NAME = "metrics-server"
+COMPATIBILITY_URL = "https://raw.githubusercontent.com/kubernetes-sigs/metrics-server/master/README.md"
+LOW_KUBE_REQUIREMENT = (
+    "Kubernetes versions lower than v1.16 require "
+    "--authorization-always-allow-paths=/livez,/readyz."
+)
+
+
+def _decode(content):
+    return content.decode("utf-8") if isinstance(content, bytes) else content
+
+
+def _clean_cell(cell):
+    return cell.strip().strip("`").replace("*", "")
+
+
+def _parse_kube_versions(expr):
+    expr = _clean_cell(expr).replace(" ", "").lstrip("v")
+    if expr.endswith("+"):
+        return expand_kube_versions(expr[:-1], current_kube_version())
+    if "-" in expr:
+        start, end = expr.split("-", 1)
+        return expand_kube_versions(start.lstrip("v"), end.lstrip("v"))
+    return [expr]
+
+
+def parse_compatibility_matrix(content):
+    rows = {}
+    in_matrix = False
+
+    for line in _decode(content).splitlines():
+        stripped = line.strip()
+        if stripped == "### Compatibility Matrix":
+            in_matrix = True
+            continue
+        if in_matrix and stripped.startswith("### "):
+            break
+        if not in_matrix or "|" not in stripped:
+            continue
+        if set(stripped.replace("|", "").strip()) <= {"-"}:
+            continue
+
+        columns = [_clean_cell(column) for column in stripped.split("|")]
+        if len(columns) != 3 or columns[0] == "Metrics Server":
+            continue
+
+        version_match = re.match(r"^(\d+\.\d+)\.x$", columns[0])
+        if not version_match:
+            continue
+        rows[version_match.group(1)] = _parse_kube_versions(columns[2])
+
+    if not rows:
+        print_error("No metrics-server compatibility matrix rows found.")
+    return rows
+
+
+def _requirements_for(kube_versions):
+    if any(Version(version) < Version("1.16") for version in kube_versions):
+        return [LOW_KUBE_REQUIREMENT]
+    return []
+
+
+def extract_table_data(compatibility_matrix, chart_versions):
+    rows = []
+
+    for app_version, chart_version in chart_versions.items():
+        parsed_version = Version(app_version)
+        minor_key = f"{parsed_version.major}.{parsed_version.minor}"
+        kube_versions = compatibility_matrix.get(minor_key)
+        if not kube_versions:
+            continue
+
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", app_version),
+                    ("kube", kube_versions),
+                    ("chart_version", chart_version),
+                    ("images", []),
+                    ("requirements", _requirements_for(kube_versions)),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    return rows
+
+
+def scrape():
+    page_content = fetch_page(COMPATIBILITY_URL)
+    if not page_content:
+        return
+
+    compatibility_matrix = parse_compatibility_matrix(page_content)
+    chart_versions = get_chart_versions(APP_NAME)
+    rows = extract_table_data(compatibility_matrix, chart_versions)
+    update_compatibility_info(
+        f"../../static/compatibilities/{APP_NAME}.yaml", rows
+    )


### PR DESCRIPTION
## Summary
- Add metrics-server compatibility data and manifest entry.
- Add a scraper that parses the official metrics-server compatibility matrix.
- Include Helm chart metadata and default image references for the generated rows.

## Sources
- Compatibility matrix: https://github.com/kubernetes-sigs/metrics-server#compatibility-matrix
- Helm chart repo: https://kubernetes-sigs.github.io/metrics-server

## Verification
- python3 -m compileall utils/compatibility/scrapers/metrics-server.py
- YAML load check for the metrics-server table, manifest, and aggregate file
- Parser checks against the metrics-server README and Helm index
- git diff --check

Note: Full scraper image refresh was not run locally because Helm is not installed. Default image references were checked from the selected metrics-server chart values.