### PR TITLE
fix global service deletion

### DIFF
--- a/go/controller/internal/controller/globalservice_controller.go
+++ b/go/controller/internal/controller/globalservice_controller.go
@@ -276,17 +276,15 @@ func (r *GlobalServiceReconciler) handleCreate(sha string, global *v1alpha1.Glob
 
 func (r *GlobalServiceReconciler) handleDelete(service *v1alpha1.GlobalService) error {
 	if controllerutil.ContainsFinalizer(service, GlobalServiceFinalizer) {
-		if service.Status.GetID() != "" {
-			existingGlobalService, err := r.ConsoleClient.GetGlobalService(service.Status.GetID())
-			if err != nil && !errors.IsNotFound(err) {
+		existingGlobalService, err := r.ConsoleClient.GetGlobalServiceByName(service.ConsoleName())
+		if err != nil && !errors.IsNotFound(err) {
+			utils.MarkCondition(service.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
+			return err
+		}
+		if existingGlobalService != nil {
+			if err := r.ConsoleClient.DeleteGlobalService(existingGlobalService.ID); err != nil {
 				utils.MarkCondition(service.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
 				return err
-			}
-			if existingGlobalService != nil {
-				if err := r.ConsoleClient.DeleteGlobalService(*service.Status.ID); err != nil {
-					utils.MarkCondition(service.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
-					return err
-				}
 			}
 		}
 		controllerutil.RemoveFinalizer(service, GlobalServiceFinalizer)

--- a/go/controller/internal/controller/globalservice_controller_test.go
+++ b/go/controller/internal/controller/globalservice_controller_test.go
@@ -352,8 +352,8 @@ var _ = Describe("Global Service Controller", Ordered, func() {
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
-			fakeConsoleClient.On("GetGlobalService", mock.Anything, mock.Anything).Return(test.returnCreateService, nil)
-			fakeConsoleClient.On("DeleteGlobalService", mock.Anything, mock.Anything).Return(nil)
+			fakeConsoleClient.On("GetGlobalServiceByName", mock.Anything).Return(test.returnCreateService, nil)
+			fakeConsoleClient.On("DeleteGlobalService", mock.Anything).Return(nil)
 			serviceReconciler := &controller.GlobalServiceReconciler{
 				Client:           k8sClient,
 				Scheme:           k8sClient.Scheme(),

--- a/go/controller/internal/errors/base.go
+++ b/go/controller/internal/errors/base.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"errors"
+	"net/http"
 	"strings"
 
 	client "github.com/Yamashou/gqlgenc/clientv2"
@@ -49,6 +50,14 @@ func (er *wrappedErrorResponse) Has(err KnownError) bool {
 	return false
 }
 
+func (er *wrappedErrorResponse) HasNetworkError(code int) bool {
+	if er.err.NetworkError == nil {
+		return false
+	}
+
+	return er.err.NetworkError.Code == code
+}
+
 func newAPIError(err *client.ErrorResponse) *wrappedErrorResponse {
 	return &wrappedErrorResponse{
 		err: err,
@@ -66,9 +75,14 @@ func IsNotFound(err error) bool {
 		return false
 	}
 
-	return (newAPIError(errorResponse).Has(ErrNotFound) ||
-		newAPIError(errorResponse).Has(ErrNotFoundOIDCProvider) ||
-		newAPIError(errorResponse).Has(ErrNotFoundAlt))
+	wrapped := newAPIError(errorResponse)
+	if wrapped.HasNetworkError(http.StatusNotFound) {
+		return true
+	}
+
+	return wrapped.Has(ErrNotFound) ||
+		wrapped.Has(ErrNotFoundOIDCProvider) ||
+		wrapped.Has(ErrNotFoundAlt)
 }
 
 func IgnoreNotFound(err error) error {


### PR DESCRIPTION
 - Treat Console HTTP 404 network errors as not found so GlobalService deletion can clear its finalizer when the upstream object is already gone. 

- Simplify handleDelete to look up by name and delete using the Console object’s ID.

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.your-env.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
