### PR TITLE
fix search results navigating back flows

### DIFF
--- a/assets/src/components/flows/FlowCard.tsx
+++ b/assets/src/components/flows/FlowCard.tsx
@@ -19,7 +19,7 @@ import { hasAccess } from 'components/utils/persona'
 import { FlowBasicWithBindingsFragment } from 'generated/graphql'
 import pluralize from 'pluralize'
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { getFlowDetailsPath } from 'routes/flowRoutesConsts'
 import styled from 'styled-components'
 
@@ -30,6 +30,7 @@ export function FlowCard({
   flow: FlowBasicWithBindingsFragment
   refetch: () => void
 }) {
+  const { search } = useLocation()
   const navigate = useNavigate()
   const { personaConfiguration } = useLogin()
   const showPermissionsBtn = hasAccess(
@@ -46,7 +47,7 @@ export function FlowCard({
       <CardSC
         fillLevel={1}
         forwardedAs={Link}
-        to={flowPath}
+        to={`${flowPath}/services${search}`}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
       >
@@ -94,7 +95,7 @@ export function FlowCard({
                 onClick={(e) => {
                   e.preventDefault()
                   e.stopPropagation()
-                  navigate(`${flowPath}/pipelines`)
+                  navigate(`${flowPath}/pipelines${search}`)
                 }}
                 icon={<GitPullIcon color="icon-light" />}
               />

--- a/assets/src/components/flows/Flows.tsx
+++ b/assets/src/components/flows/Flows.tsx
@@ -19,7 +19,6 @@ import { useFetchPaginatedData } from 'components/utils/table/useFetchPaginatedD
 import { Body2P, InlineA, Subtitle1H1 } from 'components/utils/typography/Text'
 import { useFlowsQuery } from 'generated/graphql'
 import { isEmpty } from 'lodash'
-import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { FLOWS_ABS_PATH } from 'routes/flowRoutesConsts'
 import styled, { useTheme } from 'styled-components'
@@ -33,21 +32,8 @@ export function Flows() {
   useSetBreadcrumbs(breadcrumbs)
   const theme = useTheme()
   const [searchParams, setSearchParams] = useSearchParams()
-  const [searchString, setSearchString] = useState(
-    () => searchParams.get('q') ?? ''
-  )
+  const searchString = searchParams.get('q') ?? ''
   const debouncedSearchString = useThrottle(searchString, 200)
-
-  useEffect(() => {
-    const q = searchParams.get('q')
-
-    if ((debouncedSearchString || null) !== q) {
-      setSearchParams(
-        { ...(debouncedSearchString && { q: debouncedSearchString }) },
-        { replace: true }
-      )
-    }
-  }, [debouncedSearchString, searchParams, setSearchParams])
 
   const { data, error, loading, pageInfo, refetch, fetchNextPage } =
     useFetchPaginatedData(
@@ -76,7 +62,12 @@ export function Flows() {
         placeholder="Search flows"
         startIcon={<SearchIcon />}
         value={searchString}
-        onChange={(e) => setSearchString(e.currentTarget.value)}
+        onChange={(e) =>
+          setSearchParams(
+            { ...(e.currentTarget.value && { q: e.currentTarget.value }) },
+            { replace: true }
+          )
+        }
       />
       {error && <GqlError error={error} />}
       {isEmpty(flows) ? (

--- a/assets/src/components/flows/Flows.tsx
+++ b/assets/src/components/flows/Flows.tsx
@@ -19,7 +19,8 @@ import { useFetchPaginatedData } from 'components/utils/table/useFetchPaginatedD
 import { Body2P, InlineA, Subtitle1H1 } from 'components/utils/typography/Text'
 import { useFlowsQuery } from 'generated/graphql'
 import { isEmpty } from 'lodash'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { FLOWS_ABS_PATH } from 'routes/flowRoutesConsts'
 import styled, { useTheme } from 'styled-components'
 import { mapExistingNodes } from 'utils/graphql'
@@ -31,8 +32,22 @@ export const FLOW_DOCS_URL = 'https://docs.plural.sh/plural-features/flows'
 export function Flows() {
   useSetBreadcrumbs(breadcrumbs)
   const theme = useTheme()
-  const [searchString, setSearchString] = useState('')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [searchString, setSearchString] = useState(
+    () => searchParams.get('q') ?? ''
+  )
   const debouncedSearchString = useThrottle(searchString, 200)
+
+  useEffect(() => {
+    const q = searchParams.get('q')
+
+    if ((debouncedSearchString || null) !== q) {
+      setSearchParams(
+        { ...(debouncedSearchString && { q: debouncedSearchString }) },
+        { replace: true }
+      )
+    }
+  }, [debouncedSearchString, searchParams, setSearchParams])
 
   const { data, error, loading, pageInfo, refetch, fetchNextPage } =
     useFetchPaginatedData(

--- a/assets/src/components/flows/flow/Flow.tsx
+++ b/assets/src/components/flows/flow/Flow.tsx
@@ -26,7 +26,7 @@ import {
   PersonaConfigurationFragment,
 } from 'generated/graphql'
 import { ReactNode, createContext, use, useMemo, useState } from 'react'
-import { Link, Outlet, useMatch } from 'react-router-dom'
+import { Link, Outlet, useLocation, useMatch } from 'react-router-dom'
 import {
   FLOW_WORKBENCHES_REL_PATH,
   FLOWS_ABS_PATH,
@@ -93,6 +93,8 @@ export const getFlowBreadcrumbs = (flowName: string = '', tab: string = '') =>
     : []
 
 export function Flow() {
+  const { search } = useLocation()
+  const flowsPath = `${FLOWS_ABS_PATH}${search}`
   const [showPermissions, setShowPermissions] = useState(false)
   const [sidePanelContent, setSidePanelContent] = useState<ReactNode | null>(
     null
@@ -131,7 +133,7 @@ export function Flow() {
         <Button
           floating
           as={Link}
-          to={FLOWS_ABS_PATH}
+          to={flowsPath}
           startIcon={<ReturnIcon />}
         >
           View Flows
@@ -157,7 +159,7 @@ export function Flow() {
                   as={Link}
                   size="large"
                   type="secondary"
-                  to={FLOWS_ABS_PATH}
+                  to={flowsPath}
                   tooltip="Return to flows"
                 />
                 <Flex


### PR DESCRIPTION
When a user searches for a specific workspace, the relevant workspace environments are displayed. However, after selecting an environment and then navigating back, the previously entered search criteria are not retained. This change preserves the search state and reduces the need for users repeat their search.



<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.plrl-dev-aws.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
