### PR TITLE
feat: add streaming proxy for responses

### DIFF
--- a/assets/public/setup-guides/webhooks/gitlab.md
+++ b/assets/public/setup-guides/webhooks/gitlab.md
@@ -28,7 +28,7 @@ Open your GitLab host (for example `https://<your-gitlab-host>/`) and navigate t
 
 Enable at least:
 
-- Issue events
+- Issue events for classic GitLab issues, or Work item events for GitLab work items
 - Note/comment events (if comments matter for workflows)
 - Label or state changes used by your routing logic
 

--- a/go/deployment-operator/cmd/mcpserver/agent/args/args.go
+++ b/go/deployment-operator/cmd/mcpserver/agent/args/args.go
@@ -157,6 +157,15 @@ func OpenAIUpstreamURL() string {
 	return resolveOpenAIUpstreamURL(explicit, helpers.GetEnv(EnvConsoleURL, ""))
 }
 
+func OpenAIResponsesUpstreamURL() string {
+	chatURL := OpenAIUpstreamURL()
+	if chatURL != "" && strings.HasSuffix(chatURL, "/v1/chat/completions") {
+		return strings.TrimSuffix(chatURL, "/v1/chat/completions") + "/v1/responses"
+	}
+
+	return resolveOpenAIResponsesUpstreamURL("", helpers.GetEnv(EnvConsoleURL, ""))
+}
+
 func resolveOpenAIUpstreamURL(explicit, consoleURL string) string {
 	if strings.TrimSpace(explicit) != "" {
 		return strings.TrimSpace(explicit)
@@ -171,6 +180,22 @@ func resolveOpenAIUpstreamURL(explicit, consoleURL string) string {
 	}
 
 	return fmt.Sprintf("%s/ext/ai/v1/chat/completions", consoleURL)
+}
+
+func resolveOpenAIResponsesUpstreamURL(explicit, consoleURL string) string {
+	if strings.TrimSpace(explicit) != "" {
+		return strings.TrimSpace(explicit)
+	}
+
+	consoleURL = strings.TrimSpace(consoleURL)
+	consoleURL = strings.TrimSuffix(consoleURL, "/ext/gql")
+	consoleURL = strings.TrimSuffix(consoleURL, "/gql")
+	consoleURL = strings.TrimSuffix(consoleURL, "/")
+	if consoleURL == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/ext/ai/v1/responses", consoleURL)
 }
 
 func ensureOrDie(argName string, arg *string) {

--- a/go/deployment-operator/cmd/mcpserver/agent/main.go
+++ b/go/deployment-operator/cmd/mcpserver/agent/main.go
@@ -172,7 +172,7 @@ func createServerOptions(client, runtimeClient console.Client, agentRun *console
 	}
 
 	if helpers.GetPluralEnvBool(controller.EnvStreamingProxy, false) {
-		opts = append(opts, agent.WithOpenAIProxy(args.OpenAIUpstreamURL()))
+		opts = append(opts, agent.WithOpenAIProxy(args.OpenAIUpstreamURL(), args.OpenAIResponsesUpstreamURL()))
 	}
 
 	return append(opts, createServerTools(client, runtimeClient, agentRun)...)

--- a/go/deployment-operator/internal/mcpserver/agent/openaiproxy/handler_test.go
+++ b/go/deployment-operator/internal/mcpserver/agent/openaiproxy/handler_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/packages/param"
 )
 
 func TestHandlerNonStreamingPassthrough(t *testing.T) {
@@ -69,15 +68,11 @@ func TestHandlerStreamingConvertsToNonStreamingUpstream(t *testing.T) {
 			t.Fatalf("read upstream body: %v", err)
 		}
 
-		var req openai.ChatCompletionNewParams
-		if err := json.Unmarshal(body, &req); err != nil {
-			t.Fatalf("unmarshal upstream body: %v", err)
-		}
-		if !param.IsOmitted(req.StreamOptions) {
-			t.Fatal("expected stream_options to be removed")
-		}
 		if strings.Contains(string(body), `"stream"`) {
 			t.Fatalf("expected stream to be removed, got %s", body)
+		}
+		if !strings.Contains(string(body), `"input_audio"`) {
+			t.Fatalf("expected message content object to be preserved, got %s", body)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -100,7 +95,18 @@ func TestHandlerStreamingConvertsToNonStreamingUpstream(t *testing.T) {
 		t.Fatalf("NewHandler() failed: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true,"stream_options":{"include_usage":true}}`))
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{
+		"model":"gpt-4",
+		"messages":[{
+			"role":"user",
+			"content":[
+				{"type":"text","text":"transcribe this"},
+				{"type":"input_audio","input_audio":{"data":"abc","format":"wav"}}
+			]
+		}],
+		"stream":true,
+		"stream_options":{"include_usage":true}
+	}`))
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -272,23 +278,44 @@ func TestStreamChunksFromCompletionToolCalls(t *testing.T) {
 func TestForceNonStreaming(t *testing.T) {
 	t.Parallel()
 
-	body, err := forceNonStreaming([]byte(`{"model":"gpt-4","stream":true,"stream_options":{"include_usage":true},"max_tokens":100}`))
+	body, err := forceNonStreaming([]byte(`{
+		"model":"gpt-4",
+		"stream":true,
+		"stream_options":{"include_usage":true},
+		"max_tokens":100,
+		"messages":[{
+			"role":"user",
+			"content":[{"type":"text","text":"hi"}]
+		}]
+	}`))
 	if err != nil {
 		t.Fatalf("forceNonStreaming() failed: %v", err)
 	}
 
-	var params openai.ChatCompletionNewParams
-	if err := json.Unmarshal(body, &params); err != nil {
-		t.Fatalf("unmarshal payload: %v", err)
-	}
-	if !param.IsOmitted(params.StreamOptions) {
-		t.Fatal("expected stream_options to be removed")
-	}
-	if params.MaxTokens.Value != 100 {
-		t.Fatalf("max_tokens = %d, want 100", params.MaxTokens.Value)
-	}
 	if strings.Contains(string(body), `"stream"`) {
 		t.Fatalf("expected stream to be removed, got %s", body)
+	}
+
+	var payload struct {
+		MaxTokens int64 `json:"max_tokens"`
+		Messages  []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.MaxTokens != 100 {
+		t.Fatalf("max_tokens = %d, want 100", payload.MaxTokens)
+	}
+	if len(payload.Messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(payload.Messages))
+	}
+	if string(payload.Messages[0].Content) == "null" || len(payload.Messages[0].Content) == 0 {
+		t.Fatalf("expected message content to be preserved, got %s", payload.Messages[0].Content)
+	}
+	if !strings.Contains(string(payload.Messages[0].Content), `"type":"text"`) {
+		t.Fatalf("expected message content array to be preserved, got %s", payload.Messages[0].Content)
 	}
 }
 

--- a/go/deployment-operator/internal/mcpserver/agent/openaiproxy/proxy.go
+++ b/go/deployment-operator/internal/mcpserver/agent/openaiproxy/proxy.go
@@ -1,0 +1,73 @@
+package openaiproxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func forwardRequest(client HTTPDoer, upstreamURL string, r *http.Request, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, upstreamURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create upstream request: %w", err)
+	}
+
+	for _, header := range forwardRequestHeaders {
+		if value := r.Header.Get(header); value != "" {
+			req.Header.Set(header, value)
+		}
+	}
+
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return client.Do(req)
+}
+
+func copyResponse(w http.ResponseWriter, resp *http.Response, body []byte) {
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(body)
+}
+
+func readUpstreamResponse(resp *http.Response) ([]byte, error) {
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+
+func newProxyClient(client HTTPDoer) HTTPDoer {
+	if client == nil {
+		return http.DefaultClient
+	}
+	return client
+}
+
+func validateUpstreamURL(upstreamURL string) (string, error) {
+	upstreamURL = strings.TrimSpace(upstreamURL)
+	if upstreamURL == "" {
+		return "", fmt.Errorf("upstream URL is required")
+	}
+	return upstreamURL, nil
+}
+
+func removeTopLevelJSONFields(body []byte, fields ...string) ([]byte, error) {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+
+	for _, field := range fields {
+		delete(payload, field)
+	}
+
+	return json.Marshal(payload)
+}

--- a/go/deployment-operator/internal/mcpserver/agent/openaiproxy/responses_handler.go
+++ b/go/deployment-operator/internal/mcpserver/agent/openaiproxy/responses_handler.go
@@ -2,52 +2,40 @@ package openaiproxy
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
 )
 
-var forwardRequestHeaders = []string{
-	"Authorization",
-	"Content-Type",
-	"OpenAI-Organization",
-	"OpenAI-Project",
-	"X-Request-Id",
-}
-
-// HTTPDoer performs outbound HTTP requests. It matches *http.Client.
-type HTTPDoer interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
-// Config configures the OpenAI chat completion proxy.
-type Config struct {
+// ResponsesConfig configures the OpenAI responses proxy.
+type ResponsesConfig struct {
 	UpstreamURL string
 	Client      HTTPDoer
 }
 
-// Handler proxies OpenAI chat completion requests, converting streaming client
+// ResponsesHandler proxies OpenAI responses requests, converting streaming client
 // requests into non-streaming upstream calls and re-emitting the response as SSE.
-type Handler struct {
+type ResponsesHandler struct {
 	upstreamURL string
 	client      HTTPDoer
 }
 
-// NewHandler creates a proxy handler.
-func NewHandler(cfg Config) (*Handler, error) {
+// NewResponsesHandler creates a responses proxy handler.
+func NewResponsesHandler(cfg ResponsesConfig) (*ResponsesHandler, error) {
 	upstreamURL, err := validateUpstreamURL(cfg.UpstreamURL)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Handler{
+	return &ResponsesHandler{
 		upstreamURL: upstreamURL,
 		client:      newProxyClient(cfg.Client),
 	}, nil
 }
 
-func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *ResponsesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -67,7 +55,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	upstreamBody := body
 	if streaming {
-		upstreamBody, err = forceNonStreaming(body)
+		upstreamBody, err = forceNonStreamingResponses(body)
 		if err != nil {
 			http.Error(w, "invalid JSON request body", http.StatusBadRequest)
 			return
@@ -96,13 +84,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var completion openai.ChatCompletion
-	if err := json.Unmarshal(respBody, &completion); err != nil {
+	var response responses.Response
+	if err := json.Unmarshal(respBody, &response); err != nil {
 		http.Error(w, "upstream returned non-JSON response for streaming request", http.StatusBadGateway)
 		return
 	}
 
-	chunks, err := StreamChunksFromCompletion(completion)
+	events, err := StreamEventsFromResponse(response)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
@@ -118,8 +106,23 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 
-	if err := WriteSSE(w, chunks); err != nil {
+	if err := WriteResponseSSE(w, events); err != nil {
 		return
 	}
 	flusher.Flush()
+}
+
+// WriteResponseSSE writes OpenAI-compatible SSE events for the given response stream events.
+func WriteResponseSSE(w io.Writer, events []json.RawMessage) error {
+	for _, payload := range events {
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", payload); err != nil {
+			return err
+		}
+	}
+
+	if _, err := io.WriteString(w, "data: [DONE]\n\n"); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/go/deployment-operator/internal/mcpserver/agent/openaiproxy/responses_handler_test.go
+++ b/go/deployment-operator/internal/mcpserver/agent/openaiproxy/responses_handler_test.go
@@ -1,0 +1,171 @@
+package openaiproxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResponsesHandlerStreamingConvertsToNonStreamingUpstream(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := readRequestBody(r)
+		if err != nil {
+			t.Fatalf("read upstream body: %v", err)
+		}
+		if strings.Contains(string(body), `"stream"`) {
+			t.Fatalf("expected stream to be removed, got %s", body)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"resp_abc",
+			"object":"response",
+			"created_at":123,
+			"status":"completed",
+			"model":"gpt-5.4",
+			"output":[{
+				"type":"message",
+				"id":"msg_1",
+				"role":"assistant",
+				"status":"completed",
+				"content":[{
+					"type":"output_text",
+					"text":"Hello there",
+					"annotations":[]
+				}]
+			}]
+		}`))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewResponsesHandler(ResponsesConfig{UpstreamURL: upstream.URL, Client: &http.Client{}})
+	if err != nil {
+		t.Fatalf("NewResponsesHandler() failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5.4","input":"hi","stream":true}`))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("content-type = %q, want text/event-stream", got)
+	}
+
+	events := parseSSE(rec.Body.String())
+	if len(events) < 3 {
+		t.Fatalf("expected at least 3 SSE events, got %d: %v", len(events), events)
+	}
+
+	var first struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal([]byte(events[0]), &first); err != nil {
+		t.Fatalf("decode first event: %v", err)
+	}
+	if first.Type != "response.created" {
+		t.Fatalf("first event type = %q, want response.created", first.Type)
+	}
+
+	var combined strings.Builder
+	for _, event := range events {
+		if event == "[DONE]" {
+			continue
+		}
+
+		var payload struct {
+			Type  string `json:"type"`
+			Delta string `json:"delta"`
+		}
+		if err := json.Unmarshal([]byte(event), &payload); err != nil {
+			continue
+		}
+		if payload.Type == "response.output_text.delta" {
+			combined.WriteString(payload.Delta)
+		}
+	}
+	if combined.String() != "Hello there" {
+		t.Fatalf("streamed content = %q, want %q", combined.String(), "Hello there")
+	}
+
+	lastEvent := events[len(events)-1]
+	if lastEvent != "[DONE]" {
+		t.Fatalf("expected final [DONE] event, got %q", lastEvent)
+	}
+}
+
+func TestResponsesHandlerNonStreamingPassthrough(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","status":"completed"}`))
+	}))
+	defer upstream.Close()
+
+	handler, err := NewResponsesHandler(ResponsesConfig{UpstreamURL: upstream.URL, Client: &http.Client{}})
+	if err != nil {
+		t.Fatalf("NewResponsesHandler() failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5.4","input":"hi","stream":false}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"object":"response"`) {
+		t.Fatalf("expected upstream body passthrough, got %q", rec.Body.String())
+	}
+}
+
+func TestForceNonStreamingResponses(t *testing.T) {
+	t.Parallel()
+
+	body, err := forceNonStreamingResponses([]byte(`{
+		"model":"gpt-5.4",
+		"stream":true,
+		"input":[{
+			"role":"user",
+			"content":[{"type":"input_text","text":"hi"}]
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("forceNonStreamingResponses() failed: %v", err)
+	}
+	if strings.Contains(string(body), `"stream"`) {
+		t.Fatalf("expected stream to be removed, got %s", body)
+	}
+
+	var payload struct {
+		Input []struct {
+			Content json.RawMessage `json:"content"`
+		} `json:"input"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("unmarshal rewritten body: %v", err)
+	}
+	if len(payload.Input) != 1 {
+		t.Fatalf("input item count = %d, want 1", len(payload.Input))
+	}
+	if string(payload.Input[0].Content) == "null" || len(payload.Input[0].Content) == 0 {
+		t.Fatalf("expected input content to be preserved, got %s", payload.Input[0].Content)
+	}
+	if !strings.Contains(string(payload.Input[0].Content), `"input_text"`) {
+		t.Fatalf("expected input content object to be preserved, got %s", payload.Input[0].Content)
+	}
+}
+
+func readRequestBody(r *http.Request) ([]byte, error) {
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}

--- a/go/deployment-operator/internal/mcpserver/agent/openaiproxy/responses_stream.go
+++ b/go/deployment-operator/internal/mcpserver/agent/openaiproxy/responses_stream.go
@@ -1,0 +1,336 @@
+package openaiproxy
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openai/openai-go/responses"
+	"github.com/openai/openai-go/shared/constant"
+)
+
+// StreamEventsFromResponse converts a non-streaming response into OpenAI Responses API SSE event payloads.
+func StreamEventsFromResponse(response responses.Response) ([]json.RawMessage, error) {
+	var events []json.RawMessage
+	seq := int64(0)
+
+	shell, err := responseShell(response)
+	if err != nil {
+		return nil, err
+	}
+
+	events = append(events, mustEventJSON(responses.ResponseCreatedEvent{
+		Response:       shell,
+		SequenceNumber: nextSeq(&seq),
+		Type:           constant.ResponseCreated("response.created"),
+	}))
+	events = append(events, mustEventJSON(responses.ResponseInProgressEvent{
+		Response:       shell,
+		SequenceNumber: nextSeq(&seq),
+		Type:           constant.ResponseInProgress("response.in_progress"),
+	}))
+
+	for outputIndex, item := range response.Output {
+		itemEvents, err := streamEventsForOutputItem(item, int64(outputIndex), &seq)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, itemEvents...)
+	}
+
+	events = append(events, mustEventJSON(responses.ResponseCompletedEvent{
+		Response:       response,
+		SequenceNumber: nextSeq(&seq),
+		Type:           constant.ResponseCompleted("response.completed"),
+	}))
+
+	return events, nil
+}
+
+func streamEventsForOutputItem(item responses.ResponseOutputItemUnion, outputIndex int64, seq *int64) ([]json.RawMessage, error) {
+	switch item.Type {
+	case "message":
+		return streamEventsForMessage(item.AsMessage(), outputIndex, seq)
+	case "function_call":
+		return streamEventsForFunctionCall(item.AsFunctionCall(), outputIndex, seq)
+	default:
+		return streamEventsForGenericItem(item, outputIndex, seq)
+	}
+}
+
+func streamEventsForMessage(message responses.ResponseOutputMessage, outputIndex int64, seq *int64) ([]json.RawMessage, error) {
+	var events []json.RawMessage
+
+	inProgress, err := messageWithStatus(message, responses.ResponseOutputMessageStatusInProgress, true)
+	if err != nil {
+		return nil, err
+	}
+
+	events = append(events, mustEventJSON(responses.ResponseOutputItemAddedEvent{
+		Item:           inProgress,
+		OutputIndex:    outputIndex,
+		SequenceNumber: nextSeq(seq),
+		Type:           constant.ResponseOutputItemAdded("response.output_item.added"),
+	}))
+
+	for contentIndex, content := range message.Content {
+		switch content.Type {
+		case "output_text":
+			events = append(events, mustEventJSON(responses.ResponseContentPartAddedEvent{
+				ContentIndex: int64(contentIndex),
+				ItemID:       message.ID,
+				OutputIndex:  outputIndex,
+				Part: responses.ResponseContentPartAddedEventPartUnion{
+					Type: "output_text",
+					Text: "",
+				},
+				SequenceNumber: nextSeq(seq),
+				Type:           constant.ResponseContentPartAdded("response.content_part.added"),
+			}))
+			events = append(events, mustEventJSON(responses.ResponseTextDeltaEvent{
+				ContentIndex:   int64(contentIndex),
+				Delta:          content.Text,
+				ItemID:         message.ID,
+				OutputIndex:    outputIndex,
+				SequenceNumber: nextSeq(seq),
+				Type:           constant.ResponseOutputTextDelta("response.output_text.delta"),
+			}))
+			events = append(events, mustEventJSON(responses.ResponseTextDoneEvent{
+				ContentIndex:   int64(contentIndex),
+				ItemID:         message.ID,
+				OutputIndex:    outputIndex,
+				SequenceNumber: nextSeq(seq),
+				Text:           content.Text,
+				Type:           constant.ResponseOutputTextDone("response.output_text.done"),
+			}))
+			events = append(events, mustEventJSON(responses.ResponseContentPartDoneEvent{
+				ContentIndex: int64(contentIndex),
+				ItemID:       message.ID,
+				OutputIndex:  outputIndex,
+				Part: responses.ResponseContentPartDoneEventPartUnion{
+					Type: "output_text",
+					Text: content.Text,
+				},
+				SequenceNumber: nextSeq(seq),
+				Type:           constant.ResponseContentPartDone("response.content_part.done"),
+			}))
+		case "refusal":
+			events = append(events, mustEventJSON(responses.ResponseContentPartAddedEvent{
+				ContentIndex: int64(contentIndex),
+				ItemID:       message.ID,
+				OutputIndex:  outputIndex,
+				Part: responses.ResponseContentPartAddedEventPartUnion{
+					Type:    "refusal",
+					Refusal: "",
+				},
+				SequenceNumber: nextSeq(seq),
+				Type:           constant.ResponseContentPartAdded("response.content_part.added"),
+			}))
+			events = append(events, mustEventJSON(responses.ResponseContentPartDoneEvent{
+				ContentIndex: int64(contentIndex),
+				ItemID:       message.ID,
+				OutputIndex:  outputIndex,
+				Part: responses.ResponseContentPartDoneEventPartUnion{
+					Type:    "refusal",
+					Refusal: content.Refusal,
+				},
+				SequenceNumber: nextSeq(seq),
+				Type:           constant.ResponseContentPartDone("response.content_part.done"),
+			}))
+		}
+	}
+
+	completedItem, err := messageAsOutputItem(message)
+	if err != nil {
+		return nil, err
+	}
+
+	events = append(events, mustEventJSON(responses.ResponseOutputItemDoneEvent{
+		Item:           completedItem,
+		OutputIndex:    outputIndex,
+		SequenceNumber: nextSeq(seq),
+		Type:           constant.ResponseOutputItemDone("response.output_item.done"),
+	}))
+
+	return events, nil
+}
+
+func streamEventsForFunctionCall(call responses.ResponseFunctionToolCall, outputIndex int64, seq *int64) ([]json.RawMessage, error) {
+	var events []json.RawMessage
+
+	inProgress, err := functionCallWithStatus(call, "in_progress")
+	if err != nil {
+		return nil, err
+	}
+
+	events = append(events, mustEventJSON(responses.ResponseOutputItemAddedEvent{
+		Item:           inProgress,
+		OutputIndex:    outputIndex,
+		SequenceNumber: nextSeq(seq),
+		Type:           constant.ResponseOutputItemAdded("response.output_item.added"),
+	}))
+	events = append(events, mustEventJSON(responses.ResponseFunctionCallArgumentsDeltaEvent{
+		Delta:          call.Arguments,
+		ItemID:         call.ID,
+		OutputIndex:    outputIndex,
+		SequenceNumber: nextSeq(seq),
+		Type:           constant.ResponseFunctionCallArgumentsDelta("response.function_call_arguments.delta"),
+	}))
+	events = append(events, mustEventJSON(responses.ResponseFunctionCallArgumentsDoneEvent{
+		Arguments:      call.Arguments,
+		ItemID:         call.ID,
+		OutputIndex:    outputIndex,
+		SequenceNumber: nextSeq(seq),
+		Type:           constant.ResponseFunctionCallArgumentsDone("response.function_call_arguments.done"),
+	}))
+
+	completed, err := functionCallWithStatus(call, "completed")
+	if err != nil {
+		return nil, err
+	}
+
+	events = append(events, mustEventJSON(responses.ResponseOutputItemDoneEvent{
+		Item:           completed,
+		OutputIndex:    outputIndex,
+		SequenceNumber: nextSeq(seq),
+		Type:           constant.ResponseOutputItemDone("response.output_item.done"),
+	}))
+
+	return events, nil
+}
+
+func streamEventsForGenericItem(item responses.ResponseOutputItemUnion, outputIndex int64, seq *int64) ([]json.RawMessage, error) {
+	inProgress, err := outputItemWithStatus(item, "in_progress")
+	if err != nil {
+		return nil, err
+	}
+	completed, err := outputItemWithStatus(item, "completed")
+	if err != nil {
+		return nil, err
+	}
+
+	return []json.RawMessage{
+		mustEventJSON(responses.ResponseOutputItemAddedEvent{
+			Item:           inProgress,
+			OutputIndex:    outputIndex,
+			SequenceNumber: nextSeq(seq),
+			Type:           constant.ResponseOutputItemAdded("response.output_item.added"),
+		}),
+		mustEventJSON(responses.ResponseOutputItemDoneEvent{
+			Item:           completed,
+			OutputIndex:    outputIndex,
+			SequenceNumber: nextSeq(seq),
+			Type:           constant.ResponseOutputItemDone("response.output_item.done"),
+		}),
+	}, nil
+}
+
+func responseShell(response responses.Response) (responses.Response, error) {
+	raw, err := json.Marshal(response)
+	if err != nil {
+		return responses.Response{}, fmt.Errorf("marshal response shell: %w", err)
+	}
+
+	var shell responses.Response
+	if err := json.Unmarshal(raw, &shell); err != nil {
+		return responses.Response{}, fmt.Errorf("unmarshal response shell: %w", err)
+	}
+
+	shell.Output = nil
+	shell.Status = responses.ResponseStatusInProgress
+	return shell, nil
+}
+
+func messageWithStatus(message responses.ResponseOutputMessage, status responses.ResponseOutputMessageStatus, clearContent bool) (responses.ResponseOutputItemUnion, error) {
+	raw, err := json.Marshal(message)
+	if err != nil {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("marshal message: %w", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("unmarshal message: %w", err)
+	}
+
+	payload["status"] = string(status)
+	if clearContent {
+		payload["content"] = []any{}
+	}
+
+	return outputItemFromMap(payload)
+}
+
+func functionCallWithStatus(call responses.ResponseFunctionToolCall, status string) (responses.ResponseOutputItemUnion, error) {
+	raw, err := json.Marshal(call)
+	if err != nil {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("marshal function call: %w", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("unmarshal function call: %w", err)
+	}
+
+	payload["status"] = status
+	return outputItemFromMap(payload)
+}
+
+func outputItemWithStatus(item responses.ResponseOutputItemUnion, status string) (responses.ResponseOutputItemUnion, error) {
+	raw := item.RawJSON()
+	if raw == "" {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("output item has no raw JSON")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("unmarshal output item: %w", err)
+	}
+
+	payload["status"] = status
+	return outputItemFromMap(payload)
+}
+
+func outputItemFromMap(payload map[string]any) (responses.ResponseOutputItemUnion, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("marshal output item: %w", err)
+	}
+
+	var item responses.ResponseOutputItemUnion
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("unmarshal output item union: %w", err)
+	}
+
+	return item, nil
+}
+
+func messageAsOutputItem(message responses.ResponseOutputMessage) (responses.ResponseOutputItemUnion, error) {
+	raw, err := json.Marshal(message)
+	if err != nil {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("marshal message: %w", err)
+	}
+
+	var item responses.ResponseOutputItemUnion
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return responses.ResponseOutputItemUnion{}, fmt.Errorf("unmarshal message union: %w", err)
+	}
+
+	return item, nil
+}
+
+func mustEventJSON(event any) json.RawMessage {
+	raw, err := json.Marshal(event)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func nextSeq(seq *int64) int64 {
+	current := *seq
+	*seq++
+	return current
+}
+
+func forceNonStreamingResponses(body []byte) ([]byte, error) {
+	return removeTopLevelJSONFields(body, "stream")
+}

--- a/go/deployment-operator/internal/mcpserver/agent/openaiproxy/responses_stream_test.go
+++ b/go/deployment-operator/internal/mcpserver/agent/openaiproxy/responses_stream_test.go
@@ -1,0 +1,66 @@
+package openaiproxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openai/openai-go/responses"
+)
+
+func TestStreamEventsFromResponseTextMessage(t *testing.T) {
+	t.Parallel()
+
+	var response responses.Response
+	if err := json.Unmarshal([]byte(`{
+		"id":"resp_abc",
+		"object":"response",
+		"created_at":123,
+		"status":"completed",
+		"model":"gpt-5.4",
+		"output":[{
+			"type":"message",
+			"id":"msg_1",
+			"role":"assistant",
+			"status":"completed",
+			"content":[{
+				"type":"output_text",
+				"text":"Hello there",
+				"annotations":[]
+			}]
+		}]
+	}`), &response); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	events, err := StreamEventsFromResponse(response)
+	if err != nil {
+		t.Fatalf("StreamEventsFromResponse() failed: %v", err)
+	}
+	if len(events) < 5 {
+		t.Fatalf("expected at least 5 events, got %d", len(events))
+	}
+
+	firstRaw := events[0]
+	if !strings.Contains(string(firstRaw), `"type":"response.created"`) {
+		t.Fatalf("expected response.created first, got %s", firstRaw)
+	}
+
+	lastRaw := events[len(events)-1]
+	if !strings.Contains(string(lastRaw), `"type":"response.completed"`) {
+		t.Fatalf("expected response.completed last, got %s", lastRaw)
+	}
+
+	foundDelta := false
+	for _, event := range events {
+		if strings.Contains(string(event), `"type":"response.output_text.delta"`) {
+			foundDelta = true
+			if !strings.Contains(string(event), `"delta":"Hello there"`) {
+				t.Fatalf("expected delta text in event, got %s", event)
+			}
+		}
+	}
+	if !foundDelta {
+		t.Fatal("expected response.output_text.delta event")
+	}
+}

--- a/go/deployment-operator/internal/mcpserver/agent/openaiproxy/stream.go
+++ b/go/deployment-operator/internal/mcpserver/agent/openaiproxy/stream.go
@@ -136,14 +136,7 @@ func WriteSSE(w io.Writer, chunks []openai.ChatCompletionChunk) error {
 }
 
 func forceNonStreaming(body []byte) ([]byte, error) {
-	var params openai.ChatCompletionNewParams
-	if err := json.Unmarshal(body, &params); err != nil {
-		return nil, err
-	}
-
-	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{}
-
-	return json.Marshal(params)
+	return removeTopLevelJSONFields(body, "stream", "stream_options")
 }
 
 func streamingRequested(body []byte) (bool, error) {

--- a/go/deployment-operator/internal/mcpserver/agent/server.go
+++ b/go/deployment-operator/internal/mcpserver/agent/server.go
@@ -43,6 +43,9 @@ type Server struct {
 
 	// openaiProxy optionally exposes a local OpenAI chat completion endpoint
 	openaiProxy *openaiproxy.Handler
+
+	// openaiResponsesProxy optionally exposes a local OpenAI responses endpoint
+	openaiResponsesProxy *openaiproxy.ResponsesHandler
 }
 
 // Start starts the MCP server with streamable HTTP transport
@@ -84,6 +87,10 @@ func (in *Server) init() *Server {
 	if in.openaiProxy != nil {
 		mux.Handle(common.AgentOpenAIChatCompletionsPath, in.openaiProxy)
 		klog.V(log.LogLevelDefault).InfoS("registered openai chat completion proxy", "path", common.AgentOpenAIChatCompletionsPath)
+	}
+	if in.openaiResponsesProxy != nil {
+		mux.Handle(common.AgentOpenAIResponsesPath, in.openaiResponsesProxy)
+		klog.V(log.LogLevelDefault).InfoS("registered openai responses proxy", "path", common.AgentOpenAIResponsesPath)
 	}
 
 	in.httpServer = &http.Server{Handler: mux}

--- a/go/deployment-operator/internal/mcpserver/agent/server_options.go
+++ b/go/deployment-operator/internal/mcpserver/agent/server_options.go
@@ -31,19 +31,24 @@ func WithVersion(version string) Option {
 	}
 }
 
-// WithOpenAIProxy registers a local OpenAI chat completion endpoint that converts
-// streaming client requests into non-streaming upstream calls.
-func WithOpenAIProxy(upstreamURL string) Option {
+// WithOpenAIProxy registers local OpenAI chat completion and responses endpoints
+// that convert streaming client requests into non-streaming upstream calls.
+func WithOpenAIProxy(chatCompletionsURL, responsesURL string) Option {
 	return func(s *Server) {
-		if upstreamURL == "" {
-			return
+		if chatCompletionsURL != "" {
+			handler, err := openaiproxy.NewHandler(openaiproxy.Config{UpstreamURL: chatCompletionsURL})
+			if err != nil {
+				klog.Fatalf("could not configure openai chat completion proxy: %v", err)
+			}
+			s.openaiProxy = handler
 		}
 
-		handler, err := openaiproxy.NewHandler(openaiproxy.Config{UpstreamURL: upstreamURL})
-		if err != nil {
-			klog.Fatalf("could not configure openai proxy: %v", err)
+		if responsesURL != "" {
+			handler, err := openaiproxy.NewResponsesHandler(openaiproxy.ResponsesConfig{UpstreamURL: responsesURL})
+			if err != nil {
+				klog.Fatalf("could not configure openai responses proxy: %v", err)
+			}
+			s.openaiResponsesProxy = handler
 		}
-
-		s.openaiProxy = handler
 	}
 }

--- a/go/deployment-operator/internal/mcpserver/agent/server_test.go
+++ b/go/deployment-operator/internal/mcpserver/agent/server_test.go
@@ -18,7 +18,7 @@ func TestServerRegistersOpenAIProxyRoute(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	srv := NewServer(nil, WithOpenAIProxy(upstream.URL))
+	srv := NewServer(nil, WithOpenAIProxy(upstream.URL, upstream.URL))
 
 	mux, ok := srv.httpServer.Handler.(*http.ServeMux)
 	if !ok {
@@ -28,6 +28,26 @@ func TestServerRegistersOpenAIProxyRoute(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, common.AgentOpenAIChatCompletionsPath, strings.NewReader(`{"model":"gpt-4","messages":[]}`))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestServerRegistersOpenAIResponsesProxyRoute(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp-1","object":"response","status":"completed"}`))
+	}))
+	defer upstream.Close()
+
+	srv := NewServer(nil, WithOpenAIProxy("", upstream.URL))
+
+	req := httptest.NewRequest(http.MethodPost, common.AgentOpenAIResponsesPath, strings.NewReader(`{"model":"gpt-5.4","input":"hi"}`))
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())

--- a/go/deployment-operator/pkg/agentrun-harness/tool/opencode/opencode_templates_test.go
+++ b/go/deployment-operator/pkg/agentrun-harness/tool/opencode/opencode_templates_test.go
@@ -151,10 +151,26 @@ func TestConfigTemplate_Provider(t *testing.T) {
 
 		providers := out["provider"].(map[string]any)
 		plural := providers["plural"].(map[string]any)
+		if plural["npm"] != "@ai-sdk/openai" {
+			t.Fatalf("expected npm=@ai-sdk/openai for streaming proxy, got %v", plural["npm"])
+		}
 		options := plural["options"].(map[string]any)
 
 		if options["baseURL"] != common.AgentOpenAIBaseURL {
 			t.Errorf("expected mcpserver baseURL %s, got %v", common.AgentOpenAIBaseURL, options["baseURL"])
+		}
+	})
+
+	t.Run("plural provider without streaming proxy uses responses sdk", func(t *testing.T) {
+		input := baseInput(console.AgentRunModeWrite)
+		input.Provider = ProviderPlural
+
+		out := renderJSON(t, input)
+
+		providers := out["provider"].(map[string]any)
+		plural := providers["plural"].(map[string]any)
+		if plural["npm"] != "@ai-sdk/openai" {
+			t.Fatalf("expected npm=@ai-sdk/openai, got %v", plural["npm"])
 		}
 	})
 

--- a/go/deployment-operator/pkg/agentrun-harness/tool/opencode/templates/opencode.json.gotmpl
+++ b/go/deployment-operator/pkg/agentrun-harness/tool/opencode/templates/opencode.json.gotmpl
@@ -63,8 +63,10 @@
   "username": "plural",
   "provider": {
     "{{ .Provider }}": {
-      {{ if or (eq .Provider "plural") .OpenAICompatible }}"npm": "@ai-sdk/openai",
-      {{ end }}"name": "{{ .Provider }}",
+      {{- if or .OpenAICompatible (eq .Provider "plural") }}
+      "npm": "@ai-sdk/openai",
+      {{- end }}
+      "name": "{{ .Provider }}",
       "options": {
         {{- if eq .Provider "plural" }}
         {{- if .StreamingProxy }}

--- a/go/deployment-operator/pkg/common/mcp.go
+++ b/go/deployment-operator/pkg/common/mcp.go
@@ -7,6 +7,8 @@ const (
 
 	AgentOpenAIChatCompletionsPath = "/v1/chat/completions"
 	AgentOpenAIChatCompletionsURL  = "http://127.0.0.1:8080/v1/chat/completions"
+	AgentOpenAIResponsesPath       = "/v1/responses"
+	AgentOpenAIResponsesURL        = "http://127.0.0.1:8080/v1/responses"
 	AgentOpenAIBaseURL             = "http://127.0.0.1:8080/v1"
 
 	AgentMCPGRPCPort          = 8081

--- a/lib/console/ai/workbench/skills.ex
+++ b/lib/console/ai/workbench/skills.ex
@@ -89,10 +89,10 @@ defmodule Console.AI.Workbench.Skills do
   end
   defp convert_db_skills(_), do: []
 
-  @regex ~r/---(.*)---(.*)/s
+  @metadata_regex ~r/\A---[ \t]*\r?\n(.*?)\r?\n---[ \t]*(?:\r?\n|\z)(.*)\z/s
 
   def parse_skill(file, skill) when is_binary(skill) do
-    with {:regex, [_, meta, contents]} <- {:regex, Regex.run(@regex, skill)},
+    with {:regex, [_, meta, contents]} <- {:regex, Regex.run(@metadata_regex, skill)},
          {:yaml, {:ok, %{"name" => name, "description" => description} = meta}} <- {:yaml, YamlElixir.read_from_string(meta)} do
       {:ok, %Skill{
         name: String.trim(name),

--- a/lib/console/deployments/issues/webhook.ex
+++ b/lib/console/deployments/issues/webhook.ex
@@ -77,6 +77,14 @@ defmodule Console.Deployments.Issues.Webhook do
     |> ok()
   end
 
+  def payload(%IssueWebhook{provider: :gitlab} = webhook, %{"object_attributes" => _, "object_kind" => "work_item"} = payload) do
+    build_attributes(Gitlab, payload)
+    |> Map.put(:provider, :gitlab)
+    |> with_payload(payload)
+    |> workbench_association(webhook)
+    |> ok()
+  end
+
   def payload(
         %IssueWebhook{provider: :gitlab} = webhook,
         %{"object_kind" => "note", "object_attributes" => %{"noteable_type" => "MergeRequest"}} = payload

--- a/lib/console/deployments/issues/webhook/gitlab.ex
+++ b/lib/console/deployments/issues/webhook/gitlab.ex
@@ -11,6 +11,12 @@ defmodule Console.Deployments.Issues.Webhook.Gitlab do
   def external_id(%{"object_kind" => "note", "object_attributes" => %{"id" => id}} = payload)
       when is_binary(id),
       do: "#{infer_project(payload)}:comment:#{id}"
+  def external_id(%{"object_kind" => "work_item", "object_attributes" => %{"iid" => iid}} = payload)
+      when is_integer(iid),
+      do: "#{infer_project(payload)}:work_item:#{iid}"
+  def external_id(%{"object_kind" => "work_item", "object_attributes" => %{"iid" => iid}} = payload)
+      when is_binary(iid),
+      do: "#{infer_project(payload)}:work_item:#{iid}"
   def external_id(%{"object_attributes" => %{"iid" => iid}} = payload) when is_integer(iid),
     do: "#{infer_project(payload)}:issue:#{iid}"
   def external_id(%{"object_attributes" => %{"iid" => iid}} = payload) when is_binary(iid),
@@ -35,10 +41,14 @@ defmodule Console.Deployments.Issues.Webhook.Gitlab do
 
   def status(%{"object_kind" => "note", "merge_request" => %{"state" => state}}), do: map_status(state)
   def status(%{"object_attributes" => %{"state" => state}}), do: map_status(state)
+  def status(%{"object_attributes" => %{"action" => action}}), do: map_status(action)
   def status(_), do: :open
 
+  defp map_status("open"), do: :open
   defp map_status("opened"), do: :open
+  defp map_status("reopen"), do: :open
   defp map_status("reopened"), do: :open
+  defp map_status("close"), do: :completed
   defp map_status("closed"), do: :completed
   defp map_status(_), do: :open
 

--- a/lib/console/deployments/issues/webhook/gitlab.ex
+++ b/lib/console/deployments/issues/webhook/gitlab.ex
@@ -2,8 +2,7 @@ defmodule Console.Deployments.Issues.Webhook.Gitlab do
   @behaviour Console.Deployments.Issues.Provider
 
   def body(%{"object_kind" => "note", "object_attributes" => %{"note" => body}}) when is_binary(body), do: body
-  def body(%{"object_attributes" => %{"description" => body}}) when is_binary(body), do: body
-  def body(_), do: "{empty}"
+  def body(%{} = payload), do: string_field(payload, "description") || "{empty}"
 
   def external_id(%{"object_kind" => "note", "object_attributes" => %{"id" => id}} = payload)
       when is_integer(id),
@@ -11,17 +10,27 @@ defmodule Console.Deployments.Issues.Webhook.Gitlab do
   def external_id(%{"object_kind" => "note", "object_attributes" => %{"id" => id}} = payload)
       when is_binary(id),
       do: "#{infer_project(payload)}:comment:#{id}"
-  def external_id(%{"object_kind" => "work_item", "object_attributes" => %{"iid" => iid}} = payload)
-      when is_integer(iid),
-      do: "#{infer_project(payload)}:work_item:#{iid}"
-  def external_id(%{"object_kind" => "work_item", "object_attributes" => %{"iid" => iid}} = payload)
-      when is_binary(iid),
-      do: "#{infer_project(payload)}:work_item:#{iid}"
-  def external_id(%{"object_attributes" => %{"iid" => iid}} = payload) when is_integer(iid),
-    do: "#{infer_project(payload)}:issue:#{iid}"
-  def external_id(%{"object_attributes" => %{"iid" => iid}} = payload) when is_binary(iid),
-    do: "#{infer_project(payload)}:issue:#{iid}"
+  def external_id(%{"object_kind" => "work_item"} = payload) do
+    iid = field(payload, "iid")
+    work_item_external_id(payload, iid)
+  end
+  def external_id(%{} = payload) do
+    iid = field(payload, "iid")
+    issue_external_id(payload, iid)
+  end
   def external_id(_), do: nil
+
+  defp work_item_external_id(payload, iid) when is_integer(iid),
+      do: "#{infer_project(payload)}:work_item:#{iid}"
+  defp work_item_external_id(payload, iid) when is_binary(iid),
+      do: "#{infer_project(payload)}:work_item:#{iid}"
+  defp work_item_external_id(_, _), do: nil
+
+  defp issue_external_id(payload, iid) when is_integer(iid),
+    do: "#{infer_project(payload)}:issue:#{iid}"
+  defp issue_external_id(payload, iid) when is_binary(iid),
+    do: "#{infer_project(payload)}:issue:#{iid}"
+  defp issue_external_id(_, _), do: nil
 
   def title(
         %{
@@ -31,17 +40,23 @@ defmodule Console.Deployments.Issues.Webhook.Gitlab do
         }
       ),
       do: "Comment on MR: #{mr_title} (##{id})"
-  def title(%{"object_attributes" => %{"title" => title}}), do: title
+  def title(%{} = payload), do: string_field(payload, "title")
   def title(_), do: nil
 
   def url(%{"object_kind" => "note", "object_attributes" => %{"url" => url}}), do: url
   def url(%{"object_kind" => "note", "merge_request" => %{"url" => url}}), do: url
-  def url(%{"object_attributes" => %{"url" => url}}), do: url
+  def url(%{} = payload), do: string_field(payload, "url")
   def url(_), do: nil
 
   def status(%{"object_kind" => "note", "merge_request" => %{"state" => state}}), do: map_status(state)
-  def status(%{"object_attributes" => %{"state" => state}}), do: map_status(state)
-  def status(%{"object_attributes" => %{"action" => action}}), do: map_status(action)
+  def status(%{} = payload) do
+    field(payload, "state")
+    |> map_status()
+    |> case do
+      :open -> field(payload, "action") |> map_status()
+      status -> status
+    end
+  end
   def status(_), do: :open
 
   defp map_status("open"), do: :open
@@ -68,4 +83,27 @@ defmodule Console.Deployments.Issues.Webhook.Gitlab do
     end
   end
   defp parse_project_from_url(_), do: "unknown"
+
+  defp string_field(payload, key) do
+    case field(payload, key) do
+      value when is_binary(value) -> value
+      _ -> nil
+    end
+  end
+
+  defp field(%{"object_attributes" => attrs} = payload, key) when is_map(attrs) do
+    case current_value(Map.get(attrs, key)) do
+      nil -> changed_field(payload, key)
+      value -> value
+    end
+  end
+  defp field(%{} = payload, key), do: changed_field(payload, key)
+
+  defp changed_field(%{"changes" => changes}, key) when is_map(changes),
+    do: Map.get(changes, key) |> current_value()
+  defp changed_field(_, _), do: nil
+
+  defp current_value(%{"current" => current}), do: current
+  defp current_value(%{current: current}), do: current
+  defp current_value(value), do: value
 end

--- a/lib/console/grpc/server.ex
+++ b/lib/console/grpc/server.ex
@@ -4,6 +4,8 @@ defmodule Console.GRPC.Server do
   alias Console.Deployments.{Settings, Agents}
   alias Console.Schema.{DeploymentSettings, User, Cluster}
 
+  @dummy_key "ignore"
+
   def meter_metrics(%Plrl.MeterMetricsRequest{bytes: bytes}, _) do
     Console.Prom.Meter.incr(max(bytes, 0))
     %Plrl.MeterMetricsResponse{success: true}
@@ -71,7 +73,7 @@ defmodule Console.GRPC.Server do
     defaults = Provider.defaults(:openai)
 
     %Plrl.OpenAiConfig{
-      apiKey: Map.get(openai, :access_token),
+      apiKey: openai_api_key(openai),
       model: Map.get(openai, :model) || defaults[:model],
       embeddingModel: Map.get(openai, :embedding_model) || defaults[:embedding_model],
       toolModel: Map.get(openai, :tool_model) || defaults[:tool_model],
@@ -82,6 +84,8 @@ defmodule Console.GRPC.Server do
     }
   end
   defp to_openai_pb(_), do: nil
+
+  defp openai_api_key(%{} = openai), do: Map.get(openai, :access_token) || @dummy_key
 
   defp to_openai_token_exchange_pb(%{} = token_exchange) do
     case {Map.get(token_exchange, :enabled), Map.get(token_exchange, :token_url),

--- a/priv/prompts/workbench/infrastructure.md.eex
+++ b/priv/prompts/workbench/infrastructure.md.eex
@@ -53,7 +53,7 @@ you should bias towards probing GitOps.  If you're simply reading it, both are u
 
 You should only use Plural's GitOps source of truth for actually achieving a change, unless an explicit skill tells you how to accomplish it otherwise.
 
-**IMPORTANT**: Once you've completed all the work you plan to do, always call the `subagent_result` tool to complete the subagent session.
+**IMPORTANT**: Once you've completed all the work you plan to do, always call the `subagent_result` tool *exactly once* to complete the subagent session.
 
 ## Tone of Voice Gudiance
 

--- a/priv/prompts/workbench/observability.md.eex
+++ b/priv/prompts/workbench/observability.md.eex
@@ -55,7 +55,7 @@ The overarching task is as follows:
 
 <%= @prompt %>
 
-**IMPORTANT**: Once you've completed all the work you plan to do, always call the `observability_result` tool to complete the subagent session.
+**IMPORTANT**: Once you've completed all the work you plan to do, always call the `observability_result` tool  *exactly once* to complete the subagent session.
 
 <%= if @engine.iteration >= @engine.max_iterations - 5 do %>
 This workbench only supports <%= @engine.max_iterations %> iterations and <%= @engine.iteration %> iterations have been completed.

--- a/priv/prompts/workbench/search.md.eex
+++ b/priv/prompts/workbench/search.md.eex
@@ -13,7 +13,7 @@ The overarching task is as follows:
 
 <%= @prompt %>
 
-Once you've completed all the work you plan to do, **always call the `subagent_result` tool to complete the subagent session**.
+Once you've completed all the work you plan to do, **always call the `subagent_result` tool *exactly once* to complete the subagent session**.
 
 ## Tone of Voice Guidance
 

--- a/priv/tools/workbench/observability_result.json
+++ b/priv/tools/workbench/observability_result.json
@@ -3,7 +3,7 @@
     "properties": {
         "output": {
             "type": "string",
-            "description": "The output of this investigation.  Should be an informative summary of the investigation in markdown.  You *must* provide this to record a result."
+            "description": "The final output of this investigation.  Should be an informative summary of the investigation in markdown.  You *must* provide this to record a result, and nothing else will be used as the final output."
         },
         "metrics_query": {
             "type": "object",

--- a/priv/tools/workbench/subagent_result.json
+++ b/priv/tools/workbench/subagent_result.json
@@ -3,7 +3,7 @@
     "properties": {
         "output": {
             "type": "string",
-            "description": "The output of this investigation.  Should be an informative summary of the investigation in markdown.  You *must* provide this to record a result."
+            "description": "The final output of this investigation.  Should be an informative summary of the investigation in markdown.  You *must* provide this to record a result, and nothing else will be used as the final output."
         }
     },
     "required": ["output"]

--- a/static/compatibilities/coredns.yaml
+++ b/static/compatibilities/coredns.yaml
@@ -3,56 +3,61 @@ release_url: https://github.com/coredns/coredns/releases/tag/{vsn}
 helm_repository_url: https://coredns.github.io/helm
 versions:
 - version: 1.12.0
-  kube: ['1.33']
+  kube: ['1.35', '1.34', '1.33']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 1.42.2
   images: ['coredns/coredns:1.12.0']
 - version: 1.11.3
-  kube: ['1.32', '1.31']
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 1.36.1
   images: ['coredns/coredns:1.11.3']
 - version: 1.11.1
-  kube: ['1.30', '1.29']
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 1.31.0
   images: []
 - version: 1.10.1
-  kube: ['1.28', '1.27']
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+    '1.27']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 1.24.5
   images: ['coredns/coredns:1.10.1']
 - version: 1.9.3
-  kube: ['1.26', '1.25']
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+    '1.27', '1.26', '1.25']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 1.19.6
   images: ['coredns/coredns:1.9.3']
 - version: 1.8.6
-  kube: ['1.24', '1.23']
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+    '1.27', '1.26', '1.25', '1.24', '1.23']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 1.16.6
   images: ['coredns/coredns:1.8.6']
 - version: 1.8.4
-  kube: ['1.22']
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+    '1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 1.16.4
   images: ['coredns/coredns:1.8.4']
 - version: 1.8.0
-  kube: ['1.21']
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+    '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
   requirements: []
   incompatibilities: []
   summary: null

--- a/test/console/ai/workbench/skills_test.exs
+++ b/test/console/ai/workbench/skills_test.exs
@@ -4,6 +4,43 @@ defmodule Console.AI.Workbench.SkillsTest do
   alias Console.AI.Workbench.Skills
   alias Console.Schema.{Workbench, WorkbenchSkill}
 
+  @example """
+  ---
+  name: cluster-gitops-workflow
+  description: Use when you need guidance on the GitOps-based cluster management workflow — covers the hub-and-spoke ArgoCD deployment model, associated git projects, pipeline stages, and known caveats. WIP — workflow is not yet complete. Do NOT use for any unrelated legacy workflow; use /legacy-cluster-workflow for that.
+  allowed-tools: "Bash, Read, Glob, Grep"
+  metadata:
+    author: ai-dev
+    version: "1.0.0"
+    category: infrastructure
+    tags: [cluster, openshift, gitops, argocd, hub-spoke]
+  ---
+
+  You are an expert on your organization's **modern GitOps-based cluster management workflow**. This workflow leverages a hub-and-spoke cluster architecture with ArgoCD for continuous deployment. **This workflow is still a work in progress (WIP).**
+
+  Use the knowledge base below to answer the user's question. Be specific, accurate, and practical. Flag anything that is still WIP or not yet fully tested. If the user asks about a legacy workflow, instruct them to use `/legacy-cluster-workflow` instead.
+
+  ---
+
+  ## KNOWLEDGE BASE: Cluster GitOps Workflow (WIP)
+
+  ### Architecture Overview
+
+  This workflow uses a **hub-and-spoke** model:
+
+  - **Hub cluster** — Central management cluster running ArgoCD and a Multicluster Engine. Manages all spoke clusters. Multiple hubs may exist for geographic or environment distribution, such as `west-hub1`, `east-hub1`, and `preprod-hub` (lab).
+  - **Spoke cluster** — Tenant-specific cluster, created via agent-based installation and managed continuously by the hub using ArgoCD.
+
+  ArgoCD on the hub monitors a `siteconfigs` Git repo. When a new cluster config is pushed, ArgoCD syncs it to the hub, which provisions the spoke cluster. **Any manual changes to a spoke cluster are reverted by ArgoCD during the next sync.**
+
+  ### Git Projects
+
+  | Instance | URL |
+  |---|---|
+  | Lab | `https://gitlab.example.org/cluster-gitops` |
+  | Production | `https://git.example.org/cluster-gitops` |
+  """
+
   describe "plural?/2" do
     test "returns false when db-backed skills list is empty" do
       wb = struct(Workbench, %{workbench_skills: []})
@@ -30,6 +67,16 @@ defmodule Console.AI.Workbench.SkillsTest do
       assert parsed.name == "MySkill"
       assert parsed.description == "Guides users through X"
       assert parsed.contents == "Content here."
+    end
+
+    test "returns ok with a more complex skill" do
+      assert {:ok, parsed} = Skills.parse_skill("SKILL.md", @example)
+
+      assert parsed.name == "cluster-gitops-workflow"
+      assert parsed.description == "Use when you need guidance on the GitOps-based cluster management workflow — covers the hub-and-spoke ArgoCD deployment model, associated git projects, pipeline stages, and known caveats. WIP — workflow is not yet complete. Do NOT use for any unrelated legacy workflow; use /legacy-cluster-workflow for that."
+      assert parsed.contents =~ "## KNOWLEDGE BASE: Cluster GitOps Workflow (WIP)"
+      assert parsed.contents =~ "|---|---|"
+      refute parsed.contents =~ "name: cluster-gitops-workflow"
     end
 
     test "trims name, description, and contents" do

--- a/test/console/deployments/pubsub/cacheable_test.exs
+++ b/test/console/deployments/pubsub/cacheable_test.exs
@@ -5,7 +5,7 @@ defmodule Console.Deployments.PubSub.CacheableTest do
   alias Console.PubSub.Consumers.Cache
 
   describe "WorkbenchWebhookCreated" do
-    test "calls Console.Cache.put with {:wb_webhooks, webhook_id} and the hook" do
+    test "calls Console.Cache.delete with {:wb_webhooks, webhook_id} and the hook" do
       %{id: id} = obs_webhook = insert(:observability_webhook, type: :grafana)
       workbench = insert(:workbench)
       hook =
@@ -20,10 +20,26 @@ defmodule Console.Deployments.PubSub.CacheableTest do
       event = %PubSub.WorkbenchWebhookCreated{item: hook}
       Cache.handle_event(event)
     end
+
+    test "calls Console.Cache.delete with {:wb_webhooks_for_issue, issue_webhook_id} and the hook" do
+      %{id: id} = issue_webhook = insert(:issue_webhook, provider: :gitlab)
+      workbench = insert(:workbench)
+      hook =
+        insert(:workbench_webhook,
+          workbench: workbench,
+          issue_webhook: issue_webhook,
+          name: "gitlab-issues"
+        )
+
+      expect(Console.Cache, :delete, fn {:wb_webhooks_for_issue, ^id} -> :ok end)
+
+      event = %PubSub.WorkbenchWebhookCreated{item: hook}
+      Cache.handle_event(event)
+    end
   end
 
   describe "WorkbenchWebhookUpdated" do
-    test "calls Console.Cache.put with {:wb_webhooks, webhook_id} and the hook" do
+    test "calls Console.Cache.delete with {:wb_webhooks, webhook_id} and the hook" do
       %{id: id} = obs_webhook = insert(:observability_webhook, type: :grafana)
       workbench = insert(:workbench)
       hook =
@@ -38,10 +54,26 @@ defmodule Console.Deployments.PubSub.CacheableTest do
       event = %PubSub.WorkbenchWebhookUpdated{item: hook}
       Cache.handle_event(event)
     end
+
+    test "calls Console.Cache.delete with {:wb_webhooks_for_issue, issue_webhook_id} and the hook" do
+      %{id: id} = issue_webhook = insert(:issue_webhook, provider: :gitlab)
+      workbench = insert(:workbench)
+      hook =
+        insert(:workbench_webhook,
+          workbench: workbench,
+          issue_webhook: issue_webhook,
+          name: "updated-gitlab-issues"
+        )
+
+      expect(Console.Cache, :delete, fn {:wb_webhooks_for_issue, ^id} -> :ok end)
+
+      event = %PubSub.WorkbenchWebhookUpdated{item: hook}
+      Cache.handle_event(event)
+    end
   end
 
   describe "WorkbenchWebhookDeleted" do
-    test "calls Console.Cache.put with {:wb_webhooks, webhook_id} and the hook" do
+    test "calls Console.Cache.delete with {:wb_webhooks, webhook_id} and the hook" do
       %{id: id} = obs_webhook = insert(:observability_webhook, type: :grafana)
       workbench = insert(:workbench)
       hook =
@@ -52,6 +84,22 @@ defmodule Console.Deployments.PubSub.CacheableTest do
         )
 
       expect(Console.Cache, :delete, fn {:wb_webhooks, ^id} -> :ok end)
+
+      event = %PubSub.WorkbenchWebhookDeleted{item: hook}
+      Cache.handle_event(event)
+    end
+
+    test "calls Console.Cache.delete with {:wb_webhooks_for_issue, issue_webhook_id} and the hook" do
+      %{id: id} = issue_webhook = insert(:issue_webhook, provider: :gitlab)
+      workbench = insert(:workbench)
+      hook =
+        insert(:workbench_webhook,
+          workbench: workbench,
+          issue_webhook: issue_webhook,
+          name: "deleted-gitlab-issues"
+        )
+
+      expect(Console.Cache, :delete, fn {:wb_webhooks_for_issue, ^id} -> :ok end)
 
       event = %PubSub.WorkbenchWebhookDeleted{item: hook}
       Cache.handle_event(event)

--- a/test/console/grpc/server_test.exs
+++ b/test/console/grpc/server_test.exs
@@ -1,0 +1,42 @@
+defmodule Console.GRPC.ServerTest do
+  use Console.DataCase, async: true
+
+  alias Console.GRPC.Server
+
+  describe "get_ai_config/2" do
+    test "uses a dummy OpenAI-compatible api key when no token is configured" do
+      deployment_settings(
+        ai: %{
+          enabled: true,
+          openai_compatible: %{
+            base_url: "https://openai-compatible.example.com",
+            model: "custom-model"
+          }
+        }
+      )
+
+      config = Server.get_ai_config(%Plrl.AiConfigRequest{}, nil)
+
+      assert config.enabled
+      assert config.openaiCompatible.apiKey == "ignore"
+      assert config.openaiCompatible.baseUrl == "https://openai-compatible.example.com"
+      assert config.openaiCompatible.model == "custom-model"
+    end
+
+    test "preserves configured OpenAI-compatible api keys" do
+      deployment_settings(
+        ai: %{
+          enabled: true,
+          openai_compatible: %{
+            access_token: "configured-token",
+            base_url: "https://openai-compatible.example.com"
+          }
+        }
+      )
+
+      config = Server.get_ai_config(%Plrl.AiConfigRequest{}, nil)
+
+      assert config.openaiCompatible.apiKey == "configured-token"
+    end
+  end
+end

--- a/test/console_web/controllers/webhook_controller_test.exs
+++ b/test/console_web/controllers/webhook_controller_test.exs
@@ -1447,6 +1447,97 @@ defmodule ConsoleWeb.WebhookControllerTest do
       assert issue.workbench_webhook_id == wh.id
     end
 
+    test "it matches GitLab work item URLs delivered as issue events", %{conn: conn} do
+      hook = insert(:issue_webhook, provider: :gitlab)
+      wh = insert(:workbench_webhook,
+        issue_webhook: hook,
+        matches: %{substring: "plural fix this"}
+      )
+      gitlab_payload = %{
+        "changes" => %{
+          "description" => %{"current" => "plural fix this", "previous" => nil},
+          "iid" => %{"current" => 5, "previous" => nil},
+          "title" => %{"current" => "double the size of the grafana database", "previous" => nil}
+        },
+        "event_type" => "issue",
+        "labels" => [],
+        "object_attributes" => %{
+          "action" => "open",
+          "description" => "plural fix this",
+          "id" => 192678093,
+          "iid" => 5,
+          "state" => "opened",
+          "title" => "double the size of the grafana database",
+          "type" => "Issue",
+          "url" => "https://gitlab.com/pluralsh/infra/docs/-/work_items/5"
+        },
+        "object_kind" => "issue",
+        "project" => %{
+          "path_with_namespace" => "pluralsh/infra/docs"
+        }
+      }
+      payload = Jason.encode!(gitlab_payload)
+
+      result =
+        conn
+        |> put_req_header("x-gitlab-token", hook.secret)
+        |> put_req_header("content-type", "application/json")
+        |> post("/ext/v1/webhooks/issues/gitlab/#{hook.external_id}", payload)
+        |> json_response(200)
+
+      assert result["message"] == "persisted issue"
+      refute result["ignored"]
+
+      [issue] = Console.Repo.all(Console.Schema.Issue)
+      assert issue.external_id == "pluralsh/infra/docs:issue:5"
+      assert issue.title == "double the size of the grafana database"
+      assert issue.body == "plural fix this"
+      assert issue.url == "https://gitlab.com/pluralsh/infra/docs/-/work_items/5"
+      assert issue.workbench_webhook_id == wh.id
+    end
+
+    test "it extracts current values from GitLab issue change objects", %{conn: conn} do
+      hook = insert(:issue_webhook, provider: :gitlab)
+      wh = insert(:workbench_webhook,
+        issue_webhook: hook,
+        matches: %{substring: "plural fix this"}
+      )
+      gitlab_payload = %{
+        "changes" => %{
+          "description" => %{"current" => "plural fix this", "previous" => nil},
+          "iid" => %{"current" => 5, "previous" => nil},
+          "title" => %{"current" => "double the size of the grafana database", "previous" => nil}
+        },
+        "event_type" => "issue",
+        "object_attributes" => %{
+          "action" => "open",
+          "description" => %{"current" => "plural fix this", "previous" => nil},
+          "iid" => %{"current" => 5, "previous" => nil},
+          "state" => "opened",
+          "title" => %{"current" => "double the size of the grafana database", "previous" => nil},
+          "type" => "Issue",
+          "url" => "https://gitlab.com/pluralsh/infra/docs/-/work_items/5"
+        },
+        "object_kind" => "issue",
+        "project" => %{
+          "path_with_namespace" => "pluralsh/infra/docs"
+        }
+      }
+      payload = Jason.encode!(gitlab_payload)
+
+      conn
+      |> put_req_header("x-gitlab-token", hook.secret)
+      |> put_req_header("content-type", "application/json")
+      |> post("/ext/v1/webhooks/issues/gitlab/#{hook.external_id}", payload)
+      |> response(200)
+
+      [issue] = Console.Repo.all(Console.Schema.Issue)
+      assert issue.external_id == "pluralsh/infra/docs:issue:5"
+      assert issue.title == "double the size of the grafana database"
+      assert issue.body == "plural fix this"
+      assert issue.workbench_webhook_id == wh.id
+    end
+
     test "it can handle a valid GitLab work item webhook and creates the issue", %{conn: conn} do
       hook = insert(:issue_webhook, provider: :gitlab)
       wh = insert(:workbench_webhook,

--- a/test/console_web/controllers/webhook_controller_test.exs
+++ b/test/console_web/controllers/webhook_controller_test.exs
@@ -1447,6 +1447,52 @@ defmodule ConsoleWeb.WebhookControllerTest do
       assert issue.workbench_webhook_id == wh.id
     end
 
+    test "it can handle a valid GitLab work item webhook and creates the issue", %{conn: conn} do
+      hook = insert(:issue_webhook, provider: :gitlab)
+      wh = insert(:workbench_webhook,
+        issue_webhook: hook,
+        matches: %{substring: "plural fix this"}
+      )
+      gitlab_payload = %{
+        "object_kind" => "work_item",
+        "event_type" => "work_item",
+        "project" => %{
+          "path_with_namespace" => "mygroup/myproject"
+        },
+        "object_attributes" => %{
+          "id" => 301,
+          "iid" => 101,
+          "title" => "Provision demo database",
+          "description" => "plural fix this by wiring the database bootstrap",
+          "type" => "Task",
+          "url" => "https://gitlab.com/mygroup/myproject/-/work_items/101",
+          "state" => "opened",
+          "action" => "open"
+        }
+      }
+      payload = Jason.encode!(gitlab_payload)
+
+      result =
+        conn
+        |> put_req_header("x-gitlab-token", hook.secret)
+        |> put_req_header("content-type", "application/json")
+        |> post("/ext/v1/webhooks/issues/gitlab/#{hook.external_id}", payload)
+        |> json_response(200)
+
+      assert result["message"] == "persisted issue"
+      refute result["ignored"]
+
+      [issue] = Console.Repo.all(Console.Schema.Issue)
+      assert issue.provider == :gitlab
+      assert issue.external_id == "mygroup/myproject:work_item:101"
+      assert issue.title == "Provision demo database"
+      assert issue.url == "https://gitlab.com/mygroup/myproject/-/work_items/101"
+      assert issue.body == "plural fix this by wiring the database bootstrap"
+      assert issue.status == :open
+      assert issue.payload == gitlab_payload
+      assert issue.workbench_webhook_id == wh.id
+    end
+
     test "it matches workbench webhook using title and body format", %{conn: conn} do
       hook = insert(:issue_webhook, provider: :gitlab)
       wh = insert(:workbench_webhook,

--- a/utils/compatibility/scrapers/coredns.py
+++ b/utils/compatibility/scrapers/coredns.py
@@ -3,6 +3,8 @@ from utils import (
     fetch_page,
     update_compatibility_info,
     get_chart_versions,
+    current_kube_version,
+    expand_kube_versions,
 )
 from collections import OrderedDict
 import re
@@ -31,6 +33,27 @@ def parse_markdown_table(markdown: str) -> list[tuple[str, str]]:
     return rows
 
 
+def kube_version_key(version: str) -> tuple[int, int]:
+    major, minor = version.split(".")
+    return int(major), int(minor)
+
+
+def expand_min_kube_versions(kubernetes_versions: str) -> list[str]:
+    latest_kube_version = current_kube_version()
+    if not latest_kube_version:
+        print_error("Could not determine current Kubernetes version.")
+        return []
+
+    versions = set()
+    for version in re.split(r"&|,", kubernetes_versions):
+        minimum = re.sub(r"^v", "", version.strip())
+        if not minimum:
+            continue
+        versions.update(expand_kube_versions(minimum, latest_kube_version))
+
+    return sorted(versions, key=kube_version_key)
+
+
 def extract_table_data(table_rows: list[tuple[str, str]], chart_versions):
     combined: dict[str, dict[str, object]] = {}
     for kube_cell, coredns_cell in table_rows:
@@ -47,11 +70,10 @@ def extract_table_data(table_rows: list[tuple[str, str]], chart_versions):
             )
             continue
 
-        # Remove leading 'v' from Kubernetes versions
-        kubernetes_versions_list = [
-            re.sub(r"^v", "", version.strip())
-            for version in re.split(r"&|,", kubernetes_versions)
-        ]
+        kubernetes_versions_list = expand_min_kube_versions(kubernetes_versions)
+        if not kubernetes_versions_list:
+            continue
+
         chart_version = chart_versions.get(coredns_version)
         if not chart_version:
             continue
@@ -68,7 +90,7 @@ def extract_table_data(table_rows: list[tuple[str, str]], chart_versions):
             OrderedDict(
                 [
                     ("version", version),
-                    ("kube", sorted(entry["kube"])),
+                    ("kube", sorted(entry["kube"], key=kube_version_key)),
                     ("chart_version", entry["chart_version"]),
                     ("images", []),
                     ("requirements", []),


### PR DESCRIPTION
Seems like opencode uses responses api too now

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.plrldemo.onplural.sh/cd/clusters/a1748282-ce8b-48ab-ae7e-326e74fce04e/services/f3f89a54-d1a7-4bc8-9152-daa07ede918d/components

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
