### PR TITLE
feat(cloud-query): introduce MetricsLabelSearch functionality

### DIFF
--- a/go/cloud-query/README.md
+++ b/go/cloud-query/README.md
@@ -70,18 +70,18 @@ For detailed information about the API endpoints, request/response schemas, and 
 
 Cloud-Query also exposes ToolQuery gRPC endpoints for observability tools (metrics, logs, traces). Compatibility is per operation:
 
-| Tool | Metrics | Logs | Traces | Notes                                                                                                |
-|------|---------|------|--------|------------------------------------------------------------------------------------------------------|
-| Prometheus | Yes | No | No | Prometheus HTTP API via `prometheus/client_golang` with optional bearer token or basic auth          |
-| Datadog | Yes | Yes | Yes | Datadog API v1/v2 via `datadog-api-client-go` (requires API key + app key; site optional)            |
-| Elasticsearch | No | Yes | No | Elasticsearch typed client v9 Search API (API key required)                                          |
-| Loki | No | Yes | No | REST client to `/loki/api/v1/query_range` (bearer token; optional `X-Scope-OrgID`)                   |
-| Splunk | No | Yes | No | Splunk export search API (token or basic auth)                                                       |
-| Tempo | No | No | Yes | REST client to `/api/search` and `/api/traces/{traceID}` (bearer token; optional `X-Scope-OrgID`)    |
-| Jaeger | No | No | Yes | Jaeger Query v3 REST API (`GET /api/v3/traces`) with structured trace filters                        |
-| Dynatrace | Yes | Yes | Yes | Dynatrace Grail Query API (DQL via `/platform/storage/query/v1/query:*`, bearer token required)      |
-| CloudWatch | Yes | Yes | No | AWS SDK v2 (`GetMetricData`, Logs Insights `StartQuery`/`GetQueryResults`) with optional assume-role |
-| Azure | Yes | Yes | No | Azure Monitor Go SDK with Azure AD client credentials                                                |
+| Tool | Metrics | Metric Label Search | Logs | Traces | Notes                                                                                                |
+|------|---------|---------------------|------|--------|------------------------------------------------------------------------------------------------------|
+| Prometheus | Yes | Yes | No | No | Prometheus HTTP API via `prometheus/client_golang` with optional bearer token or basic auth          |
+| Datadog | Yes | Yes | Yes | Yes | Datadog API v1/v2 via `datadog-api-client-go` (requires API key + app key; site optional)            |
+| Elasticsearch | No | No | Yes | No | Elasticsearch typed client v9 Search API (API key required)                                          |
+| Loki | No | No | Yes | No | REST client to `/loki/api/v1/query_range` (bearer token; optional `X-Scope-OrgID`)                   |
+| Splunk | No | No | Yes | No | Splunk export search API (token or basic auth)                                                       |
+| Tempo | No | No | No | Yes | REST client to `/api/search` and `/api/traces/{traceID}` (bearer token; optional `X-Scope-OrgID`)    |
+| Jaeger | No | No | No | Yes | Jaeger Query v3 REST API (`GET /api/v3/traces`) with structured trace filters                        |
+| Dynatrace | Yes | No | Yes | Yes | Dynatrace Grail Query API (DQL via `/platform/storage/query/v1/query:*`, bearer token required)      |
+| CloudWatch | Yes | Yes | Yes | No | AWS SDK v2 (`GetMetricData`, `ListMetrics`, Logs Insights) with optional assume-role                 |
+| Azure | Yes | Yes | Yes | No | Azure Monitor Go SDK with Azure AD client credentials                                                |
 
 ToolQuery also supports cloud function invocation via `InvokeLambda` for AWS Lambda, GCP Cloud Run services (Gen2), and Azure Functions using canonical identifiers and cloud connection credentials.
 
@@ -97,6 +97,7 @@ ToolQuery also supports cloud function invocation via `InvokeLambda` for AWS Lam
     - `storage:buckets:read`
 - `Datadog`:
   - Requires `apiKey` and `appKey` for ToolQuery operations.
+  - Metric label search returns indexed metric tags from the previous hour.
 - `Elasticsearch`:
   - Requires URL + username/password + index.
 - `Prometheus` / `Loki` / `Tempo`:
@@ -119,6 +120,7 @@ ToolQuery also supports cloud function invocation via `InvokeLambda` for AWS Lam
     - Logs with provider log groups: set `"log_group_names": ["/aws/eks/prod/app"]` and use query like `"fields @timestamp, @message | sort @timestamp desc"`.
     - Logs without provider log groups: omit `log_group_names` and use query like `"SOURCE logGroups(namePrefix: [\"/aws/eks/prod/app\"]) | fields @timestamp, @message | sort @timestamp desc"`.
     - Metrics: use CloudWatch metric math expression, for example `SEARCH("{AWS/EC2,InstanceId} MetricName=\"CPUUtilization\"", "Average", 300)`.
+    - Metric label search: use the `MetricsSearch` result format `<namespace>/<metric>`, for example `"AWS/EC2/CPUUtilization"`; labels are CloudWatch dimensions.
 - `Azure`:
   - Connection requires `subscription_id`, `tenant_id`, `client_id`, and `client_secret`.
   - Metrics use `azmetrics.QueryResources`:
@@ -126,6 +128,10 @@ ToolQuery also supports cloud function invocation via `InvokeLambda` for AWS Lam
     - `options.azure.resource_id` and `options.azure.metrics_namespace` are required.
     - Optional Azure metrics options: `aggregation`, `filter`, `order_by`, `roll_up_by`, `metrics_endpoint`.
     - `options.azure.metrics_endpoint` overrides the metrics endpoint per request. If omitted, Cloud Query falls back to `https://global.metrics.monitor.azure.com`.
+  - Metric label search:
+    - Azure Managed Prometheus (`options.azure.prometheus_url`) delegates to Prometheus label APIs.
+    - Native Azure Monitor label names come from metric-definition dimensions.
+    - Native Azure Monitor label values require `options.azure.metrics_namespace` and are inferred from recent metric time-series metadata.
   - Logs use `azlogs.QueryResource`:
     - `query` is Azure Log Analytics query syntax (KQL).
 

--- a/go/cloud-query/api/proto/toolquery.proto
+++ b/go/cloud-query/api/proto/toolquery.proto
@@ -225,6 +225,35 @@ message MetricsSearchOutput {
   repeated MetricsSearchResult metrics = 1;
 }
 
+message MetricsLabelSearchInput {
+  ToolConnection connection = 1;
+  string metric = 2;
+  optional string query = 3;
+  optional string label = 4;
+  optional int64 limit = 5;
+  optional MetricsLabelSearchOptions options = 6;
+}
+
+message MetricsLabelSearchOptions {
+  optional AzureMetricsLabelSearchOptions azure = 1;
+}
+
+message AzureMetricsLabelSearchOptions {
+  string resource_id = 1;
+  optional string metrics_namespace = 2;
+  optional string prometheus_url = 3;
+  optional string metrics_endpoint = 4;
+}
+
+message MetricsLabelSearchResult {
+  // Name of the matching label or label value.
+  string name = 1;
+}
+
+message MetricsLabelSearchOutput {
+  repeated MetricsLabelSearchResult results = 1;
+}
+
 message LogEntry {
   google.protobuf.Timestamp timestamp = 1;
   string message = 2;
@@ -274,6 +303,7 @@ message RunLuaOutput {
 service ToolQuery {
   rpc Metrics(MetricsQueryInput) returns (MetricsQueryOutput) {}
   rpc MetricsSearch(MetricsSearchInput) returns (MetricsSearchOutput) {}
+  rpc MetricsLabelSearch(MetricsLabelSearchInput) returns (MetricsLabelSearchOutput) {}
   rpc Logs(LogsQueryInput) returns (LogsQueryOutput) {}
   rpc Traces(TracesQueryInput) returns (TracesQueryOutput) {}
   rpc InvokeLambda(InvokeLambdaInput) returns (InvokeLambdaOutput) {}

--- a/go/cloud-query/docs/api-reference.md
+++ b/go/cloud-query/docs/api-reference.md
@@ -289,17 +289,17 @@ ToolQuery exposes a gRPC service for querying external observability tools (metr
 
 ToolQuery support varies by operation:
 
-| Tool | Metrics | Logs | Traces | Notes |
-|------|---------|------|--------|-------|
-| Prometheus | Yes | No | No | Prometheus HTTP API range queries and metric name search |
-| Datadog | Yes | Yes | Yes | Datadog Metrics (v1), Logs (v2), Spans (v2) APIs, plus metric search (v2 HTTP) |
-| Elasticsearch | No | Yes | No | Elasticsearch typed Search API with query string |
-| Loki | No | Yes | No | Loki HTTP `query_range` API |
-| Tempo | No | No | Yes | Tempo HTTP search + trace fetch |
-| Jaeger | No | No | Yes | Jaeger Query v3 REST API with structured filters |
-| Dynatrace | Yes | Yes | Yes | Dynatrace Grail Query API (DQL via `/platform/storage/query/v1/query:*`) |
-| CloudWatch | Yes | Yes | No | AWS SDK v2 CloudWatch + Logs Insights |
-| Azure | Yes | Yes | No | Azure Monitor `azmetrics` + `azlogs` |
+| Tool | Metrics | Metric Label Search | Logs | Traces | Notes |
+|------|---------|---------------------|------|--------|-------|
+| Prometheus | Yes | Yes | No | No | Prometheus HTTP API range queries, metric name search, and metric-scoped label search |
+| Datadog | Yes | Yes | Yes | Yes | Datadog Metrics (v1), Logs (v2), Spans (v2) APIs, metric search, and metric tag search |
+| Elasticsearch | No | No | Yes | No | Elasticsearch typed Search API with query string |
+| Loki | No | No | Yes | No | Loki HTTP `query_range` API |
+| Tempo | No | No | No | Yes | Tempo HTTP search + trace fetch |
+| Jaeger | No | No | No | Yes | Jaeger Query v3 REST API with structured filters |
+| Dynatrace | Yes | No | Yes | Yes | Dynatrace Grail Query API (DQL via `/platform/storage/query/v1/query:*`) |
+| CloudWatch | Yes | Yes | Yes | No | AWS SDK v2 CloudWatch + Logs Insights |
+| Azure | Yes | Yes | Yes | No | Azure Monitor `azmetrics` + `azlogs`; Managed Prometheus delegates to Prometheus |
 
 ## Client and Endpoint Details
 
@@ -308,6 +308,7 @@ ToolQuery uses the following clients/SDKs and endpoints for each integration:
 - Prometheus: `prometheus/client_golang` HTTP API client, `QueryRange` (Prometheus `/api/v1/query_range`). Supports bearer token or basic auth.
 - Datadog: `datadog-api-client-go` v2 SDK.
   - Metrics: v1 `QueryMetrics`.
+  - Metrics label search: v2 `ListTagsByMetricName`.
   - Logs: v2 `ListLogs`.
   - Traces: v2 `ListSpans`.
 - Elasticsearch: `elastic/go-elasticsearch` v9 typed client, `Search` (Elasticsearch `/_search`) with a `query_string` query and `@timestamp` range filter. Requires API key.
@@ -319,9 +320,11 @@ ToolQuery uses the following clients/SDKs and endpoints for each integration:
   - Logs: CloudWatch Logs Insights `StartQuery` + `GetQueryResults`.
   - Metrics: CloudWatch `GetMetricData` (query expression).
   - Metrics search: CloudWatch `ListMetrics` with bounded pagination and local filtering.
+  - Metrics label search: CloudWatch `ListMetrics` dimensions with bounded pagination.
 - Azure: Azure Monitor Go SDK via Azure AD client credentials.
   - Metrics: `monitor/query/azmetrics` `QueryResources`.
   - Metrics search: `resourcemanager/monitor/armmonitor` metric definitions pager.
+  - Metrics label search: metric definitions dimensions for label names; `azmetrics.QueryResources` time-series metadata for native Azure label values; Managed Prometheus delegates to Prometheus label APIs.
   - Logs: `monitor/query/azlogs` `QueryResource`.
 
 ## Service Definition
@@ -330,6 +333,7 @@ ToolQuery uses the following clients/SDKs and endpoints for each integration:
 service ToolQuery {
   rpc Metrics(MetricsQueryInput) returns (MetricsQueryOutput) {}
   rpc MetricsSearch(MetricsSearchInput) returns (MetricsSearchOutput) {}
+  rpc MetricsLabelSearch(MetricsLabelSearchInput) returns (MetricsLabelSearchOutput) {}
   rpc Logs(LogsQueryInput) returns (LogsQueryOutput) {}
   rpc Traces(TracesQueryInput) returns (TracesQueryOutput) {}
   rpc InvokeLambda(InvokeLambdaInput) returns (InvokeLambdaOutput) {}
@@ -475,6 +479,7 @@ message AzureMetricsOptions {
   optional string order_by = 5;
   optional string roll_up_by = 6;
   optional string metrics_endpoint = 7;
+  optional string prometheus_url = 8;
 }
 ```
 
@@ -505,6 +510,7 @@ message MetricsSearchOptions {
 
 message AzureMetricsSearchOptions {
   string resource_id = 1;
+  optional string prometheus_url = 2;
 }
 
 message MetricsSearchResult {
@@ -513,6 +519,34 @@ message MetricsSearchResult {
 
 message MetricsSearchOutput {
   repeated MetricsSearchResult metrics = 1;
+}
+
+message MetricsLabelSearchInput {
+  ToolConnection connection = 1;
+  string metric = 2;
+  optional string query = 3;
+  optional string label = 4;
+  optional int64 limit = 5;
+  optional MetricsLabelSearchOptions options = 6;
+}
+
+message MetricsLabelSearchOptions {
+  optional AzureMetricsLabelSearchOptions azure = 1;
+}
+
+message AzureMetricsLabelSearchOptions {
+  string resource_id = 1;
+  optional string metrics_namespace = 2;
+  optional string prometheus_url = 3;
+  optional string metrics_endpoint = 4;
+}
+
+message MetricsLabelSearchResult {
+  string name = 1;
+}
+
+message MetricsLabelSearchOutput {
+  repeated MetricsLabelSearchResult results = 1;
 }
 ```
 
@@ -794,7 +828,10 @@ grpcurl -d '{
 
 ## Metrics Search
 
-`MetricsSearch` returns metric names only.
+`MetricsSearch` returns metric names or provider-specific metric identifiers that can be passed to `MetricsLabelSearch`.
+- `query` is the search term. Most providers apply it as a plain substring or provider-native search filter.
+- `limit` defaults to a provider-specific conservative value.
+- Results contain only metric names. Use `Metrics` to query time-series data and `MetricsLabelSearch` to inspect available labels for a specific metric.
 
 ### Prometheus
 
@@ -953,6 +990,112 @@ grpcurl -d '{
   "metrics": [
     { "name": "node_cpu_usage_percentage" },
     { "name": "node_memory_working_set" }
+  ]
+}
+```
+
+## Metrics Label Search
+
+`MetricsLabelSearch` returns metric-scoped label metadata.
+- `metric` is required. Use a metric name or provider-specific metric identifier, typically from `MetricsSearch`.
+- If `label` is omitted, results are label names for `metric`.
+- If `label` is provided, results are values for that label on `metric`.
+- `query` is an optional case-insensitive substring filter applied locally to returned names or values.
+- `limit` defaults to a provider-specific conservative value.
+
+Provider notes:
+- Prometheus and Azure Managed Prometheus use Prometheus label APIs over a recent 24-hour window.
+- Datadog uses indexed metric tags from `ListTagsByMetricName`.
+- CloudWatch uses `ListMetrics` dimensions for recently active metrics. CloudWatch metric identifiers should match `MetricsSearch` output, for example `AWS/EC2/CPUUtilization`.
+- Native Azure Monitor uses metric-definition dimensions for label names. Label values require `options.azure.metrics_namespace` and are inferred from recent metric time-series metadata.
+- Dynatrace metric label search is currently unsupported.
+
+### Prometheus label names
+
+```bash
+grpcurl -d '{
+  "connection": {
+    "prometheus": {
+      "url": "http://vmauth-vm-auth.monitoring:8427/select/0/prometheus",
+      "username": "<USERNAME>",
+      "password": "<PASSWORD>"
+    }
+  },
+  "metric": "container_cpu_usage_seconds_total",
+  "query": "pod",
+  "limit": 10
+}' -plaintext localhost:9192 toolquery.ToolQuery/MetricsLabelSearch
+```
+
+#### Output
+
+```json
+{
+  "results": [
+    { "name": "pod" },
+    { "name": "pod_name" }
+  ]
+}
+```
+
+### Prometheus label values
+
+```bash
+grpcurl -d '{
+  "connection": {
+    "prometheus": {
+      "url": "http://vmauth-vm-auth.monitoring:8427/select/0/prometheus",
+      "username": "<USERNAME>",
+      "password": "<PASSWORD>"
+    }
+  },
+  "metric": "container_cpu_usage_seconds_total",
+  "label": "namespace",
+  "query": "prod",
+  "limit": 10
+}' -plaintext localhost:9192 toolquery.ToolQuery/MetricsLabelSearch
+```
+
+#### Output
+
+```json
+{
+  "results": [
+    { "name": "prod" },
+    { "name": "prod-system" }
+  ]
+}
+```
+
+### Azure native label names
+
+```bash
+grpcurl -d '{
+  "connection": {
+    "azure": {
+      "subscription_id": "<SUBSCRIPTION_ID>",
+      "tenant_id": "<TENANT_ID>",
+      "client_id": "<CLIENT_ID>",
+      "client_secret": "<CLIENT_SECRET>"
+    }
+  },
+  "metric": "node_cpu_usage_percentage",
+  "options": {
+    "azure": {
+      "resource_id": "/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/rg-prod/providers/Microsoft.ContainerService/managedClusters/aks-prod",
+      "metrics_namespace": "Microsoft.ContainerService/managedClusters"
+    }
+  },
+  "limit": 10
+}' -plaintext localhost:9192 toolquery.ToolQuery/MetricsLabelSearch
+```
+
+#### Output
+
+```json
+{
+  "results": [
+    { "name": "node" }
   ]
 }
 ```

--- a/go/cloud-query/internal/proto/toolquery/toolquery.pb.go
+++ b/go/cloud-query/internal/proto/toolquery/toolquery.pb.go
@@ -2183,6 +2183,291 @@ func (x *MetricsSearchOutput) GetMetrics() []*MetricsSearchResult {
 	return nil
 }
 
+type MetricsLabelSearchInput struct {
+	state         protoimpl.MessageState     `protogen:"open.v1"`
+	Connection    *ToolConnection            `protobuf:"bytes,1,opt,name=connection,proto3" json:"connection,omitempty"`
+	Metric        string                     `protobuf:"bytes,2,opt,name=metric,proto3" json:"metric,omitempty"`
+	Query         *string                    `protobuf:"bytes,3,opt,name=query,proto3,oneof" json:"query,omitempty"`
+	Label         *string                    `protobuf:"bytes,4,opt,name=label,proto3,oneof" json:"label,omitempty"`
+	Limit         *int64                     `protobuf:"varint,5,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	Options       *MetricsLabelSearchOptions `protobuf:"bytes,6,opt,name=options,proto3,oneof" json:"options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MetricsLabelSearchInput) Reset() {
+	*x = MetricsLabelSearchInput{}
+	mi := &file_toolquery_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MetricsLabelSearchInput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MetricsLabelSearchInput) ProtoMessage() {}
+
+func (x *MetricsLabelSearchInput) ProtoReflect() protoreflect.Message {
+	mi := &file_toolquery_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MetricsLabelSearchInput.ProtoReflect.Descriptor instead.
+func (*MetricsLabelSearchInput) Descriptor() ([]byte, []int) {
+	return file_toolquery_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *MetricsLabelSearchInput) GetConnection() *ToolConnection {
+	if x != nil {
+		return x.Connection
+	}
+	return nil
+}
+
+func (x *MetricsLabelSearchInput) GetMetric() string {
+	if x != nil {
+		return x.Metric
+	}
+	return ""
+}
+
+func (x *MetricsLabelSearchInput) GetQuery() string {
+	if x != nil && x.Query != nil {
+		return *x.Query
+	}
+	return ""
+}
+
+func (x *MetricsLabelSearchInput) GetLabel() string {
+	if x != nil && x.Label != nil {
+		return *x.Label
+	}
+	return ""
+}
+
+func (x *MetricsLabelSearchInput) GetLimit() int64 {
+	if x != nil && x.Limit != nil {
+		return *x.Limit
+	}
+	return 0
+}
+
+func (x *MetricsLabelSearchInput) GetOptions() *MetricsLabelSearchOptions {
+	if x != nil {
+		return x.Options
+	}
+	return nil
+}
+
+type MetricsLabelSearchOptions struct {
+	state         protoimpl.MessageState          `protogen:"open.v1"`
+	Azure         *AzureMetricsLabelSearchOptions `protobuf:"bytes,1,opt,name=azure,proto3,oneof" json:"azure,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MetricsLabelSearchOptions) Reset() {
+	*x = MetricsLabelSearchOptions{}
+	mi := &file_toolquery_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MetricsLabelSearchOptions) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MetricsLabelSearchOptions) ProtoMessage() {}
+
+func (x *MetricsLabelSearchOptions) ProtoReflect() protoreflect.Message {
+	mi := &file_toolquery_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MetricsLabelSearchOptions.ProtoReflect.Descriptor instead.
+func (*MetricsLabelSearchOptions) Descriptor() ([]byte, []int) {
+	return file_toolquery_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *MetricsLabelSearchOptions) GetAzure() *AzureMetricsLabelSearchOptions {
+	if x != nil {
+		return x.Azure
+	}
+	return nil
+}
+
+type AzureMetricsLabelSearchOptions struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	ResourceId       string                 `protobuf:"bytes,1,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
+	MetricsNamespace *string                `protobuf:"bytes,2,opt,name=metrics_namespace,json=metricsNamespace,proto3,oneof" json:"metrics_namespace,omitempty"`
+	PrometheusUrl    *string                `protobuf:"bytes,3,opt,name=prometheus_url,json=prometheusUrl,proto3,oneof" json:"prometheus_url,omitempty"`
+	MetricsEndpoint  *string                `protobuf:"bytes,4,opt,name=metrics_endpoint,json=metricsEndpoint,proto3,oneof" json:"metrics_endpoint,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *AzureMetricsLabelSearchOptions) Reset() {
+	*x = AzureMetricsLabelSearchOptions{}
+	mi := &file_toolquery_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AzureMetricsLabelSearchOptions) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AzureMetricsLabelSearchOptions) ProtoMessage() {}
+
+func (x *AzureMetricsLabelSearchOptions) ProtoReflect() protoreflect.Message {
+	mi := &file_toolquery_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AzureMetricsLabelSearchOptions.ProtoReflect.Descriptor instead.
+func (*AzureMetricsLabelSearchOptions) Descriptor() ([]byte, []int) {
+	return file_toolquery_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *AzureMetricsLabelSearchOptions) GetResourceId() string {
+	if x != nil {
+		return x.ResourceId
+	}
+	return ""
+}
+
+func (x *AzureMetricsLabelSearchOptions) GetMetricsNamespace() string {
+	if x != nil && x.MetricsNamespace != nil {
+		return *x.MetricsNamespace
+	}
+	return ""
+}
+
+func (x *AzureMetricsLabelSearchOptions) GetPrometheusUrl() string {
+	if x != nil && x.PrometheusUrl != nil {
+		return *x.PrometheusUrl
+	}
+	return ""
+}
+
+func (x *AzureMetricsLabelSearchOptions) GetMetricsEndpoint() string {
+	if x != nil && x.MetricsEndpoint != nil {
+		return *x.MetricsEndpoint
+	}
+	return ""
+}
+
+type MetricsLabelSearchResult struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Name of the matching label or label value.
+	Name          string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MetricsLabelSearchResult) Reset() {
+	*x = MetricsLabelSearchResult{}
+	mi := &file_toolquery_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MetricsLabelSearchResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MetricsLabelSearchResult) ProtoMessage() {}
+
+func (x *MetricsLabelSearchResult) ProtoReflect() protoreflect.Message {
+	mi := &file_toolquery_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MetricsLabelSearchResult.ProtoReflect.Descriptor instead.
+func (*MetricsLabelSearchResult) Descriptor() ([]byte, []int) {
+	return file_toolquery_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *MetricsLabelSearchResult) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type MetricsLabelSearchOutput struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	Results       []*MetricsLabelSearchResult `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MetricsLabelSearchOutput) Reset() {
+	*x = MetricsLabelSearchOutput{}
+	mi := &file_toolquery_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MetricsLabelSearchOutput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MetricsLabelSearchOutput) ProtoMessage() {}
+
+func (x *MetricsLabelSearchOutput) ProtoReflect() protoreflect.Message {
+	mi := &file_toolquery_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MetricsLabelSearchOutput.ProtoReflect.Descriptor instead.
+func (*MetricsLabelSearchOutput) Descriptor() ([]byte, []int) {
+	return file_toolquery_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *MetricsLabelSearchOutput) GetResults() []*MetricsLabelSearchResult {
+	if x != nil {
+		return x.Results
+	}
+	return nil
+}
+
 type LogEntry struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
@@ -2194,7 +2479,7 @@ type LogEntry struct {
 
 func (x *LogEntry) Reset() {
 	*x = LogEntry{}
-	mi := &file_toolquery_proto_msgTypes[31]
+	mi := &file_toolquery_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2206,7 +2491,7 @@ func (x *LogEntry) String() string {
 func (*LogEntry) ProtoMessage() {}
 
 func (x *LogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_toolquery_proto_msgTypes[31]
+	mi := &file_toolquery_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2219,7 +2504,7 @@ func (x *LogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogEntry.ProtoReflect.Descriptor instead.
 func (*LogEntry) Descriptor() ([]byte, []int) {
-	return file_toolquery_proto_rawDescGZIP(), []int{31}
+	return file_toolquery_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *LogEntry) GetTimestamp() *timestamppb.Timestamp {
@@ -2252,7 +2537,7 @@ type LogsQueryOutput struct {
 
 func (x *LogsQueryOutput) Reset() {
 	*x = LogsQueryOutput{}
-	mi := &file_toolquery_proto_msgTypes[32]
+	mi := &file_toolquery_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2264,7 +2549,7 @@ func (x *LogsQueryOutput) String() string {
 func (*LogsQueryOutput) ProtoMessage() {}
 
 func (x *LogsQueryOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_toolquery_proto_msgTypes[32]
+	mi := &file_toolquery_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2277,7 +2562,7 @@ func (x *LogsQueryOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogsQueryOutput.ProtoReflect.Descriptor instead.
 func (*LogsQueryOutput) Descriptor() ([]byte, []int) {
-	return file_toolquery_proto_rawDescGZIP(), []int{32}
+	return file_toolquery_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *LogsQueryOutput) GetLogs() []*LogEntry {
@@ -2303,7 +2588,7 @@ type TraceSpan struct {
 
 func (x *TraceSpan) Reset() {
 	*x = TraceSpan{}
-	mi := &file_toolquery_proto_msgTypes[33]
+	mi := &file_toolquery_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2315,7 +2600,7 @@ func (x *TraceSpan) String() string {
 func (*TraceSpan) ProtoMessage() {}
 
 func (x *TraceSpan) ProtoReflect() protoreflect.Message {
-	mi := &file_toolquery_proto_msgTypes[33]
+	mi := &file_toolquery_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2328,7 +2613,7 @@ func (x *TraceSpan) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TraceSpan.ProtoReflect.Descriptor instead.
 func (*TraceSpan) Descriptor() ([]byte, []int) {
-	return file_toolquery_proto_rawDescGZIP(), []int{33}
+	return file_toolquery_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *TraceSpan) GetTraceId() string {
@@ -2396,7 +2681,7 @@ type TracesQueryOutput struct {
 
 func (x *TracesQueryOutput) Reset() {
 	*x = TracesQueryOutput{}
-	mi := &file_toolquery_proto_msgTypes[34]
+	mi := &file_toolquery_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2408,7 +2693,7 @@ func (x *TracesQueryOutput) String() string {
 func (*TracesQueryOutput) ProtoMessage() {}
 
 func (x *TracesQueryOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_toolquery_proto_msgTypes[34]
+	mi := &file_toolquery_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2421,7 +2706,7 @@ func (x *TracesQueryOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracesQueryOutput.ProtoReflect.Descriptor instead.
 func (*TracesQueryOutput) Descriptor() ([]byte, []int) {
-	return file_toolquery_proto_rawDescGZIP(), []int{34}
+	return file_toolquery_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *TracesQueryOutput) GetSpans() []*TraceSpan {
@@ -2442,7 +2727,7 @@ type InvokeLambdaInput struct {
 
 func (x *InvokeLambdaInput) Reset() {
 	*x = InvokeLambdaInput{}
-	mi := &file_toolquery_proto_msgTypes[35]
+	mi := &file_toolquery_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2454,7 +2739,7 @@ func (x *InvokeLambdaInput) String() string {
 func (*InvokeLambdaInput) ProtoMessage() {}
 
 func (x *InvokeLambdaInput) ProtoReflect() protoreflect.Message {
-	mi := &file_toolquery_proto_msgTypes[35]
+	mi := &file_toolquery_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2467,7 +2752,7 @@ func (x *InvokeLambdaInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvokeLambdaInput.ProtoReflect.Descriptor instead.
 func (*InvokeLambdaInput) Descriptor() ([]byte, []int) {
-	return file_toolquery_proto_rawDescGZIP(), []int{35}
+	return file_toolquery_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *InvokeLambdaInput) GetConnection() *cloudquery.Connection {
@@ -2501,7 +2786,7 @@ type InvokeLambdaOutput struct {
 
 func (x *InvokeLambdaOutput) Reset() {
 	*x = InvokeLambdaOutput{}
-	mi := &file_toolquery_proto_msgTypes[36]
+	mi := &file_toolquery_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2513,7 +2798,7 @@ func (x *InvokeLambdaOutput) String() string {
 func (*InvokeLambdaOutput) ProtoMessage() {}
 
 func (x *InvokeLambdaOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_toolquery_proto_msgTypes[36]
+	mi := &file_toolquery_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2526,7 +2811,7 @@ func (x *InvokeLambdaOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InvokeLambdaOutput.ProtoReflect.Descriptor instead.
 func (*InvokeLambdaOutput) Descriptor() ([]byte, []int) {
-	return file_toolquery_proto_rawDescGZIP(), []int{36}
+	return file_toolquery_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *InvokeLambdaOutput) GetResult() string {
@@ -2553,7 +2838,7 @@ type RunLuaInput struct {
 
 func (x *RunLuaInput) Reset() {
 	*x = RunLuaInput{}
-	mi := &file_toolquery_proto_msgTypes[37]
+	mi := &file_toolquery_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2565,7 +2850,7 @@ func (x *RunLuaInput) String() string {
 func (*RunLuaInput) ProtoMessage() {}
 
 func (x *RunLuaInput) ProtoReflect() protoreflect.Message {
-	mi := &file_toolquery_proto_msgTypes[37]
+	mi := &file_toolquery_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2578,7 +2863,7 @@ func (x *RunLuaInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunLuaInput.ProtoReflect.Descriptor instead.
 func (*RunLuaInput) Descriptor() ([]byte, []int) {
-	return file_toolquery_proto_rawDescGZIP(), []int{37}
+	return file_toolquery_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *RunLuaInput) GetScript() string {
@@ -2598,7 +2883,7 @@ type RunLuaOutput struct {
 
 func (x *RunLuaOutput) Reset() {
 	*x = RunLuaOutput{}
-	mi := &file_toolquery_proto_msgTypes[38]
+	mi := &file_toolquery_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2610,7 +2895,7 @@ func (x *RunLuaOutput) String() string {
 func (*RunLuaOutput) ProtoMessage() {}
 
 func (x *RunLuaOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_toolquery_proto_msgTypes[38]
+	mi := &file_toolquery_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2623,7 +2908,7 @@ func (x *RunLuaOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunLuaOutput.ProtoReflect.Descriptor instead.
 func (*RunLuaOutput) Descriptor() ([]byte, []int) {
-	return file_toolquery_proto_rawDescGZIP(), []int{38}
+	return file_toolquery_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *RunLuaOutput) GetResultJson() string {
@@ -2878,7 +3163,37 @@ const file_toolquery_proto_rawDesc = "" +
 	"\x13MetricsSearchResult\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"O\n" +
 	"\x13MetricsSearchOutput\x128\n" +
-	"\ametrics\x18\x01 \x03(\v2\x1e.toolquery.MetricsSearchResultR\ametrics\"\xd2\x01\n" +
+	"\ametrics\x18\x01 \x03(\v2\x1e.toolquery.MetricsSearchResultR\ametrics\"\xac\x02\n" +
+	"\x17MetricsLabelSearchInput\x129\n" +
+	"\n" +
+	"connection\x18\x01 \x01(\v2\x19.toolquery.ToolConnectionR\n" +
+	"connection\x12\x16\n" +
+	"\x06metric\x18\x02 \x01(\tR\x06metric\x12\x19\n" +
+	"\x05query\x18\x03 \x01(\tH\x00R\x05query\x88\x01\x01\x12\x19\n" +
+	"\x05label\x18\x04 \x01(\tH\x01R\x05label\x88\x01\x01\x12\x19\n" +
+	"\x05limit\x18\x05 \x01(\x03H\x02R\x05limit\x88\x01\x01\x12C\n" +
+	"\aoptions\x18\x06 \x01(\v2$.toolquery.MetricsLabelSearchOptionsH\x03R\aoptions\x88\x01\x01B\b\n" +
+	"\x06_queryB\b\n" +
+	"\x06_labelB\b\n" +
+	"\x06_limitB\n" +
+	"\n" +
+	"\b_options\"k\n" +
+	"\x19MetricsLabelSearchOptions\x12D\n" +
+	"\x05azure\x18\x01 \x01(\v2).toolquery.AzureMetricsLabelSearchOptionsH\x00R\x05azure\x88\x01\x01B\b\n" +
+	"\x06_azure\"\x8d\x02\n" +
+	"\x1eAzureMetricsLabelSearchOptions\x12\x1f\n" +
+	"\vresource_id\x18\x01 \x01(\tR\n" +
+	"resourceId\x120\n" +
+	"\x11metrics_namespace\x18\x02 \x01(\tH\x00R\x10metricsNamespace\x88\x01\x01\x12*\n" +
+	"\x0eprometheus_url\x18\x03 \x01(\tH\x01R\rprometheusUrl\x88\x01\x01\x12.\n" +
+	"\x10metrics_endpoint\x18\x04 \x01(\tH\x02R\x0fmetricsEndpoint\x88\x01\x01B\x14\n" +
+	"\x12_metrics_namespaceB\x11\n" +
+	"\x0f_prometheus_urlB\x13\n" +
+	"\x11_metrics_endpoint\".\n" +
+	"\x18MetricsLabelSearchResult\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"Y\n" +
+	"\x18MetricsLabelSearchOutput\x12=\n" +
+	"\aresults\x18\x01 \x03(\v2#.toolquery.MetricsLabelSearchResultR\aresults\"\xd2\x01\n" +
 	"\bLogEntry\x128\n" +
 	"\ttimestamp\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x127\n" +
@@ -2917,10 +3232,11 @@ const file_toolquery_proto_rawDesc = "" +
 	"\x06script\x18\x01 \x01(\tR\x06script\"/\n" +
 	"\fRunLuaOutput\x12\x1f\n" +
 	"\vresult_json\x18\x01 \x01(\tR\n" +
-	"resultJson2\xbb\x03\n" +
+	"resultJson2\x9c\x04\n" +
 	"\tToolQuery\x12H\n" +
 	"\aMetrics\x12\x1c.toolquery.MetricsQueryInput\x1a\x1d.toolquery.MetricsQueryOutput\"\x00\x12P\n" +
-	"\rMetricsSearch\x12\x1d.toolquery.MetricsSearchInput\x1a\x1e.toolquery.MetricsSearchOutput\"\x00\x12?\n" +
+	"\rMetricsSearch\x12\x1d.toolquery.MetricsSearchInput\x1a\x1e.toolquery.MetricsSearchOutput\"\x00\x12_\n" +
+	"\x12MetricsLabelSearch\x12\".toolquery.MetricsLabelSearchInput\x1a#.toolquery.MetricsLabelSearchOutput\"\x00\x12?\n" +
 	"\x04Logs\x12\x19.toolquery.LogsQueryInput\x1a\x1a.toolquery.LogsQueryOutput\"\x00\x12E\n" +
 	"\x06Traces\x12\x1b.toolquery.TracesQueryInput\x1a\x1c.toolquery.TracesQueryOutput\"\x00\x12M\n" +
 	"\fInvokeLambda\x12\x1c.toolquery.InvokeLambdaInput\x1a\x1d.toolquery.InvokeLambdaOutput\"\x00\x12;\n" +
@@ -2938,52 +3254,57 @@ func file_toolquery_proto_rawDescGZIP() []byte {
 	return file_toolquery_proto_rawDescData
 }
 
-var file_toolquery_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_toolquery_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
 var file_toolquery_proto_goTypes = []any{
-	(*ElasticConnection)(nil),         // 0: toolquery.ElasticConnection
-	(*OpensearchConnection)(nil),      // 1: toolquery.OpensearchConnection
-	(*DatadogConnection)(nil),         // 2: toolquery.DatadogConnection
-	(*PrometheusConnection)(nil),      // 3: toolquery.PrometheusConnection
-	(*LokiConnection)(nil),            // 4: toolquery.LokiConnection
-	(*TempoConnection)(nil),           // 5: toolquery.TempoConnection
-	(*JaegerConnection)(nil),          // 6: toolquery.JaegerConnection
-	(*SplunkConnection)(nil),          // 7: toolquery.SplunkConnection
-	(*DynatraceConnection)(nil),       // 8: toolquery.DynatraceConnection
-	(*CloudwatchConnection)(nil),      // 9: toolquery.CloudwatchConnection
-	(*AzureConnection)(nil),           // 10: toolquery.AzureConnection
-	(*ToolConnection)(nil),            // 11: toolquery.ToolConnection
-	(*TimeRange)(nil),                 // 12: toolquery.TimeRange
-	(*MetricsQueryInput)(nil),         // 13: toolquery.MetricsQueryInput
-	(*MetricsOptions)(nil),            // 14: toolquery.MetricsOptions
-	(*AzureMetricsOptions)(nil),       // 15: toolquery.AzureMetricsOptions
-	(*LogsQueryFacet)(nil),            // 16: toolquery.LogsQueryFacet
-	(*LogsQueryInput)(nil),            // 17: toolquery.LogsQueryInput
-	(*LogsOptions)(nil),               // 18: toolquery.LogsOptions
-	(*AzureLogsOptions)(nil),          // 19: toolquery.AzureLogsOptions
-	(*TracesQueryInput)(nil),          // 20: toolquery.TracesQueryInput
-	(*TracesOptions)(nil),             // 21: toolquery.TracesOptions
-	(*JaegerTraceQueryAttribute)(nil), // 22: toolquery.JaegerTraceQueryAttribute
-	(*JaegerTracesOptions)(nil),       // 23: toolquery.JaegerTracesOptions
-	(*MetricPoint)(nil),               // 24: toolquery.MetricPoint
-	(*MetricsQueryOutput)(nil),        // 25: toolquery.MetricsQueryOutput
-	(*MetricsSearchInput)(nil),        // 26: toolquery.MetricsSearchInput
-	(*MetricsSearchOptions)(nil),      // 27: toolquery.MetricsSearchOptions
-	(*AzureMetricsSearchOptions)(nil), // 28: toolquery.AzureMetricsSearchOptions
-	(*MetricsSearchResult)(nil),       // 29: toolquery.MetricsSearchResult
-	(*MetricsSearchOutput)(nil),       // 30: toolquery.MetricsSearchOutput
-	(*LogEntry)(nil),                  // 31: toolquery.LogEntry
-	(*LogsQueryOutput)(nil),           // 32: toolquery.LogsQueryOutput
-	(*TraceSpan)(nil),                 // 33: toolquery.TraceSpan
-	(*TracesQueryOutput)(nil),         // 34: toolquery.TracesQueryOutput
-	(*InvokeLambdaInput)(nil),         // 35: toolquery.InvokeLambdaInput
-	(*InvokeLambdaOutput)(nil),        // 36: toolquery.InvokeLambdaOutput
-	(*RunLuaInput)(nil),               // 37: toolquery.RunLuaInput
-	(*RunLuaOutput)(nil),              // 38: toolquery.RunLuaOutput
-	nil,                               // 39: toolquery.MetricPoint.LabelsEntry
-	nil,                               // 40: toolquery.LogEntry.LabelsEntry
-	nil,                               // 41: toolquery.TraceSpan.TagsEntry
-	(*timestamppb.Timestamp)(nil),     // 42: google.protobuf.Timestamp
-	(*cloudquery.Connection)(nil),     // 43: cloudquery.Connection
+	(*ElasticConnection)(nil),              // 0: toolquery.ElasticConnection
+	(*OpensearchConnection)(nil),           // 1: toolquery.OpensearchConnection
+	(*DatadogConnection)(nil),              // 2: toolquery.DatadogConnection
+	(*PrometheusConnection)(nil),           // 3: toolquery.PrometheusConnection
+	(*LokiConnection)(nil),                 // 4: toolquery.LokiConnection
+	(*TempoConnection)(nil),                // 5: toolquery.TempoConnection
+	(*JaegerConnection)(nil),               // 6: toolquery.JaegerConnection
+	(*SplunkConnection)(nil),               // 7: toolquery.SplunkConnection
+	(*DynatraceConnection)(nil),            // 8: toolquery.DynatraceConnection
+	(*CloudwatchConnection)(nil),           // 9: toolquery.CloudwatchConnection
+	(*AzureConnection)(nil),                // 10: toolquery.AzureConnection
+	(*ToolConnection)(nil),                 // 11: toolquery.ToolConnection
+	(*TimeRange)(nil),                      // 12: toolquery.TimeRange
+	(*MetricsQueryInput)(nil),              // 13: toolquery.MetricsQueryInput
+	(*MetricsOptions)(nil),                 // 14: toolquery.MetricsOptions
+	(*AzureMetricsOptions)(nil),            // 15: toolquery.AzureMetricsOptions
+	(*LogsQueryFacet)(nil),                 // 16: toolquery.LogsQueryFacet
+	(*LogsQueryInput)(nil),                 // 17: toolquery.LogsQueryInput
+	(*LogsOptions)(nil),                    // 18: toolquery.LogsOptions
+	(*AzureLogsOptions)(nil),               // 19: toolquery.AzureLogsOptions
+	(*TracesQueryInput)(nil),               // 20: toolquery.TracesQueryInput
+	(*TracesOptions)(nil),                  // 21: toolquery.TracesOptions
+	(*JaegerTraceQueryAttribute)(nil),      // 22: toolquery.JaegerTraceQueryAttribute
+	(*JaegerTracesOptions)(nil),            // 23: toolquery.JaegerTracesOptions
+	(*MetricPoint)(nil),                    // 24: toolquery.MetricPoint
+	(*MetricsQueryOutput)(nil),             // 25: toolquery.MetricsQueryOutput
+	(*MetricsSearchInput)(nil),             // 26: toolquery.MetricsSearchInput
+	(*MetricsSearchOptions)(nil),           // 27: toolquery.MetricsSearchOptions
+	(*AzureMetricsSearchOptions)(nil),      // 28: toolquery.AzureMetricsSearchOptions
+	(*MetricsSearchResult)(nil),            // 29: toolquery.MetricsSearchResult
+	(*MetricsSearchOutput)(nil),            // 30: toolquery.MetricsSearchOutput
+	(*MetricsLabelSearchInput)(nil),        // 31: toolquery.MetricsLabelSearchInput
+	(*MetricsLabelSearchOptions)(nil),      // 32: toolquery.MetricsLabelSearchOptions
+	(*AzureMetricsLabelSearchOptions)(nil), // 33: toolquery.AzureMetricsLabelSearchOptions
+	(*MetricsLabelSearchResult)(nil),       // 34: toolquery.MetricsLabelSearchResult
+	(*MetricsLabelSearchOutput)(nil),       // 35: toolquery.MetricsLabelSearchOutput
+	(*LogEntry)(nil),                       // 36: toolquery.LogEntry
+	(*LogsQueryOutput)(nil),                // 37: toolquery.LogsQueryOutput
+	(*TraceSpan)(nil),                      // 38: toolquery.TraceSpan
+	(*TracesQueryOutput)(nil),              // 39: toolquery.TracesQueryOutput
+	(*InvokeLambdaInput)(nil),              // 40: toolquery.InvokeLambdaInput
+	(*InvokeLambdaOutput)(nil),             // 41: toolquery.InvokeLambdaOutput
+	(*RunLuaInput)(nil),                    // 42: toolquery.RunLuaInput
+	(*RunLuaOutput)(nil),                   // 43: toolquery.RunLuaOutput
+	nil,                                    // 44: toolquery.MetricPoint.LabelsEntry
+	nil,                                    // 45: toolquery.LogEntry.LabelsEntry
+	nil,                                    // 46: toolquery.TraceSpan.TagsEntry
+	(*timestamppb.Timestamp)(nil),          // 47: google.protobuf.Timestamp
+	(*cloudquery.Connection)(nil),          // 48: cloudquery.Connection
 }
 var file_toolquery_proto_depIdxs = []int32{
 	0,  // 0: toolquery.ToolConnection.elastic:type_name -> toolquery.ElasticConnection
@@ -2997,8 +3318,8 @@ var file_toolquery_proto_depIdxs = []int32{
 	10, // 8: toolquery.ToolConnection.azure:type_name -> toolquery.AzureConnection
 	6,  // 9: toolquery.ToolConnection.jaeger:type_name -> toolquery.JaegerConnection
 	1,  // 10: toolquery.ToolConnection.opensearch:type_name -> toolquery.OpensearchConnection
-	42, // 11: toolquery.TimeRange.start:type_name -> google.protobuf.Timestamp
-	42, // 12: toolquery.TimeRange.end:type_name -> google.protobuf.Timestamp
+	47, // 11: toolquery.TimeRange.start:type_name -> google.protobuf.Timestamp
+	47, // 12: toolquery.TimeRange.end:type_name -> google.protobuf.Timestamp
 	11, // 13: toolquery.MetricsQueryInput.connection:type_name -> toolquery.ToolConnection
 	12, // 14: toolquery.MetricsQueryInput.range:type_name -> toolquery.TimeRange
 	14, // 15: toolquery.MetricsQueryInput.options:type_name -> toolquery.MetricsOptions
@@ -3013,38 +3334,44 @@ var file_toolquery_proto_depIdxs = []int32{
 	21, // 24: toolquery.TracesQueryInput.options:type_name -> toolquery.TracesOptions
 	23, // 25: toolquery.TracesOptions.jaeger:type_name -> toolquery.JaegerTracesOptions
 	22, // 26: toolquery.JaegerTracesOptions.attributes:type_name -> toolquery.JaegerTraceQueryAttribute
-	42, // 27: toolquery.MetricPoint.timestamp:type_name -> google.protobuf.Timestamp
-	39, // 28: toolquery.MetricPoint.labels:type_name -> toolquery.MetricPoint.LabelsEntry
+	47, // 27: toolquery.MetricPoint.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 28: toolquery.MetricPoint.labels:type_name -> toolquery.MetricPoint.LabelsEntry
 	24, // 29: toolquery.MetricsQueryOutput.metrics:type_name -> toolquery.MetricPoint
 	11, // 30: toolquery.MetricsSearchInput.connection:type_name -> toolquery.ToolConnection
 	27, // 31: toolquery.MetricsSearchInput.options:type_name -> toolquery.MetricsSearchOptions
 	28, // 32: toolquery.MetricsSearchOptions.azure:type_name -> toolquery.AzureMetricsSearchOptions
 	29, // 33: toolquery.MetricsSearchOutput.metrics:type_name -> toolquery.MetricsSearchResult
-	42, // 34: toolquery.LogEntry.timestamp:type_name -> google.protobuf.Timestamp
-	40, // 35: toolquery.LogEntry.labels:type_name -> toolquery.LogEntry.LabelsEntry
-	31, // 36: toolquery.LogsQueryOutput.logs:type_name -> toolquery.LogEntry
-	42, // 37: toolquery.TraceSpan.start:type_name -> google.protobuf.Timestamp
-	42, // 38: toolquery.TraceSpan.end:type_name -> google.protobuf.Timestamp
-	41, // 39: toolquery.TraceSpan.tags:type_name -> toolquery.TraceSpan.TagsEntry
-	33, // 40: toolquery.TracesQueryOutput.spans:type_name -> toolquery.TraceSpan
-	43, // 41: toolquery.InvokeLambdaInput.connection:type_name -> cloudquery.Connection
-	13, // 42: toolquery.ToolQuery.Metrics:input_type -> toolquery.MetricsQueryInput
-	26, // 43: toolquery.ToolQuery.MetricsSearch:input_type -> toolquery.MetricsSearchInput
-	17, // 44: toolquery.ToolQuery.Logs:input_type -> toolquery.LogsQueryInput
-	20, // 45: toolquery.ToolQuery.Traces:input_type -> toolquery.TracesQueryInput
-	35, // 46: toolquery.ToolQuery.InvokeLambda:input_type -> toolquery.InvokeLambdaInput
-	37, // 47: toolquery.ToolQuery.RunLua:input_type -> toolquery.RunLuaInput
-	25, // 48: toolquery.ToolQuery.Metrics:output_type -> toolquery.MetricsQueryOutput
-	30, // 49: toolquery.ToolQuery.MetricsSearch:output_type -> toolquery.MetricsSearchOutput
-	32, // 50: toolquery.ToolQuery.Logs:output_type -> toolquery.LogsQueryOutput
-	34, // 51: toolquery.ToolQuery.Traces:output_type -> toolquery.TracesQueryOutput
-	36, // 52: toolquery.ToolQuery.InvokeLambda:output_type -> toolquery.InvokeLambdaOutput
-	38, // 53: toolquery.ToolQuery.RunLua:output_type -> toolquery.RunLuaOutput
-	48, // [48:54] is the sub-list for method output_type
-	42, // [42:48] is the sub-list for method input_type
-	42, // [42:42] is the sub-list for extension type_name
-	42, // [42:42] is the sub-list for extension extendee
-	0,  // [0:42] is the sub-list for field type_name
+	11, // 34: toolquery.MetricsLabelSearchInput.connection:type_name -> toolquery.ToolConnection
+	32, // 35: toolquery.MetricsLabelSearchInput.options:type_name -> toolquery.MetricsLabelSearchOptions
+	33, // 36: toolquery.MetricsLabelSearchOptions.azure:type_name -> toolquery.AzureMetricsLabelSearchOptions
+	34, // 37: toolquery.MetricsLabelSearchOutput.results:type_name -> toolquery.MetricsLabelSearchResult
+	47, // 38: toolquery.LogEntry.timestamp:type_name -> google.protobuf.Timestamp
+	45, // 39: toolquery.LogEntry.labels:type_name -> toolquery.LogEntry.LabelsEntry
+	36, // 40: toolquery.LogsQueryOutput.logs:type_name -> toolquery.LogEntry
+	47, // 41: toolquery.TraceSpan.start:type_name -> google.protobuf.Timestamp
+	47, // 42: toolquery.TraceSpan.end:type_name -> google.protobuf.Timestamp
+	46, // 43: toolquery.TraceSpan.tags:type_name -> toolquery.TraceSpan.TagsEntry
+	38, // 44: toolquery.TracesQueryOutput.spans:type_name -> toolquery.TraceSpan
+	48, // 45: toolquery.InvokeLambdaInput.connection:type_name -> cloudquery.Connection
+	13, // 46: toolquery.ToolQuery.Metrics:input_type -> toolquery.MetricsQueryInput
+	26, // 47: toolquery.ToolQuery.MetricsSearch:input_type -> toolquery.MetricsSearchInput
+	31, // 48: toolquery.ToolQuery.MetricsLabelSearch:input_type -> toolquery.MetricsLabelSearchInput
+	17, // 49: toolquery.ToolQuery.Logs:input_type -> toolquery.LogsQueryInput
+	20, // 50: toolquery.ToolQuery.Traces:input_type -> toolquery.TracesQueryInput
+	40, // 51: toolquery.ToolQuery.InvokeLambda:input_type -> toolquery.InvokeLambdaInput
+	42, // 52: toolquery.ToolQuery.RunLua:input_type -> toolquery.RunLuaInput
+	25, // 53: toolquery.ToolQuery.Metrics:output_type -> toolquery.MetricsQueryOutput
+	30, // 54: toolquery.ToolQuery.MetricsSearch:output_type -> toolquery.MetricsSearchOutput
+	35, // 55: toolquery.ToolQuery.MetricsLabelSearch:output_type -> toolquery.MetricsLabelSearchOutput
+	37, // 56: toolquery.ToolQuery.Logs:output_type -> toolquery.LogsQueryOutput
+	39, // 57: toolquery.ToolQuery.Traces:output_type -> toolquery.TracesQueryOutput
+	41, // 58: toolquery.ToolQuery.InvokeLambda:output_type -> toolquery.InvokeLambdaOutput
+	43, // 59: toolquery.ToolQuery.RunLua:output_type -> toolquery.RunLuaOutput
+	53, // [53:60] is the sub-list for method output_type
+	46, // [46:53] is the sub-list for method input_type
+	46, // [46:46] is the sub-list for extension type_name
+	46, // [46:46] is the sub-list for extension extendee
+	0,  // [0:46] is the sub-list for field type_name
 }
 
 func init() { file_toolquery_proto_init() }
@@ -3084,13 +3411,16 @@ func file_toolquery_proto_init() {
 	file_toolquery_proto_msgTypes[26].OneofWrappers = []any{}
 	file_toolquery_proto_msgTypes[27].OneofWrappers = []any{}
 	file_toolquery_proto_msgTypes[28].OneofWrappers = []any{}
+	file_toolquery_proto_msgTypes[31].OneofWrappers = []any{}
+	file_toolquery_proto_msgTypes[32].OneofWrappers = []any{}
+	file_toolquery_proto_msgTypes[33].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_toolquery_proto_rawDesc), len(file_toolquery_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   42,
+			NumMessages:   47,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/go/cloud-query/internal/proto/toolquery/toolquery_grpc.pb.go
+++ b/go/cloud-query/internal/proto/toolquery/toolquery_grpc.pb.go
@@ -19,12 +19,13 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ToolQuery_Metrics_FullMethodName       = "/toolquery.ToolQuery/Metrics"
-	ToolQuery_MetricsSearch_FullMethodName = "/toolquery.ToolQuery/MetricsSearch"
-	ToolQuery_Logs_FullMethodName          = "/toolquery.ToolQuery/Logs"
-	ToolQuery_Traces_FullMethodName        = "/toolquery.ToolQuery/Traces"
-	ToolQuery_InvokeLambda_FullMethodName  = "/toolquery.ToolQuery/InvokeLambda"
-	ToolQuery_RunLua_FullMethodName        = "/toolquery.ToolQuery/RunLua"
+	ToolQuery_Metrics_FullMethodName            = "/toolquery.ToolQuery/Metrics"
+	ToolQuery_MetricsSearch_FullMethodName      = "/toolquery.ToolQuery/MetricsSearch"
+	ToolQuery_MetricsLabelSearch_FullMethodName = "/toolquery.ToolQuery/MetricsLabelSearch"
+	ToolQuery_Logs_FullMethodName               = "/toolquery.ToolQuery/Logs"
+	ToolQuery_Traces_FullMethodName             = "/toolquery.ToolQuery/Traces"
+	ToolQuery_InvokeLambda_FullMethodName       = "/toolquery.ToolQuery/InvokeLambda"
+	ToolQuery_RunLua_FullMethodName             = "/toolquery.ToolQuery/RunLua"
 )
 
 // ToolQueryClient is the client API for ToolQuery service.
@@ -33,6 +34,7 @@ const (
 type ToolQueryClient interface {
 	Metrics(ctx context.Context, in *MetricsQueryInput, opts ...grpc.CallOption) (*MetricsQueryOutput, error)
 	MetricsSearch(ctx context.Context, in *MetricsSearchInput, opts ...grpc.CallOption) (*MetricsSearchOutput, error)
+	MetricsLabelSearch(ctx context.Context, in *MetricsLabelSearchInput, opts ...grpc.CallOption) (*MetricsLabelSearchOutput, error)
 	Logs(ctx context.Context, in *LogsQueryInput, opts ...grpc.CallOption) (*LogsQueryOutput, error)
 	Traces(ctx context.Context, in *TracesQueryInput, opts ...grpc.CallOption) (*TracesQueryOutput, error)
 	InvokeLambda(ctx context.Context, in *InvokeLambdaInput, opts ...grpc.CallOption) (*InvokeLambdaOutput, error)
@@ -61,6 +63,16 @@ func (c *toolQueryClient) MetricsSearch(ctx context.Context, in *MetricsSearchIn
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(MetricsSearchOutput)
 	err := c.cc.Invoke(ctx, ToolQuery_MetricsSearch_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *toolQueryClient) MetricsLabelSearch(ctx context.Context, in *MetricsLabelSearchInput, opts ...grpc.CallOption) (*MetricsLabelSearchOutput, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(MetricsLabelSearchOutput)
+	err := c.cc.Invoke(ctx, ToolQuery_MetricsLabelSearch_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -113,6 +125,7 @@ func (c *toolQueryClient) RunLua(ctx context.Context, in *RunLuaInput, opts ...g
 type ToolQueryServer interface {
 	Metrics(context.Context, *MetricsQueryInput) (*MetricsQueryOutput, error)
 	MetricsSearch(context.Context, *MetricsSearchInput) (*MetricsSearchOutput, error)
+	MetricsLabelSearch(context.Context, *MetricsLabelSearchInput) (*MetricsLabelSearchOutput, error)
 	Logs(context.Context, *LogsQueryInput) (*LogsQueryOutput, error)
 	Traces(context.Context, *TracesQueryInput) (*TracesQueryOutput, error)
 	InvokeLambda(context.Context, *InvokeLambdaInput) (*InvokeLambdaOutput, error)
@@ -132,6 +145,9 @@ func (UnimplementedToolQueryServer) Metrics(context.Context, *MetricsQueryInput)
 }
 func (UnimplementedToolQueryServer) MetricsSearch(context.Context, *MetricsSearchInput) (*MetricsSearchOutput, error) {
 	return nil, status.Error(codes.Unimplemented, "method MetricsSearch not implemented")
+}
+func (UnimplementedToolQueryServer) MetricsLabelSearch(context.Context, *MetricsLabelSearchInput) (*MetricsLabelSearchOutput, error) {
+	return nil, status.Error(codes.Unimplemented, "method MetricsLabelSearch not implemented")
 }
 func (UnimplementedToolQueryServer) Logs(context.Context, *LogsQueryInput) (*LogsQueryOutput, error) {
 	return nil, status.Error(codes.Unimplemented, "method Logs not implemented")
@@ -198,6 +214,24 @@ func _ToolQuery_MetricsSearch_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ToolQueryServer).MetricsSearch(ctx, req.(*MetricsSearchInput))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ToolQuery_MetricsLabelSearch_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(MetricsLabelSearchInput)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ToolQueryServer).MetricsLabelSearch(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ToolQuery_MetricsLabelSearch_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ToolQueryServer).MetricsLabelSearch(ctx, req.(*MetricsLabelSearchInput))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -288,6 +322,10 @@ var ToolQuery_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "MetricsSearch",
 			Handler:    _ToolQuery_MetricsSearch_Handler,
+		},
+		{
+			MethodName: "MetricsLabelSearch",
+			Handler:    _ToolQuery_MetricsLabelSearch_Handler,
 		},
 		{
 			MethodName: "Logs",

--- a/go/cloud-query/internal/service/toolquery.go
+++ b/go/cloud-query/internal/service/toolquery.go
@@ -78,6 +78,31 @@ func (in *ToolQueryService) MetricsSearch(ctx context.Context, input *toolquery.
 	return output, nil
 }
 
+func (in *ToolQueryService) MetricsLabelSearch(ctx context.Context, input *toolquery.MetricsLabelSearchInput) (*toolquery.MetricsLabelSearchOutput, error) {
+	if input == nil {
+		return nil, status.Error(codes.InvalidArgument, "input is required")
+	}
+
+	if err := in.validateSearchInput(input.GetConnection()); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(input.GetMetric()) == "" {
+		return nil, status.Error(codes.InvalidArgument, "metric is required")
+	}
+
+	provider, err := tools.NewProvider(input.GetConnection())
+	if err != nil {
+		return nil, in.mapError("metrics_label_search", err)
+	}
+
+	output, err := provider.MetricsLabelSearch(ctx, input)
+	if err != nil {
+		return nil, in.mapError("metrics_label_search", err)
+	}
+
+	return output, nil
+}
+
 func (in *ToolQueryService) Logs(ctx context.Context, input *toolquery.LogsQueryInput) (*toolquery.LogsQueryOutput, error) {
 	if input == nil {
 		return nil, status.Error(codes.InvalidArgument, "input is required")

--- a/go/cloud-query/internal/tools/metrics_label_search.go
+++ b/go/cloud-query/internal/tools/metrics_label_search.go
@@ -1,0 +1,56 @@
+package tools
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/pluralsh/console/go/cloud-query/internal/proto/toolquery"
+)
+
+const (
+	defaultMetricsLabelSearchLimit = 200
+)
+
+func metricsLabelSearchLimit(limit int64) int {
+	if limit <= 0 {
+		return defaultMetricsLabelSearchLimit
+	}
+
+	return int(limit)
+}
+
+func newMetricsLabelSearchOutput(values []string, query string, limit int) *toolquery.MetricsLabelSearchOutput {
+	filter := strings.ToLower(strings.TrimSpace(query))
+	seen := make(map[string]struct{}, len(values))
+	results := make([]string, 0, min(len(values), limit))
+
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if filter != "" && !strings.Contains(strings.ToLower(value), filter) {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+
+		seen[value] = struct{}{}
+		results = append(results, value)
+	}
+
+	sort.Strings(results)
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+
+	output := &toolquery.MetricsLabelSearchOutput{
+		Results: make([]*toolquery.MetricsLabelSearchResult, 0, len(results)),
+	}
+	for _, result := range results {
+		output.Results = append(output.Results, &toolquery.MetricsLabelSearchResult{Name: result})
+	}
+
+	return output
+}

--- a/go/cloud-query/internal/tools/metrics_label_search_test.go
+++ b/go/cloud-query/internal/tools/metrics_label_search_test.go
@@ -1,0 +1,89 @@
+package tools
+
+import "testing"
+
+func TestNewMetricsLabelSearchOutputFiltersDedupesSortsAndLimits(t *testing.T) {
+	output := newMetricsLabelSearchOutput([]string{
+		"pod",
+		"namespace",
+		"node",
+		"pod",
+		"",
+		"service",
+	}, "o", 2)
+
+	if got := len(output.GetResults()); got != 2 {
+		t.Fatalf("expected 2 results, got %d", got)
+	}
+	if output.GetResults()[0].GetName() != "node" {
+		t.Fatalf("unexpected first result: %s", output.GetResults()[0].GetName())
+	}
+	if output.GetResults()[1].GetName() != "pod" {
+		t.Fatalf("unexpected second result: %s", output.GetResults()[1].GetName())
+	}
+}
+
+func TestCloudwatchMetricIdentifier(t *testing.T) {
+	namespace, name, err := cloudwatchMetricIdentifier("AWS/EC2/CPUUtilization")
+	if err != nil {
+		t.Fatalf("failed to parse cloudwatch metric identifier: %v", err)
+	}
+	if namespace != "AWS/EC2" {
+		t.Fatalf("unexpected namespace: %s", namespace)
+	}
+	if name != "CPUUtilization" {
+		t.Fatalf("unexpected metric name: %s", name)
+	}
+
+	namespace, name, err = cloudwatchMetricIdentifier("CPUUtilization")
+	if err != nil {
+		t.Fatalf("failed to parse metric name without namespace: %v", err)
+	}
+	if namespace != "" || name != "CPUUtilization" {
+		t.Fatalf("unexpected metric identifier: namespace=%q name=%q", namespace, name)
+	}
+}
+
+func TestCloudwatchMetricIdentifierRejectsInvalidInput(t *testing.T) {
+	if _, _, err := cloudwatchMetricIdentifier("AWS/EC2/"); err == nil {
+		t.Fatal("expected error for missing metric name")
+	}
+	if _, _, err := cloudwatchMetricIdentifier("/CPUUtilization"); err == nil {
+		t.Fatal("expected error for missing namespace")
+	}
+}
+
+func TestDatadogMetricLabelsFromTags(t *testing.T) {
+	provider := &DatadogProvider{}
+	tags := []string{
+		"env:prod",
+		"env:staging",
+		"host:node-1",
+		"custom",
+	}
+
+	names := newMetricsLabelSearchOutput(provider.datadogMetricLabelNames(tags), "", 10)
+	if got := len(names.GetResults()); got != 3 {
+		t.Fatalf("expected 3 label names, got %d", got)
+	}
+	if names.GetResults()[0].GetName() != "custom" {
+		t.Fatalf("unexpected first label name: %s", names.GetResults()[0].GetName())
+	}
+	if names.GetResults()[1].GetName() != "env" {
+		t.Fatalf("unexpected second label name: %s", names.GetResults()[1].GetName())
+	}
+	if names.GetResults()[2].GetName() != "host" {
+		t.Fatalf("unexpected third label name: %s", names.GetResults()[2].GetName())
+	}
+
+	values := newMetricsLabelSearchOutput(provider.datadogMetricLabelValues(tags, "env"), "", 10)
+	if got := len(values.GetResults()); got != 2 {
+		t.Fatalf("expected 2 label values, got %d", got)
+	}
+	if values.GetResults()[0].GetName() != "prod" {
+		t.Fatalf("unexpected first label value: %s", values.GetResults()[0].GetName())
+	}
+	if values.GetResults()[1].GetName() != "staging" {
+		t.Fatalf("unexpected second label value: %s", values.GetResults()[1].GetName())
+	}
+}

--- a/go/cloud-query/internal/tools/provider.go
+++ b/go/cloud-query/internal/tools/provider.go
@@ -15,6 +15,7 @@ var (
 type MetricsProvider interface {
 	Metrics(ctx context.Context, input *toolquery.MetricsQueryInput) (*toolquery.MetricsQueryOutput, error)
 	MetricsSearch(ctx context.Context, input *toolquery.MetricsSearchInput) (*toolquery.MetricsSearchOutput, error)
+	MetricsLabelSearch(ctx context.Context, input *toolquery.MetricsLabelSearchInput) (*toolquery.MetricsLabelSearchOutput, error)
 }
 
 func newMetricsProvider(conn *toolquery.ToolConnection) (MetricsProvider, error) {
@@ -106,6 +107,14 @@ func (p *toolProvider) MetricsSearch(ctx context.Context, input *toolquery.Metri
 	}
 
 	return p.metrics.MetricsSearch(ctx, input)
+}
+
+func (p *toolProvider) MetricsLabelSearch(ctx context.Context, input *toolquery.MetricsLabelSearchInput) (*toolquery.MetricsLabelSearchOutput, error) {
+	if p.metrics == nil {
+		return nil, ErrUnsupportedOperation
+	}
+
+	return p.metrics.MetricsLabelSearch(ctx, input)
 }
 
 func (p *toolProvider) Logs(ctx context.Context, input *toolquery.LogsQueryInput) (*toolquery.LogsQueryOutput, error) {

--- a/go/cloud-query/internal/tools/provider_azure.go
+++ b/go/cloud-query/internal/tools/provider_azure.go
@@ -76,10 +76,9 @@ func (in *AzureProvider) metricsManagedPrometheus(ctx context.Context, input *to
 		return nil, err
 	}
 
-	tok := token
 	prom := NewPrometheusProvider(&toolquery.PrometheusConnection{
 		Url:   strings.TrimRight(strings.TrimSpace(url), "/"),
-		Token: &tok,
+		Token: new(token),
 	})
 
 	return prom.Metrics(ctx, input)
@@ -124,10 +123,9 @@ func (in *AzureProvider) metricsSearchManagedPrometheus(ctx context.Context, inp
 		return nil, err
 	}
 
-	tok := token
 	prom := NewPrometheusProvider(&toolquery.PrometheusConnection{
 		Url:   strings.TrimRight(strings.TrimSpace(url), "/"),
-		Token: &tok,
+		Token: new(token),
 	})
 
 	return prom.MetricsSearch(ctx, input)
@@ -201,10 +199,6 @@ func (in *AzureProvider) metricsLabelSearchValues(ctx context.Context, input *to
 
 	end := time.Now().UTC()
 	start := end.Add(-24 * time.Hour)
-	startStr := start.Format(time.RFC3339Nano)
-	endStr := end.Format(time.RFC3339Nano)
-	interval := "PT1M"
-
 	resp, err := in.client.Metrics(
 		ctx,
 		strings.TrimSpace(opts.GetMetricsEndpoint()),
@@ -212,9 +206,9 @@ func (in *AzureProvider) metricsLabelSearchValues(ctx context.Context, input *to
 		[]string{strings.TrimSpace(input.GetMetric())},
 		azmetrics.ResourceIDList{ResourceIDs: []string{resourceID}},
 		&azmetrics.QueryResourcesOptions{
-			StartTime: &startStr,
-			EndTime:   &endStr,
-			Interval:  &interval,
+			StartTime: new(start.Format(time.RFC3339Nano)),
+			EndTime:   new(end.Format(time.RFC3339Nano)),
+			Interval:  new("PT1M"),
 		},
 	)
 	if err != nil {

--- a/go/cloud-query/internal/tools/provider_azure.go
+++ b/go/cloud-query/internal/tools/provider_azure.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azlogs"
+	"github.com/Azure/azure-sdk-for-go/sdk/monitor/query/azmetrics"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/samber/lo"
 
 	"github.com/pluralsh/console/go/cloud-query/internal/proto/toolquery"
 	"github.com/pluralsh/console/go/cloud-query/internal/tools/client"
@@ -127,6 +131,103 @@ func (in *AzureProvider) metricsSearchManagedPrometheus(ctx context.Context, inp
 	})
 
 	return prom.MetricsSearch(ctx, input)
+}
+
+func (in *AzureProvider) MetricsLabelSearch(ctx context.Context, input *toolquery.MetricsLabelSearchInput) (*toolquery.MetricsLabelSearchOutput, error) {
+	if input == nil || strings.TrimSpace(input.GetMetric()) == "" {
+		return nil, fmt.Errorf("%w: metric is required", ErrInvalidArgument)
+	}
+	if input.GetOptions() == nil || input.GetOptions().GetAzure() == nil {
+		return nil, fmt.Errorf("%w: azure metrics label search options are required", ErrInvalidArgument)
+	}
+
+	opts := input.GetOptions().GetAzure()
+	if u := opts.GetPrometheusUrl(); u != "" {
+		return in.metricsLabelSearchManagedPrometheus(ctx, input, u)
+	}
+
+	resourceID := strings.TrimSpace(opts.GetResourceId())
+	if resourceID == "" {
+		return nil, fmt.Errorf("%w: azure metrics label search requires resource_id unless prometheus_url is set", ErrInvalidArgument)
+	}
+
+	if strings.TrimSpace(input.GetLabel()) != "" {
+		return in.metricsLabelSearchValues(ctx, input, opts, resourceID)
+	}
+
+	listOptions := &armmonitor.MetricDefinitionsClientListOptions{}
+	if namespace := strings.TrimSpace(opts.GetMetricsNamespace()); namespace != "" {
+		listOptions.Metricnamespace = &namespace
+	}
+
+	definitions, err := in.client.MetricsSearch(ctx, resourceID, listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	values := make([]string, 0)
+	metricName := strings.TrimSpace(input.GetMetric())
+	for _, definition := range definitions {
+		if definition == nil || lo.FromPtr(definition.Name.Value) != metricName {
+			continue
+		}
+		for _, dimension := range definition.Dimensions {
+			values = append(values, lo.FromPtr(dimension.Value))
+		}
+	}
+
+	return newMetricsLabelSearchOutput(values, input.GetQuery(), metricsLabelSearchLimit(input.GetLimit())), nil
+}
+
+func (in *AzureProvider) metricsLabelSearchManagedPrometheus(ctx context.Context, input *toolquery.MetricsLabelSearchInput, url string) (*toolquery.MetricsLabelSearchOutput, error) {
+	token, err := in.client.PrometheusAccessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	prom := NewPrometheusProvider(&toolquery.PrometheusConnection{
+		Url:   strings.TrimRight(strings.TrimSpace(url), "/"),
+		Token: new(token),
+	})
+
+	return prom.MetricsLabelSearch(ctx, input)
+}
+
+func (in *AzureProvider) metricsLabelSearchValues(ctx context.Context, input *toolquery.MetricsLabelSearchInput, opts *toolquery.AzureMetricsLabelSearchOptions, resourceID string) (*toolquery.MetricsLabelSearchOutput, error) {
+	namespace := strings.TrimSpace(opts.GetMetricsNamespace())
+	if namespace == "" {
+		return nil, fmt.Errorf("%w: azure metrics label value search requires metrics_namespace", ErrInvalidArgument)
+	}
+
+	end := time.Now().UTC()
+	start := end.Add(-24 * time.Hour)
+	startStr := start.Format(time.RFC3339Nano)
+	endStr := end.Format(time.RFC3339Nano)
+	interval := "PT1M"
+
+	resp, err := in.client.Metrics(
+		ctx,
+		strings.TrimSpace(opts.GetMetricsEndpoint()),
+		namespace,
+		[]string{strings.TrimSpace(input.GetMetric())},
+		azmetrics.ResourceIDList{ResourceIDs: []string{resourceID}},
+		&azmetrics.QueryResourcesOptions{
+			StartTime: &startStr,
+			EndTime:   &endStr,
+			Interval:  &interval,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	label := strings.TrimSpace(input.GetLabel())
+	values := make([]string, 0)
+	for _, point := range datasource.NewAzureMetricsResponse(resp).ToMetricsQueryOutput().GetMetrics() {
+		values = append(values, point.GetLabels()[label])
+	}
+
+	return newMetricsLabelSearchOutput(values, input.GetQuery(), metricsLabelSearchLimit(input.GetLimit())), nil
 }
 
 func (in *AzureProvider) Logs(ctx context.Context, input *toolquery.LogsQueryInput) (*toolquery.LogsQueryOutput, error) {

--- a/go/cloud-query/internal/tools/provider_cloudwatch.go
+++ b/go/cloud-query/internal/tools/provider_cloudwatch.go
@@ -160,6 +160,59 @@ func (in *CloudwatchProvider) MetricsSearch(ctx context.Context, searchInput *to
 	return &toolquery.MetricsSearchOutput{Metrics: results}, nil
 }
 
+func (in *CloudwatchProvider) MetricsLabelSearch(ctx context.Context, input *toolquery.MetricsLabelSearchInput) (*toolquery.MetricsLabelSearchOutput, error) {
+	if in.conn == nil {
+		return nil, fmt.Errorf("%w: cloudwatch connection is required", ErrInvalidArgument)
+	}
+	namespace, metricName, err := cloudwatchMetricIdentifier(input.GetMetric())
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := in.newAWSConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	listInput := &cloudwatch.ListMetricsInput{
+		MetricName:     aws.String(metricName),
+		RecentlyActive: cloudwatchtypes.RecentlyActivePt3h,
+	}
+	if namespace != "" {
+		listInput.Namespace = aws.String(namespace)
+	}
+
+	label := strings.TrimSpace(input.GetLabel())
+	if label != "" {
+		listInput.Dimensions = []cloudwatchtypes.DimensionFilter{{Name: aws.String(label)}}
+	}
+
+	const maxPages = 6
+	limit := metricsLabelSearchLimit(input.GetLimit())
+	values := make([]string, 0, limit)
+	paginator := cloudwatch.NewListMetricsPaginator(cloudwatch.NewFromConfig(cfg), listInput)
+	for pageNum := 0; paginator.HasMorePages() && pageNum < maxPages && len(values) < limit; pageNum++ {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, metric := range page.Metrics {
+			for _, dimension := range metric.Dimensions {
+				if label == "" {
+					values = append(values, aws.ToString(dimension.Name))
+					continue
+				}
+				if aws.ToString(dimension.Name) == label {
+					values = append(values, aws.ToString(dimension.Value))
+				}
+			}
+		}
+	}
+
+	return newMetricsLabelSearchOutput(values, input.GetQuery(), limit), nil
+}
+
 func (in *CloudwatchProvider) Logs(ctx context.Context, input *toolquery.LogsQueryInput) (*toolquery.LogsQueryOutput, error) {
 	if in.conn == nil {
 		return nil, fmt.Errorf("%w: cloudwatch connection is required", ErrInvalidArgument)
@@ -233,8 +286,9 @@ func (in *CloudwatchProvider) newAWSConfig(ctx context.Context) (aws.Config, err
 	}
 
 	if roleARN := strings.TrimSpace(in.conn.GetRoleArn()); roleARN != "" {
+		baseCfg := cfg
 		cfg.Credentials = aws.NewCredentialsCache(aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
-			return cachedAssumeRoleCredentials(ctx, cfg, roleARN, func(input *sts.AssumeRoleInput) {
+			return cachedAssumeRoleCredentials(ctx, baseCfg, roleARN, func(input *sts.AssumeRoleInput) {
 				if externalID := strings.TrimSpace(in.conn.GetExternalId()); externalID != "" {
 					input.ExternalId = aws.String(externalID)
 				}
@@ -448,4 +502,21 @@ func cloudwatchMetricResultName(metric cloudwatchtypes.Metric) string {
 	default:
 		return ""
 	}
+}
+
+func cloudwatchMetricIdentifier(metric string) (namespace string, name string, err error) {
+	metric = strings.TrimSpace(metric)
+	if metric == "" {
+		return "", "", fmt.Errorf("%w: metric is required", ErrInvalidArgument)
+	}
+
+	idx := strings.LastIndex(metric, "/")
+	if idx == -1 {
+		return "", metric, nil
+	}
+	if idx == 0 || idx == len(metric)-1 {
+		return "", "", fmt.Errorf("%w: cloudwatch metric must be formatted as namespace/metric", ErrInvalidArgument)
+	}
+
+	return metric[:idx], metric[idx+1:], nil
 }

--- a/go/cloud-query/internal/tools/provider_datadog.go
+++ b/go/cloud-query/internal/tools/provider_datadog.go
@@ -78,6 +78,37 @@ func (in *DatadogProvider) MetricsSearch(ctx context.Context, input *toolquery.M
 	return &toolquery.MetricsSearchOutput{Metrics: results}, nil
 }
 
+func (in *DatadogProvider) MetricsLabelSearch(ctx context.Context, input *toolquery.MetricsLabelSearchInput) (*toolquery.MetricsLabelSearchOutput, error) {
+	if in.conn == nil {
+		return nil, ErrInvalidArgument
+	}
+	if input == nil || strings.TrimSpace(input.GetMetric()) == "" {
+		return nil, fmt.Errorf("%w: metric is required", ErrInvalidArgument)
+	}
+
+	ctx, client, err := in.newDatadogClient(ctx, in.conn)
+	if err != nil {
+		return nil, err
+	}
+
+	api := datadogV2.NewMetricsApi(client)
+	resp, _, err := api.ListTagsByMetricName(ctx, strings.TrimSpace(input.GetMetric()))
+	if err != nil {
+		return nil, err
+	}
+
+	data := resp.GetData()
+	attributes := data.GetAttributes()
+	tags := attributes.GetTags()
+	label := strings.TrimSpace(input.GetLabel())
+	values := in.datadogMetricLabelNames(tags)
+	if label != "" {
+		values = in.datadogMetricLabelValues(tags, label)
+	}
+
+	return newMetricsLabelSearchOutput(values, input.GetQuery(), metricsLabelSearchLimit(input.GetLimit())), nil
+}
+
 func (in *DatadogProvider) toMetricsQueryOutput(resp datadogV1.MetricsQueryResponse) *toolquery.MetricsQueryOutput {
 	metrics := make([]*toolquery.MetricPoint, 0)
 
@@ -299,4 +330,26 @@ func (in *DatadogProvider) tagsToLabels(tags []string) map[string]string {
 		}
 	}
 	return labels
+}
+
+func (in *DatadogProvider) datadogMetricLabelNames(tags []string) []string {
+	labels := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		key, _, _ := strings.Cut(tag, ":")
+		labels = append(labels, key)
+	}
+
+	return labels
+}
+
+func (in *DatadogProvider) datadogMetricLabelValues(tags []string, label string) []string {
+	values := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		key, value, ok := strings.Cut(tag, ":")
+		if ok && key == label {
+			values = append(values, value)
+		}
+	}
+
+	return values
 }

--- a/go/cloud-query/internal/tools/provider_dynatrace.go
+++ b/go/cloud-query/internal/tools/provider_dynatrace.go
@@ -59,6 +59,10 @@ func (in *DynatraceProvider) MetricsSearch(ctx context.Context, input *toolquery
 	return result.ToMetricsSearchOutput(), nil
 }
 
+func (in *DynatraceProvider) MetricsLabelSearch(ctx context.Context, input *toolquery.MetricsLabelSearchInput) (*toolquery.MetricsLabelSearchOutput, error) {
+	return nil, ErrUnsupportedOperation
+}
+
 func (in *DynatraceProvider) Logs(ctx context.Context, input *toolquery.LogsQueryInput) (*toolquery.LogsQueryOutput, error) {
 	if in.client == nil {
 		return nil, ErrInvalidArgument

--- a/go/cloud-query/internal/tools/provider_prometheus.go
+++ b/go/cloud-query/internal/tools/provider_prometheus.go
@@ -110,6 +110,50 @@ func (in *PrometheusProvider) MetricsSearch(ctx context.Context, input *toolquer
 	return &toolquery.MetricsSearchOutput{Metrics: results}, nil
 }
 
+func (in *PrometheusProvider) MetricsLabelSearch(ctx context.Context, input *toolquery.MetricsLabelSearchInput) (*toolquery.MetricsLabelSearchOutput, error) {
+	if in.conn == nil {
+		return nil, fmt.Errorf("%w: prometheus connection is required", ErrInvalidArgument)
+	}
+	if input == nil || strings.TrimSpace(input.GetMetric()) == "" {
+		return nil, fmt.Errorf("%w: metric is required", ErrInvalidArgument)
+	}
+
+	client, err := in.newClient()
+	if err != nil {
+		return nil, err
+	}
+
+	end := time.Now()
+	start := end.Add(-24 * time.Hour)
+	limit := metricsLabelSearchLimit(input.GetLimit())
+	matches := []string{fmt.Sprintf(`{__name__=%q}`, strings.TrimSpace(input.GetMetric()))}
+
+	label := strings.TrimSpace(input.GetLabel())
+	if label == "" {
+		names, _, err := client.LabelNames(ctx, matches, start, end, v1.WithLimit(uint64(limit)))
+		if err != nil {
+			return nil, err
+		}
+
+		names = lo.Filter(names, func(name string, _ int) bool {
+			return name != model.MetricNameLabel
+		})
+
+		return newMetricsLabelSearchOutput(names, input.GetQuery(), limit), nil
+	}
+
+	values, _, err := client.LabelValues(ctx, label, matches, start, end, v1.WithLimit(uint64(limit)))
+	if err != nil {
+		return nil, err
+	}
+
+	resultValues := lo.Map(values, func(value model.LabelValue, _ int) string {
+		return string(value)
+	})
+
+	return newMetricsLabelSearchOutput(resultValues, input.GetQuery(), limit), nil
+}
+
 func (in *PrometheusProvider) toStep(input *toolquery.MetricsQueryInput) (time.Duration, error) {
 	step := 30 * time.Second
 	if len(input.GetStep()) == 0 {

--- a/lib/cloud_query/toolquery.pb.ex
+++ b/lib/cloud_query/toolquery.pb.ex
@@ -450,6 +450,69 @@ defmodule Toolquery.MetricsSearchOutput do
   field :metrics, 1, repeated: true, type: Toolquery.MetricsSearchResult
 end
 
+defmodule Toolquery.MetricsLabelSearchInput do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "toolquery.MetricsLabelSearchInput",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :connection, 1, type: Toolquery.ToolConnection
+  field :metric, 2, type: :string
+  field :query, 3, proto3_optional: true, type: :string
+  field :label, 4, proto3_optional: true, type: :string
+  field :limit, 5, proto3_optional: true, type: :int64
+  field :options, 6, proto3_optional: true, type: Toolquery.MetricsLabelSearchOptions
+end
+
+defmodule Toolquery.MetricsLabelSearchOptions do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "toolquery.MetricsLabelSearchOptions",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :azure, 1, proto3_optional: true, type: Toolquery.AzureMetricsLabelSearchOptions
+end
+
+defmodule Toolquery.AzureMetricsLabelSearchOptions do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "toolquery.AzureMetricsLabelSearchOptions",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :resource_id, 1, type: :string, json_name: "resourceId"
+  field :metrics_namespace, 2, proto3_optional: true, type: :string, json_name: "metricsNamespace"
+  field :prometheus_url, 3, proto3_optional: true, type: :string, json_name: "prometheusUrl"
+  field :metrics_endpoint, 4, proto3_optional: true, type: :string, json_name: "metricsEndpoint"
+end
+
+defmodule Toolquery.MetricsLabelSearchResult do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "toolquery.MetricsLabelSearchResult",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :name, 1, type: :string
+end
+
+defmodule Toolquery.MetricsLabelSearchOutput do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "toolquery.MetricsLabelSearchOutput",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :results, 1, repeated: true, type: Toolquery.MetricsLabelSearchResult
+end
+
 defmodule Toolquery.LogEntry.LabelsEntry do
   @moduledoc false
 
@@ -584,6 +647,8 @@ defmodule Toolquery.ToolQuery.Service do
   rpc :Metrics, Toolquery.MetricsQueryInput, Toolquery.MetricsQueryOutput
 
   rpc :MetricsSearch, Toolquery.MetricsSearchInput, Toolquery.MetricsSearchOutput
+
+  rpc :MetricsLabelSearch, Toolquery.MetricsLabelSearchInput, Toolquery.MetricsLabelSearchOutput
 
   rpc :Logs, Toolquery.LogsQueryInput, Toolquery.LogsQueryOutput
 

--- a/lib/console/ai/tools/workbench/observability/metrics_label_search.ex
+++ b/lib/console/ai/tools/workbench/observability/metrics_label_search.ex
@@ -1,0 +1,78 @@
+defmodule Console.AI.Tools.Workbench.Observability.MetricsLabelSearch do
+  use Console.AI.Tools.Workbench.Base
+  import Console.AI.Tools.Workbench.Observability.Metrics, only: [azure_prom_url: 1, resource_id: 1, azure_opts: 1]
+  alias CloudQuery.Client
+  alias Toolquery.ToolQuery.{Stub}
+  alias Toolquery.{MetricsLabelSearchInput, MetricsLabelSearchOutput, MetricsLabelSearchOptions, AzureMetricsLabelSearchOptions}
+  alias Console.AI.Workbench.Conversion
+
+  embedded_schema do
+    field :tool, :map, virtual: true
+    field :metric, :string
+    field :query, :string
+    field :label, :string
+    field :limit, :integer
+
+    embeds_one :options, Options, on_replace: :update, primary_key: false do
+      embeds_one :azure, Azure, on_replace: :update, primary_key: false do
+        field :resource_id, :string
+        field :metrics_namespace, :string
+        field :metrics_endpoint, :string
+      end
+    end
+  end
+
+  @valid ~w(metric query label limit)a
+  @default_schema Console.priv_file!("tools/workbench/observability/metric_label_search.json") |> Jason.decode!()
+  @azure_schema Console.priv_file!("tools/workbench/observability/metric_label_search_azure.json") |> Jason.decode!()
+
+  def json_schema(%{tool: %{tool: :azure, configuration: %{azure: %{prometheus_url: url}}}}) when is_binary(url),
+    do: @default_schema
+  def json_schema(%{tool: %{tool: :azure}}), do: @azure_schema
+  def json_schema(_), do: @default_schema
+
+  def name(%__MODULE__{tool: %{name: n}}), do: "workbench_observability_metric_label_search_#{n}"
+
+  def description(%__MODULE__{tool: %{name: n}}) do
+    "Search metric label names or label values in the #{n} observability connection. Provide a metric and omit label to search label names, or provide label to search values for that label."
+  end
+
+  def changeset(model, attrs) do
+    model
+    |> cast(attrs, @valid)
+    |> cast_embed(:options)
+    |> validate_required([:metric])
+  end
+
+  def implement(%__MODULE__{} = tool) do
+    with {:ok, conn} <- Client.connect(),
+         {:ok, input} <- input(tool),
+         {:ok, %MetricsLabelSearchOutput{} = output} <- Stub.metrics_label_search(conn, input, Client.metrics_rpc_opts()),
+      do: Protobuf.JSON.encode(output)
+  end
+
+  defp input(%__MODULE__{tool: tool, metric: m, query: q, label: label, limit: l, options: options}) do
+    with {:ok, connection} <- Conversion.to_proto(tool) do
+      {:ok, %MetricsLabelSearchInput{
+        connection: connection,
+        metric: m,
+        query: q,
+        label: label,
+        limit: l || 200,
+        options: metrics_label_search_options(tool, options)
+      }}
+    end
+  end
+
+  defp metrics_label_search_options(%{tool: :azure} = tool, options) do
+    query_azure = azure_opts(options)
+
+    %MetricsLabelSearchOptions{azure: %AzureMetricsLabelSearchOptions{
+      resource_id: resource_id(query_azure),
+      metrics_namespace: Map.get(query_azure, :metrics_namespace),
+      prometheus_url: azure_prom_url(tool),
+      metrics_endpoint: Map.get(query_azure, :metrics_endpoint)
+    }}
+  end
+  defp metrics_label_search_options(_, _), do: nil
+end

--- a/lib/console/ai/tools/workbench/observability/plrl_metrics_label_search.ex
+++ b/lib/console/ai/tools/workbench/observability/plrl_metrics_label_search.ex
@@ -1,0 +1,33 @@
+defmodule Console.AI.Tools.Workbench.Observability.Plrl.MetricsLabelSearch do
+  use Console.AI.Tools.Workbench.Base
+  import Console.AI.Tools.Workbench.Observability.Plrl.Metrics, only: [build_tool_connection: 0]
+  alias Console.AI.Tools.Workbench.Observability.MetricsLabelSearch
+
+  embedded_schema do
+    field :metric, :string
+    field :query, :string
+    field :label, :string
+    field :limit, :integer
+  end
+
+  @valid ~w(metric query label limit)a
+
+  @json_schema Console.priv_file!("tools/workbench/observability/metric_label_search.json") |> Jason.decode!()
+
+  def json_schema(), do: @json_schema
+  def name(), do: "plrl_metric_label_search"
+  def description(), do: "Search metric label names or label values in the Plural observability connection"
+
+  def changeset(model, attrs) do
+    model
+    |> cast(attrs, @valid)
+    |> validate_required([:metric])
+  end
+
+  def implement(%__MODULE__{metric: m, query: q, label: label, limit: l}) do
+    with {:ok, conn} <- build_tool_connection() do
+      tool = %MetricsLabelSearch{tool: conn, metric: m, query: q, label: label, limit: l}
+      MetricsLabelSearch.implement(tool)
+    end
+  end
+end

--- a/lib/console/ai/workbench/subagents/observability.ex
+++ b/lib/console/ai/workbench/subagents/observability.ex
@@ -2,7 +2,7 @@ defmodule Console.AI.Workbench.Subagents.Observability do
   use Console.AI.Workbench.Subagents.Base
   alias Console.Schema.{Workbench, WorkbenchJob, WorkbenchJobActivity, WorkbenchTool, User}
   alias Console.AI.Tools.Workbench.{ObservabilityResult, Skills, Skill, Lua, History, Infrastructure.PodLogs, Scratchpad}
-  alias Console.AI.Tools.Workbench.Observability.{Metrics, MetricsSearch, Logs, Traces, Plrl}
+  alias Console.AI.Tools.Workbench.Observability.{Metrics, MetricsSearch, MetricsLabelSearch, Logs, Traces, Plrl}
   alias Console.AI.Tools.Workbench.Integration.Sentry.Tools, as: SentryTools
   alias Console.AI.Workbench.{Environment, MCP}
   import Console.AI.Workbench.Environment, only: [engine_opts: 1]
@@ -71,7 +71,7 @@ defmodule Console.AI.Workbench.Subagents.Observability do
   defp pod_logs_tools(_, _), do: []
 
   defp plrl_metric_tools(%WorkbenchJob{workbench: %Workbench{configuration: %{observability: %{metrics: true}}}}),
-    do: [Plrl.Metrics, Plrl.MetricsSearch]
+    do: [Plrl.Metrics, Plrl.MetricsSearch, Plrl.MetricsLabelSearch]
   defp plrl_metric_tools(_), do: []
 
   @allowed_tools MapSet.new(~w(metrics logs traces error_tracking)a)
@@ -91,7 +91,7 @@ defmodule Console.AI.Workbench.Subagents.Observability do
     end)
   end
 
-  defp to_tool(%WorkbenchTool{} = tool, :metrics), do: [%Metrics{tool: tool}, %MetricsSearch{tool: tool}]
+  defp to_tool(%WorkbenchTool{} = tool, :metrics), do: [%Metrics{tool: tool}, %MetricsSearch{tool: tool}, %MetricsLabelSearch{tool: tool}]
   defp to_tool(%WorkbenchTool{} = tool, :logs), do: [%Logs{tool: tool}]
   defp to_tool(%WorkbenchTool{} = tool, :traces), do: [%Traces{tool: tool}]
   defp to_tool(_, _), do: []

--- a/priv/tools/workbench/observability/metric_label_search.json
+++ b/priv/tools/workbench/observability/metric_label_search.json
@@ -1,0 +1,22 @@
+{
+    "type": "object",
+    "properties": {
+        "metric": {
+            "type": "string",
+            "description": "The metric name to inspect for labels."
+        },
+        "query": {
+            "type": "string",
+            "description": "Optional substring filter for returned label names or label values."
+        },
+        "label": {
+            "type": "string",
+            "description": "Optional label name. Omit this to search label names for the metric; provide it to search values for this label."
+        },
+        "limit": {
+            "type": "integer",
+            "description": "The maximum number of label names or values to return."
+        }
+    },
+    "required": ["metric"]
+}

--- a/priv/tools/workbench/observability/metric_label_search_azure.json
+++ b/priv/tools/workbench/observability/metric_label_search_azure.json
@@ -1,0 +1,47 @@
+{
+    "type": "object",
+    "properties": {
+        "metric": {
+            "type": "string",
+            "description": "The Azure Monitor metric name to inspect for dimensions."
+        },
+        "query": {
+            "type": "string",
+            "description": "Optional substring filter for returned dimension names or dimension values."
+        },
+        "label": {
+            "type": "string",
+            "description": "Optional dimension name. Omit this to search dimension names for the metric; provide it to search values for this dimension."
+        },
+        "limit": {
+            "type": "integer",
+            "description": "The maximum number of dimension names or values to return."
+        },
+        "options": {
+            "type": "object",
+            "description": "Provider-specific Azure metric label search options.",
+            "properties": {
+                "azure": {
+                    "type": "object",
+                    "description": "Per-query Azure metrics label search options.",
+                    "properties": {
+                        "resource_id": {
+                            "type": "string",
+                            "description": "Azure resource ID to list metric definitions from or query metric values for."
+                        },
+                        "metrics_namespace": {
+                            "type": "string",
+                            "description": "Azure metrics namespace. Required when searching values for a provided label on native Azure Monitor."
+                        },
+                        "metrics_endpoint": {
+                            "type": "string",
+                            "description": "Optional Azure metrics endpoint override."
+                        }
+                    },
+                    "required": ["resource_id"]
+                }
+            }
+        }
+    },
+    "required": ["metric"]
+}


### PR DESCRIPTION
- Add `MetricsLabelSearchInput`, `MetricsLabelSearchOptions`, and `AzureMetricsLabelSearchOptions` to support label search in metrics.
- Implement `MetricsLabelSearchResult` and `MetricsLabelSearchOutput` for returning search outcomes.
- Extend `ToolQuery` interface with `MetricsLabelSearch` method for querying metrics labels.
- Update proto message indexes to accommodate new structures.

<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.plrl-dev-aws.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
