### PR TITLE
hide stale flow results while search is loading

### DIFF
--- a/assets/src/components/flows/Flows.tsx
+++ b/assets/src/components/flows/Flows.tsx
@@ -1,3 +1,4 @@
+import { NetworkStatus } from '@apollo/client'
 import {
   ArrowTopRightIcon,
   Breadcrumb,
@@ -35,14 +36,24 @@ export function Flows() {
   const searchString = searchParams.get('q') ?? ''
   const debouncedSearchString = useThrottle(searchString, 200)
 
-  const { data, error, loading, pageInfo, refetch, fetchNextPage } =
-    useFetchPaginatedData(
-      { queryHook: useFlowsQuery, keyPath: ['flows'] },
-      { q: debouncedSearchString }
-    )
+  const {
+    data,
+    error,
+    loading,
+    networkStatus,
+    pageInfo,
+    refetch,
+    fetchNextPage,
+  } = useFetchPaginatedData(
+    { queryHook: useFlowsQuery, keyPath: ['flows'] },
+    { q: debouncedSearchString }
+  )
 
   const flows = mapExistingNodes(data?.flows)
   const hasActiveSearch = !!debouncedSearchString
+  const isSearchPending =
+    searchString !== debouncedSearchString ||
+    networkStatus === NetworkStatus.setVariables
 
   if (!data && loading) return <LoadingIndicator />
 
@@ -70,7 +81,9 @@ export function Flows() {
         }
       />
       {error && <GqlError error={error} />}
-      {isEmpty(flows) ? (
+      {isSearchPending ? (
+        <LoadingIndicator />
+      ) : isEmpty(flows) ? (
         hasActiveSearch ? (
           <Card css={{ padding: theme.spacing.large }}>
             <EmptyState message="No flows found" />

--- a/assets/src/components/flows/Flows.tsx
+++ b/assets/src/components/flows/Flows.tsx
@@ -1,4 +1,3 @@
-import { NetworkStatus } from '@apollo/client'
 import {
   ArrowTopRightIcon,
   Breadcrumb,
@@ -36,24 +35,15 @@ export function Flows() {
   const searchString = searchParams.get('q') ?? ''
   const debouncedSearchString = useThrottle(searchString, 200)
 
-  const {
-    data,
-    error,
-    loading,
-    networkStatus,
-    pageInfo,
-    refetch,
-    fetchNextPage,
-  } = useFetchPaginatedData(
-    { queryHook: useFlowsQuery, keyPath: ['flows'] },
-    { q: debouncedSearchString }
-  )
+  const { data, error, loading, pageInfo, refetch, fetchNextPage } =
+    useFetchPaginatedData(
+      { queryHook: useFlowsQuery, keyPath: ['flows'] },
+      { q: debouncedSearchString }
+    )
 
   const flows = mapExistingNodes(data?.flows)
   const hasActiveSearch = !!debouncedSearchString
-  const isSearchPending =
-    searchString !== debouncedSearchString ||
-    networkStatus === NetworkStatus.setVariables
+  const isSearchPending = searchString !== debouncedSearchString || loading
 
   if (!data && loading) return <LoadingIndicator />
 

--- a/assets/src/components/utils/table/useFetchPaginatedData.tsx
+++ b/assets/src/components/utils/table/useFetchPaginatedData.tsx
@@ -1,5 +1,6 @@
 import {
   ErrorPolicy,
+  NetworkStatus,
   OperationVariables,
   QueryHookOptions,
   QueryResult,
@@ -48,6 +49,7 @@ export type VirtualSlice = Parameters<
 export type FetchPaginatedDataResult<TQueryType> = {
   data: TQueryType | undefined
   loading: boolean
+  networkStatus: NetworkStatus
   error: any
   refetch: () => Promise<any>
   pageInfo: PageInfoFragment
@@ -132,6 +134,7 @@ export function useFetchPaginatedData<
   return {
     data,
     loading,
+    networkStatus: queryResult.networkStatus,
     error,
     refetch,
     pageInfo,

--- a/assets/src/components/utils/table/useFetchPaginatedData.tsx
+++ b/assets/src/components/utils/table/useFetchPaginatedData.tsx
@@ -1,6 +1,5 @@
 import {
   ErrorPolicy,
-  NetworkStatus,
   OperationVariables,
   QueryHookOptions,
   QueryResult,
@@ -49,7 +48,6 @@ export type VirtualSlice = Parameters<
 export type FetchPaginatedDataResult<TQueryType> = {
   data: TQueryType | undefined
   loading: boolean
-  networkStatus: NetworkStatus
   error: any
   refetch: () => Promise<any>
   pageInfo: PageInfoFragment
@@ -134,7 +132,6 @@ export function useFetchPaginatedData<
   return {
     data,
     loading,
-    networkStatus: queryResult.networkStatus,
     error,
     refetch,
     pageInfo,


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
Prevent stale Flow results from appearing while a throttled search query is loading.

<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.plrl-dev-aws.onplural.sh

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
