### PR TITLE
feat: Allow using custom namespaces

### DIFF
--- a/assets/src/components/kubernetes/Cluster.tsx
+++ b/assets/src/components/kubernetes/Cluster.tsx
@@ -21,7 +21,9 @@ import { mapExistingNodes } from '../../utils/graphql'
 import { useProjectId } from '../contexts/ProjectsContext'
 import { GqlError } from '../utils/Alert'
 import LoadingIndicator from '../utils/LoadingIndicator'
+import { useSimpleToast } from '../utils/SimpleToastContext'
 import { DataSelectProvider } from './common/DataSelect'
+import { getNamespaceListLoadError } from './common/namespaceList'
 
 import { LAST_SELECTED_CLUSTER_KEY } from './Navigation'
 
@@ -92,6 +94,7 @@ export const useNamespaces = () => {
 
 export default function Cluster() {
   const theme = useTheme()
+  const { popToast } = useSimpleToast()
   const projectId = useProjectId()
   const { clusterId } = useParams()
   const { search } = useLocation()
@@ -115,15 +118,34 @@ export default function Cluster() {
     [clusterId, clusters]
   )
 
+  const namespaceQueryOptions = getNamespacesOptions({
+    client: AxiosInstance(clusterId!),
+  })
+
   const {
     data: namespacesData,
     error: namespacesError,
+    isError: namespacesQueryError,
     refetch: refetchNamespaces,
   } = useQuery({
-    ...getNamespacesOptions({ client: AxiosInstance(clusterId!) }),
+    ...namespaceQueryOptions,
+    queryKey: [
+      ...namespaceQueryOptions.queryKey,
+      clusterId ?? '',
+    ] as unknown as typeof namespaceQueryOptions.queryKey,
     enabled: !!clusterId,
     refetchInterval: 30_000,
   })
+
+  const namespaceListError = useMemo(
+    () =>
+      getNamespaceListLoadError(
+        namespacesData,
+        namespacesQueryError,
+        namespacesError
+      ),
+    [namespacesData, namespacesQueryError, namespacesError]
+  )
 
   const namespaces = useMemo(
     () =>
@@ -132,6 +154,16 @@ export default function Cluster() {
         .filter((namespace): namespace is string => !isEmpty(namespace)),
     [namespacesData?.namespaces]
   )
+
+  useEffect(() => {
+    if (!clusterId || !namespaceListError) return
+
+    popToast({
+      heading: 'Cannot load namespaces',
+      content: namespaceListError,
+      severity: 'danger',
+    })
+  }, [clusterId, namespaceListError, popToast])
 
   const context = useMemo(
     () => ({ clusters, refetch, cluster, namespaces }) as ClusterContextT,
@@ -170,16 +202,6 @@ export default function Cluster() {
         <GqlError
           header="Cannot load clusters"
           error={error}
-        />
-      </div>
-    )
-
-  if (namespacesError)
-    return (
-      <div css={{ padding: theme.spacing.large }}>
-        <GqlError
-          header="Cannot load namespaces"
-          error={namespacesError}
         />
       </div>
     )

--- a/assets/src/components/kubernetes/common/NamespaceFilter.tsx
+++ b/assets/src/components/kubernetes/common/NamespaceFilter.tsx
@@ -1,13 +1,20 @@
 import {
   ComponentProps,
   Dispatch,
+  KeyboardEvent,
   SetStateAction,
+  useCallback,
   useEffect,
   useMemo,
   useState,
 } from 'react'
 import Fuse from 'fuse.js'
-import { ComboBox, ListBoxItem } from '@pluralsh/design-system'
+import {
+  AddIcon,
+  ComboBox,
+  ListBoxFooterPlus,
+  ListBoxItem,
+} from '@pluralsh/design-system'
 
 import { useTheme } from 'styled-components'
 import { NamespaceListFooter } from '../../utils/NamespaceListFooter.tsx'
@@ -29,16 +36,41 @@ export function NamespaceFilter({
     setValue(namespace)
   }, [namespace])
 
+  const trimmedValue = value?.trim() ?? ''
+
   const filteredNamespaces = useMemo(() => {
     const fuse = new Fuse(namespaces, { threshold: 0.25 })
 
-    return value ? fuse.search(value).map(({ item }) => item) : namespaces
-  }, [namespaces, value])
+    return trimmedValue
+      ? fuse.search(trimmedValue).map(({ item }) => item)
+      : namespaces
+  }, [namespaces, trimmedValue])
+
+  const isCustomNamespace = !!trimmedValue && !namespaces.includes(trimmedValue)
+
+  const applyNamespace = useCallback(
+    (ns: string) => {
+      onChange(ns)
+      setValue(ns)
+    },
+    [onChange]
+  )
+
+  const handleEnter = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key !== 'Enter' || !trimmedValue) return
+
+      event.preventDefault()
+      applyNamespace(trimmedValue)
+    },
+    [applyNamespace, trimmedValue]
+  )
 
   return (
     <ComboBox
       startIcon={null}
       showArrow={false}
+      allowsEmptyCollection={isCustomNamespace}
       inputProps={{
         placeholder: 'Filter by namespace',
         style: {
@@ -46,14 +78,31 @@ export function NamespaceFilter({
           borderRadius: 0,
           background: theme.colors['fill-two'],
         },
+        onKeyDown: handleEnter,
       }}
       inputValue={value}
       onInputChange={setValue}
       selectedKey={namespace}
       onSelectionChange={(key) => {
-        onChange(key as string | undefined)
-        setValue((key ?? '') as string)
+        applyNamespace((key ?? '') as string)
       }}
+      onFooterClick={
+        isCustomNamespace ? () => applyNamespace(trimmedValue) : undefined
+      }
+      dropdownFooter={
+        isCustomNamespace ? (
+          <ListBoxFooterPlus
+            leftContent={
+              <AddIcon
+                size={16}
+                color="text-primary-accent"
+              />
+            }
+          >
+            Use &quot;{trimmedValue}&quot;
+          </ListBoxFooterPlus>
+        ) : undefined
+      }
       dropdownFooterFixed={
         <NamespaceListFooter
           onClick={() => {

--- a/assets/src/components/kubernetes/common/NamespaceFilter.tsx
+++ b/assets/src/components/kubernetes/common/NamespaceFilter.tsx
@@ -58,12 +58,12 @@ export function NamespaceFilter({
 
   const handleEnter = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
-      if (event.key !== 'Enter' || !trimmedValue) return
+      if (event.key !== 'Enter' || !trimmedValue || !isCustomNamespace) return
 
       event.preventDefault()
       applyNamespace(trimmedValue)
     },
-    [applyNamespace, trimmedValue]
+    [applyNamespace, trimmedValue, isCustomNamespace]
   )
 
   return (

--- a/assets/src/components/kubernetes/common/create/secret/SecretModal.tsx
+++ b/assets/src/components/kubernetes/common/create/secret/SecretModal.tsx
@@ -170,21 +170,30 @@ export function CreateSecretModal({
           label="Namespace"
           required
         >
-          <Select
-            label="Select namespace"
-            selectedKey={namespace}
-            onSelectionChange={(key) => {
-              setNamespace(key as string)
-            }}
-          >
-            {namespaces.map((ns) => (
-              <ListBoxItem
-                key={ns}
-                label={ns}
-                textValue={ns}
-              />
-            ))}
-          </Select>
+          {namespaces.length > 0 ? (
+            <Select
+              label="Select namespace"
+              selectedKey={namespace}
+              onSelectionChange={(key) => {
+                setNamespace(key as string)
+              }}
+            >
+              {namespaces.map((ns) => (
+                <ListBoxItem
+                  key={ns}
+                  label={ns}
+                  textValue={ns}
+                />
+              ))}
+            </Select>
+          ) : (
+            <Input
+              placeholder="Enter namespace"
+              value={namespace}
+              onChange={(e) => setNamespace(e.target.value)}
+              required
+            />
+          )}
         </FormField>
         <FormField
           label="Type"

--- a/assets/src/components/kubernetes/common/namespaceList.ts
+++ b/assets/src/components/kubernetes/common/namespaceList.ts
@@ -1,0 +1,29 @@
+import { GetNamespacesResponse } from '../../../generated/kubernetes'
+import { Error as K8sError } from './types'
+
+function getForbiddenNamespaceListError(
+  errors: GetNamespacesResponse['errors'] | undefined
+): string | undefined {
+  const forbidden = (errors ?? []).find((error) => {
+    const k8sError = error as K8sError
+
+    return (
+      k8sError?.ErrStatus?.code === 403 ||
+      k8sError?.ErrStatus?.reason === 'Forbidden'
+    )
+  }) as K8sError | undefined
+
+  return forbidden?.ErrStatus?.message
+}
+
+export function getNamespaceListLoadError(
+  data: GetNamespacesResponse | undefined,
+  isError: boolean,
+  queryError: Error | null | undefined
+): string | undefined {
+  if (isError) {
+    return queryError?.message || 'Failed to load namespaces'
+  }
+
+  return getForbiddenNamespaceListError(data?.errors)
+}

--- a/assets/src/components/utils/network-graph/NetworkGraph.tsx
+++ b/assets/src/components/utils/network-graph/NetworkGraph.tsx
@@ -82,11 +82,10 @@ function NetworkGraphInternal({
 
   const { updateEdge } = useReactFlow()
 
-  const { data: namespacesData, error: namespacesError } =
-    useClusterNamespacesQuery({
-      variables: { clusterId },
-      skip: !enableNamespaceFilter,
-    })
+  const { data: namespacesData } = useClusterNamespacesQuery({
+    variables: { clusterId },
+    skip: !enableNamespaceFilter,
+  })
   const namespaces =
     namespacesData?.namespaces
       ?.filter(isNonNullable)
@@ -129,7 +128,7 @@ function NetworkGraphInternal({
           startIcon={<SearchIcon color="icon-light" />}
           flex={1}
         />
-        {enableNamespaceFilter && !namespacesError && (
+        {enableNamespaceFilter && (
           <NamespaceFilter
             namespaces={namespaces}
             namespace={namespace ?? ''}


### PR DESCRIPTION
The Kubernetes dashboard no longer blocks when namespace listing fails. Users can enter a namespace manually, and list errors show as a toast instead of breaking the page.

## Test Plan
<img width="614" height="288" alt="Zrzut ekranu 2026-06-12 o 12 30 17" src="https://github.com/user-attachments/assets/65875c2f-b6a0-4463-9aac-d2f94f0294b1" />

## Checklist
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
