### PR TITLE
fix(provider): update Ready method to remove TTL check

### DIFF
--- a/go/observability-proxy/internal/console/provider.go
+++ b/go/observability-proxy/internal/console/provider.go
@@ -47,7 +47,7 @@ func (p *CachingProvider) Ready() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	return p.config != nil && time.Since(p.updatedAt) < p.ttl
+	return p.config != nil
 }
 
 func (p *CachingProvider) GetConfig(_ context.Context) (ObservabilityConfig, error) {

--- a/go/observability-proxy/internal/console/provider_test.go
+++ b/go/observability-proxy/internal/console/provider_test.go
@@ -50,6 +50,23 @@ func (f *fakeConfigClient) Calls() int {
 	return f.calls
 }
 
+func TestReadyRemainsTrueWhenConfigIsStale(t *testing.T) {
+	client := &fakeConfigClient{resp: observabilityProto("http://prom", "http://elastic")}
+	provider := NewCachingProvider(client, 10*time.Millisecond)
+
+	if provider.Ready() {
+		t.Fatal("provider should not be ready before loading config")
+	}
+	if _, err := provider.GetConfig(context.Background()); err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	time.Sleep(15 * time.Millisecond)
+	if !provider.Ready() {
+		t.Fatal("provider should remain ready while it has a valid cached config")
+	}
+}
+
 func TestGetConfigDeduplicatesConcurrentColdStartRefresh(t *testing.T) {
 	client := &fakeConfigClient{
 		delay: 50 * time.Millisecond,


### PR DESCRIPTION
- Remove TTL comparison from `Ready` method to ensure provider remains ready with a valid cached config
- Add test to verify behavior when config becomes stale

<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.plrl-dev-aws.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
