### PR TITLE
Add KubeVirt compatibility scraper

### DIFF
--- a/static/compatibilities/kubevirt.yaml
+++ b/static/compatibilities/kubevirt.yaml
@@ -1,0 +1,30 @@
+icon: https://raw.githubusercontent.com/kubevirt/community/main/logo/KubeVirt_icon.png
+git_url: https://github.com/kubevirt/kubevirt
+release_url: https://github.com/kubevirt/kubevirt/releases/tag/v{vsn}
+readme_url: https://github.com/kubevirt/sig-release/blob/main/releases/k8s-support-matrix.md
+versions:
+- version: 1.8.4
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 1.7.4
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 1.6.6
+  kube: ['1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 1.5.3
+  kube: ['1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 1.4.1
+  kube: ['1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null

--- a/static/compatibilities/kubevirt.yaml
+++ b/static/compatibilities/kubevirt.yaml
@@ -4,12 +4,12 @@ release_url: https://github.com/kubevirt/kubevirt/releases/tag/v{vsn}
 readme_url: https://github.com/kubevirt/sig-release/blob/main/releases/k8s-support-matrix.md
 versions:
 - version: 1.8.4
-  kube: ['1.35', '1.34', '1.33']
+  kube: ['1.35', '1.34']
   requirements: []
   incompatibilities: []
   summary: null
 - version: 1.7.4
-  kube: ['1.34', '1.33', '1.32']
+  kube: ['1.34']
   requirements: []
   incompatibilities: []
   summary: null

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -1,4 +1,5 @@
 names:
+- kubevirt
 - argo-rollouts
 - aws-ebs-csi-driver
 - aws-efs-csi-driver

--- a/utils/compatibility/scrapers/kubevirt.py
+++ b/utils/compatibility/scrapers/kubevirt.py
@@ -14,6 +14,7 @@ from utils import (
 
 app_name = "kubevirt"
 matrix_url = "https://raw.githubusercontent.com/kubevirt/sig-release/main/releases/k8s-support-matrix.md"
+REQUEST_TIMEOUT = 30
 
 
 def decode_markdown(content: bytes) -> str | None:
@@ -38,6 +39,7 @@ def latest_stable_release_by_minor() -> dict[str, str]:
         response = requests.get(
             "https://api.github.com/repos/kubevirt/kubevirt/releases",
             params={"page": page, "per_page": 100},
+            timeout=REQUEST_TIMEOUT,
         )
         if response.status_code != 200:
             raise Exception(f"Failed to fetch KubeVirt releases: {response.status_code}")
@@ -61,8 +63,29 @@ def latest_stable_release_by_minor() -> dict[str, str]:
     return latest
 
 
+def extract_support_matrix_table(markdown: str) -> list[str]:
+    lines = markdown.splitlines()
+    table_lines: list[str] = []
+    found_heading = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("# KubeVirt to Kubernetes version support matrix"):
+            found_heading = True
+            continue
+        if not found_heading:
+            continue
+
+        if stripped.startswith("|"):
+            table_lines.append(stripped)
+        elif table_lines:
+            break
+
+    return table_lines
+
+
 def parse_matrix(markdown: str, release_versions: dict[str, str]) -> list[OrderedDict[str, object]]:
-    table_lines = [line.strip() for line in markdown.splitlines() if line.strip().startswith("|")]
+    table_lines = extract_support_matrix_table(markdown)
     if len(table_lines) < 3:
         return []
 
@@ -83,7 +106,7 @@ def parse_matrix(markdown: str, release_versions: dict[str, str]) -> list[Ordere
         supported_kube_versions = [
             kube_version
             for kube_version, value in zip(kube_versions, cells[1:])
-            if value in {"✓", "EOL"}
+            if value == "\u2713"
         ]
         if not supported_kube_versions:
             continue

--- a/utils/compatibility/scrapers/kubevirt.py
+++ b/utils/compatibility/scrapers/kubevirt.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import requests
+from packaging.version import Version
+
+from utils import (
+    fetch_page,
+    print_error,
+    update_compatibility_info,
+)
+
+app_name = "kubevirt"
+matrix_url = "https://raw.githubusercontent.com/kubevirt/sig-release/main/releases/k8s-support-matrix.md"
+
+
+def decode_markdown(content: bytes) -> str | None:
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        print_error(f"Failed to decode KubeVirt support matrix: {exc}")
+        return None
+
+
+def normalize_cell(value: str) -> str:
+    cleaned = re.sub(r"<[^>]+>", "", value).strip()
+    version_match = re.search(r"\d+\.\d+", cleaned)
+    return version_match.group(0) if version_match else cleaned
+
+
+def latest_stable_release_by_minor() -> dict[str, str]:
+    latest: dict[str, str] = {}
+    releases: list[str] = []
+
+    for page in range(1, 4):
+        response = requests.get(
+            "https://api.github.com/repos/kubevirt/kubevirt/releases",
+            params={"page": page, "per_page": 100},
+        )
+        if response.status_code != 200:
+            raise Exception(f"Failed to fetch KubeVirt releases: {response.status_code}")
+
+        page_releases = response.json()
+        if not page_releases:
+            break
+        releases.extend(release["tag_name"] for release in page_releases)
+
+    for release in releases:
+        version = release.lstrip("v")
+        if not re.match(r"^\d+\.\d+\.\d+$", version):
+            continue
+
+        parsed = Version(version)
+        minor_key = f"{parsed.major}.{parsed.minor}"
+        current = latest.get(minor_key)
+        if current is None or parsed > Version(current):
+            latest[minor_key] = version
+
+    return latest
+
+
+def parse_matrix(markdown: str, release_versions: dict[str, str]) -> list[OrderedDict[str, object]]:
+    table_lines = [line.strip() for line in markdown.splitlines() if line.strip().startswith("|")]
+    if len(table_lines) < 3:
+        return []
+
+    headers = [normalize_cell(cell) for cell in table_lines[0].strip("|").split("|")]
+    kube_versions = headers[1:]
+    versions: list[OrderedDict[str, object]] = []
+
+    for line in table_lines[2:]:
+        cells = [normalize_cell(cell) for cell in line.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+
+        minor_version = cells[0]
+        release_version = release_versions.get(minor_version)
+        if not release_version:
+            continue
+
+        supported_kube_versions = [
+            kube_version
+            for kube_version, value in zip(kube_versions, cells[1:])
+            if value in {"✓", "EOL"}
+        ]
+        if not supported_kube_versions:
+            continue
+
+        versions.append(
+            OrderedDict(
+                [
+                    ("version", release_version),
+                    ("kube", supported_kube_versions),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    return versions
+
+
+def scrape() -> None:
+    content = fetch_page(matrix_url)
+    if not content:
+        return
+
+    markdown = decode_markdown(content)
+    if not markdown:
+        return
+
+    release_versions = latest_stable_release_by_minor()
+    versions = parse_matrix(markdown, release_versions)
+    if not versions:
+        print_error("No compatibility information found for KubeVirt")
+        return
+
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", versions)


### PR DESCRIPTION
## Summary
- add KubeVirt compatibility metadata
- add a scraper for the official KubeVirt Kubernetes support matrix
- register KubeVirt in the compatibility manifest

## Sources
- KubeVirt Kubernetes support matrix: https://github.com/kubevirt/sig-release/blob/main/releases/k8s-support-matrix.md
- KubeVirt GitHub releases: https://github.com/kubevirt/kubevirt/releases

## Validation
- `python -c "import importlib; importlib.import_module('scrapers.kubevirt').scrape()"`
- `python -m py_compile utils/compatibility/scrapers/kubevirt.py`
- `python -c "import yaml; yaml.safe_load(open('static/compatibilities/kubevirt.yaml')); yaml.safe_load(open('static/compatibilities/manifest.yaml')); print('yaml ok')"`
- `git diff --check`
