### PR TITLE
Dechonk the UI: default controls to the small size variant

### DIFF
--- a/assets/design-system/src/components/Button.tsx
+++ b/assets/design-system/src/components/Button.tsx
@@ -35,6 +35,7 @@ export type ButtonProps = {
   innerFlexProps?: FlexProps
   // flags- keeping this pattern instead of using "size" and "type" for backwards compatibility
   small?: boolean
+  medium?: boolean
   large?: boolean
   primary?: boolean
   secondary?: boolean
@@ -75,6 +76,7 @@ const Button = memo(
     disabled,
     children,
     small,
+    medium,
     large,
     secondary,
     tertiary,
@@ -97,7 +99,7 @@ const Button = memo(
       'auto'
     )
 
-    const buttonSize = large ? 'large' : small ? 'small' : 'medium'
+    const buttonSize = large ? 'large' : medium && !small ? 'medium' : 'small'
     const buttonType = secondary
       ? 'secondary'
       : tertiary

--- a/assets/design-system/src/components/Button.tsx
+++ b/assets/design-system/src/components/Button.tsx
@@ -99,8 +99,7 @@ const Button = memo(
       'auto'
     )
 
-    // `small` is the default, but stays destructured so it never reaches the DOM
-    const buttonSize = large ? 'large' : medium ? 'medium' : 'small'
+    const buttonSize = large ? 'large' : medium && !small ? 'medium' : 'small'
     const buttonType = secondary
       ? 'secondary'
       : tertiary

--- a/assets/design-system/src/components/Button.tsx
+++ b/assets/design-system/src/components/Button.tsx
@@ -99,7 +99,8 @@ const Button = memo(
       'auto'
     )
 
-    const buttonSize = large ? 'large' : medium && !small ? 'medium' : 'small'
+    // `small` is the default, but stays destructured so it never reaches the DOM
+    const buttonSize = large ? 'large' : medium ? 'medium' : 'small'
     const buttonType = secondary
       ? 'secondary'
       : tertiary

--- a/assets/design-system/src/components/Input2.tsx
+++ b/assets/design-system/src/components/Input2.tsx
@@ -289,8 +289,7 @@ function Input2({
 
   const parentFillLevel = useFillLevel()
 
-  // `small` is the default, but stays destructured so it never reaches the DOM
-  size = size || (large ? 'large' : medium ? 'medium' : 'small')
+  size = size || (large ? 'large' : medium && !small ? 'medium' : 'small')
 
   inputProps = mergeProps(useFormField()?.fieldProps ?? {}, inputProps)
 

--- a/assets/design-system/src/components/Input2.tsx
+++ b/assets/design-system/src/components/Input2.tsx
@@ -234,6 +234,7 @@ function Input2({
   titleContent,
   size,
   small,
+  medium,
   large,
   raised = false,
   onEnter,
@@ -288,7 +289,7 @@ function Input2({
 
   const parentFillLevel = useFillLevel()
 
-  size = size || (large ? 'large' : small ? 'small' : 'medium')
+  size = size || (large ? 'large' : medium && !small ? 'medium' : 'small')
 
   inputProps = mergeProps(useFormField()?.fieldProps ?? {}, inputProps)
 

--- a/assets/design-system/src/components/Input2.tsx
+++ b/assets/design-system/src/components/Input2.tsx
@@ -289,7 +289,8 @@ function Input2({
 
   const parentFillLevel = useFillLevel()
 
-  size = size || (large ? 'large' : medium && !small ? 'medium' : 'small')
+  // `small` is the default, but stays destructured so it never reaches the DOM
+  size = size || (large ? 'large' : medium ? 'medium' : 'small')
 
   inputProps = mergeProps(useFormField()?.fieldProps ?? {}, inputProps)
 

--- a/assets/design-system/src/components/ListBoxItem.tsx
+++ b/assets/design-system/src/components/ListBoxItem.tsx
@@ -41,7 +41,7 @@ const ListBoxItemInner = styled.div<Partial<ListBoxItemProps>>(
     alignItems: 'center',
     position: 'relative',
     width: 'auto',
-    padding: `${theme.spacing.xsmall}px ${theme.spacing.medium}px`,
+    padding: `${theme.spacing.xxsmall}px ${theme.spacing.small}px`,
     backgroundColor: 'none',
     cursor: 'pointer',
     '&:hover': {
@@ -147,7 +147,7 @@ const ListBoxFooterInner = styled.button<{ $focused?: boolean }>(
     display: 'flex',
     position: 'relative',
     width: '100%',
-    padding: `${theme.spacing.small}px ${theme.spacing.medium}px`,
+    padding: `${theme.spacing.xsmall}px ${theme.spacing.small}px`,
     '&:hover': {
       backgroundColor:
         theme.mode === 'light'

--- a/assets/design-system/src/components/Select.tsx
+++ b/assets/design-system/src/components/Select.tsx
@@ -168,7 +168,7 @@ const SelectButtonInner = styled.div<{
       display: 'flex',
       flexDirection: 'row',
       flexShrink: 1,
-      padding: `${size === 'medium' ? 9 : 5}px ${theme.spacing.medium}px`,
+      padding: `${size === 'large' ? 13 : size === 'medium' ? 9 : 5}px ${theme.spacing.medium}px`,
       width: '100%',
       '.children': {
         flexGrow: 1,
@@ -221,7 +221,7 @@ function SelectButton({
   children,
   showArrow = true,
   isOpen,
-  size = 'medium',
+  size = 'small',
   transparent = false,
   isDisabled,
   ...props
@@ -299,7 +299,7 @@ function Select({
   name,
   triggerButton,
   placement,
-  size = 'medium',
+  size = 'small',
   width,
   maxHeight,
   transparent = false,

--- a/assets/design-system/src/theme.tsx
+++ b/assets/design-system/src/theme.tsx
@@ -162,7 +162,7 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
     Input: {
       Root: [
         {
-          caption: true,
+          body2: true,
           display: 'flex',
           overflow: 'hidden',
           justifyContent: 'space-between',
@@ -180,11 +180,6 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
             borderColor: 'border-outline-focused',
           },
         },
-        // multi-line inputs hold prose, so they keep the larger body type
-        ({ multiline }: any) =>
-          multiline && {
-            body2: true,
-          },
         ({ valid }: any) =>
           valid && {
             borderColor: 'border-outline',
@@ -210,6 +205,10 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
           flex: '1 1',
           height: '30px',
           lineHeight: '30px',
+          // caption type, written out because the `caption` alias resolves from
+          // props and would drag its own 16px line height along with it
+          fontSize: 12,
+          letterSpacing: '0.5px',
           color: 'text',
           _placeholder: {
             color: 'text-xlight',
@@ -224,6 +223,7 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
           large && {
             height: '46px',
             lineHeight: '46px',
+            fontSize: 14,
           },
         ({ disabled }: any) =>
           disabled && {

--- a/assets/design-system/src/theme.tsx
+++ b/assets/design-system/src/theme.tsx
@@ -162,7 +162,7 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
     Input: {
       Root: [
         {
-          body2: true,
+          caption: true,
           display: 'flex',
           overflow: 'hidden',
           justifyContent: 'space-between',
@@ -180,6 +180,11 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
             borderColor: 'border-outline-focused',
           },
         },
+        // multi-line inputs hold prose, so they keep the larger body type
+        ({ multiline }: any) =>
+          multiline && {
+            body2: true,
+          },
         ({ valid }: any) =>
           valid && {
             borderColor: 'border-outline',
@@ -203,8 +208,8 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
         {
           width: '100%',
           flex: '1 1',
-          height: '38px',
-          lineHeight: '38px',
+          height: '30px',
+          lineHeight: '30px',
           color: 'text',
           _placeholder: {
             color: 'text-xlight',
@@ -234,8 +239,8 @@ const getHonorableThemeProps = ({ mode }: { mode: ColorMode }) => {
           paddingLeft: 'medium',
           paddingRight: 'medium',
           lineHeight: 'inherit',
-          paddingTop: 9,
-          paddingBottom: 9,
+          paddingTop: 7,
+          paddingBottom: 7,
         },
         ({ small }: any) =>
           small && {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses [PROD-4897 — dechonk the UI](https://linear.app/pluralsh/issue/PROD-4897/dechonk-the-ui).

The theory behind this PR is that the console isn't chonky because its controls are badly designed, it's chonky because it defaults to the `medium` variant of controls that already ship a perfectly good `small` variant. Most call sites already know this: **302 of the 535 `<Button>` usages in `assets/src` pass `small` explicitly.** This flips the defaults in the design system so the remaining ones come along too, rather than editing hundreds of call sites.

No call site was touched and no size variant was removed, so reverting is a matter of flipping the defaults back.

## What changes

**Controls now render at 32px instead of 38–40px.**

| Component | Before | After |
| --- | --- | --- |
| `Button` | `medium`, 38px, 14px type | `small`, 32px, 12px type |
| `Input2` (and `ComboBox`, which wraps it) | `medium`, 40px, 14px type | `small`, 32px, 12px type |
| `Select` / `SelectButton` | `medium`, 40px | `small`, 32px |
| Legacy honorable `Input` | 40px, 14px type | 32px, 12px type |

`Button` and `Input2` gain an explicit `medium` prop so anything that genuinely needs the old size can ask for it, and an explicit `small` still wins over it. `large` is untouched, and the 16 buttons that pass it stay large.

**Dropdown menu rows got tighter.** `ListBoxItem` was 8px vertical / 16px horizontal padding, making a 36px row hang off a control that is now 32px. It's now 4px / 12px, so a menu row matches the trigger that opened it. `ListBoxFooter` moves in step.

**Multi-line inputs keep the larger type.** Shrinking a textarea's font to 12px makes prose genuinely harder to write, so the smaller type is set on honorable's `InputBase` part rather than on the `Input` root — textareas render through the `TextArea` part and never see it. Worth knowing if you touch this: setting `caption: true` on the root does *not* work here, because honorable resolves those typography flags from props and its `caption` resolver runs after `body2` regardless of declaration order, so `caption` silently wins. That's also why the 12px is written out as `fontSize`/`letterSpacing` instead of using the alias, which would drag its own 16px line height along with it.

**Bug fix in `Select`:** the content padding read `size === 'medium' ? 9 : 5`, so a `size="large"` select silently rendered with small padding. It's now `large ? 13 : medium ? 9 : 5`, which lines the three sizes up with `Input2` at 32 / 40 / 48px.

## What this deliberately does not touch

Chips are already dense at 24px, `IconFrame`'s `medium` is 32px and now lines up with the new control height, and table rows, tabs and card padding are a separate axis of chonk. If the control-size change lands well, those are the natural follow-ups.

## Test Plan

`tsc --build`, eslint, prettier and both vitest suites (design system + console, 167 tests) pass.

Beyond that this is a pure default-size change with no behavioral surface, so verification was visual. I ran the design system Storybook and measured the rendered results in the browser:

- Default buttons now render identically to explicitly-`small` ones, and `large` buttons are still visibly larger.
- Input boxes measured 48px for `large`, 32px for default, 32px for `small`, with 14/12/12px type respectively.
- The textarea in the Multiline story measured 14px, confirming prose inputs kept the larger type.
- Nothing clipped, and icons stayed vertically centred.

Buttons — items 3 and 4 are the default size, items 5 and 6 are explicitly `small`, and they now match:

[Button story showing default buttons matching the small variant](https://cursor.com/agents/bc-26074c1a-ab61-437f-a921-f07911d6fa83/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdechonk-buttons.png)

Select with its dropdown open — trigger and menu rows are now the same scale:

[Select story with an open dropdown menu](https://cursor.com/agents/bc-26074c1a-ab61-437f-a921-f07911d6fa83/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdechonk-select-open.png)

Inputs — the first pair is `large`, the rest are default and `small`:

[Input story showing large, default and small input sizes](https://cursor.com/agents/bc-26074c1a-ab61-437f-a921-f07911d6fa83/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdechonk-inputs.png)

To try it locally, run `yarn start` in `assets/`. The vite config aliases `@pluralsh/design-system` straight to `design-system/src`, so no design-system build step is needed. Worth looking at: rows that mix a `Button` with an `IconFrame` or a `Select`, forms that mix legacy `Input` with `Input2`, and long dropdown menus with `description` text on their items.

Test environment: https://console.your-env.onplural.sh/

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26074c1a-ab61-437f-a921-f07911d6fa83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26074c1a-ab61-437f-a921-f07911d6fa83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

