### PR TITLE
fix: add musl build tags to Dockerfiles for compatibility with monty

### DIFF
--- a/go/deployment-operator/dockerfiles/agent-harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/agent-harness/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6-alpine AS builder
+FROM golang:1.26.6-bookworm AS builder
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/go/deployment-operator/dockerfiles/agent-harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/agent-harness/base.Dockerfile
@@ -26,6 +26,7 @@ RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build \
+    -tags musl \
     -trimpath \
     -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/agentrun-harness/environment.Version=${VERSION}" \
     -o /agent-harness \
@@ -36,6 +37,7 @@ RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build \
+    -tags musl \
     -trimpath \
     -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/cmd/mcpserver/agent.Version=${VERSION}" \
     -o /agent-mcpserver \
@@ -46,6 +48,7 @@ RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build \
+    -tags musl \
     -trimpath \
     -ldflags="-s -w" \
     -o /agent-bootstrap \

--- a/go/deployment-operator/dockerfiles/agent-harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/agent-harness/base.Dockerfile
@@ -26,7 +26,6 @@ RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build \
-    -tags musl \
     -trimpath \
     -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/agentrun-harness/environment.Version=${VERSION}" \
     -o /agent-harness \
@@ -37,7 +36,6 @@ RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build \
-    -tags musl \
     -trimpath \
     -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/cmd/mcpserver/agent.Version=${VERSION}" \
     -o /agent-mcpserver \
@@ -48,7 +46,6 @@ RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build \
-    -tags musl \
     -trimpath \
     -ldflags="-s -w" \
     -o /agent-bootstrap \

--- a/go/deployment-operator/dockerfiles/harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/harness/base.Dockerfile
@@ -27,6 +27,7 @@ RUN CGO_ENABLED=0 \
   GOOS=${TARGETOS} \
   GOARCH=${TARGETARCH} \
   go build \
+  -tags musl \
   -trimpath \
   -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/harness/environment.Version=${VERSION}" \
   -o /plural/harness \

--- a/go/deployment-operator/dockerfiles/harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/harness/base.Dockerfile
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 \
   go build \
   -tags musl \
   -trimpath \
-  -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/harness/environment.Version=${VERSION}" \
+  -ldflags="-s -w -X github.com/pluralsh/deployment-operator/pkg/harness/environment.Version=${VERSION}" \
   -o /plural/harness \
   cmd/harness/main.go
 

--- a/go/deployment-operator/dockerfiles/harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/harness/base.Dockerfile
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 \
   go build \
   -tags musl \
   -trimpath \
-  -ldflags="-s -w -X github.com/pluralsh/deployment-operator/pkg/harness/environment.Version=${VERSION}" \
+  -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/harness/environment.Version=${VERSION}" \
   -o /plural/harness \
   cmd/harness/main.go
 

--- a/go/deployment-operator/dockerfiles/harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/harness/base.Dockerfile
@@ -27,7 +27,6 @@ RUN CGO_ENABLED=0 \
   GOOS=${TARGETOS} \
   GOARCH=${TARGETARCH} \
   go build \
-  -tags musl \
   -trimpath \
   -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/harness/environment.Version=${VERSION}" \
   -o /plural/harness \

--- a/go/deployment-operator/dockerfiles/harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/harness/base.Dockerfile
@@ -27,6 +27,7 @@ RUN CGO_ENABLED=0 \
   GOOS=${TARGETOS} \
   GOARCH=${TARGETARCH} \
   go build \
+  -tags musl \
   -trimpath \
   -ldflags="-s -w -X github.com/pluralsh/deployment-operator/pkg/harness/environment.Version=${VERSION}" \
   -o /plural/harness \

--- a/go/deployment-operator/dockerfiles/mcpserver/terraform-server/Dockerfile
+++ b/go/deployment-operator/dockerfiles/mcpserver/terraform-server/Dockerfile
@@ -18,7 +18,7 @@ RUN go mod download
 COPY deployment-operator/ ./
 
 # Build the MCP server binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o terraform-mcpserver cmd/mcpserver/terraform-server/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -tags musl -a -installsuffix cgo -o terraform-mcpserver cmd/mcpserver/terraform-server/main.go
 
 # Use a minimal base image
 FROM alpine:3.22.1

--- a/go/deployment-operator/dockerfiles/mcpserver/terraform-server/Dockerfile
+++ b/go/deployment-operator/dockerfiles/mcpserver/terraform-server/Dockerfile
@@ -18,7 +18,7 @@ RUN go mod download
 COPY deployment-operator/ ./
 
 # Build the MCP server binary
-RUN CGO_ENABLED=0 GOOS=linux go build -tags musl -a -installsuffix cgo -o terraform-mcpserver cmd/mcpserver/terraform-server/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o terraform-mcpserver cmd/mcpserver/terraform-server/main.go
 
 # Use a minimal base image
 FROM alpine:3.22.1

--- a/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 \
     go build \
     -tags musl \
     -trimpath \
-    -ldflags="-s -w -X github.com/pluralsh/deployment-operator/pkg/sentinel-harness/environment.Version=${VERSION}" \
+    -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/sentinel-harness/environment.Version=${VERSION}" \
     -o /sentinel-harness \
     cmd/sentinel-harness/main.go
 

--- a/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.26.6-alpine AS builder
 
 ARG TARGETARCH
-ARG TARGETOS  
+ARG TARGETOS
 ARG VERSION
 
 WORKDIR /workspace
@@ -26,6 +26,7 @@ RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build \
+    -tags musl \
     -trimpath \
     -ldflags="-s -w -X github.com/pluralsh/deployment-operator/pkg/sentinel-harness/environment.Version=${VERSION}" \
     -o /sentinel-harness \

--- a/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
@@ -26,7 +26,6 @@ RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build \
-    -tags musl \
     -trimpath \
     -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/sentinel-harness/environment.Version=${VERSION}" \
     -o /sentinel-harness \

--- a/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 \
     go build \
     -tags musl \
     -trimpath \
-    -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/sentinel-harness/environment.Version=${VERSION}" \
+    -ldflags="-s -w -X github.com/pluralsh/deployment-operator/pkg/sentinel-harness/environment.Version=${VERSION}" \
     -o /sentinel-harness \
     cmd/sentinel-harness/main.go
 

--- a/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
+++ b/go/deployment-operator/dockerfiles/sentinel-harness/base.Dockerfile
@@ -26,6 +26,7 @@ RUN CGO_ENABLED=0 \
     GOOS=${TARGETOS} \
     GOARCH=${TARGETARCH} \
     go build \
+    -tags musl \
     -trimpath \
     -ldflags="-s -w -X github.com/pluralsh/console/go/deployment-operator/pkg/sentinel-harness/environment.Version=${VERSION}" \
     -o /sentinel-harness \


### PR DESCRIPTION
- Updated MCP server Dockerfile to include `-tags musl` for building the server binary.
- Added `-tags musl` to the build commands in harness, sentinel-harness, and agent-harness Dockerfiles for improved compatibility across platforms.

<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

## Test Plan
<!--- Please describe the tests you have added and your testing environment (if applicable). -->
Test environment: https://console.plrl-dev-aws.onplural.sh/

## Checklist
<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console
