### PR TITLE
recreate missing flow if sha matches and unchanged

### DIFF
--- a/go/controller/internal/controller/flow_controller.go
+++ b/go/controller/internal/controller/flow_controller.go
@@ -99,6 +99,18 @@ func (r *FlowReconciler) Process(ctx context.Context, req ctrl.Request) (_ ctrl.
 		utils.MarkCondition(flow.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
 		return ctrl.Result{}, err
 	}
+	if !changed {
+		exists, err := r.flowExists(ctx, flow)
+		if err != nil {
+			logger.Error(err, "unable to get flow from Console API")
+			utils.MarkCondition(flow.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionFalse, v1alpha1.SynchronizedConditionReasonError, err.Error())
+			return ctrl.Result{}, err
+		}
+		if !exists {
+			logger.Info("flow not found in Console API, recreating", "flow", flow.FlowName())
+			changed = true
+		}
+	}
 	if changed {
 		project, res, err := common.Project(ctx, r.Client, r.Scheme, flow)
 		if res != nil || err != nil {
@@ -141,6 +153,22 @@ func (r *FlowReconciler) Process(ctx context.Context, req ctrl.Request) (_ ctrl.
 	utils.MarkCondition(flow.SetCondition, v1alpha1.SynchronizedConditionType, v1.ConditionTrue, v1alpha1.SynchronizedConditionReason, "")
 
 	return flow.Spec.Reconciliation.Requeue(), nil
+}
+
+func (r *FlowReconciler) flowExists(ctx context.Context, flow *v1alpha1.Flow) (bool, error) {
+	if !flow.Status.HasID() {
+		return false, nil
+	}
+
+	existingFlow, err := r.ConsoleClient.GetFlow(ctx, flow.Status.GetID())
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return existingFlow != nil, nil
 }
 
 func (r *FlowReconciler) Attributes(

--- a/go/controller/internal/controller/flow_controller_test.go
+++ b/go/controller/internal/controller/flow_controller_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Flow Controller", Ordered, func() {
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
-			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
+			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
 			fakeConsoleClient.On("UpsertFlow", mock.Anything, mock.Anything).Return(test.flowFragment, nil)
 
 			nr := &controller.FlowReconciler{
@@ -146,6 +146,42 @@ var _ = Describe("Flow Controller", Ordered, func() {
 			Expect(common.SanitizeStatusConditions(flw.Status)).To(Equal(common.SanitizeStatusConditions(test.expectedStatus)))
 		})
 
+		It("should recreate the API flow when status points to a missing resource", func() {
+			const recreatedID = "456"
+			const missingID = "missing-flow"
+
+			Expect(common.MaybePatch(k8sClient, &v1alpha1.Flow{
+				ObjectMeta: metav1.ObjectMeta{Name: flowName, Namespace: namespace},
+			}, func(p *v1alpha1.Flow) {
+				p.Status.ID = lo.ToPtr(missingID)
+				p.Status.SHA = lo.ToPtr("PWP5EBI7YMVTF7VLCCKG7K3LXEKCNK36HGVFIOJIT3MJFBSKVEOQ====")
+			})).To(Succeed())
+
+			flowFragment := &gqlclient.FlowFragment{ID: recreatedID}
+			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
+			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
+			fakeConsoleClient.On("GetFlow", mock.Anything, missingID).Return(nil, errors.NewNotFound(schema.GroupResource{}, missingID))
+			fakeConsoleClient.
+				On("UpsertFlow", mock.Anything, mock.MatchedBy(func(attrs gqlclient.FlowAttributes) bool {
+					return attrs.Name == flowName
+				})).
+				Return(flowFragment, nil)
+
+			reconciler := &controller.FlowReconciler{
+				Client:        k8sClient,
+				Scheme:        k8sClient.Scheme(),
+				ConsoleClient: fakeConsoleClient,
+			}
+
+			_, err := reconciler.Process(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			flow := &v1alpha1.Flow{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, flow)).To(Succeed())
+			Expect(flow.Status.GetID()).To(Equal(recreatedID))
+			Expect(flow.Status.GetSHA()).To(Equal("PWP5EBI7YMVTF7VLCCKG7K3LXEKCNK36HGVFIOJIT3MJFBSKVEOQ===="))
+		})
+
 		It("should requeue when binding is not ready", func() {
 			Expect(common.MaybePatchObject(k8sClient, &v1alpha1.Flow{
 				ObjectMeta: metav1.ObjectMeta{Name: flowName, Namespace: namespace},
@@ -165,7 +201,7 @@ var _ = Describe("Flow Controller", Ordered, func() {
 
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
-			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
+			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
 
 			fr := &controller.FlowReconciler{
 				Client:        k8sClient,
@@ -197,7 +233,7 @@ var _ = Describe("Flow Controller", Ordered, func() {
 			flowFragment := &gqlclient.FlowFragment{ID: id}
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
-			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
+			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
 			fakeConsoleClient.
 				On("UpsertFlow", mock.Anything, mock.MatchedBy(func(attrs gqlclient.FlowAttributes) bool {
 					if len(attrs.FlowWorkbenches) != 1 {
@@ -227,7 +263,7 @@ var _ = Describe("Flow Controller", Ordered, func() {
 			flowFragment := &gqlclient.FlowFragment{ID: id}
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
-			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
+			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything).Return(nil, errors.NewNotFound(schema.GroupResource{}, id))
 			fakeConsoleClient.
 				On("UpsertFlow", mock.Anything, mock.MatchedBy(func(attrs gqlclient.FlowAttributes) bool {
 					return attrs.MaxPreviews != nil && *attrs.MaxPreviews == 5
@@ -263,7 +299,7 @@ var _ = Describe("Flow Controller", Ordered, func() {
 			}
 			fakeConsoleClient := mocks.NewConsoleClientMock(mocks.TestingT)
 			fakeConsoleClient.On("UseCredentials", mock.Anything, mock.Anything).Return("", nil)
-			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything, mock.Anything).Return(flowFragment, nil)
+			fakeConsoleClient.On("GetFlow", mock.Anything, mock.Anything).Return(flowFragment, nil)
 			fakeConsoleClient.On("DeleteFlow", mock.Anything, mock.Anything).Return(nil)
 
 			nsReconciler := &controller.FlowReconciler{


### PR DESCRIPTION
<!-- Describe your changes here, include the motivation/context, test coverage, -->
<!-- the type of change i.e. breaking change, new feature, or bug fix -->
<!-- and related GitHub issue or screenshots (if applicable). -->

<!-- Adding a meaningful title and description allows us to better communicate -->
<!-- your work with our users. -->

Mirrors behavior in the servicedeployment reconciler. Will correct drift between K8s API Storage and the Console DB. If the Flow sha is unchanged and it doesn't exist in the console db, recreate it in the db.  

## Test Plan

<!--- Please describe the tests you have added and your testing environment (if applicable). -->

Test environment: https://console.plrl-dev-aws.onplural.sh/

## Checklist

<!--- Go over all the following points to make sure you've checked all that apply before merging. -->
<!--- If you're unsure about any of these, don't hesitate to ask in our Discord. -->

- [ ] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code).

Plural Flow: console

<!-- To enable a documentation preview, uncomment the next two lines. -->
<!-- Plural Flow: docs -->
<!-- Plural Preview: docs -->
