### PR TITLE
Add Kubeflow Spark Operator compatibility scraper

### DIFF
--- a/.github/workflows/compatibility-schema-validation.yaml
+++ b/.github/workflows/compatibility-schema-validation.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/compatibility-schema-validation.yaml'
+      - 'utils/compatibility/**'
       - 'static/addons/**'
       - 'static/compatibilities/**'
       - 'static/compatibilities.yaml'
@@ -12,6 +13,7 @@ on:
       - master
     paths:
       - '.github/workflows/compatibility-schema-validation.yaml'
+      - 'utils/compatibility/**'
       - 'static/addons/**'
       - 'static/compatibilities/**'
       - 'static/compatibilities.yaml'
@@ -20,6 +22,23 @@ permissions:
   contents: read
 
 jobs:
+  test-compatibility-scrapers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install parser test dependency
+        run: python -m pip install packaging==24.1
+
+      - name: Test compatibility scrapers
+        run: python -m unittest discover -s utils/compatibility/tests -v
+
   validate-compatibility-schemas:
     runs-on: ubuntu-latest
     steps:

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -1,4 +1,5 @@
 names:
+- spark-operator
 - kubevirt
 - argo-rollouts
 - aws-ebs-csi-driver

--- a/static/compatibilities/spark-operator.yaml
+++ b/static/compatibilities/spark-operator.yaml
@@ -1,0 +1,41 @@
+icon: https://avatars.githubusercontent.com/u/33164907?s=48&v=4
+git_url: https://github.com/kubeflow/spark-operator
+release_url: https://github.com/kubeflow/spark-operator/releases/tag/v{vsn}
+helm_repository_url: https://kubeflow.github.io/spark-operator
+versions:
+- version: 2.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.3.0
+  images: ['ghcr.io/kubeflow/spark-operator/controller:2.3.0']
+- version: 2.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.2.0
+  images: ['ghcr.io/kubeflow/spark-operator/controller:2.2.0']
+- version: 2.1.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.1.0
+  images: ['docker.io/kubeflow/spark-operator:2.1.0']
+- version: 2.0.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.0.0
+  images: ['docker.io/kubeflow/spark-operator:2.0.0']

--- a/utils/compatibility/scrapers/spark-operator.py
+++ b/utils/compatibility/scrapers/spark-operator.py
@@ -1,0 +1,88 @@
+"""Kubeflow Spark Operator compatibility from the upstream version matrix.
+
+Only modern semver operator releases are supported. Legacy v1beta2 tags encode
+both operator and Spark versions and cannot use the standard release URL.
+"""
+
+import re
+from collections import OrderedDict
+
+from packaging.version import Version
+
+README_URL = "https://raw.githubusercontent.com/kubeflow/spark-operator/master/README.md"
+
+
+def parse_matrix(markdown):
+    """Read explicit modern operator families, never the Base Spark column."""
+    section = re.search(r"^## Version Matrix\s*$(.*?)(?=^## |\Z)", markdown, re.M | re.S)
+    if not section:
+        raise ValueError("Spark Operator Version Matrix section not found")
+    rows = [
+        [cell.strip().strip("`") for cell in line.strip().strip("|").split("|")]
+        for line in section.group(1).splitlines()
+        if line.strip().startswith("|")
+    ]
+    if not rows or rows[0] != [
+        "Operator Version", "API Version", "Kubernetes Version", "Base Spark Version"
+    ]:
+        raise ValueError("Unexpected Spark Operator matrix columns")
+    families = {}
+    for cells in rows[2:]:
+        if len(cells) != 4:
+            raise ValueError("Malformed Spark Operator matrix row")
+        operator, _, kube, _ = cells
+        if operator.startswith("v1beta2-"):
+            continue
+        family = re.fullmatch(r"v(\d+)\.(\d+)\.x", operator)
+        minimum = re.fullmatch(r"1\.(\d+)\+", kube)
+        if not family or not minimum:
+            raise ValueError(f"Unsupported matrix row: {operator}: {kube}")
+        key = tuple(map(int, family.groups()))
+        if key in families:
+            raise ValueError(f"Duplicate operator family: {operator}")
+        families[key] = int(minimum.group(1))
+    if not families:
+        raise ValueError("No modern operator families found")
+    return families
+
+
+def build_rows(markdown, chart_versions, current_kube):
+    families = parse_matrix(markdown)
+    latest = re.fullmatch(r"1\.(\d+)", current_kube)
+    if not latest:
+        raise ValueError(f"Unsupported Kubernetes upper bound: {current_kube}")
+    latest_minor = int(latest.group(1))
+    rows = []
+    for app, chart in chart_versions.items():
+        # Chart appVersion is the operator version, not its bundled Spark version.
+        if not re.fullmatch(r"\d+\.\d+\.\d+", app):
+            continue
+        version = Version(app)
+        minimum = families.get((version.major, version.minor))
+        if minimum is None:
+            continue
+        if minimum > latest_minor:
+            raise ValueError("Kubernetes upper bound precedes documented minimum")
+        rows.append(OrderedDict([
+            ("version", app),
+            ("kube", [f"1.{minor}" for minor in range(latest_minor, minimum - 1, -1)]),
+            ("chart_version", chart),
+            ("images", []),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ]))
+    if not rows:
+        raise ValueError("No chart versions matched the documented operator families")
+    return sorted(rows, key=lambda row: Version(row["version"]), reverse=True)
+
+
+def scrape():
+    from utils import fetch_page, get_chart_versions, current_kube_version, update_compatibility_info
+
+    page = fetch_page(README_URL)
+    if not page:
+        raise ValueError("Could not fetch Spark Operator version matrix")
+    rows = build_rows(
+        page.decode("utf-8"), get_chart_versions("spark-operator"), current_kube_version()
+    )
+    update_compatibility_info("../../static/compatibilities/spark-operator.yaml", rows)

--- a/utils/compatibility/tests/README.md
+++ b/utils/compatibility/tests/README.md
@@ -1,0 +1,33 @@
+# Spark Operator scraper verification
+
+Run from the repository root:
+
+```sh
+python -m unittest discover -s utils/compatibility/tests -v
+```
+
+The scraper reads the **Version Matrix** in the upstream
+[Kubeflow Spark Operator README](https://github.com/kubeflow/spark-operator#version-matrix),
+matches modern operator families against `appVersion` in the official
+[Helm index](https://kubeflow.github.io/spark-operator/index.yaml), and expands the
+documented open-ended Kubernetes minimum only as far as this repository's
+`KUBE_VERSION`. This represents upstream's declared compatibility, not a claim
+that every expanded Kubernetes version was independently tested.
+
+Only documented modern semver families are emitted. Legacy `v1beta2-...` tags
+encode both operator and Spark versions and are excluded because they do not
+fit the shared version sorting and standard `v{vsn}` release URL. New families
+absent from the upstream matrix are also excluded. As of the initial generation,
+this includes operator 2.4 and 2.5. Prerelease app versions are excluded.
+
+For a live generation, install `requirements.txt` and Helm, then run from
+`utils/compatibility`:
+
+```sh
+python -c "import importlib; importlib.import_module('scrapers.spark-operator').scrape()"
+```
+
+The shared updater reduces patch versions using the repository's existing
+convention and resolves container images through Helm. No Kubernetes cluster
+is needed for generation. Optional paid summarization is not needed for this
+scraper; leave its API keys unset when verifying only compatibility data.

--- a/utils/compatibility/tests/README.md
+++ b/utils/compatibility/tests/README.md
@@ -1,5 +1,9 @@
 # Spark Operator scraper verification
 
+The `test-compatibility-scrapers` job in `compatibility-schema-validation.yaml`
+runs this suite on pull requests and master pushes touching compatibility code
+or data. Tests isolate external helpers; no network, Helm or API keys are needed.
+
 Run from the repository root:
 
 ```sh

--- a/utils/compatibility/tests/test_spark_operator.py
+++ b/utils/compatibility/tests/test_spark_operator.py
@@ -1,0 +1,54 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "spark_operator", Path(__file__).parents[1] / "scrapers" / "spark-operator.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+MATRIX = """## Version Matrix
+
+| Operator Version | API Version | Kubernetes Version | Base Spark Version |
+| --- | --- | --- | --- |
+| `v2.3.x` | `v1beta2` | 1.16+ | `4.0.0` |
+| `v2.2.x` | `v1beta2` | 1.16+ | `3.5.5` |
+| `v1beta2-1.6.x-3.5.0` | `v1beta2` | 1.16+ | `3.5.0` |
+
+## Developer Guide
+| unrelated | table |
+"""
+
+
+class SparkOperatorTests(unittest.TestCase):
+    def test_operator_not_spark_or_chart_version(self):
+        rows = scraper.build_rows(MATRIX, {"2.3.0": "9.1.0", "4.0.0": "4.0.0"}, "1.18")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["version"], "2.3.0")
+        self.assertEqual(rows[0]["chart_version"], "9.1.0")
+        self.assertEqual(rows[0]["kube"], ["1.18", "1.17", "1.16"])
+
+    def test_skips_undocumented_prerelease_and_legacy(self):
+        rows = scraper.build_rows(MATRIX, {
+            "2.2.1": "2.2.1", "2.3.0": "2.3.0", "2.5.2": "2.5.2",
+            "2.3.0-rc.1": "2.3.0-rc.1", "v1beta2-1.6.2-3.5.0": "1.4.6"
+        }, "1.16")
+        self.assertEqual([r["version"] for r in rows], ["2.3.0", "2.2.1"])
+        self.assertEqual(rows[0]["kube"], ["1.16"])
+
+    def test_document_drift_fails_closed(self):
+        for document in ["", MATRIX.replace("Kubernetes Version", "Spark Version"),
+                         MATRIX.replace("1.16+", "TBD"), MATRIX.replace("v2.3.x", "latest")]:
+            with self.subTest(document=document), self.assertRaises(ValueError):
+                scraper.parse_matrix(document)
+
+    def test_bounds_and_empty_matches(self):
+        for charts, upper in [({"2.3.0": "2.3.0"}, "1.15"),
+                              ({"2.3.0": "2.3.0"}, "2.0"), ({}, "1.36")]:
+            with self.subTest(charts=charts, upper=upper), self.assertRaises(ValueError):
+                scraper.build_rows(MATRIX, charts, upper)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_spark_operator.py
+++ b/utils/compatibility/tests/test_spark_operator.py
@@ -1,6 +1,8 @@
 import importlib.util
 from pathlib import Path
 import unittest
+from unittest.mock import Mock, patch
+from types import ModuleType
 
 spec = importlib.util.spec_from_file_location(
     "spark_operator", Path(__file__).parents[1] / "scrapers" / "spark-operator.py"
@@ -22,6 +24,36 @@ MATRIX = """## Version Matrix
 
 
 class SparkOperatorTests(unittest.TestCase):
+    def fake_utils(self, page):
+        helpers = ModuleType("utils")
+        helpers.fetch_page = Mock(return_value=page)
+        helpers.get_chart_versions = Mock(return_value={"2.3.0": "9.1.0"})
+        helpers.current_kube_version = Mock(return_value="1.17")
+        helpers.update_compatibility_info = Mock()
+        return helpers
+
+    def test_scrape_connects_sources_to_updater(self):
+        helpers = self.fake_utils(MATRIX.encode("utf-8"))
+        with patch.dict("sys.modules", {"utils": helpers}):
+            scraper.scrape()
+        helpers.fetch_page.assert_called_once_with(scraper.README_URL)
+        helpers.get_chart_versions.assert_called_once_with("spark-operator")
+        helpers.current_kube_version.assert_called_once_with()
+        helpers.update_compatibility_info.assert_called_once_with(
+            "../../static/compatibilities/spark-operator.yaml",
+            [{"version": "2.3.0", "kube": ["1.17", "1.16"],
+              "chart_version": "9.1.0", "images": [],
+              "requirements": [], "incompatibilities": []}],
+        )
+
+    def test_scrape_does_not_update_on_unusable_source(self):
+        for page in (None, b"", b"no matrix", b"\xff"):
+            helpers = self.fake_utils(page)
+            with self.subTest(page=page), patch.dict("sys.modules", {"utils": helpers}):
+                with self.assertRaises(ValueError):
+                    scraper.scrape()
+            helpers.update_compatibility_info.assert_not_called()
+
     def test_operator_not_spark_or_chart_version(self):
         rows = scraper.build_rows(MATRIX, {"2.3.0": "9.1.0", "4.0.0": "4.0.0"}, "1.18")
         self.assertEqual(len(rows), 1)


### PR DESCRIPTION
Adds Kubeflow Spark Operator to the compatibility manifest with a scraper, application metadata, generated YAML, and focused regression tests. Resolves #4130.

The scraper reads the operator/Kubernetes columns from the upstream [Version Matrix](https://github.com/kubeflow/spark-operator/blob/cfc9cbaa571330df17140f1bc8e6560e566f33e2/README.md#version-matrix), matches concrete operator `appVersion` entries from the [official Helm index](https://kubeflow.github.io/spark-operator/index.yaml), and uses the shared updater to reduce versions and render chart images.

The documented `1.16+` minimum is expanded through the repository's `KUBE_VERSION` (1.36). These are upstream-declared compatibility ranges; this does not claim independent cluster testing on each Kubernetes version. The checked-in output covers the documented 2.0–2.3 families. The upstream matrix does not yet document 2.4/2.5, so they are deliberately skipped. Legacy compound `v1beta2-...` tags are excluded because they do not fit the shared semantic-version sorting/release URL. Base Spark versions are never treated as operator versions.

Validation:
- `python -m unittest discover -s utils/compatibility/tests -v`: 6 tests passed with Python 3.13 and packaging 24.1, including malformed/missing matrix, invalid bounds, operator-vs-Spark/chart separation, prerelease and undocumented-family exclusion, source-to-updater entry-point wiring, and no update on unusable source.
- Added the focused suite to the existing compatibility schema workflow with compatibility-code path triggers. Tests require no network, Helm or API keys. Workflow YAML and trigger/job wiring verified locally; hosted execution remains subject to repository CI policy.
- Executed the real `scrape()` entry point against upstream README and Helm index, using Helm 3.18.6: generated four version rows and resolved all four container image references successfully.
- `git diff --cached --check`: passed before commit.

No full Console application tests or live Kubernetes deployment tests were run; changes are confined to compatibility data and its scraper. See `utils/compatibility/tests/README.md` for reproduction and scope.

Submitted for consideration under the README's $300 new-scraper contributor reward. Payout eligibility and PayPal support are not yet confirmed; see #4130.
