### PR TITLE
Add cluster-autoscaler compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -5323,6 +5323,118 @@ addons:
     chart_version: 0.13.0
     images: ['ghcr.io/cloudnative-pg/cloudnative-pg:1.15.0']
   name: cloudnative-pg
+- icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
+  git_url: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+  release_url: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-{vsn}
+  helm_repository_url: https://kubernetes.github.io/autoscaler
+  chart_name: cluster-autoscaler
+  versions:
+  - version: 1.35.0
+    kube: ['1.35']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.57.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0']
+  - version: 1.34.2
+    kube: ['1.34']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.53.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.2']
+  - version: 1.33.0
+    kube: ['1.33']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.51.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.0']
+  - version: 1.32.0
+    kube: ['1.32']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.46.6
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0']
+  - version: 1.31.0
+    kube: ['1.31']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.44.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.0']
+  - version: 1.30.0
+    kube: ['1.30']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.37.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0']
+  - version: 1.29.0
+    kube: ['1.29']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.36.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.0']
+  - version: 1.28.2
+    kube: ['1.28']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.34.1
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.28.2']
+  - version: 1.27.2
+    kube: ['1.27']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.33.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.27.2']
+  - version: 1.26.2
+    kube: ['1.26']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.28.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.2']
+  - version: 1.24.0
+    kube: ['1.24']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.27.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.0']
+  - version: 1.23.0
+    kube: ['1.23']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.24.0
+    images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.0']
+  - version: 1.21.1
+    kube: ['1.21']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.13.1
+    images: ['k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1']
+  - version: 1.20.0
+    kube: ['1.20']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.9.2
+    images: ['k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0']
+  - version: 1.18.1
+    kube: ['1.18']
+    requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+        control-plane minor version.]
+    incompatibilities: []
+    chart_version: 9.4.0
+    images: ['us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.18.1']
+  name: cluster-autoscaler
 - icon: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/img/external-dns.png?raw=true
   git_url: https://github.com/kubernetes-sigs/external-dns
   release_url: https://github.com/kubernetes-sigs/external-dns/releases/tag/v{vsn}

--- a/static/compatibilities/cluster-autoscaler.yaml
+++ b/static/compatibilities/cluster-autoscaler.yaml
@@ -1,0 +1,111 @@
+icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
+git_url: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler
+release_url: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-{vsn}
+helm_repository_url: https://kubernetes.github.io/autoscaler
+chart_name: cluster-autoscaler
+versions:
+- version: 1.35.0
+  kube: ['1.35']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.57.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0']
+- version: 1.34.2
+  kube: ['1.34']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.53.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.34.2']
+- version: 1.33.0
+  kube: ['1.33']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.51.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.33.0']
+- version: 1.32.0
+  kube: ['1.32']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.46.6
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.32.0']
+- version: 1.31.0
+  kube: ['1.31']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.44.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.31.0']
+- version: 1.30.0
+  kube: ['1.30']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.37.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.30.0']
+- version: 1.29.0
+  kube: ['1.29']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.36.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.29.0']
+- version: 1.28.2
+  kube: ['1.28']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.34.1
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.28.2']
+- version: 1.27.2
+  kube: ['1.27']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.33.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.27.2']
+- version: 1.26.2
+  kube: ['1.26']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.28.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.26.2']
+- version: 1.24.0
+  kube: ['1.24']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.27.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.24.0']
+- version: 1.23.0
+  kube: ['1.23']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.24.0
+  images: ['registry.k8s.io/autoscaling/cluster-autoscaler:v1.23.0']
+- version: 1.21.1
+  kube: ['1.21']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.13.1
+  images: ['k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.1']
+- version: 1.20.0
+  kube: ['1.20']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.9.2
+  images: ['k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.0']
+- version: 1.18.1
+  kube: ['1.18']
+  requirements: [Use the Cluster Autoscaler release that corresponds to the Kubernetes
+      control-plane minor version.]
+  incompatibilities: []
+  chart_version: 9.4.0
+  images: ['us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.18.1']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -10,6 +10,7 @@ names:
 - contour
 - coredns
 - cloudnative-pg
+- cluster-autoscaler
 - external-dns
 - external-secrets
 - flux

--- a/utils/compatibility/scrapers/cluster-autoscaler.py
+++ b/utils/compatibility/scrapers/cluster-autoscaler.py
@@ -1,0 +1,174 @@
+import re
+import io
+import tarfile
+from collections import OrderedDict
+
+import yaml
+from packaging.version import Version
+
+from utils import (
+    fetch_page,
+    print_error,
+    update_compatibility_info,
+)
+
+
+APP_NAME = "cluster-autoscaler"
+COMPATIBILITY_URL = "https://raw.githubusercontent.com/kubernetes/autoscaler/master/cluster-autoscaler/README.md"
+HELM_REPO_URL = "https://kubernetes.github.io/autoscaler"
+CHART_NAME = "cluster-autoscaler"
+IMAGE_REPOSITORY = "registry.k8s.io/autoscaling/cluster-autoscaler"
+MIN_EXACT_MINOR = Version("1.12.0")
+REQUIREMENT = (
+    "Use the Cluster Autoscaler release that corresponds to the Kubernetes "
+    "control-plane minor version."
+)
+
+
+def _decode(content):
+    return content.decode("utf-8") if isinstance(content, bytes) else content
+
+
+def _minor_key(version):
+    parsed = Version(version)
+    return f"{parsed.major}.{parsed.minor}"
+
+
+def parse_compatibility_table(content):
+    rows = {}
+    in_table = False
+
+    for line in _decode(content).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("| Kubernetes Version | CA Version"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not stripped.startswith("|"):
+            if rows:
+                break
+            continue
+        if set(stripped.replace("|", "").strip()) <= {"-"}:
+            continue
+
+        columns = [column.strip().strip("`") for column in stripped.strip("|").split("|")]
+        if len(columns) < 2:
+            continue
+
+        kube_match = re.search(r"(\d+\.\d+)", columns[0])
+        autoscaler_match = re.search(r"(\d+\.\d+)", columns[1])
+        if not kube_match or not autoscaler_match:
+            continue
+
+        rows[autoscaler_match.group(1)] = kube_match.group(1)
+
+    return rows
+
+
+def get_chart_releases(index_content):
+    index_yaml = yaml.safe_load(index_content)
+    entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
+    chart_releases = {}
+
+    for entry in entries:
+        app_version = str(entry.get("appVersion", "")).lstrip("v")
+        chart_version = str(entry.get("version", "")).lstrip("v")
+        chart_urls = entry.get("urls", [])
+        if not app_version or not chart_version:
+            continue
+        try:
+            Version(app_version)
+            Version(chart_version)
+        except ValueError:
+            continue
+
+        current = chart_releases.get(app_version)
+        if not current or Version(chart_version) > Version(current["chart_version"]):
+            chart_releases[app_version] = {
+                "chart_version": chart_version,
+                "url": chart_urls[0] if chart_urls else "",
+            }
+
+    return chart_releases
+
+
+def read_chart_yaml(archive, filename):
+    for member in archive.getmembers():
+        if member.name.endswith(f"/{filename}"):
+            return yaml.safe_load(archive.extractfile(member))
+    return {}
+
+
+def get_default_image(chart_url, app_version):
+    content = fetch_page(chart_url)
+    if not content:
+        return f"{IMAGE_REPOSITORY}:v{app_version}"
+
+    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+        chart = read_chart_yaml(archive, "Chart.yaml")
+        values = read_chart_yaml(archive, "values.yaml")
+
+    image = values.get("image", {})
+    repository = image.get("repository") or IMAGE_REPOSITORY
+    tag = str(image.get("tag") or chart.get("appVersion") or app_version)
+    if not tag.startswith("v"):
+        tag = f"v{tag}"
+
+    return f"{repository}:{tag}"
+
+
+def extract_table_data(compatibility_by_minor, chart_releases):
+    latest_by_minor = {}
+
+    for app_version, chart in chart_releases.items():
+        parsed = Version(app_version)
+        if parsed.major != 1:
+            continue
+
+        minor = _minor_key(app_version)
+        kube_version = compatibility_by_minor.get(minor)
+        if not kube_version and parsed >= MIN_EXACT_MINOR:
+            kube_version = minor
+        if not kube_version:
+            continue
+
+        existing = latest_by_minor.get(minor)
+        if existing and Version(existing["version"]) > parsed:
+            continue
+
+        latest_by_minor[minor] = OrderedDict(
+            [
+                ("version", app_version),
+                ("kube", [kube_version]),
+                ("requirements", [REQUIREMENT]),
+                ("incompatibilities", []),
+                ("chart_version", chart["chart_version"]),
+                ("images", [get_default_image(chart["url"], app_version)]),
+            ]
+        )
+
+    return list(latest_by_minor.values())
+
+
+def scrape():
+    compatibility_content = fetch_page(COMPATIBILITY_URL)
+    if not compatibility_content:
+        return
+    compatibility_by_minor = parse_compatibility_table(compatibility_content)
+    if not compatibility_by_minor:
+        print_error("No Cluster Autoscaler compatibility table found.")
+        return
+
+    chart_index = fetch_page(f"{HELM_REPO_URL}/index.yaml")
+    if not chart_index:
+        return
+    chart_releases = get_chart_releases(chart_index)
+    rows = extract_table_data(compatibility_by_minor, chart_releases)
+    if not rows:
+        print_error("No Cluster Autoscaler versions extracted.")
+        return
+
+    update_compatibility_info(
+        f"../../static/compatibilities/{APP_NAME}.yaml", rows
+    )

--- a/utils/compatibility/scrapers/cluster-autoscaler.py
+++ b/utils/compatibility/scrapers/cluster-autoscaler.py
@@ -72,7 +72,12 @@ def get_chart_releases(index_content):
         print_error("Invalid Cluster Autoscaler Helm index.")
         return {}
 
-    entries = index_yaml.get("entries", {}).get(CHART_NAME) or []
+    chart_entries = index_yaml.get("entries") or {}
+    if not isinstance(chart_entries, dict):
+        print_error("Invalid Cluster Autoscaler Helm index entries.")
+        return {}
+
+    entries = chart_entries.get(CHART_NAME) or []
     if not isinstance(entries, list):
         print_error("Invalid Cluster Autoscaler chart entries.")
         return {}

--- a/utils/compatibility/scrapers/cluster-autoscaler.py
+++ b/utils/compatibility/scrapers/cluster-autoscaler.py
@@ -2,6 +2,7 @@ import re
 import io
 import tarfile
 from collections import OrderedDict
+from urllib.parse import urljoin
 
 import yaml
 from packaging.version import Version
@@ -96,11 +97,15 @@ def get_chart_releases(index_content):
         except ValueError:
             continue
 
+        chart_url = chart_urls[0] if chart_urls else ""
+        if chart_url and not chart_url.startswith("http"):
+            chart_url = urljoin(f"{HELM_REPO_URL}/", chart_url)
+
         current = chart_releases.get(app_version)
         if not current or Version(chart_version) > Version(current["chart_version"]):
             chart_releases[app_version] = {
                 "chart_version": chart_version,
-                "url": chart_urls[0] if chart_urls else "",
+                "url": chart_url,
             }
 
     return chart_releases
@@ -124,7 +129,12 @@ def get_default_image(chart_url, app_version):
     if not chart_url:
         return fallback_image(app_version)
 
-    content = fetch_page(chart_url)
+    try:
+        content = fetch_page(chart_url)
+    except Exception as error:
+        print_error(f"Failed to fetch Cluster Autoscaler chart defaults: {error}")
+        return fallback_image(app_version)
+
     if not content:
         return fallback_image(app_version)
 

--- a/utils/compatibility/scrapers/cluster-autoscaler.py
+++ b/utils/compatibility/scrapers/cluster-autoscaler.py
@@ -95,19 +95,32 @@ def get_chart_releases(index_content):
 
 def read_chart_yaml(archive, filename):
     for member in archive.getmembers():
-        if member.name.endswith(f"/{filename}"):
-            return yaml.safe_load(archive.extractfile(member))
+        if member.isfile() and member.name.split("/")[-1] == filename:
+            extracted = archive.extractfile(member)
+            if extracted:
+                return yaml.safe_load(extracted) or {}
     return {}
 
 
+def fallback_image(app_version):
+    return f"{IMAGE_REPOSITORY}:v{app_version}"
+
+
 def get_default_image(chart_url, app_version):
+    if not chart_url:
+        return fallback_image(app_version)
+
     content = fetch_page(chart_url)
     if not content:
-        return f"{IMAGE_REPOSITORY}:v{app_version}"
+        return fallback_image(app_version)
 
-    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
-        chart = read_chart_yaml(archive, "Chart.yaml")
-        values = read_chart_yaml(archive, "values.yaml")
+    try:
+        with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+            chart = read_chart_yaml(archive, "Chart.yaml")
+            values = read_chart_yaml(archive, "values.yaml")
+    except (tarfile.TarError, yaml.YAMLError, OSError) as error:
+        print_error(f"Failed to read Cluster Autoscaler chart defaults: {error}")
+        return fallback_image(app_version)
 
     image = values.get("image", {})
     repository = image.get("repository") or IMAGE_REPOSITORY

--- a/utils/compatibility/scrapers/cluster-autoscaler.py
+++ b/utils/compatibility/scrapers/cluster-autoscaler.py
@@ -72,7 +72,11 @@ def get_chart_releases(index_content):
         print_error("Invalid Cluster Autoscaler Helm index.")
         return {}
 
-    entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
+    entries = index_yaml.get("entries", {}).get(CHART_NAME) or []
+    if not isinstance(entries, list):
+        print_error("Invalid Cluster Autoscaler chart entries.")
+        return {}
+
     chart_releases = {}
 
     for entry in entries:

--- a/utils/compatibility/scrapers/cluster-autoscaler.py
+++ b/utils/compatibility/scrapers/cluster-autoscaler.py
@@ -98,7 +98,8 @@ def read_chart_yaml(archive, filename):
         if member.isfile() and member.name.split("/")[-1] == filename:
             extracted = archive.extractfile(member)
             if extracted:
-                return yaml.safe_load(extracted) or {}
+                parsed = yaml.safe_load(extracted)
+                return parsed if isinstance(parsed, dict) else {}
     return {}
 
 
@@ -175,6 +176,7 @@ def scrape():
 
     chart_index = fetch_page(f"{HELM_REPO_URL}/index.yaml")
     if not chart_index:
+        print_error("No Cluster Autoscaler Helm index found.")
         return
     chart_releases = get_chart_releases(chart_index)
     rows = extract_table_data(compatibility_by_minor, chart_releases)

--- a/utils/compatibility/scrapers/cluster-autoscaler.py
+++ b/utils/compatibility/scrapers/cluster-autoscaler.py
@@ -68,6 +68,10 @@ def parse_compatibility_table(content):
 
 def get_chart_releases(index_content):
     index_yaml = yaml.safe_load(index_content)
+    if not isinstance(index_yaml, dict):
+        print_error("Invalid Cluster Autoscaler Helm index.")
+        return {}
+
     entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
     chart_releases = {}
 


### PR DESCRIPTION
## Summary
- Add Cluster Autoscaler compatibility data and manifest entry.
- Add a scraper that parses the official Cluster Autoscaler release compatibility table and Helm index.
- Include Helm chart metadata and default image references for generated rows.

## Sources
- Compatibility table: https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases
- Helm chart repo: https://kubernetes.github.io/autoscaler

## Verification
- python3 -m py_compile utils/compatibility/scrapers/cluster-autoscaler.py
- YAML load check for the cluster-autoscaler table, manifest, and aggregate file
- Parser output check against the Cluster Autoscaler README, Helm index, and selected chart tarballs
- Chart values image check from official chart tarballs
- git diff --check

Note: Full Helm template rendering was not run locally because Helm is not installed. Default image references were checked from the selected Cluster Autoscaler chart values.
