### PR TITLE
Add the ability to respect all agentconfiguration fields at boot time

### DIFF
--- a/go/deployment-operator/cmd/agent/args/args.go
+++ b/go/deployment-operator/cmd/agent/args/args.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pluralsh/console/go/deployment-operator/api/v1alpha1"
 	"github.com/pluralsh/console/go/polly/containers"
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
@@ -85,6 +86,9 @@ const (
 	defaultRuntimeServicePingInterval         = "3m"
 	defaultRuntimeServicePingIntervalDuration = 3 * time.Minute
 
+	defaultStackPollInterval         = "30s"
+	defaultStackPollIntervalDuration = 30 * time.Second
+
 	defaultPipelineGatesPollInterval         = "0s"
 	defaultPipelineGatesPollIntervalDuration = 0 * time.Second
 
@@ -153,7 +157,9 @@ var (
 	argWorkqueueBurst                       = flag.Int("workqueue-burst", 50, "The maximum number of items to process at a time.")
 	argClusterPingInterval                  = flag.String("cluster-ping-interval", defaultClusterPingInterval, "Time interval to ping cluster.")
 	argRuntimeServicePingInterval           = flag.String("runtime-service-ping-interval", defaultRuntimeServicePingInterval, "Time interval to register runtime services.")
+	argStackPollInterval                    = flag.String("stack-poll-interval", defaultStackPollInterval, "Time interval to poll stack resources from the Console API. Use '0s' to disable.")
 	argPipelineGatesPollInterval            = flag.String("pipline-gates-poll-interval", defaultPipelineGatesPollInterval, "Time interval to poll PipelineGates resources from the Console API. It's disabled by default.")
+	argDisableWebsocket                     = flag.Bool("disable-websocket", false, "Disable the cluster websocket connection to the Console.")
 	argDiscoveryCacheRefreshInterval        = flag.String("discovery-cache-refresh-interval", defaultDiscoveryCacheRefreshInterval, "Time interval to refresh discovery cache.")
 	argStoreStorage                         = flag.String("store-storage", defaultStoreStorage, "The storage backend to use for the agent store. Supported values are 'memory' and 'file'.")
 	argStoreFilePath                        = flag.String("store-file-path", defaultStoreFilePath, "The path to the file to use for the agent store. This is only used if the store-storage is set to 'file'.")
@@ -488,6 +494,16 @@ func RuntimeServicesPingInterval() time.Duration {
 	return duration
 }
 
+func StackPollInterval() time.Duration {
+	duration, err := time.ParseDuration(*argStackPollInterval)
+	if err != nil {
+		klog.ErrorS(err, "Could not parse stack-poll-interval", "value", *argStackPollInterval, "default", defaultStackPollInterval)
+		return defaultStackPollIntervalDuration
+	}
+
+	return duration
+}
+
 func PipelineGatesInterval() time.Duration {
 	duration, err := time.ParseDuration(*argPipelineGatesPollInterval)
 	if err != nil {
@@ -496,6 +512,28 @@ func PipelineGatesInterval() time.Duration {
 	}
 
 	return duration
+}
+
+func DisableWebsocket() bool {
+	return *argDisableWebsocket
+}
+
+func AgentConfigurationDefaults() v1alpha1.AgentConfigurationSpec {
+	servicePollInterval := PollInterval().String()
+	clusterPingInterval := ClusterPingInterval().String()
+	compatibilityUploadInterval := RuntimeServicesPingInterval().String()
+	stackPollInterval := StackPollInterval().String()
+	pipelineGateInterval := PipelineGatesInterval().String()
+	disableWebsocket := DisableWebsocket()
+
+	return v1alpha1.AgentConfigurationSpec{
+		ServicePollInterval:         &servicePollInterval,
+		ClusterPingInterval:         &clusterPingInterval,
+		CompatibilityUploadInterval: &compatibilityUploadInterval,
+		StackPollInterval:           &stackPollInterval,
+		PipelineGateInterval:        &pipelineGateInterval,
+		DisableWebsocket:            &disableWebsocket,
+	}
 }
 
 func DiscoveryCacheRefreshInterval() time.Duration {

--- a/go/deployment-operator/cmd/agent/console.go
+++ b/go/deployment-operator/cmd/agent/console.go
@@ -50,7 +50,6 @@ func initConsoleManagerOrDie() *consolectrl.Manager {
 
 const (
 	// Use custom (short) poll intervals for these reconcilers.
-	stacksPollInterval   = 30 * time.Second
 	sentinelPollInterval = 30 * time.Second
 )
 
@@ -116,7 +115,7 @@ func registerConsoleReconcilersOrDie(
 			os.Exit(1)
 		}
 
-		r := stacks.NewStackReconciler(consoleClient, k8sClient, scheme, args.ControllerCacheTTL(), stacksPollInterval, namespace, args.ConsoleUrl(), args.DeployToken())
+		r := stacks.NewStackReconciler(consoleClient, k8sClient, scheme, args.ControllerCacheTTL(), args.StackPollInterval(), namespace, args.ConsoleUrl(), args.DeployToken())
 		return r, nil
 	})
 

--- a/go/deployment-operator/cmd/agent/main.go
+++ b/go/deployment-operator/cmd/agent/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	pollycache "github.com/pluralsh/console/go/polly/cache"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
@@ -38,10 +40,12 @@ import (
 	"github.com/pluralsh/console/go/deployment-operator/pkg/cache"
 	discoverycache "github.com/pluralsh/console/go/deployment-operator/pkg/cache/discovery"
 	"github.com/pluralsh/console/go/deployment-operator/pkg/client"
+	"github.com/pluralsh/console/go/deployment-operator/pkg/common"
 	"github.com/pluralsh/console/go/deployment-operator/pkg/ping"
 	"github.com/pluralsh/console/go/deployment-operator/pkg/scraper"
 	"github.com/pluralsh/console/go/deployment-operator/pkg/streamline"
 	"github.com/pluralsh/console/go/deployment-operator/pkg/streamline/store"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	deploymentsv1alpha1 "github.com/pluralsh/console/go/deployment-operator/api/v1alpha1"
 	"github.com/pluralsh/console/go/deployment-operator/cmd/agent/args"
@@ -117,6 +121,7 @@ func main() {
 
 	kubeManager := initKubeManagerOrDie(config)
 	consoleManager := initConsoleManagerOrDie()
+	loadAgentConfigurationOrDie(ctx, kubeManager.GetAPIReader())
 
 	// Start the discovery cache manager in background.
 	runDiscoveryManagerOrDie(ctx, discoveryCache)
@@ -168,6 +173,35 @@ func main() {
 
 	// Start the standard kubernetes manager and block the main thread until context cancel.
 	runKubeManagerOrDie(ctx, kubeManager)
+}
+
+func loadAgentConfigurationOrDie(ctx context.Context, reader ctrlclient.Reader) {
+	if err := loadAgentConfiguration(ctx, reader, args.AgentConfigurationDefaults()); err != nil {
+		setupLog.Error(err, "unable to load agent configuration")
+		os.Exit(1)
+	}
+}
+
+func loadAgentConfiguration(ctx context.Context, reader ctrlclient.Reader, defaults deploymentsv1alpha1.AgentConfigurationSpec) error {
+	if err := common.GetConfigurationManager().SetDefaults(defaults); err != nil {
+		return fmt.Errorf("set agent configuration defaults: %w", err)
+	}
+
+	config := &deploymentsv1alpha1.AgentConfiguration{}
+	if err := reader.Get(ctx, ctrlclient.ObjectKey{Name: "default"}, config); err != nil {
+		if apierrors.IsNotFound(err) {
+			setupLog.Info("AgentConfiguration/default not found, using flag defaults")
+			return nil
+		}
+
+		return fmt.Errorf("fetch AgentConfiguration/default: %w", err)
+	}
+
+	if err := common.GetConfigurationManager().SetValue(config.Spec); err != nil {
+		return fmt.Errorf("set AgentConfiguration/default: %w", err)
+	}
+
+	return nil
 }
 
 func initKubeResourcesOrDie(config *rest.Config) (meta.RESTMapper, discovery.DiscoveryInterface, kubernetes.Interface, dynamic.Interface) {

--- a/go/deployment-operator/cmd/agent/main_test.go
+++ b/go/deployment-operator/cmd/agent/main_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pluralsh/console/go/deployment-operator/api/v1alpha1"
+	"github.com/pluralsh/console/go/deployment-operator/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestLoadAgentConfigurationUsesDefaultsWhenMissing(t *testing.T) {
+	t.Cleanup(resetAgentConfiguration)
+	resetAgentConfiguration()
+
+	defaults := agentConfigurationDefaults()
+	reader := fake.NewClientBuilder().WithScheme(agentConfigurationScheme(t)).Build()
+
+	require.NoError(t, loadAgentConfiguration(context.Background(), reader, defaults))
+
+	assertDuration(t, 2*time.Minute, common.GetConfigurationManager().GetServicePollInterval())
+	assertDuration(t, 2*time.Minute, common.GetConfigurationManager().GetClusterPingInterval())
+	assertDuration(t, 3*time.Minute, common.GetConfigurationManager().GetRuntimeServicesPingInterval())
+	assertDuration(t, 30*time.Second, common.GetConfigurationManager().GetStackPollInterval())
+	assertDuration(t, 0, common.GetConfigurationManager().GetPipelineGateInterval())
+	assert.False(t, common.GetConfigurationManager().IsWebsocketDisabled())
+}
+
+func TestLoadAgentConfigurationOverlaysDefaultResource(t *testing.T) {
+	t.Cleanup(resetAgentConfiguration)
+	resetAgentConfiguration()
+
+	disableWebsocket := true
+	reader := fake.NewClientBuilder().
+		WithScheme(agentConfigurationScheme(t)).
+		WithObjects(&v1alpha1.AgentConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			Spec: v1alpha1.AgentConfigurationSpec{
+				ClusterPingInterval:         ptr("15m"),
+				CompatibilityUploadInterval: ptr("30m"),
+				DisableWebsocket:            &disableWebsocket,
+				PipelineGateInterval:        ptr("0s"),
+				ServicePollInterval:         ptr("10m"),
+				StackPollInterval:           ptr("0s"),
+			},
+		}).
+		Build()
+
+	require.NoError(t, loadAgentConfiguration(context.Background(), reader, agentConfigurationDefaults()))
+
+	assertDuration(t, 10*time.Minute, common.GetConfigurationManager().GetServicePollInterval())
+	assertDuration(t, 15*time.Minute, common.GetConfigurationManager().GetClusterPingInterval())
+	assertDuration(t, 30*time.Minute, common.GetConfigurationManager().GetRuntimeServicesPingInterval())
+	assertDuration(t, 0, common.GetConfigurationManager().GetStackPollInterval())
+	assertDuration(t, 0, common.GetConfigurationManager().GetPipelineGateInterval())
+	assert.True(t, common.GetConfigurationManager().IsWebsocketDisabled())
+
+	require.NoError(t, common.GetConfigurationManager().SetValue(v1alpha1.AgentConfigurationSpec{}))
+	assertDuration(t, 2*time.Minute, common.GetConfigurationManager().GetServicePollInterval())
+	assertDuration(t, 2*time.Minute, common.GetConfigurationManager().GetClusterPingInterval())
+	assertDuration(t, 3*time.Minute, common.GetConfigurationManager().GetRuntimeServicesPingInterval())
+	assertDuration(t, 30*time.Second, common.GetConfigurationManager().GetStackPollInterval())
+	assertDuration(t, 0, common.GetConfigurationManager().GetPipelineGateInterval())
+	assert.False(t, common.GetConfigurationManager().IsWebsocketDisabled())
+}
+
+func TestLoadAgentConfigurationReturnsInvalidDurationError(t *testing.T) {
+	t.Cleanup(resetAgentConfiguration)
+	resetAgentConfiguration()
+
+	reader := fake.NewClientBuilder().
+		WithScheme(agentConfigurationScheme(t)).
+		WithObjects(&v1alpha1.AgentConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			Spec: v1alpha1.AgentConfigurationSpec{
+				ClusterPingInterval: ptr("not-a-duration"),
+			},
+		}).
+		Build()
+
+	require.Error(t, loadAgentConfiguration(context.Background(), reader, agentConfigurationDefaults()))
+}
+
+func agentConfigurationDefaults() v1alpha1.AgentConfigurationSpec {
+	disableWebsocket := false
+
+	return v1alpha1.AgentConfigurationSpec{
+		ServicePollInterval:         ptr("2m"),
+		ClusterPingInterval:         ptr("2m"),
+		CompatibilityUploadInterval: ptr("3m"),
+		StackPollInterval:           ptr("30s"),
+		PipelineGateInterval:        ptr("0s"),
+		DisableWebsocket:            &disableWebsocket,
+	}
+}
+
+func agentConfigurationScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func assertDuration(t *testing.T, expected time.Duration, actual *time.Duration) {
+	t.Helper()
+
+	require.NotNil(t, actual)
+	assert.Equal(t, expected, *actual)
+}
+
+func resetAgentConfiguration() {
+	_ = common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{})
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/go/deployment-operator/pkg/common/config.go
+++ b/go/deployment-operator/pkg/common/config.go
@@ -25,6 +25,7 @@ var configurationManager *ConfigurationManager
 // Configuration is a thread-safe structure for agent configuration
 type ConfigurationManager struct {
 	mu                          sync.RWMutex
+	defaults                    v1alpha1.AgentConfigurationSpec
 	servicePollInterval         *time.Duration
 	clusterPingInterval         *time.Duration
 	runtimeServicesPingInterval *time.Duration
@@ -48,6 +49,19 @@ func (s *ConfigurationManager) SetValue(config v1alpha1.AgentConfigurationSpec) 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	return s.setValueLocked(mergeAgentConfigurationSpec(s.defaults, config))
+}
+
+// SetDefaults configures the fallback values used when AgentConfiguration omits fields.
+func (s *ConfigurationManager) SetDefaults(config v1alpha1.AgentConfigurationSpec) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.defaults = copyAgentConfigurationSpec(config)
+	return s.setValueLocked(s.defaults)
+}
+
+func (s *ConfigurationManager) setValueLocked(config v1alpha1.AgentConfigurationSpec) error {
 	interval, err := setDuration(config.ClusterPingInterval)
 	if err != nil {
 		return err
@@ -92,6 +106,53 @@ func (s *ConfigurationManager) SetValue(config v1alpha1.AgentConfigurationSpec) 
 	s.disableWebsocket = config.DisableWebsocket
 
 	return nil
+}
+
+func mergeAgentConfigurationSpec(defaults, overrides v1alpha1.AgentConfigurationSpec) v1alpha1.AgentConfigurationSpec {
+	merged := copyAgentConfigurationSpec(defaults)
+
+	if overrides.ServicePollInterval != nil {
+		merged.ServicePollInterval = overrides.ServicePollInterval
+	}
+	if overrides.ClusterPingInterval != nil {
+		merged.ClusterPingInterval = overrides.ClusterPingInterval
+	}
+	if overrides.CompatibilityUploadInterval != nil {
+		merged.CompatibilityUploadInterval = overrides.CompatibilityUploadInterval
+	}
+	if overrides.StackPollInterval != nil {
+		merged.StackPollInterval = overrides.StackPollInterval
+	}
+	if overrides.PipelineGateInterval != nil {
+		merged.PipelineGateInterval = overrides.PipelineGateInterval
+	}
+	if overrides.MaxConcurrentReconciles != nil {
+		merged.MaxConcurrentReconciles = overrides.MaxConcurrentReconciles
+	}
+	if overrides.VulnerabilityReportUploadInterval != nil {
+		merged.VulnerabilityReportUploadInterval = overrides.VulnerabilityReportUploadInterval
+	}
+	if overrides.BaseRegistryURL != nil {
+		merged.BaseRegistryURL = overrides.BaseRegistryURL
+	}
+	if overrides.MaxSentinelRunJobs != nil {
+		merged.MaxSentinelRunJobs = overrides.MaxSentinelRunJobs
+	}
+	if overrides.MaxStackRunJobs != nil {
+		merged.MaxStackRunJobs = overrides.MaxStackRunJobs
+	}
+	if overrides.MaxAgentRunPods != nil {
+		merged.MaxAgentRunPods = overrides.MaxAgentRunPods
+	}
+	if overrides.DisableWebsocket != nil {
+		merged.DisableWebsocket = overrides.DisableWebsocket
+	}
+
+	return merged
+}
+
+func copyAgentConfigurationSpec(config v1alpha1.AgentConfigurationSpec) v1alpha1.AgentConfigurationSpec {
+	return *config.DeepCopy()
 }
 
 func setDuration(interval *string) (*time.Duration, error) {

--- a/go/deployment-operator/pkg/controller/pipelinegates/interval_test.go
+++ b/go/deployment-operator/pkg/controller/pipelinegates/interval_test.go
@@ -1,0 +1,35 @@
+package pipelinegates
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pluralsh/console/go/deployment-operator/api/v1alpha1"
+	"github.com/pluralsh/console/go/deployment-operator/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineGateIntervalCanBeDisabledByConfiguration(t *testing.T) {
+	t.Cleanup(resetAgentConfiguration)
+	resetAgentConfiguration()
+
+	require.NoError(t, common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{
+		PipelineGateInterval: ptr("30s"),
+	}))
+	require.NoError(t, common.GetConfigurationManager().SetValue(v1alpha1.AgentConfigurationSpec{
+		PipelineGateInterval: ptr("0s"),
+	}))
+
+	reconciler := &GateReconciler{pollInterval: 30 * time.Second}
+
+	assert.Equal(t, time.Duration(0), reconciler.GetPollInterval()())
+}
+
+func resetAgentConfiguration() {
+	_ = common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{})
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/go/deployment-operator/pkg/controller/service/interval_test.go
+++ b/go/deployment-operator/pkg/controller/service/interval_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pluralsh/console/go/deployment-operator/api/v1alpha1"
+	"github.com/pluralsh/console/go/deployment-operator/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServicePollIntervalCannotBeDisabledByConfiguration(t *testing.T) {
+	t.Cleanup(resetAgentConfiguration)
+	resetAgentConfiguration()
+
+	require.NoError(t, common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{
+		ServicePollInterval: ptr("2m"),
+	}))
+	require.NoError(t, common.GetConfigurationManager().SetValue(v1alpha1.AgentConfigurationSpec{
+		ServicePollInterval: ptr("0s"),
+	}))
+
+	reconciler := &ServiceReconciler{pollInterval: 2 * time.Minute}
+
+	assert.Equal(t, 2*time.Minute, reconciler.GetPollInterval()())
+}
+
+func TestServicePollIntervalBelowMinimumFallsBackToDefault(t *testing.T) {
+	t.Cleanup(resetAgentConfiguration)
+	resetAgentConfiguration()
+
+	require.NoError(t, common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{
+		ServicePollInterval: ptr("2m"),
+	}))
+	require.NoError(t, common.GetConfigurationManager().SetValue(v1alpha1.AgentConfigurationSpec{
+		ServicePollInterval: ptr("5s"),
+	}))
+
+	reconciler := &ServiceReconciler{pollInterval: 2 * time.Minute}
+
+	assert.Equal(t, 2*time.Minute, reconciler.GetPollInterval()())
+}
+
+func resetAgentConfiguration() {
+	_ = common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{})
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/go/deployment-operator/pkg/controller/service/reconciler.go
+++ b/go/deployment-operator/pkg/controller/service/reconciler.go
@@ -162,9 +162,10 @@ func (s *ServiceReconciler) Shutdown() {
 
 func (s *ServiceReconciler) GetPollInterval() func() time.Duration {
 	return func() time.Duration {
-		// poll-interval cannot be lower than 10s
-		if servicePollInterval := agentcommon.GetConfigurationManager().GetServicePollInterval(); servicePollInterval != nil && *servicePollInterval >= 10*time.Second {
-			return *servicePollInterval
+		if servicePollInterval := agentcommon.GetConfigurationManager().GetServicePollInterval(); servicePollInterval != nil {
+			if *servicePollInterval >= 10*time.Second {
+				return *servicePollInterval
+			}
 		}
 		return s.pollInterval
 	}

--- a/go/deployment-operator/pkg/controller/stacks/interval_test.go
+++ b/go/deployment-operator/pkg/controller/stacks/interval_test.go
@@ -1,0 +1,35 @@
+package stacks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pluralsh/console/go/deployment-operator/api/v1alpha1"
+	"github.com/pluralsh/console/go/deployment-operator/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackPollIntervalCanBeDisabledByConfiguration(t *testing.T) {
+	t.Cleanup(resetAgentConfiguration)
+	resetAgentConfiguration()
+
+	require.NoError(t, common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{
+		StackPollInterval: ptr("30s"),
+	}))
+	require.NoError(t, common.GetConfigurationManager().SetValue(v1alpha1.AgentConfigurationSpec{
+		StackPollInterval: ptr("0s"),
+	}))
+
+	reconciler := &StackReconciler{pollInterval: 30 * time.Second}
+
+	assert.Equal(t, time.Duration(0), reconciler.GetPollInterval()())
+}
+
+func resetAgentConfiguration() {
+	_ = common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{})
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/go/deployment-operator/pkg/ping/cluster.go
+++ b/go/deployment-operator/pkg/ping/cluster.go
@@ -22,10 +22,7 @@ import (
 
 func RunClusterPingerInBackgroundOrDie(ctx context.Context, pinger *Pinger, duration time.Duration) {
 	interval := func() time.Duration {
-		if clusterPingInterval := common.GetConfigurationManager().GetClusterPingInterval(); clusterPingInterval != nil && *clusterPingInterval > 0 {
-			duration = *clusterPingInterval
-		}
-		return duration
+		return clusterPingInterval(duration)
 	}
 
 	_ = helpers.DynamicBackgroundPollUntilContextCancel(ctx, interval, false, func(_ context.Context) (done bool, err error) {
@@ -36,6 +33,13 @@ func RunClusterPingerInBackgroundOrDie(ctx context.Context, pinger *Pinger, dura
 	})
 
 	klog.V(internallog.LogLevelDefault).InfoS("started cluster pinger", "interval", duration)
+}
+
+func clusterPingInterval(defaultDuration time.Duration) time.Duration {
+	if clusterPingInterval := common.GetConfigurationManager().GetClusterPingInterval(); clusterPingInterval != nil {
+		return *clusterPingInterval
+	}
+	return defaultDuration
 }
 
 func (p *Pinger) PingCluster() error {

--- a/go/deployment-operator/pkg/ping/interval_test.go
+++ b/go/deployment-operator/pkg/ping/interval_test.go
@@ -1,0 +1,47 @@
+package ping
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pluralsh/console/go/deployment-operator/api/v1alpha1"
+	"github.com/pluralsh/console/go/deployment-operator/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterPingIntervalCanBeDisabledByConfiguration(t *testing.T) {
+	t.Cleanup(resetAgentConfiguration)
+	resetAgentConfiguration()
+
+	require.NoError(t, common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{
+		ClusterPingInterval: ptr("2m"),
+	}))
+	require.NoError(t, common.GetConfigurationManager().SetValue(v1alpha1.AgentConfigurationSpec{
+		ClusterPingInterval: ptr("0s"),
+	}))
+
+	assert.Equal(t, time.Duration(0), clusterPingInterval(2*time.Minute))
+}
+
+func TestRuntimeServicesPingIntervalCanBeDisabledByConfiguration(t *testing.T) {
+	t.Cleanup(resetAgentConfiguration)
+	resetAgentConfiguration()
+
+	require.NoError(t, common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{
+		CompatibilityUploadInterval: ptr("3m"),
+	}))
+	require.NoError(t, common.GetConfigurationManager().SetValue(v1alpha1.AgentConfigurationSpec{
+		CompatibilityUploadInterval: ptr("0s"),
+	}))
+
+	assert.Equal(t, time.Duration(0), runtimeServicesPingInterval(3*time.Minute))
+}
+
+func resetAgentConfiguration() {
+	_ = common.GetConfigurationManager().SetDefaults(v1alpha1.AgentConfigurationSpec{})
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/go/deployment-operator/pkg/ping/runtime_service.go
+++ b/go/deployment-operator/pkg/ping/runtime_service.go
@@ -43,10 +43,7 @@ func RunRuntimeServicePingerInBackgroundOrDie(ctx context.Context, pinger *Pinge
 	klog.Info("starting ", runtimeServicePingerName)
 
 	interval := func() time.Duration {
-		if runtimeServicesPingInterval := common.GetConfigurationManager().GetRuntimeServicesPingInterval(); runtimeServicesPingInterval != nil && *runtimeServicesPingInterval > 0 {
-			duration = *runtimeServicesPingInterval
-		}
-		return duration
+		return runtimeServicesPingInterval(duration)
 	}
 
 	err := helpers.DynamicBackgroundPollUntilContextCancel(ctx, interval, false, func(_ context.Context) (done bool, err error) {
@@ -56,6 +53,13 @@ func RunRuntimeServicePingerInBackgroundOrDie(ctx context.Context, pinger *Pinge
 	if err != nil {
 		panic(fmt.Errorf("failed to start %s in background: %w", runtimeServicePingerName, err))
 	}
+}
+
+func runtimeServicesPingInterval(defaultDuration time.Duration) time.Duration {
+	if runtimeServicesPingInterval := common.GetConfigurationManager().GetRuntimeServicesPingInterval(); runtimeServicesPingInterval != nil {
+		return *runtimeServicesPingInterval
+	}
+	return defaultDuration
 }
 
 func (p *Pinger) PingRuntimeServices(ctx context.Context) {

--- a/lib/console/ai/tools/workbench/integration/github/client.ex
+++ b/lib/console/ai/tools/workbench/integration/github/client.ex
@@ -25,9 +25,9 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.Client do
     end
   end
 
-  @spec json_get(Tentacat.Client.t(), String.t()) :: Tentacat.response() | {:error, String.t()}
-  def json_get(%Tentacat.Client{} = client, path) when is_binary(path),
-    do: json_request(:get, client, path)
+  @spec json_get(Tentacat.Client.t(), String.t(), keyword()) :: Tentacat.response() | {:error, String.t()}
+  def json_get(%Tentacat.Client{} = client, path, opts \\ []) when is_binary(path),
+    do: json_request(:get, client, path, opts)
 
   @spec json_delete(Tentacat.Client.t(), String.t()) :: Tentacat.response() | {:error, String.t()}
   def json_delete(%Tentacat.Client{} = client, path) when is_binary(path),
@@ -109,12 +109,12 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.Client do
     if String.ends_with?(url, "/"), do: url, else: url <> "/"
   end
 
-  defp json_request(method, %Tentacat.Client{} = client, path) do
+  defp json_request(method, %Tentacat.Client{} = client, path, opts \\ []) do
     url = client.endpoint <> path
 
     case HTTPoison.request(method, url, "", json_headers(client), request_options(client)) do
       {:ok, %HTTPoison.Response{status_code: code, body: body} = resp} ->
-        response(method, code, decode_json_body(body), resp)
+        response(method, code, decode_json_body(body), resp, opts)
 
       {:error, reason} ->
         Http.error("GitHub", reason)
@@ -130,10 +130,13 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.Client do
     end
   end
 
-  defp response(:get, code, body, %HTTPoison.Response{} = resp) when is_list(body),
+  defp response(:get, code, body, %HTTPoison.Response{} = resp, pagination: :manual),
     do: {{code, body, resp}, next_url(resp), nil}
 
-  defp response(_, code, body, %HTTPoison.Response{} = resp),
+  defp response(:get, code, body, %HTTPoison.Response{} = resp, _) when is_list(body),
+    do: {{code, body, resp}, next_url(resp), nil}
+
+  defp response(_, code, body, %HTTPoison.Response{} = resp, _),
     do: {code, body, resp}
 
   defp next_url(%HTTPoison.Response{headers: headers}) do

--- a/lib/console/ai/tools/workbench/integration/github/pull_request_read.ex
+++ b/lib/console/ai/tools/workbench/integration/github/pull_request_read.ex
@@ -4,7 +4,6 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.PullRequestRead do
   use Console.AI.Tools.Workbench.Base
 
   import EctoEnum
-  import Tentacat
 
   alias Console.Schema.WorkbenchTool
   alias Console.Schema.WorkbenchTool.{Configuration, Configuration.GithubConnection}
@@ -88,7 +87,7 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.PullRequestRead do
     with {:ok, client} <- GhClient.build(m.tool) do
       case Tentacat.Pulls.find(client, m.owner, m.repo, m.pull_number) do
         {_, %{"head" => %{"sha" => sha}}, _} ->
-          get("repos/#{m.owner}/#{m.repo}/commits/#{sha}/status", client)
+          GhClient.json_get(client, "repos/#{m.owner}/#{m.repo}/commits/#{sha}/status")
           |> Response.json()
 
         other ->
@@ -109,10 +108,9 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.PullRequestRead do
       |> Query.paginated()
       |> Query.stringify_params()
       |> then(
-        &get(
-          "repos/#{m.owner}/#{m.repo}/pulls/#{m.pull_number}/files#{Query.qp(&1)}",
+        &GhClient.json_get(
           client,
-          [],
+          "repos/#{m.owner}/#{m.repo}/pulls/#{m.pull_number}/files#{Query.qp(&1)}",
           Query.manual_pagination()
         )
       )
@@ -132,10 +130,9 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.PullRequestRead do
       |> Query.paginated()
       |> Query.stringify_params()
       |> then(
-        &get(
-          "repos/#{m.owner}/#{m.repo}/pulls/#{m.pull_number}/comments#{Query.qp(&1)}",
+        &GhClient.json_get(
           client,
-          [],
+          "repos/#{m.owner}/#{m.repo}/pulls/#{m.pull_number}/comments#{Query.qp(&1)}",
           Query.manual_pagination()
         )
       )
@@ -155,10 +152,9 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.PullRequestRead do
       |> Query.paginated()
       |> Query.stringify_params()
       |> then(
-        &get(
-          "repos/#{m.owner}/#{m.repo}/pulls/#{m.pull_number}/reviews#{Query.qp(&1)}",
+        &GhClient.json_get(
           client,
-          [],
+          "repos/#{m.owner}/#{m.repo}/pulls/#{m.pull_number}/reviews#{Query.qp(&1)}",
           Query.manual_pagination()
         )
       )
@@ -178,10 +174,9 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.PullRequestRead do
       |> Query.paginated()
       |> Query.stringify_params()
       |> then(
-        &get(
-          "repos/#{m.owner}/#{m.repo}/issues/#{m.pull_number}/comments#{Query.qp(&1)}",
+        &GhClient.json_get(
           client,
-          [],
+          "repos/#{m.owner}/#{m.repo}/issues/#{m.pull_number}/comments#{Query.qp(&1)}",
           Query.manual_pagination()
         )
       )
@@ -203,10 +198,9 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.PullRequestRead do
           |> Query.paginated()
           |> Query.stringify_params()
           |> then(
-            &get(
-              "repos/#{m.owner}/#{m.repo}/commits/#{sha}/check-runs#{Query.qp(&1)}",
+            &GhClient.json_get(
               client,
-              [],
+              "repos/#{m.owner}/#{m.repo}/commits/#{sha}/check-runs#{Query.qp(&1)}",
               Query.manual_pagination()
             )
           )

--- a/lib/console/deployments/global.ex
+++ b/lib/console/deployments/global.ex
@@ -263,10 +263,10 @@ defmodule Console.Deployments.Global do
   def sync_service(%GlobalService{template: %ServiceTemplate{} = tpl, id: id} = global, %Service{} = dest, %User{} = user) do
     Logger.info "Attempting to resync service #{dest.id}"
     global = Repo.preload(global, [:context])
-    dest = Repo.preload(dest, [:context_bindings, :dependencies, :cluster])
-    tpl = Repo.preload(tpl, [:dependencies])
-    tpl = dynamic_template(tpl, dest.cluster, global)
-          |> ServiceTemplate.load_contexts()
+    dest   = Repo.preload(dest, [:context_bindings, :dependencies, :cluster])
+    tpl    = Repo.preload(tpl, [:dependencies])
+    tpl    = dynamic_template(tpl, dest.cluster, global)
+             |> ServiceTemplate.load_contexts()
     case diff?(tpl, dest) do
       true -> ServiceTemplate.attributes(tpl)
               |> Map.put(:dependencies, svc_deps(tpl.dependencies, dest.dependencies))

--- a/lib/console/deployments/pipelines.ex
+++ b/lib/console/deployments/pipelines.ex
@@ -64,6 +64,13 @@ defmodule Console.Deployments.Pipelines do
 
   def gate_job(_), do: {:ok, nil}
 
+  @decorate cacheable(cache: @cache, key: :pipelined_services, opts: [ttl: :timer.minutes(30)])
+  def pipelined_services() do
+    StageService.service_ids()
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
   @doc """
   Will either create or recreate a pipeline with the given attributes. Requires write permissions to the pipeline
   """

--- a/lib/console/deployments/pubsub/protocols/cacheable.ex
+++ b/lib/console/deployments/pubsub/protocols/cacheable.ex
@@ -51,3 +51,11 @@ defimpl Console.PubSub.Cacheable, for: [
     do: {:del, {:obs_webhook, ext_id}, hook}
   def cache(_), do: :ok
 end
+
+defimpl Console.PubSub.Cacheable, for: [
+  Console.PubSub.PipelineUpserted,
+  Console.PubSub.PipelineDeleted,
+  Console.PubSub.PipelineStageUpdated,
+] do
+  def cache(%@for{item: _}), do: {:del, :pipelined_services, :ignore}
+end

--- a/lib/console/deployments/pubsub/protocols/pipelineable.ex
+++ b/lib/console/deployments/pubsub/protocols/pipelineable.ex
@@ -16,10 +16,14 @@ end
 defimpl Console.Deployments.PubSub.Pipelineable, for: Console.PubSub.ServiceComponentsUpdated do
   require Logger
   alias Console.Schema.Service
+  alias Console.Deployments.Pipelines
+  use Nebulex.Caching
+
+  @local_adapter Console.conf(:local_cache)
 
   def pipe(%{item: %{status: s} = svc}) when s in ~w(healthy failed)a do
     Logger.info "Kicking any pipelines associated with #{svc.id}"
-    if recent?(svc) do
+    if recent?(svc) && MapSet.member?(eligible_sids(), svc.id) do
       stages(svc)
       |> handle_status(s)
     else
@@ -27,6 +31,9 @@ defimpl Console.Deployments.PubSub.Pipelineable, for: Console.PubSub.ServiceComp
     end
   end
   def pipe(_), do: :ok
+
+  @decorate cacheable(cache: @local_adapter, key: :eligible_sids, opts: [ttl: :timer.minutes(2)])
+  def eligible_sids(), do: Pipelines.pipelined_services()
 
   defp handle_status([], _), do: :ok
   defp handle_status(stages, :healthy), do: stages

--- a/lib/console/schema/stage_service.ex
+++ b/lib/console/schema/stage_service.ex
@@ -11,6 +11,10 @@ defmodule Console.Schema.StageService do
     timestamps()
   end
 
+  def service_ids(query \\ __MODULE__) do
+    from(s in query, select: s.service_id, distinct: true)
+  end
+
   def changeset(model, attrs \\ %{}) do
     model
     |> cast(attrs, ~w(stage_id service_id)a)

--- a/test/console/ai/tools/workbench/integration/github/response_test.exs
+++ b/test/console/ai/tools/workbench/integration/github/response_test.exs
@@ -1,7 +1,8 @@
 defmodule Console.AI.Tools.Workbench.Integration.Github.ResponseTest do
-  use Console.DataCase, async: true
+  use Console.DataCase
+  use Mimic
 
-  alias Console.AI.Tools.Workbench.Integration.Github.{Query, Response}
+  alias Console.AI.Tools.Workbench.Integration.Github.{Client, Query, Response}
 
   describe "json/1" do
     test "merges multi-page Tentacat search bodies before encoding" do
@@ -54,6 +55,74 @@ defmodule Console.AI.Tools.Workbench.Integration.Github.ResponseTest do
       assert message =~ "GitHub request failed: TLS unknown_ca:"
       assert message =~ "certificate verify failed"
       refute message =~ "%HTTPoison.Error"
+    end
+  end
+
+  describe "client json_get/3" do
+    test "safely decodes manually paginated object responses" do
+      next = "https://api.github.com/repos/pluralsh/console/commits/sha/check-runs?page=2&per_page=30"
+
+      expect(HTTPoison, :request, fn
+        :get,
+        "https://api.github.com/repos/pluralsh/console/commits/sha/check-runs?page=1&per_page=30",
+        "",
+        _headers,
+        _opts ->
+          {:ok,
+           %HTTPoison.Response{
+             status_code: 200,
+             body: Jason.encode!(%{"total_count" => 1, "check_runs" => [%{"id" => 1}]}),
+             headers: [{"Link", "<#{next}>; rel=\"next\""}]
+           }}
+      end)
+
+      client = Tentacat.Client.new(%{access_token: "token"})
+
+      assert {:ok, json} =
+               client
+               |> Client.json_get(
+                 "repos/pluralsh/console/commits/sha/check-runs?page=1&per_page=30",
+                 pagination: :manual
+               )
+               |> Response.json()
+
+      assert Jason.decode!(json) == %{
+               "check_runs" => [%{"id" => 1}],
+               "total_count" => 1,
+               "pagination" => %{
+                 "has_next_page" => true,
+                 "link" => "<#{next}>; rel=\"next\"",
+                 "next_page" => "2",
+                 "next_url" => next,
+                 "per_page" => "30"
+               }
+             }
+    end
+
+    test "returns an error for non-json GitHub responses instead of raising a decoder error" do
+      expect(HTTPoison, :request, fn
+        :get,
+        "https://api.github.com/bad/path",
+        "",
+        _headers,
+        _opts ->
+          {:ok,
+           %HTTPoison.Response{
+             status_code: 404,
+             body: "<html>not found</html>",
+             headers: []
+           }}
+      end)
+
+      client = Tentacat.Client.new(%{access_token: "token"})
+
+      assert {:error, message} =
+               client
+               |> Client.json_get("bad/path", pagination: :manual)
+               |> Response.json()
+
+      assert message =~ "GitHub API 404"
+      assert message =~ "not found"
     end
   end
 

--- a/test/console/deployments/pubsub/cacheable_test.exs
+++ b/test/console/deployments/pubsub/cacheable_test.exs
@@ -171,4 +171,27 @@ defmodule Console.Deployments.PubSub.CacheableTest do
       Cache.handle_event(event)
     end
   end
+
+  describe "pipeline cache invalidation" do
+    test "PipelineUpserted deletes the pipelined services cache" do
+      expect(Console.Cache, :delete, fn :pipelined_services -> :ok end)
+
+      event = %PubSub.PipelineUpserted{item: insert(:pipeline)}
+      Cache.handle_event(event)
+    end
+
+    test "PipelineDeleted deletes the pipelined services cache" do
+      expect(Console.Cache, :delete, fn :pipelined_services -> :ok end)
+
+      event = %PubSub.PipelineDeleted{item: insert(:pipeline)}
+      Cache.handle_event(event)
+    end
+
+    test "PipelineStageUpdated deletes the pipelined services cache" do
+      expect(Console.Cache, :delete, fn :pipelined_services -> :ok end)
+
+      event = %PubSub.PipelineStageUpdated{item: insert(:pipeline_stage)}
+      Cache.handle_event(event)
+    end
+  end
 end


### PR DESCRIPTION
This will be used to ensure agent tuning occurs as fast as possible.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.plrldemo.onplural.sh/cd/clusters/a1748282-ce8b-48ab-ae7e-326e74fce04e/services/f3f89a54-d1a7-4bc8-9152-daa07ede918d/components

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
