### PR TITLE
Migrate from asdf dev setup to mise

### DIFF
--- a/.github/workflows/oci-charts-ghcr.yaml
+++ b/.github/workflows/oci-charts-ghcr.yaml
@@ -62,7 +62,7 @@ jobs:
         include:
         - name: console
           dir: charts/console
-          repository: pluralsh/console-chart
+          repository: pluralsh/charts
         - name: controller
           dir: charts/controller
           repository: pluralsh/controller-chart

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 erlang 28.5
 elixir 1.19.4
+rust stable

--- a/README.md
+++ b/README.md
@@ -55,15 +55,14 @@ yarn start:cd # or any other yarn target, we often test on different Console ins
 ```
 
 ### Developing Server
-To make changes to the server codebase, you'll want to install elixir on your machine.  For Mac desktops, we do this via asdf, which can be done simply at the root of the repo like so:
+To make changes to the server codebase, you'll want to install elixir and rust (for nif compilation) on your machine.  For Mac desktops, we do this via mise, which can be done simply at the root of the repo like so:
 
 ```sh
-asdf install
-brew install rustup-init
-rustup toolchain install stable
+brew install mise
+mise install
 ```
 
-Once elixir is available, all server dependencies are managed via docker-compose, and tests can be run via `mix`, like so:
+Once elixir/rust is available, all server dependencies are managed via docker-compose, and tests can be run via `mix`, like so:
 
 ```sh
 make testup
@@ -74,17 +73,20 @@ mix test
 
 ### Git Hooks
 Custom Git hooks are stored in `.githooks` directory. They ensure that when controller or client files are changed, automated code generation targets are executed. In order to enable git hooks for this repo run:
+
 ```sh
 make install-git-hooks
 ```
 
 ### Troubleshooting
 #### Installing Erlang 
-If `asdf install` fails with `cannot find required auxiliary files: install-sh config.guess config.sub` then run:
+If `mise install` fails with `cannot find required auxiliary files: install-sh config.guess config.sub` then run:
 
 ```sh
 brew install autoconf
 autoconf -V
 ```
+
+(this was more of an issue with asdf but possibly an issue with mise installs of erlang/elixir as well, keeping around for posterity)
 
 You can read more here: https://github.com/asdf-vm/asdf-erlang?tab=readme-ov-file#osx# Registry cache test - run 1

--- a/assets/src/generated/graphql.ts
+++ b/assets/src/generated/graphql.ts
@@ -427,6 +427,8 @@ export type AgentRun = {
   babysitInterval?: Maybe<Scalars['Int']['output']>;
   /** the branch this agent run is operating on (if not set, use default branch on clone) */
   branch?: Maybe<Scalars['String']['output']>;
+  /** the agent run this run consumed */
+  consumed?: Maybe<Scalars['ID']['output']>;
   /** the error reason of the agent run */
   error?: Maybe<Scalars['String']['output']>;
   /** the flow this agent is associated with */
@@ -567,6 +569,8 @@ export type AgentRunStatusAttributes = {
   babysit?: InputMaybe<Scalars['Boolean']['input']>;
   /** interval in seconds between babysit checks for this run */
   babysitInterval?: InputMaybe<Scalars['Int']['input']>;
+  /** the agent run this run consumed */
+  consumed?: InputMaybe<Scalars['ID']['input']>;
   /** the error reason of the agent run */
   error?: InputMaybe<Scalars['String']['input']>;
   /** the messages this agent run has generated during its run */

--- a/go/client/models_gen.go
+++ b/go/client/models_gen.go
@@ -368,6 +368,8 @@ type AgentRun struct {
 	Approval *bool `json:"approval,omitempty"`
 	// when this run was approved
 	ApprovedAt *string `json:"approvedAt,omitempty"`
+	// the agent run this run consumed
+	Consumed *string `json:"consumed,omitempty"`
 	// the programming language used in the agent run
 	Language *AgentRunLanguage `json:"language,omitempty"`
 	// the version of the language to use, if you wish to specify
@@ -470,6 +472,8 @@ type AgentRunStatusAttributes struct {
 	Approval *bool `json:"approval,omitempty"`
 	// when this run was approved
 	ApprovedAt *string `json:"approvedAt,omitempty"`
+	// the agent run this run consumed
+	Consumed *string `json:"consumed,omitempty"`
 }
 
 type AgentRunUpload struct {
@@ -10552,6 +10556,8 @@ type WorkbenchToolConfiguration struct {
 	HTTP *WorkbenchToolHTTPConfiguration `json:"http,omitempty"`
 	// elasticsearch connection (no secrets)
 	Elastic *WorkbenchToolElasticConnection `json:"elastic,omitempty"`
+	// aws opensearch connection (no secrets)
+	Opensearch *WorkbenchToolOpensearchConnection `json:"opensearch,omitempty"`
 	// prometheus connection (no secrets)
 	Prometheus *WorkbenchToolPrometheusConnection `json:"prometheus,omitempty"`
 	// loki connection (no secrets)
@@ -10601,6 +10607,8 @@ type WorkbenchToolConfigurationAttributes struct {
 	HTTP *WorkbenchToolHTTPConfigurationAttributes `json:"http,omitempty"`
 	// elasticsearch connection (logs)
 	Elastic *WorkbenchToolElasticConnectionAttributes `json:"elastic,omitempty"`
+	// aws opensearch connection (logs)
+	Opensearch *WorkbenchToolOpensearchConnectionAttributes `json:"opensearch,omitempty"`
 	// prometheus connection (metrics)
 	Prometheus *WorkbenchToolPrometheusConnectionAttributes `json:"prometheus,omitempty"`
 	// loki connection (logs)
@@ -10833,6 +10841,38 @@ type WorkbenchToolLokiConnectionAttributes struct {
 	Password *string `json:"password,omitempty"`
 	// optional tenant id
 	TenantID *string `json:"tenantId,omitempty"`
+}
+
+type WorkbenchToolOpensearchConnection struct {
+	// aws opensearch endpoint
+	Host string `json:"host"`
+	// opensearch index
+	Index string `json:"index"`
+	// AWS access key id for SigV4 authentication
+	AWSAccessKeyID *string `json:"awsAccessKeyId,omitempty"`
+	// AWS region for SigV4 authentication
+	AWSRegion *string `json:"awsRegion,omitempty"`
+	// assumed role ARN when configured
+	AssumeRoleArn *string `json:"assumeRoleArn,omitempty"`
+	// whether pod identity (IRSA/Workload Identity) is used for AWS authentication
+	UsePodIdentity *bool `json:"usePodIdentity,omitempty"`
+}
+
+type WorkbenchToolOpensearchConnectionAttributes struct {
+	// aws opensearch endpoint
+	Host string `json:"host"`
+	// opensearch index
+	Index string `json:"index"`
+	// AWS access key id for SigV4 authentication
+	AWSAccessKeyID *string `json:"awsAccessKeyId,omitempty"`
+	// AWS secret access key for SigV4 authentication
+	AWSSecretAccessKey *string `json:"awsSecretAccessKey,omitempty"`
+	// AWS region for SigV4 authentication
+	AWSRegion *string `json:"awsRegion,omitempty"`
+	// optional IAM role ARN to assume before signing OpenSearch requests
+	AssumeRoleArn *string `json:"assumeRoleArn,omitempty"`
+	// whether to use pod identity (IRSA/Workload Identity) for AWS authentication instead of static credentials
+	UsePodIdentity *bool `json:"usePodIdentity,omitempty"`
 }
 
 type WorkbenchToolPagerdutyConnection struct {
@@ -17487,6 +17527,7 @@ const (
 	WorkbenchToolTypeBitbucketDatacenter WorkbenchToolType = "BITBUCKET_DATACENTER"
 	WorkbenchToolTypeAzureDevops         WorkbenchToolType = "AZURE_DEVOPS"
 	WorkbenchToolTypePagerduty           WorkbenchToolType = "PAGERDUTY"
+	WorkbenchToolTypeOpensearch          WorkbenchToolType = "OPENSEARCH"
 )
 
 var AllWorkbenchToolType = []WorkbenchToolType{
@@ -17515,11 +17556,12 @@ var AllWorkbenchToolType = []WorkbenchToolType{
 	WorkbenchToolTypeBitbucketDatacenter,
 	WorkbenchToolTypeAzureDevops,
 	WorkbenchToolTypePagerduty,
+	WorkbenchToolTypeOpensearch,
 }
 
 func (e WorkbenchToolType) IsValid() bool {
 	switch e {
-	case WorkbenchToolTypeHTTP, WorkbenchToolTypeElastic, WorkbenchToolTypeDatadog, WorkbenchToolTypePrometheus, WorkbenchToolTypeLoki, WorkbenchToolTypeTempo, WorkbenchToolTypeSentry, WorkbenchToolTypeMcp, WorkbenchToolTypeLinear, WorkbenchToolTypeAtlassian, WorkbenchToolTypeSplunk, WorkbenchToolTypeDynatrace, WorkbenchToolTypeCloudwatch, WorkbenchToolTypeAzure, WorkbenchToolTypeCloud, WorkbenchToolTypeJaeger, WorkbenchToolTypeExa, WorkbenchToolTypeGithub, WorkbenchToolTypeSLACk, WorkbenchToolTypeTeams, WorkbenchToolTypeGitlab, WorkbenchToolTypeBitbucket, WorkbenchToolTypeBitbucketDatacenter, WorkbenchToolTypeAzureDevops, WorkbenchToolTypePagerduty:
+	case WorkbenchToolTypeHTTP, WorkbenchToolTypeElastic, WorkbenchToolTypeDatadog, WorkbenchToolTypePrometheus, WorkbenchToolTypeLoki, WorkbenchToolTypeTempo, WorkbenchToolTypeSentry, WorkbenchToolTypeMcp, WorkbenchToolTypeLinear, WorkbenchToolTypeAtlassian, WorkbenchToolTypeSplunk, WorkbenchToolTypeDynatrace, WorkbenchToolTypeCloudwatch, WorkbenchToolTypeAzure, WorkbenchToolTypeCloud, WorkbenchToolTypeJaeger, WorkbenchToolTypeExa, WorkbenchToolTypeGithub, WorkbenchToolTypeSLACk, WorkbenchToolTypeTeams, WorkbenchToolTypeGitlab, WorkbenchToolTypeBitbucket, WorkbenchToolTypeBitbucketDatacenter, WorkbenchToolTypeAzureDevops, WorkbenchToolTypePagerduty, WorkbenchToolTypeOpensearch:
 		return true
 	}
 	return false

--- a/lib/console/graphql/deployments/agent.ex
+++ b/lib/console/graphql/deployments/agent.ex
@@ -49,6 +49,7 @@ defmodule Console.GraphQl.Deployments.Agent do
     field :babysit_interval, :integer, description: "interval in seconds between babysit checks for this run"
     field :approval,         :boolean, description: "whether this run requires approval before continuing"
     field :approved_at,      :datetime, description: "when this run was approved"
+    field :consumed,         :id, description: "the agent run this run consumed"
   end
 
   input_object :agent_pull_request_attributes do
@@ -162,6 +163,7 @@ defmodule Console.GraphQl.Deployments.Agent do
     field :babysit_interval, :integer, description: "interval in seconds between babysit checks for this run"
     field :approval,         :boolean, description: "whether this run requires approval before continuing"
     field :approved_at,      :datetime, description: "when this run was approved"
+    field :consumed,         :id, description: "the agent run this run consumed"
     field :language,         :agent_run_language, description: "the programming language used in the agent run"
     field :language_version, :string, description: "the version of the language to use, if you wish to specify"
 

--- a/lib/console/schema/agent_run.ex
+++ b/lib/console/schema/agent_run.ex
@@ -30,6 +30,7 @@ defmodule Console.Schema.AgentRun do
     field :repository,       :string
     field :branch,           :string
     field :error,            :binary
+    field :consumed,         :binary_id
     field :approval,         :boolean, default: false
     field :approved_at,      :utc_datetime_usec
 
@@ -88,7 +89,7 @@ defmodule Console.Schema.AgentRun do
     from(ar in query, order_by: ^order)
   end
 
-  @valid ~w(status language approval approved_at language_version shared babysit babysit_interval prompt repository runtime_id user_id flow_id session_id mode branch error)a
+  @valid ~w(status language consumed approval approved_at language_version shared babysit babysit_interval prompt repository runtime_id user_id flow_id session_id mode branch error)a
 
   def changeset(model, attrs \\ %{}) do
     model

--- a/priv/repo/migrations/20260603151344_add_agent_run_consumed_from.exs
+++ b/priv/repo/migrations/20260603151344_add_agent_run_consumed_from.exs
@@ -1,0 +1,9 @@
+defmodule Console.Repo.Migrations.AddAgentRunConsumedFrom do
+  use Ecto.Migration
+
+  def change do
+    alter table(:agent_runs) do
+      add :consumed, :uuid
+    end
+  end
+end

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1946,6 +1946,9 @@ input AgentRunStatusAttributes {
 
   "when this run was approved"
   approvedAt: DateTime
+
+  "the agent run this run consumed"
+  consumed: ID
 }
 
 input AgentPullRequestAttributes {
@@ -2159,6 +2162,9 @@ type AgentRun {
 
   "when this run was approved"
   approvedAt: DateTime
+
+  "the agent run this run consumed"
+  consumed: ID
 
   "the programming language used in the agent run"
   language: AgentRunLanguage

--- a/test/console/deployments/clusters_test.exs
+++ b/test/console/deployments/clusters_test.exs
@@ -1426,8 +1426,8 @@ defmodule Console.Deployments.ClustersTest do
 
     test "it errors if the upgrade plan is not ready" do
       user = admin_user()
-      cluster = insert(:cluster, current_version: "1.35.1", write_bindings: [%{user_id: user.id}])
-      insert(:cloud_addon, cluster: cluster, name: "coredns", version: "v1.13.1-eksbuild.1", distro: :eks)
+      cluster = insert(:cluster, current_version: "1.36.1", write_bindings: [%{user_id: user.id}])
+      insert(:cloud_addon, cluster: cluster, name: "coredns", version: "v1.14.3-eksbuild.2", distro: :eks)
 
       {:error, msg} = Clusters.create_cluster_upgrade(cluster.id, user)
 


### PR DESCRIPTION
Mise (https://mise.jdx.dev/) seems to be a much more mature/modern package manager for devboxes, and is compatible with asdf's .tool-versions file.  Moving our configs to it.  Should probably do the same for js too.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.your-env.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
