### PR TITLE
fix: Rename authentication storage keys for v3 migration

### DIFF
--- a/assets/src/helpers/auth.test.ts
+++ b/assets/src/helpers/auth.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const AUTH_STORAGE_VERSION_KEY = 'auth-storage-version'
+const AUTH_TOKEN = 'auth-token-v3'
 const storage = new Map<string, string>()
 const localStorageMock = {
   clear: () => storage.clear(),
@@ -30,26 +30,34 @@ describe('auth storage', () => {
     setToken('token')
 
     expect(fetchToken()).toBe('token')
-    expect(localStorage.getItem(AUTH_STORAGE_VERSION_KEY)).toBe('3')
+    expect(localStorage.getItem(AUTH_TOKEN)).not.toBeNull()
+  })
+
+  it('removes the auth token when given an empty value', async () => {
+    const { fetchToken, setToken } = await loadAuth()
+    setToken('token')
+
+    setToken(null)
+
+    expect(fetchToken()).toBeUndefined()
+    expect(localStorage.getItem(AUTH_TOKEN)).toBeNull()
   })
 
   it('expires legacy encrypted auth tokens during the v3 migration', async () => {
-    const initialAuth = await loadAuth()
-    initialAuth.setToken('legacy-token')
-    localStorage.removeItem(AUTH_STORAGE_VERSION_KEY)
-
-    const { fetchToken } = await loadAuth()
-
-    expect(fetchToken()).toBeUndefined()
-  })
-
-  it('expires incompatible auth tokens after the storage migration', async () => {
-    localStorage.setItem(AUTH_STORAGE_VERSION_KEY, '3')
     localStorage.setItem('auth-token', 'legacy-ciphertext')
 
     const { fetchToken } = await loadAuth()
 
     expect(fetchToken()).toBeUndefined()
     expect(localStorage.getItem('auth-token')).toBeNull()
+  })
+
+  it('expires incompatible v3 auth tokens', async () => {
+    localStorage.setItem(AUTH_TOKEN, 'incompatible-ciphertext')
+
+    const { fetchToken } = await loadAuth()
+
+    expect(fetchToken()).toBeUndefined()
+    expect(localStorage.getItem(AUTH_TOKEN)).toBeNull()
   })
 })

--- a/assets/src/helpers/auth.ts
+++ b/assets/src/helpers/auth.ts
@@ -1,23 +1,19 @@
 import Cookies from 'js-cookie'
 
 import { EncryptStorage } from 'encrypt-storage'
-import {
-  ORIGINAL_AUTH_TOKEN_KEY,
-  ORIGINAL_REFRESH_TOKEN_KEY,
-  ORIGINAL_USER_LABEL_KEY,
-} from './impersonationKeys'
 
-export const AUTH_TOKEN = 'auth-token'
-export const REFRESH_TOKEN = 'refresh-token'
+export const AUTH_TOKEN = 'auth-token-v3'
+export const REFRESH_TOKEN = 'refresh-token-v3'
 export const CHALLENGE_KEY = 'oauth-challenge'
 
-const AUTH_STORAGE_VERSION_KEY = 'auth-storage-version'
-const AUTH_STORAGE_VERSION = '3'
-const legacyEncryptedAuthKeys = [
-  AUTH_TOKEN,
-  ORIGINAL_AUTH_TOKEN_KEY,
-  ORIGINAL_REFRESH_TOKEN_KEY,
-  ORIGINAL_USER_LABEL_KEY,
+// TODO: Remove this legacy cleanup after the v3 auth storage migration rollout is complete.
+const LEGACY_REFRESH_TOKEN = 'refresh-token'
+const legacyLocalStorageKeys = [
+  'auth-token',
+  'impersonation-original-auth-token',
+  'impersonation-original-refresh-token',
+  'impersonation-original-user-label',
+  'auth-storage-version',
 ]
 
 const { MODE, VITE_DEV_SECRET_KEY, VITE_PROD_SECRET_KEY } = import.meta.env
@@ -29,11 +25,8 @@ const secretKey =
       : VITE_DEV_SECRET_KEY
 const encryptStorage = EncryptStorage.create(secretKey, { engine: 'noble' })
 
-if (localStorage.getItem(AUTH_STORAGE_VERSION_KEY) !== AUTH_STORAGE_VERSION) {
-  legacyEncryptedAuthKeys.forEach((key) => localStorage.removeItem(key))
-  wipeRefreshToken()
-  localStorage.setItem(AUTH_STORAGE_VERSION_KEY, AUTH_STORAGE_VERSION)
-}
+legacyLocalStorageKeys.forEach((key) => localStorage.removeItem(key))
+Cookies.remove(LEGACY_REFRESH_TOKEN, { path: '/' })
 
 export function getEncryptedAuthValue(key: string) {
   try {
@@ -54,7 +47,11 @@ export function fetchToken() {
 }
 
 export function setToken(token: string | null | undefined) {
-  encryptStorage.setItem(AUTH_TOKEN, token || '')
+  if (token) {
+    encryptStorage.setItem(AUTH_TOKEN, token)
+  } else {
+    wipeToken()
+  }
 }
 
 export function setEncryptedAuthValue(
@@ -91,7 +88,7 @@ export function setRefreshTokenForStorage(token: string | null | undefined) {
 }
 
 export function wipeRefreshToken() {
-  Cookies.remove(REFRESH_TOKEN)
+  Cookies.remove(REFRESH_TOKEN, { path: '/' })
 }
 
 export function fetchRefreshToken() {

--- a/assets/src/helpers/impersonation.ts
+++ b/assets/src/helpers/impersonation.ts
@@ -7,11 +7,10 @@ import {
   setRefreshTokenForStorage,
   setToken,
 } from './auth'
-import {
-  ORIGINAL_AUTH_TOKEN_KEY,
-  ORIGINAL_REFRESH_TOKEN_KEY,
-  ORIGINAL_USER_LABEL_KEY,
-} from './impersonationKeys'
+
+const ORIGINAL_AUTH_TOKEN_KEY = 'impersonation-original-auth-token-v3'
+const ORIGINAL_REFRESH_TOKEN_KEY = 'impersonation-original-refresh-token-v3'
+const ORIGINAL_USER_LABEL_KEY = 'impersonation-original-user-label-v3'
 
 export function isImpersonatingServiceAccount() {
   return !!getEncryptedAuthValue(ORIGINAL_AUTH_TOKEN_KEY)

--- a/assets/src/helpers/impersonationKeys.ts
+++ b/assets/src/helpers/impersonationKeys.ts
@@ -1,3 +1,0 @@
-export const ORIGINAL_AUTH_TOKEN_KEY = 'impersonation-original-auth-token'
-export const ORIGINAL_REFRESH_TOKEN_KEY = 'impersonation-original-refresh-token'
-export const ORIGINAL_USER_LABEL_KEY = 'impersonation-original-user-label'


### PR DESCRIPTION
Rotate auth/impersonation storage keys and the refresh-token cookie to `*-v3`, and clear legacy values so old `encrypt-storage` sessions cannot be reused after the v3 upgrade.

## Test Plan
Test environment: https://console.plrl-dev-aws.onplural.sh/

## Checklist
- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.

Plural Flow: console
