### PR TITLE
feat: improve service deletion

### DIFF
--- a/go/controller/internal/controller/servicedeployment_controller.go
+++ b/go/controller/internal/controller/servicedeployment_controller.go
@@ -695,12 +695,12 @@ func (r *ServiceDeploymentReconciler) addOrRemoveFinalizer(ctx context.Context, 
 
 		// If the service is already being deleted from Console API, requeue.
 		if r.ConsoleClient.IsServiceDeleting(serviceID) {
-			return new(common.Wait())
+			return lo.ToPtr(common.Wait())
 		}
 
 		exists, err := r.ConsoleClient.IsServiceExisting(serviceID)
 		if err != nil {
-			return new(common.WaitForResources())
+			return lo.ToPtr(common.WaitForResources())
 		}
 
 		// Remove service from Console API if it exists.
@@ -709,12 +709,12 @@ func (r *ServiceDeploymentReconciler) addOrRemoveFinalizer(ctx context.Context, 
 				// If it fails to delete the external dependency here, return with the error
 				// so that it can be retried.
 				utils.MarkCondition(service.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
-				return new(common.WaitForResources())
+				return lo.ToPtr(common.WaitForResources())
 			}
 
 			// If the deletion process started requeue so that we can make sure the service
 			// has been deleted from Console API before removing the finalizer.
-			return new(common.WaitForResources())
+			return lo.ToPtr(common.WaitForResources())
 		}
 
 		// If our finalizer is present, remove it.

--- a/go/controller/internal/controller/servicedeployment_controller.go
+++ b/go/controller/internal/controller/servicedeployment_controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pluralsh/console/go/polly/algorithms"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,7 +89,10 @@ func (r *ServiceDeploymentReconciler) Process(ctx context.Context, req ctrl.Requ
 	}
 	defer func() {
 		if err := scope.PatchObject(); err != nil && reterr == nil {
-			reterr = err
+			// The object already deleted
+			if !apierrors.IsNotFound(err) {
+				reterr = err
+			}
 		}
 	}()
 
@@ -104,7 +108,7 @@ func (r *ServiceDeploymentReconciler) Process(ctx context.Context, req ctrl.Requ
 	}
 
 	// Handle resource deletion both in Kubernetes cluster and in Console API.
-	if result := r.addOrRemoveFinalizer(service); result != nil {
+	if result := r.addOrRemoveFinalizer(ctx, service); result != nil {
 		return *result, nil
 	}
 
@@ -661,7 +665,7 @@ func (r *ServiceDeploymentReconciler) addConfigurationSecretRefs(ctx context.Con
 	return utils.AddOwnerRefAnnotation(ctx, r.Client, service, configurationSecret)
 }
 
-func (r *ServiceDeploymentReconciler) addOrRemoveFinalizer(service *v1alpha1.ServiceDeployment) *ctrl.Result {
+func (r *ServiceDeploymentReconciler) addOrRemoveFinalizer(ctx context.Context, service *v1alpha1.ServiceDeployment) *ctrl.Result {
 	// If the service is not being deleted and if it does not have the finalizer, then let's add it.
 	if service.DeletionTimestamp.IsZero() && !controllerutil.ContainsFinalizer(service, ServiceFinalizer) {
 		controllerutil.AddFinalizer(service, ServiceFinalizer)
@@ -669,34 +673,48 @@ func (r *ServiceDeploymentReconciler) addOrRemoveFinalizer(service *v1alpha1.Ser
 
 	// If the service is being deleted, cleanup and remove the finalizer.
 	if !service.DeletionTimestamp.IsZero() {
+		serviceID := service.Status.GetID()
+
+		if serviceID == "" {
+			resolvedID, err := r.getServiceIDForDeletion(ctx, service)
+			if err != nil {
+				utils.MarkCondition(service.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
+				return lo.ToPtr(common.WaitForResources())
+			}
+			serviceID = resolvedID
+			if serviceID != "" {
+				service.Status.ID = new(serviceID)
+			}
+		}
+
 		// If the service does not have an ID, the finalizer can be removed.
-		if !service.Status.HasID() {
+		if serviceID == "" {
 			controllerutil.RemoveFinalizer(service, ServiceFinalizer)
 			return &ctrl.Result{}
 		}
 
 		// If the service is already being deleted from Console API, requeue.
-		if r.ConsoleClient.IsServiceDeleting(service.Status.GetID()) {
-			return lo.ToPtr(common.Wait())
+		if r.ConsoleClient.IsServiceDeleting(serviceID) {
+			return new(common.Wait())
 		}
 
-		exists, err := r.ConsoleClient.IsServiceExisting(service.Status.GetID())
+		exists, err := r.ConsoleClient.IsServiceExisting(serviceID)
 		if err != nil {
-			return lo.ToPtr(common.WaitForResources())
+			return new(common.WaitForResources())
 		}
 
-		// Remove service from Console API if it exists and is not read-only.
-		if exists && !service.Status.IsReadonly() {
-			if err := r.deleteService(service.Status.GetID(), service.Spec.Detach); err != nil {
+		// Remove service from Console API if it exists.
+		if exists {
+			if err := r.deleteService(serviceID, service.Spec.Detach); err != nil {
 				// If it fails to delete the external dependency here, return with the error
 				// so that it can be retried.
 				utils.MarkCondition(service.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
-				return &ctrl.Result{}
+				return new(common.WaitForResources())
 			}
 
 			// If the deletion process started requeue so that we can make sure the service
 			// has been deleted from Console API before removing the finalizer.
-			return lo.ToPtr(common.WaitForResources())
+			return new(common.WaitForResources())
 		}
 
 		// If our finalizer is present, remove it.
@@ -707,6 +725,27 @@ func (r *ServiceDeploymentReconciler) addOrRemoveFinalizer(service *v1alpha1.Ser
 	}
 
 	return nil
+}
+
+func (r *ServiceDeploymentReconciler) getServiceIDForDeletion(ctx context.Context, service *v1alpha1.ServiceDeployment) (string, error) {
+	clusterID, err := r.getClusterID(ctx, service)
+	if err != nil {
+		return "", err
+	}
+
+	// get service by name
+	existingService, err := r.ConsoleClient.GetService(clusterID, service.ConsoleName())
+	if errors.IsNotFound(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if existingService == nil {
+		return "", nil
+	}
+
+	return existingService.ID, nil
 }
 
 func (r *ServiceDeploymentReconciler) deleteService(id string, detach bool) error {

--- a/go/controller/internal/controller/servicedeployment_controller_test.go
+++ b/go/controller/internal/controller/servicedeployment_controller_test.go
@@ -380,6 +380,45 @@ var _ = Describe("Service Controller", Ordered, func() {
 			Expect(err).To(HaveOccurred())
 
 		})
+
+		It("should delete service from API even when status id is missing", func() {
+			const orphanName = "service-delete-without-status"
+			nsn := types.NamespacedName{Name: orphanName, Namespace: namespace}
+
+			resource := &v1alpha1.ServiceDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       orphanName,
+					Namespace:  namespace,
+					Finalizers: []string{controller.ServiceFinalizer},
+				},
+				Spec: v1alpha1.ServiceSpec{
+					Version:       lo.ToPtr("1.24"),
+					ClusterRef:    corev1.ObjectReference{Name: clusterName, Namespace: namespace},
+					RepositoryRef: &corev1.ObjectReference{Name: repoName, Namespace: namespace},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+
+			fallbackID := "service-id-from-lookup"
+			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
+			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
+			fakeConsoleClient.On("GetService", mock.Anything, orphanName).Return(&gqlclient.ServiceDeploymentExtended{ID: fallbackID}, nil).Once()
+			fakeConsoleClient.On("IsServiceDeleting", fallbackID).Return(false).Once()
+			fakeConsoleClient.On("IsServiceExisting", fallbackID).Return(true, nil).Once()
+			fakeConsoleClient.On("DeleteService", fallbackID).Return(nil).Once()
+
+			serviceReconciler := &controller.ServiceDeploymentReconciler{
+				Client:           k8sClient,
+				Scheme:           k8sClient.Scheme(),
+				ConsoleClient:    fakeConsoleClient,
+				CredentialsCache: credentials.FakeNamespaceCredentialsCache(k8sClient),
+			}
+
+			result, err := serviceReconciler.Process(ctx, reconcile.Request{NamespacedName: nsn})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).ToNot(BeZero())
+		})
 	})
 })
 


### PR DESCRIPTION
 - ServiceDeployment could remove its finalizer without deleting the Console object when status.id was empty
 - API object deletion was skipped when the ReadOnly condition was set, but it never happened in the current code

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.your-env.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
