### PR TITLE
fix(plrl-metrics): update connection field name

### DIFF
--- a/lib/console/ai/tools/workbench/observability/plrl_metrics.ex
+++ b/lib/console/ai/tools/workbench/observability/plrl_metrics.ex
@@ -43,7 +43,7 @@ defmodule Console.AI.Tools.Workbench.Observability.Plrl.Metrics do
 
   def build_tool_connection() do
     case Settings.fetch() do
-      %DeploymentSettings{prometheus_connection: %{url: url, user: user, password: pass}}
+      %DeploymentSettings{prometheus_connection: %{host: url, user: user, password: pass}}
           when is_binary(url) and is_binary(user) and is_binary(pass) ->
         {:ok, %ToolConnection{connection: {:prometheus, %PrometheusConnection{url: url, username: user, password: pass}}}}
       _ ->

--- a/lib/console/ai/workbench/conversion.ex
+++ b/lib/console/ai/workbench/conversion.ex
@@ -15,7 +15,9 @@ defmodule Console.AI.Workbench.Conversion do
     AzureConnection,
   }
 
-  @spec to_proto(WorkbenchTool.t()) :: {:ok, %ToolConnection{}} | {:error, String.t()}
+  @spec to_proto(WorkbenchTool.t() | ToolConnection.t()) :: {:ok, %ToolConnection{}} | {:error, String.t()}
+  def to_proto(%ToolConnection{} = conn), do: {:ok, conn}
+
   def to_proto(%WorkbenchTool{tool: :datadog, configuration: %{datadog: %{} = dd}}) do
     {:ok, %ToolConnection{
       connection: {:datadog, %DatadogConnection{

--- a/lib/console/logs/time.ex
+++ b/lib/console/logs/time.ex
@@ -2,6 +2,7 @@ defmodule Console.Logs.Time do
   @type t :: %__MODULE__{}
   defstruct [:after, :before, :duration, :reverse]
 
+  def new(%__MODULE__{} = time), do: time
   def new(%{} = args), do: struct(__MODULE__,  args)
   def new(args) when is_list(args), do: struct(__MODULE__,  args)
   def new(_), do: nil

--- a/test/console/ai/tools/workbench/observability/plrl_tools_test.exs
+++ b/test/console/ai/tools/workbench/observability/plrl_tools_test.exs
@@ -30,6 +30,11 @@ defmodule Console.AI.Tools.Workbench.Observability.PlrlToolsTest do
       assert %{"type" => "object", "properties" => props} = Tool.json_schema(%Logs{})
       assert Map.has_key?(props, "service_id")
     end
+
+    test "logs_query accepts default time range" do
+      assert %{time: %{after: %DateTime{}, before: %DateTime{}}} =
+               Logs.logs_query(%Logs{cluster_id: "cluster-1"})
+    end
   end
 
   describe "LogsAggregate (plrl_logs_aggregate)" do

--- a/test/console/ai/workbench/conversion_test.exs
+++ b/test/console/ai/workbench/conversion_test.exs
@@ -2,8 +2,17 @@ defmodule Console.AI.Workbench.ConversionTest do
   use Console.DataCase, async: true
   alias Console.Schema.WorkbenchTool
   alias Console.AI.Workbench.Conversion
+  alias Toolquery.{PrometheusConnection, ToolConnection}
 
   describe "to_proto/1" do
+    test "passes through an already built tool connection" do
+      conn = %ToolConnection{
+        connection: {:prometheus, %PrometheusConnection{url: "https://prometheus.example.com"}}
+      }
+
+      assert {:ok, ^conn} = Conversion.to_proto(conn)
+    end
+
     test "converts elastic tool to proto" do
       tool = %WorkbenchTool{
         tool: :elastic,


### PR DESCRIPTION
- Change `prometheus_connection` field from `url` to `host` in `DeploymentSettings` pattern
- Ensure compatibility with settings retrieval logic

<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.plrl-dev-aws.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
