### PR TITLE
Add descheduler compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -5323,6 +5323,146 @@ addons:
     chart_version: 0.13.0
     images: ['ghcr.io/cloudnative-pg/cloudnative-pg:1.15.0']
   name: cloudnative-pg
+- icon: https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/assets/logo/descheduler-stacked-color.png
+  git_url: https://github.com/kubernetes-sigs/descheduler
+  release_url: https://github.com/kubernetes-sigs/descheduler/releases/tag/v{vsn}
+  helm_repository_url: https://kubernetes-sigs.github.io/descheduler
+  chart_name: descheduler
+  versions:
+  - version: 0.36.0
+    kube: ['1.36', '1.35', '1.34']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.36.0
+    images: ['registry.k8s.io/descheduler/descheduler:v0.36.0']
+  - version: 0.35.1
+    kube: ['1.35', '1.34', '1.33']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.35.1
+    images: ['registry.k8s.io/descheduler/descheduler:v0.35.1']
+  - version: 0.34.0
+    kube: ['1.34', '1.33', '1.32']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.34.0
+    images: ['registry.k8s.io/descheduler/descheduler:v0.34.0']
+  - version: 0.33.0
+    kube: ['1.33', '1.32', '1.31']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.33.0
+    images: ['registry.k8s.io/descheduler/descheduler:v0.33.0']
+  - version: 0.32.2
+    kube: ['1.32', '1.31', '1.30']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.32.2
+    images: ['registry.k8s.io/descheduler/descheduler:v0.32.2']
+  - version: 0.31.0
+    kube: ['1.31', '1.30', '1.29']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.31.0
+    images: ['registry.k8s.io/descheduler/descheduler:v0.31.0']
+  - version: 0.30.2
+    kube: ['1.30', '1.29', '1.28']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.30.2
+    images: ['registry.k8s.io/descheduler/descheduler:v0.30.2']
+  - version: 0.29.0
+    kube: ['1.29', '1.28', '1.27']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.29.0
+    images: ['registry.k8s.io/descheduler/descheduler:v0.29.0']
+  - version: 0.28.1
+    kube: ['1.28', '1.27', '1.26']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.28.1
+    images: ['registry.k8s.io/descheduler/descheduler:v0.28.1']
+  - version: 0.27.1
+    kube: ['1.27', '1.26', '1.25']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.27.1
+    images: ['registry.k8s.io/descheduler/descheduler:v0.27.1']
+  - version: 0.26.1
+    kube: ['1.26', '1.25', '1.24']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.26.1
+    images: ['registry.k8s.io/descheduler/descheduler:v0.26.1']
+  - version: 0.25.1
+    kube: ['1.25', '1.24', '1.23']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.25.2
+    images: ['k8s.gcr.io/descheduler/descheduler:v0.25.1']
+  - version: 0.24.1
+    kube: ['1.24', '1.23', '1.22']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.24.1
+    images: ['k8s.gcr.io/descheduler/descheduler:v0.24.1']
+  - version: 0.23.1
+    kube: ['1.23', '1.22', '1.21']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.23.2
+    images: ['k8s.gcr.io/descheduler/descheduler:v0.23.1']
+  - version: 0.22.1
+    kube: ['1.22', '1.21', '1.20']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.22.1
+    images: ['k8s.gcr.io/descheduler/descheduler:v0.22.1']
+  - version: 0.21.0
+    kube: ['1.21', '1.20', '1.19']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.21.0
+    images: ['k8s.gcr.io/descheduler/descheduler:v0.21.0']
+  - version: 0.20.0
+    kube: ['1.20', '1.19', '1.18']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.20.0
+    images: ['k8s.gcr.io/descheduler/descheduler:v0.20.0']
+  - version: 0.19.0
+    kube: ['1.19', '1.18', '1.17']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.19.2
+    images: ['k8s.gcr.io/descheduler/descheduler:v0.19.0']
+  - version: 0.18.0
+    kube: ['1.18', '1.17', '1.16']
+    requirements: [Descheduler releases are tested against the three latest Kubernetes
+        minor versions for that release.]
+    incompatibilities: []
+    chart_version: 0.18.2
+    images: ['us.gcr.io/k8s-artifacts-prod/descheduler/descheduler:v0.18.0']
+  name: descheduler
 - icon: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/img/external-dns.png?raw=true
   git_url: https://github.com/kubernetes-sigs/external-dns
   release_url: https://github.com/kubernetes-sigs/external-dns/releases/tag/v{vsn}

--- a/static/compatibilities/descheduler.yaml
+++ b/static/compatibilities/descheduler.yaml
@@ -1,0 +1,139 @@
+icon: https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/assets/logo/descheduler-stacked-color.png
+git_url: https://github.com/kubernetes-sigs/descheduler
+release_url: https://github.com/kubernetes-sigs/descheduler/releases/tag/v{vsn}
+helm_repository_url: https://kubernetes-sigs.github.io/descheduler
+chart_name: descheduler
+versions:
+- version: 0.36.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.36.0
+  images: ['registry.k8s.io/descheduler/descheduler:v0.36.0']
+- version: 0.35.1
+  kube: ['1.35', '1.34', '1.33']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.35.1
+  images: ['registry.k8s.io/descheduler/descheduler:v0.35.1']
+- version: 0.34.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.34.0
+  images: ['registry.k8s.io/descheduler/descheduler:v0.34.0']
+- version: 0.33.0
+  kube: ['1.33', '1.32', '1.31']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.33.0
+  images: ['registry.k8s.io/descheduler/descheduler:v0.33.0']
+- version: 0.32.2
+  kube: ['1.32', '1.31', '1.30']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.32.2
+  images: ['registry.k8s.io/descheduler/descheduler:v0.32.2']
+- version: 0.31.0
+  kube: ['1.31', '1.30', '1.29']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.31.0
+  images: ['registry.k8s.io/descheduler/descheduler:v0.31.0']
+- version: 0.30.2
+  kube: ['1.30', '1.29', '1.28']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.30.2
+  images: ['registry.k8s.io/descheduler/descheduler:v0.30.2']
+- version: 0.29.0
+  kube: ['1.29', '1.28', '1.27']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.29.0
+  images: ['registry.k8s.io/descheduler/descheduler:v0.29.0']
+- version: 0.28.1
+  kube: ['1.28', '1.27', '1.26']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.28.1
+  images: ['registry.k8s.io/descheduler/descheduler:v0.28.1']
+- version: 0.27.1
+  kube: ['1.27', '1.26', '1.25']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.27.1
+  images: ['registry.k8s.io/descheduler/descheduler:v0.27.1']
+- version: 0.26.1
+  kube: ['1.26', '1.25', '1.24']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.26.1
+  images: ['registry.k8s.io/descheduler/descheduler:v0.26.1']
+- version: 0.25.1
+  kube: ['1.25', '1.24', '1.23']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.25.2
+  images: ['k8s.gcr.io/descheduler/descheduler:v0.25.1']
+- version: 0.24.1
+  kube: ['1.24', '1.23', '1.22']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.24.1
+  images: ['k8s.gcr.io/descheduler/descheduler:v0.24.1']
+- version: 0.23.1
+  kube: ['1.23', '1.22', '1.21']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.23.2
+  images: ['k8s.gcr.io/descheduler/descheduler:v0.23.1']
+- version: 0.22.1
+  kube: ['1.22', '1.21', '1.20']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.22.1
+  images: ['k8s.gcr.io/descheduler/descheduler:v0.22.1']
+- version: 0.21.0
+  kube: ['1.21', '1.20', '1.19']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.21.0
+  images: ['k8s.gcr.io/descheduler/descheduler:v0.21.0']
+- version: 0.20.0
+  kube: ['1.20', '1.19', '1.18']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.20.0
+  images: ['k8s.gcr.io/descheduler/descheduler:v0.20.0']
+- version: 0.19.0
+  kube: ['1.19', '1.18', '1.17']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.19.2
+  images: ['k8s.gcr.io/descheduler/descheduler:v0.19.0']
+- version: 0.18.0
+  kube: ['1.18', '1.17', '1.16']
+  requirements: [Descheduler releases are tested against the three latest Kubernetes
+      minor versions for that release.]
+  incompatibilities: []
+  chart_version: 0.18.2
+  images: ['us.gcr.io/k8s-artifacts-prod/descheduler/descheduler:v0.18.0']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -10,6 +10,7 @@ names:
 - contour
 - coredns
 - cloudnative-pg
+- descheduler
 - external-dns
 - external-secrets
 - flux

--- a/utils/compatibility/scrapers/descheduler.py
+++ b/utils/compatibility/scrapers/descheduler.py
@@ -105,7 +105,8 @@ def read_chart_yaml(archive, filename):
         if member.isfile() and member.name.split("/")[-1] == filename:
             extracted = archive.extractfile(member)
             if extracted:
-                return yaml.safe_load(extracted) or {}
+                parsed = yaml.safe_load(extracted)
+                return parsed if isinstance(parsed, dict) else {}
     return {}
 
 
@@ -178,6 +179,7 @@ def scrape():
 
     chart_index = fetch_page(f"{HELM_REPO_URL}/index.yaml")
     if not chart_index:
+        print_error("No Descheduler Helm index found.")
         return
     chart_releases = get_chart_releases(chart_index)
     rows = extract_table_data(compatibility_by_minor, chart_releases)

--- a/utils/compatibility/scrapers/descheduler.py
+++ b/utils/compatibility/scrapers/descheduler.py
@@ -102,19 +102,32 @@ def get_chart_releases(index_content):
 
 def read_chart_yaml(archive, filename):
     for member in archive.getmembers():
-        if member.name.endswith(f"/{filename}"):
-            return yaml.safe_load(archive.extractfile(member))
+        if member.isfile() and member.name.split("/")[-1] == filename:
+            extracted = archive.extractfile(member)
+            if extracted:
+                return yaml.safe_load(extracted) or {}
     return {}
 
 
+def fallback_image(app_version):
+    return f"{IMAGE_REPOSITORY}:v{app_version}"
+
+
 def get_default_image(chart_url, app_version):
+    if not chart_url:
+        return fallback_image(app_version)
+
     content = fetch_page(chart_url)
     if not content:
-        return f"{IMAGE_REPOSITORY}:v{app_version}"
+        return fallback_image(app_version)
 
-    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
-        chart = read_chart_yaml(archive, "Chart.yaml")
-        values = read_chart_yaml(archive, "values.yaml")
+    try:
+        with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+            chart = read_chart_yaml(archive, "Chart.yaml")
+            values = read_chart_yaml(archive, "values.yaml")
+    except (tarfile.TarError, yaml.YAMLError, OSError) as error:
+        print_error(f"Failed to read Descheduler chart defaults: {error}")
+        return fallback_image(app_version)
 
     image = values.get("image", {})
     repository = image.get("repository") or IMAGE_REPOSITORY

--- a/utils/compatibility/scrapers/descheduler.py
+++ b/utils/compatibility/scrapers/descheduler.py
@@ -1,0 +1,177 @@
+import io
+import re
+import tarfile
+from collections import OrderedDict
+
+import yaml
+from packaging.version import Version
+
+from utils import (
+    fetch_page,
+    print_error,
+    update_compatibility_info,
+)
+
+
+APP_NAME = "descheduler"
+COMPATIBILITY_URL = "https://raw.githubusercontent.com/kubernetes-sigs/descheduler/master/README.md"
+HELM_REPO_URL = "https://kubernetes-sigs.github.io/descheduler"
+CHART_NAME = "descheduler"
+IMAGE_REPOSITORY = "registry.k8s.io/descheduler/descheduler"
+MIN_SUPPORTED_VERSION = Version("0.18.0")
+REQUIREMENT = (
+    "Descheduler releases are tested against the three latest Kubernetes minor "
+    "versions for that release."
+)
+
+
+def _decode(content):
+    return content.decode("utf-8") if isinstance(content, bytes) else content
+
+
+def _minor_key(version):
+    parsed = Version(version)
+    return f"{parsed.major}.{parsed.minor}"
+
+
+def expand_three_latest(kube_version):
+    major, minor = [int(part) for part in kube_version.split(".")]
+    return [f"{major}.{minor - offset}" for offset in range(3)]
+
+
+def parse_compatibility_table(content):
+    rows = {}
+    in_table = False
+
+    for line in _decode(content).splitlines():
+        stripped = line.strip()
+        if stripped.startswith("| Descheduler | Supported Kubernetes Version"):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not stripped.startswith("|"):
+            if rows:
+                break
+            continue
+        if set(stripped.replace("|", "").strip()) <= {"-"}:
+            continue
+
+        columns = [column.strip().strip("`") for column in stripped.strip("|").split("|")]
+        if len(columns) < 2:
+            continue
+
+        descheduler_match = re.search(r"v?(\d+\.\d+)", columns[0])
+        kube_match = re.search(r"v?(\d+\.\d+)", columns[1])
+        if not descheduler_match or not kube_match:
+            continue
+
+        rows[descheduler_match.group(1)] = kube_match.group(1)
+
+    return rows
+
+
+def get_chart_releases(index_content):
+    index_yaml = yaml.safe_load(index_content)
+    entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
+    chart_releases = {}
+
+    for entry in entries:
+        app_version = str(entry.get("appVersion", "")).lstrip("v")
+        chart_version = str(entry.get("version", "")).lstrip("v")
+        chart_urls = entry.get("urls", [])
+        if not app_version or not chart_version:
+            continue
+        try:
+            Version(app_version)
+            Version(chart_version)
+        except ValueError:
+            continue
+
+        minor = _minor_key(app_version)
+        current = chart_releases.get(minor)
+        if not current or Version(chart_version) > Version(current["chart_version"]):
+            chart_releases[minor] = {
+                "app_version": app_version,
+                "chart_version": chart_version,
+                "url": chart_urls[0] if chart_urls else "",
+            }
+
+    return chart_releases
+
+
+def read_chart_yaml(archive, filename):
+    for member in archive.getmembers():
+        if member.name.endswith(f"/{filename}"):
+            return yaml.safe_load(archive.extractfile(member))
+    return {}
+
+
+def get_default_image(chart_url, app_version):
+    content = fetch_page(chart_url)
+    if not content:
+        return f"{IMAGE_REPOSITORY}:v{app_version}"
+
+    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+        chart = read_chart_yaml(archive, "Chart.yaml")
+        values = read_chart_yaml(archive, "values.yaml")
+
+    image = values.get("image", {})
+    repository = image.get("repository") or IMAGE_REPOSITORY
+    tag = str(image.get("tag") or chart.get("appVersion") or app_version)
+    if not tag.startswith("v"):
+        tag = f"v{tag}"
+
+    return f"{repository}:{tag}"
+
+
+def extract_table_data(compatibility_by_minor, chart_releases):
+    rows = []
+
+    for minor, chart in chart_releases.items():
+        app_version = chart["app_version"]
+        parsed = Version(app_version)
+        if parsed < MIN_SUPPORTED_VERSION:
+            continue
+
+        kube_version = compatibility_by_minor.get(minor)
+        if not kube_version:
+            continue
+
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", app_version),
+                    ("kube", expand_three_latest(kube_version)),
+                    ("requirements", [REQUIREMENT]),
+                    ("incompatibilities", []),
+                    ("chart_version", chart["chart_version"]),
+                    ("images", [get_default_image(chart["url"], app_version)]),
+                ]
+            )
+        )
+
+    return sorted(rows, key=lambda row: Version(row["version"]), reverse=True)
+
+
+def scrape():
+    compatibility_content = fetch_page(COMPATIBILITY_URL)
+    if not compatibility_content:
+        return
+    compatibility_by_minor = parse_compatibility_table(compatibility_content)
+    if not compatibility_by_minor:
+        print_error("No Descheduler compatibility table found.")
+        return
+
+    chart_index = fetch_page(f"{HELM_REPO_URL}/index.yaml")
+    if not chart_index:
+        return
+    chart_releases = get_chart_releases(chart_index)
+    rows = extract_table_data(compatibility_by_minor, chart_releases)
+    if not rows:
+        print_error("No Descheduler versions extracted.")
+        return
+
+    update_compatibility_info(
+        f"../../static/compatibilities/{APP_NAME}.yaml", rows
+    )

--- a/utils/compatibility/scrapers/descheduler.py
+++ b/utils/compatibility/scrapers/descheduler.py
@@ -73,6 +73,10 @@ def parse_compatibility_table(content):
 
 def get_chart_releases(index_content):
     index_yaml = yaml.safe_load(index_content)
+    if not isinstance(index_yaml, dict):
+        print_error("Invalid Descheduler Helm index.")
+        return {}
+
     entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
     chart_releases = {}
 

--- a/utils/compatibility/scrapers/descheduler.py
+++ b/utils/compatibility/scrapers/descheduler.py
@@ -2,6 +2,7 @@ import io
 import re
 import tarfile
 from collections import OrderedDict
+from urllib.parse import urljoin
 
 import yaml
 from packaging.version import Version
@@ -102,12 +103,16 @@ def get_chart_releases(index_content):
             continue
 
         minor = _minor_key(app_version)
+        chart_url = chart_urls[0] if chart_urls else ""
+        if chart_url and not chart_url.startswith("http"):
+            chart_url = urljoin(f"{HELM_REPO_URL}/", chart_url)
+
         current = chart_releases.get(minor)
         if not current or Version(chart_version) > Version(current["chart_version"]):
             chart_releases[minor] = {
                 "app_version": app_version,
                 "chart_version": chart_version,
-                "url": chart_urls[0] if chart_urls else "",
+                "url": chart_url,
             }
 
     return chart_releases
@@ -131,7 +136,12 @@ def get_default_image(chart_url, app_version):
     if not chart_url:
         return fallback_image(app_version)
 
-    content = fetch_page(chart_url)
+    try:
+        content = fetch_page(chart_url)
+    except Exception as error:
+        print_error(f"Failed to fetch Descheduler chart defaults: {error}")
+        return fallback_image(app_version)
+
     if not content:
         return fallback_image(app_version)
 

--- a/utils/compatibility/scrapers/descheduler.py
+++ b/utils/compatibility/scrapers/descheduler.py
@@ -77,7 +77,11 @@ def get_chart_releases(index_content):
         print_error("Invalid Descheduler Helm index.")
         return {}
 
-    entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
+    entries = index_yaml.get("entries", {}).get(CHART_NAME) or []
+    if not isinstance(entries, list):
+        print_error("Invalid Descheduler chart entries.")
+        return {}
+
     chart_releases = {}
 
     for entry in entries:

--- a/utils/compatibility/scrapers/descheduler.py
+++ b/utils/compatibility/scrapers/descheduler.py
@@ -77,7 +77,12 @@ def get_chart_releases(index_content):
         print_error("Invalid Descheduler Helm index.")
         return {}
 
-    entries = index_yaml.get("entries", {}).get(CHART_NAME) or []
+    chart_entries = index_yaml.get("entries") or {}
+    if not isinstance(chart_entries, dict):
+        print_error("Invalid Descheduler Helm index entries.")
+        return {}
+
+    entries = chart_entries.get(CHART_NAME) or []
     if not isinstance(entries, list):
         print_error("Invalid Descheduler chart entries.")
         return {}


### PR DESCRIPTION
## Summary
- Add Descheduler compatibility data and manifest entry.
- Add a scraper that parses the official Descheduler compatibility matrix and Helm index.
- Include Helm chart metadata and default image references for generated rows.

## Sources
- Compatibility matrix: https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
- Helm chart repo: https://kubernetes-sigs.github.io/descheduler

## Verification
- python3 -m py_compile utils/compatibility/scrapers/descheduler.py
- YAML load check for the descheduler table, manifest, and aggregate file
- Parser output check against the Descheduler README, Helm index, and selected chart tarballs
- Chart values image check from official chart tarballs
- git diff --check

Note: Full Helm template rendering was not run locally because Helm is not installed. Default image references were checked from the selected Descheduler chart values.
