### PR TITLE
feat: Update stack insights display

### DIFF
--- a/assets/src/components/ai/chatbot/AISuggestFix.tsx
+++ b/assets/src/components/ai/chatbot/AISuggestFix.tsx
@@ -1,6 +1,7 @@
 import {
   AiSparkleFilledIcon,
   Button,
+  ButtonProps,
   LinkoutIcon,
   Markdown,
   PrOpenIcon,
@@ -134,7 +135,10 @@ function FixPr({
   )
 }
 
-function AISuggestFix({ insight }: { insight: Nullable<AiInsightFragment> }) {
+function AISuggestFix({
+  insight,
+  ...props
+}: { insight: Nullable<AiInsightFragment> } & ButtonProps) {
   const settings = useDeploymentSettings()
   const ref = useRef<HTMLDivElement>(null)
   const [streaming, setStreaming] = useState<boolean>(false)
@@ -177,6 +181,7 @@ function AISuggestFix({ insight }: { insight: Nullable<AiInsightFragment> }) {
     <div css={{ position: 'relative' }}>
       <Button
         startIcon={<AiSparkleFilledIcon />}
+        {...props}
         onClick={showPanel}
       >
         Suggest a fix

--- a/assets/src/components/ai/insights/InsightDisplay.tsx
+++ b/assets/src/components/ai/insights/InsightDisplay.tsx
@@ -10,13 +10,15 @@ import {
   SearchIcon,
 } from '@pluralsh/design-system'
 import { ARBITRARY_VALUE_NAME } from 'components/utils/IconExpander'
+import { CaptionP } from 'components/utils/typography/Text'
 import { AiInsightFragment } from 'generated/graphql'
-import { useState } from 'react'
+import { isEmpty } from 'lodash'
+import { ReactNode, useState } from 'react'
 import styled from 'styled-components'
+import { fromNow } from 'utils/datetime'
+import { isNonNullable } from 'utils/isNonNullable'
 import { InsightEvidence } from './InsightEvidence'
 import { InsightMainContent } from './InsightMainContent'
-import { isEmpty } from 'lodash'
-import { isNonNullable } from 'utils/isNonNullable'
 
 const HEADER_HEIGHT = 40
 
@@ -24,34 +26,59 @@ export function InsightDisplay({
   insight,
   kind = 'resource',
   loading = false,
+  headerActions,
 }: {
   insight: Nullable<AiInsightFragment>
   kind: Nullable<string>
   loading: boolean
+  /** When set, merges title, last-updated, and actions into one panel header. */
+  headerActions?: ReactNode
 }) {
   const evidence = insight?.evidence?.filter(isNonNullable)
   const hasEvidence = !isEmpty(evidence)
   const [openItem, setOpenItem] = useState(ARBITRARY_VALUE_NAME)
   const isExpanded = openItem === ARBITRARY_VALUE_NAME
+  const compactHeader = headerActions != null
 
   return (
     <WrapperSC>
       <LeftSideSC>
-        <ContentHeaderSC>
-          <Flex gap="small">
-            <AiSparkleOutlineIcon />
-            <span>insight</span>
-          </Flex>
-          {hasEvidence && !isExpanded && (
-            <Button
-              secondary
-              small
-              startIcon={<SearchDocsIcon />}
-              onClick={() => setOpenItem(ARBITRARY_VALUE_NAME)}
+        <ContentHeaderSC $compact={compactHeader}>
+          {compactHeader ? (
+            <Flex
+              direction="column"
+              gap="xxsmall"
+              justify="center"
             >
-              View evidence
-            </Button>
+              <span>insight</span>
+              {insight?.updatedAt && (
+                <CaptionP $color="text-xlight">
+                  Last updated {fromNow(insight.updatedAt)}
+                </CaptionP>
+              )}
+            </Flex>
+          ) : (
+            <Flex gap="small">
+              <AiSparkleOutlineIcon />
+              <span>insight</span>
+            </Flex>
           )}
+          <Flex
+            align="center"
+            gap="small"
+          >
+            {hasEvidence && !isExpanded && (
+              <Button
+                secondary
+                small
+                startIcon={<SearchDocsIcon />}
+                onClick={() => setOpenItem(ARBITRARY_VALUE_NAME)}
+              >
+                View evidence
+              </Button>
+            )}
+            {headerActions}
+          </Flex>
         </ContentHeaderSC>
         <InsightMainContent
           text={insight?.text}
@@ -112,21 +139,25 @@ const WrapperSC = styled.div(({ theme }) => ({
       : theme.colors['fill-one'],
 }))
 
-const ContentHeaderSC = styled.div(({ theme }) => ({
-  ...theme.partials.text.overline,
-  color: theme.colors['text-xlight'],
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  height: HEADER_HEIGHT,
-  minWidth: 'max-content',
-  background:
-    theme.mode === 'light'
-      ? theme.colors['fill-one']
-      : theme.colors['fill-two'],
-  borderBottom: theme.borders['fill-two'],
-  padding: `${theme.spacing.small}px ${theme.spacing.medium}px`,
-}))
+const ContentHeaderSC = styled.div<{ $compact?: boolean }>(
+  ({ theme, $compact }) => ({
+    ...theme.partials.text.overline,
+    color: theme.colors['text-xlight'],
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing.small,
+    height: $compact ? 'auto' : HEADER_HEIGHT,
+    minHeight: HEADER_HEIGHT,
+    minWidth: 0,
+    background:
+      theme.mode === 'light'
+        ? theme.colors['fill-one']
+        : theme.colors['fill-two'],
+    borderBottom: theme.borders['fill-two'],
+    padding: `${theme.spacing.small}px ${theme.spacing.medium}px`,
+  })
+)
 
 const LeftSideSC = styled.div({
   display: 'flex',

--- a/assets/src/components/ai/insights/InsightRefresh.tsx
+++ b/assets/src/components/ai/insights/InsightRefresh.tsx
@@ -1,7 +1,14 @@
+import { IconFrameProps } from '@pluralsh/design-system'
 import IconFrameRefreshButton from 'components/utils/RefreshIconFrame'
 import { useRefreshInsightMutation, AiInsightFragment } from 'generated/graphql'
 
-export function InsightRefresh({ insight }: { insight: AiInsightFragment }) {
+export function InsightRefresh({
+  insight,
+  size,
+}: {
+  insight: AiInsightFragment
+  size?: IconFrameProps['size']
+}) {
   const [mutation, { loading }] = useRefreshInsightMutation({
     variables: {
       id: insight.id,
@@ -12,6 +19,7 @@ export function InsightRefresh({ insight }: { insight: AiInsightFragment }) {
     <IconFrameRefreshButton
       loading={loading}
       refetch={mutation}
+      size={size}
     />
   )
 }

--- a/assets/src/components/stacks/insights/StackInsights.tsx
+++ b/assets/src/components/stacks/insights/StackInsights.tsx
@@ -2,11 +2,9 @@ import { Flex, useSetBreadcrumbs } from '@pluralsh/design-system'
 import { InsightRefresh } from 'components/ai/insights/InsightRefresh.tsx'
 import { useMemo } from 'react'
 import { useOutletContext } from 'react-router-dom'
-import { fromNow } from 'utils/datetime'
 import { AISuggestFix } from '../../ai/chatbot/AISuggestFix.tsx'
 import { InsightDisplay } from '../../ai/insights/InsightDisplay.tsx'
 import { SendInsightToWorkbenchButton } from '../../ai/insights/SendInsightToWorkbench'
-import { StackedText } from '../../utils/table/StackedText.tsx'
 import { getBreadcrumbs, StackOutletContextT } from '../Stacks'
 
 export function StackInsights() {
@@ -18,39 +16,35 @@ export function StackInsights() {
       [stack]
     )
   )
+
   return (
     <Flex
       direction="column"
-      gap="medium"
       overflow="hidden"
       height="100%"
     >
-      <Flex
-        justify="space-between"
-        alignItems="center"
-      >
-        <StackedText
-          first="Insight"
-          firstPartialType="body1Bold"
-          second={
-            stack.insight?.updatedAt &&
-            `Last updated ${fromNow(stack.insight?.updatedAt)}`
-          }
-        />
-        <Flex
-          align="center"
-          justify="flex-end"
-          gap="small"
-        >
-          {stack?.insight && <InsightRefresh insight={stack?.insight} />}
-          <SendInsightToWorkbenchButton insight={stack?.insight} />
-          <AISuggestFix insight={stack?.insight} />
-        </Flex>
-      </Flex>
       <InsightDisplay
         insight={stack.insight}
         kind="stack"
         loading={loading}
+        headerActions={
+          <>
+            {stack.insight && (
+              <InsightRefresh
+                size="medium"
+                insight={stack.insight}
+              />
+            )}
+            <SendInsightToWorkbenchButton
+              small
+              insight={stack.insight}
+            />
+            <AISuggestFix
+              small
+              insight={stack.insight}
+            />
+          </>
+        }
       />
     </Flex>
   )

--- a/assets/src/components/stacks/run/insights/StackRunInsights.tsx
+++ b/assets/src/components/stacks/run/insights/StackRunInsights.tsx
@@ -1,65 +1,42 @@
 import { Flex } from '@pluralsh/design-system'
-
-import { CaptionP } from 'components/utils/typography/Text'
-import { useOutletContext } from 'react-router-dom'
-import { useTheme } from 'styled-components'
-import { formatDateTime, fromNow } from 'utils/datetime'
 import { AISuggestFix } from 'components/ai/chatbot/AISuggestFix.tsx'
 import { InsightDisplay } from '../../../ai/insights/InsightDisplay.tsx'
 import { SendInsightToWorkbenchButton } from '../../../ai/insights/SendInsightToWorkbench'
 import IconFrameRefreshButton from '../../../utils/RefreshIconFrame.tsx'
-import { StackedText } from '../../../utils/table/StackedText.tsx'
+import { useOutletContext } from 'react-router-dom'
 import { StackRunOutletContextT } from '../Route.tsx'
 
 export function StackRunInsights() {
-  const theme = useTheme()
   const { stackRun, refetch, loading } =
     useOutletContext<StackRunOutletContextT>()
 
   return (
     <Flex
       direction="column"
-      gap="medium"
       overflow="hidden"
       height="100%"
     >
-      <Flex
-        justify="space-between"
-        alignItems="center"
-      >
-        <StackedText
-          first="Insight"
-          firstPartialType="body1Bold"
-          second={
-            stackRun.insight?.updatedAt &&
-            `Last updated ${fromNow(stackRun.insight?.updatedAt)}`
-          }
-        />
-        <Flex
-          align="center"
-          justify="flex-end"
-          gap="small"
-          paddingLeft={theme.spacing.medium}
-        >
-          <CaptionP
-            css={{ width: 'max-content' }}
-            $color="text-xlight"
-          >
-            {stackRun.insight?.updatedAt &&
-              `Last updated ${formatDateTime(stackRun?.insight?.updatedAt)}`}
-          </CaptionP>
-          <IconFrameRefreshButton
-            loading={loading}
-            refetch={refetch}
-          />
-          <SendInsightToWorkbenchButton insight={stackRun?.insight} />
-          <AISuggestFix insight={stackRun?.insight} />
-        </Flex>
-      </Flex>
       <InsightDisplay
         insight={stackRun?.insight}
         kind="stack run"
         loading={loading}
+        headerActions={
+          <>
+            <IconFrameRefreshButton
+              size="medium"
+              loading={loading}
+              refetch={refetch}
+            />
+            <SendInsightToWorkbenchButton
+              small
+              insight={stackRun?.insight}
+            />
+            <AISuggestFix
+              small
+              insight={stackRun?.insight}
+            />
+          </>
+        }
       />
     </Flex>
   )

--- a/assets/src/components/utils/RefreshIconFrame.tsx
+++ b/assets/src/components/utils/RefreshIconFrame.tsx
@@ -1,12 +1,19 @@
-import { IconFrame, ReloadIcon, Spinner } from '@pluralsh/design-system'
+import {
+  IconFrame,
+  IconFrameProps,
+  ReloadIcon,
+  Spinner,
+} from '@pluralsh/design-system'
 import { useCallback, useRef, useState } from 'react'
 
 export default function IconFrameRefreshButton({
   refetch,
   loading,
+  size = 'large',
 }: {
   refetch: () => void
   loading?: boolean
+  size?: IconFrameProps['size']
 }) {
   const [clickedRecently, setClickedRecently] = useState(false)
   const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
@@ -22,7 +29,7 @@ export default function IconFrameRefreshButton({
     <IconFrame
       clickable
       type="secondary"
-      size="large"
+      size={size}
       tooltip="Refetch data"
       onClick={handleClick}
       disabled={loading}

--- a/assets/src/components/utils/alerts/AlertInsight.tsx
+++ b/assets/src/components/utils/alerts/AlertInsight.tsx
@@ -16,6 +16,7 @@ import {
   PageHeaderContext,
   POLL_INTERVAL,
 } from 'components/cd/ContinuousDeployment'
+import { useCurrentFlow } from 'components/flows/hooks/useCurrentFlow'
 import { GqlError } from 'components/utils/Alert'
 import IconFrameRefreshButton from 'components/utils/RefreshIconFrame'
 import { StackedText } from 'components/utils/table/StackedText'
@@ -35,6 +36,8 @@ export function AlertInsight({
   type: 'cluster' | 'service' | 'flow'
 }) {
   const { clusterId, serviceId, flowIdOrName, insightId } = useParams()
+  const { flowData } = useCurrentFlow({ skip: type !== 'flow' })
+  const flowId = type === 'flow' ? flowData?.flow?.id : undefined
 
   const { data, loading, error, refetch } = useAiInsightQuery({
     variables: { id: insightId ?? '' },
@@ -125,10 +128,12 @@ export function AlertInsight({
           loading={loading}
           refetch={refetch}
         />
-        <SendInsightToWorkbenchButton
-          insight={insight}
-          flowId={type === 'flow' ? flowIdOrName : undefined}
-        />
+        {(type !== 'flow' || flowId) && (
+          <SendInsightToWorkbenchButton
+            insight={insight}
+            flowId={flowId}
+          />
+        )}
         <AISuggestFix insight={insight} />
       </Flex>
       <InsightDisplay


### PR DESCRIPTION
Continuation of https://github.com/pluralsh/console/pull/3938.

## Test Plan
<img width="1082" height="249" alt="Zrzut ekranu 2026-08-3 o 10 43 45" src="https://github.com/user-attachments/assets/d4784bb0-6510-4e8e-8ae5-25d040f8c88a" />

## Checklist
- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.

Plural Flow: console
