### PR TITLE
fix: Fix breadcrumbs

### DIFF
--- a/assets/design-system/src/components/Breadcrumbs.tsx
+++ b/assets/design-system/src/components/Breadcrumbs.tsx
@@ -152,10 +152,10 @@ function CrumbSelect({
         isDisabled={isDisabled}
         selectedKey={null}
         onSelectionChange={(key) => {
-          const url = breadcrumbs[key as number]?.url
+          const crumb = breadcrumbs.find((c) => getCrumbKey(c) === key)
 
-          if (url) {
-            navigate(url)
+          if (crumb?.url) {
+            navigate(crumb.url)
           }
         }}
         placement="left"


### PR DESCRIPTION
This pull request improves the way breadcrumb navigation works in the `Breadcrumbs.tsx` component. Instead of relying on array indices to find the selected breadcrumb, it now searches for the breadcrumb using a unique key, making the navigation logic more robust and less error-prone.

Breadcrumb navigation improvements:

* Updated the `onSelectionChange` handler in `CrumbSelect` to find the selected breadcrumb by its unique key instead of array index, ensuring correct navigation even if the breadcrumb order changes.