### PR TITLE
Add Kong Ingress Controller compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -19242,6 +19242,63 @@ addons:
     chart_version: 2.7.0
     eolAt: '2022-12-09'
   name: keda
+- icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
+  git_url: https://github.com/Kong/kubernetes-ingress-controller
+  release_url: https://github.com/Kong/kubernetes-ingress-controller/releases/tag/v{vsn}
+  readme_url: https://developer.konghq.com/kubernetes-ingress-controller/version-compatibility/
+  helm_repository_url: https://charts.konghq.com
+  chart_name: ingress
+  versions:
+  - version: 3.5.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.24.0
+    images: ['kong/kubernetes-ingress-controller:3.5', 'kong:3.9']
+  - version: 3.4.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.20.0
+    images: ['kong/kubernetes-ingress-controller:3.4', 'kong:3.9']
+  - version: 3.3.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.16.0
+    images: ['kong/kubernetes-ingress-controller:3.3', 'kong:3.8']
+  - version: 3.2.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.13.1
+    images: ['kong/kubernetes-ingress-controller:3.2', 'kong:3.6']
+  - version: 3.1.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.12.0
+    images: ['kong/kubernetes-ingress-controller:3.1', 'kong:3.6']
+  - version: 3.0.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.10.2
+    images: ['kong/kubernetes-ingress-controller:3.0', 'kong:3.5']
+  - version: 2.12.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.8.0
+    images: ['kong/kubernetes-ingress-controller:2.12', 'kong:3.4']
+  name: kong-ingress-controller
 - icon: https://github.com/pluralsh/plural-artifacts/blob/main/monitoring/plural/icons/monitoring.png?raw=true
   git_url: https://github.com/prometheus-community/helm-charts
   release_url: https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-{vsn}

--- a/static/compatibilities/kong-ingress-controller.yaml
+++ b/static/compatibilities/kong-ingress-controller.yaml
@@ -1,0 +1,56 @@
+icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
+git_url: https://github.com/Kong/kubernetes-ingress-controller
+release_url: https://github.com/Kong/kubernetes-ingress-controller/releases/tag/v{vsn}
+readme_url: https://developer.konghq.com/kubernetes-ingress-controller/version-compatibility/
+helm_repository_url: https://charts.konghq.com
+chart_name: ingress
+versions:
+- version: 3.5.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.24.0
+  images: ['kong/kubernetes-ingress-controller:3.5', 'kong:3.9']
+- version: 3.4.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.20.0
+  images: ['kong/kubernetes-ingress-controller:3.4', 'kong:3.9']
+- version: 3.3.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.0
+  images: ['kong/kubernetes-ingress-controller:3.3', 'kong:3.8']
+- version: 3.2.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.13.1
+  images: ['kong/kubernetes-ingress-controller:3.2', 'kong:3.6']
+- version: 3.1.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.0
+  images: ['kong/kubernetes-ingress-controller:3.1', 'kong:3.6']
+- version: 3.0.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.2
+  images: ['kong/kubernetes-ingress-controller:3.0', 'kong:3.5']
+- version: 2.12.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.0
+  images: ['kong/kubernetes-ingress-controller:2.12', 'kong:3.4']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -22,6 +22,7 @@ names:
 - jaeger
 - karpenter
 - keda
+- kong-ingress-controller
 - kube-prometheus-stack
 - kyverno
 - linkerd

--- a/utils/compatibility/scrapers/kong-ingress-controller.py
+++ b/utils/compatibility/scrapers/kong-ingress-controller.py
@@ -1,0 +1,121 @@
+import hashlib
+import io
+import re
+import tarfile
+from urllib.parse import urljoin
+
+import requests
+import yaml
+from packaging.version import Version
+
+from utils import update_compatibility_info
+
+
+APP_NAME = "kong-ingress-controller"
+MATRIX_URL = "https://raw.githubusercontent.com/Kong/developer.konghq.com/main/app/kubernetes-ingress-controller/version-compatibility.md"
+CHART_INDEX_URL = "https://charts.konghq.com/index.yaml"
+REQUEST_TIMEOUT = 30
+
+
+def fetch(url):
+    response = requests.get(url, timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    return response.content
+
+
+def minor_version(value):
+    match = re.fullmatch(r"v?(\d+)\.(\d+)(?:\.\d+|\.x)?", str(value))
+    if not match:
+        raise ValueError(f"Unexpected Kong compatibility version: {value!r}")
+    return f"{int(match[1])}.{int(match[2])}"
+
+
+def parse_matrix(markdown):
+    blocks = re.findall(
+        r"{%\s*version_compatibility_table\s*%}(.*?){%\s*endversion_compatibility_table\s*%}",
+        markdown,
+        re.DOTALL,
+    )
+    matrices = [yaml.safe_load(block) for block in blocks]
+    matrices = [
+        matrix for matrix in matrices
+        if isinstance(matrix, dict) and matrix.get("compatible_product") == "Kubernetes"
+    ]
+    if len(matrices) != 1:
+        raise ValueError("Expected exactly one Kong Kubernetes compatibility table")
+
+    matrix = matrices[0]
+    declared = {minor_version(version) for version in matrix["versions"]}
+    supported = {}
+    for kube_version, controllers in matrix["compatible_versions"].items():
+        if not isinstance(controllers, list):
+            raise ValueError("Expected a list of compatible Kong controller versions")
+        kube_version = minor_version(kube_version)
+        for controller in controllers:
+            controller = minor_version(controller)
+            if controller not in declared:
+                raise ValueError(f"Undeclared Kong controller version: {controller}")
+            supported.setdefault(controller, set()).add(kube_version)
+
+    if not supported:
+        raise ValueError("Kong Kubernetes compatibility table is empty")
+    return supported
+
+
+def controller_minor(archive):
+    # Read the bundled dependency, then apply the parent chart's values override.
+    # Chart.yaml appVersion identifies Kong Gateway, not the ingress controller.
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as chart:
+        with chart.extractfile("ingress/charts/kong/values.yaml") as values_file:
+            dependency = yaml.safe_load(values_file)
+        with chart.extractfile("ingress/values.yaml") as values_file:
+            parent = yaml.safe_load(values_file)
+
+    image = dict(dependency["ingressController"]["image"])
+    override = parent.get("controller", {}).get("ingressController", {}).get("image", {})
+    image.update(override)
+    if image.get("repository") != "kong/kubernetes-ingress-controller":
+        raise ValueError(f"Unexpected Kong controller image: {image.get('repository')!r}")
+    return minor_version(image["tag"])
+
+
+def chart_versions(controller_versions):
+    index = yaml.safe_load(fetch(CHART_INDEX_URL))
+    entries = [
+        entry for entry in index["entries"]["ingress"]
+        if re.fullmatch(r"\d+\.\d+\.\d+", str(entry["version"]))
+    ]
+    if not entries:
+        raise ValueError("Kong chart index has no stable ingress charts")
+    entries.sort(key=lambda entry: Version(str(entry["version"])), reverse=True)
+    matched = {}
+    for entry in entries:
+        archive = fetch(urljoin(CHART_INDEX_URL, entry["urls"][0]))
+        if hashlib.sha256(archive).hexdigest() != entry["digest"]:
+            raise ValueError(f"Kong ingress chart {entry['version']} digest mismatch")
+        controller = controller_minor(archive)
+        if controller in controller_versions and controller not in matched:
+            matched[controller] = str(entry["version"])
+        if matched.keys() >= controller_versions:
+            break
+    return matched
+
+
+def scrape():
+    supported = parse_matrix(fetch(MATRIX_URL).decode("utf-8"))
+    charts = chart_versions(set(supported))
+    versions = []
+    for controller in sorted(supported, key=Version, reverse=True):
+        # Plural uses version rows as interval boundaries. The upstream table
+        # covers a minor family, so .0 also covers its earlier patch releases.
+        # Floating chart tags such as "3.5" establish no exact patch pin.
+        row = {
+            "version": f"{controller}.0",
+            "kube": sorted(supported[controller], key=Version, reverse=True),
+            "requirements": [],
+            "incompatibilities": [],
+        }
+        if controller in charts:
+            row["chart_version"] = charts[controller]
+        versions.append(row)
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", versions)

--- a/utils/compatibility/tests/test_kong_ingress_controller.py
+++ b/utils/compatibility/tests/test_kong_ingress_controller.py
@@ -1,0 +1,127 @@
+import hashlib
+import importlib
+import io
+from pathlib import Path
+import sys
+import tarfile
+import unittest
+from unittest.mock import patch
+
+import requests
+import yaml
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+scraper = importlib.import_module("scrapers.kong-ingress-controller")
+
+
+def table(product, versions, compatible_versions):
+    return "{% version_compatibility_table %}\n" + yaml.safe_dump({
+        "compatible_product": product,
+        "versions": versions,
+        "compatible_versions": compatible_versions,
+    }) + "{% endversion_compatibility_table %}"
+
+
+MATRIX = "\n".join([
+    table("Gateway", ["3.4"], {"3.9.x": ["3.4"]}),
+    table("Kubernetes", ["3.4", "3.5"], {
+        "1.30": ["3.4", "3.5"], "1.29": ["3.4"], "1.31": ["3.5", "3.5"],
+    }),
+    table("Gateway API", ["3.4"], {"1.2": ["3.4"]}),
+    table("Istio", ["3.4"], {"1.26": ["3.4"]}),
+])
+
+
+def archive(tag, override=None):
+    files = {
+        "ingress/Chart.yaml": {"appVersion": "9.9.9"},
+        "ingress/charts/kong/values.yaml": {
+            "ingressController": {"image": {
+                "repository": "kong/kubernetes-ingress-controller", "tag": tag,
+            }},
+        },
+        "ingress/values.yaml": {"controller": {"ingressController": {"image": override or {}}}},
+    }
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as tar:
+        for name, value in files.items():
+            data = yaml.safe_dump(value).encode()
+            member = tarfile.TarInfo(name)
+            member.size = len(data)
+            tar.addfile(member, io.BytesIO(data))
+    return output.getvalue()
+
+
+class KongScraperTests(unittest.TestCase):
+    def test_selects_only_explicit_kubernetes_combinations(self):
+        self.assertEqual(scraper.parse_matrix(MATRIX), {
+            "3.4": {"1.29", "1.30"}, "3.5": {"1.30", "1.31"},
+        })
+
+    def test_missing_duplicate_empty_or_invalid_matrix_fails(self):
+        invalid = [
+            "", MATRIX + MATRIX,
+            table("Kubernetes", ["3.5"], {}),
+            table("Kubernetes", ["3.5"], {"1.30": ["3.6"]}),
+            table("Kubernetes", ["3.5"], {"1.30": "3.5"}),
+            table("Kubernetes", ["3.5"], {"1.30+": ["3.5"]}),
+        ]
+        for markdown in invalid:
+            with self.subTest(markdown=markdown), self.assertRaises(ValueError):
+                scraper.parse_matrix(markdown)
+
+    def test_chart_uses_controller_tag_and_parent_override(self):
+        self.assertEqual(scraper.controller_minor(archive("3.4")), "3.4")
+        self.assertEqual(scraper.controller_minor(archive("3.4", {"tag": "3.5.2"})), "3.5")
+
+    def test_chart_rejects_unrelated_or_unstable_images(self):
+        for image in [{"repository": "kong/gateway"}, {"tag": "latest"}, {"tag": "3.5.0-rc.1"}]:
+            with self.subTest(image=image), self.assertRaises(ValueError):
+                scraper.controller_minor(archive("3.4", image))
+
+    def test_chart_mapping_uses_semantic_order_and_checks_digest(self):
+        payload = archive("3.5")
+        digest = hashlib.sha256(payload).hexdigest()
+        entries = [{"version": version, "urls": [f"ingress-{version}.tgz"], "digest": digest}
+                   for version in ["0.9.0", "0.10.0", "0.11.0-rc.1"]]
+        index = yaml.safe_dump({"entries": {"ingress": entries}}).encode()
+        with patch.object(scraper, "fetch", side_effect=[index, payload]) as fetch:
+            self.assertEqual(scraper.chart_versions({"3.5"}), {"3.5": "0.10.0"})
+            self.assertEqual(fetch.call_args_list[1].args[0], "https://charts.konghq.com/ingress-0.10.0.tgz")
+        with patch.object(scraper, "fetch", side_effect=[index, b"corrupt archive"]):
+            with self.assertRaisesRegex(ValueError, "digest mismatch"):
+                scraper.chart_versions({"3.5"})
+
+    def test_empty_chart_index_fails(self):
+        index = yaml.safe_dump({"entries": {"ingress": []}}).encode()
+        with patch.object(scraper, "fetch", return_value=index):
+            with self.assertRaisesRegex(ValueError, "no stable ingress charts"):
+                scraper.chart_versions({"3.5"})
+
+    def test_scrape_passes_minor_boundaries_and_keeps_unmapped_compatibility(self):
+        with patch.object(scraper, "fetch", return_value=MATRIX.encode()), \
+                patch.object(scraper, "chart_versions", return_value={"3.5": "0.24.0"}), \
+                patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+        path, rows = update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/kong-ingress-controller.yaml")
+        self.assertEqual(rows, [
+            {"version": "3.5.0", "kube": ["1.31", "1.30"], "requirements": [],
+             "incompatibilities": [], "chart_version": "0.24.0"},
+            {"version": "3.4.0", "kube": ["1.30", "1.29"], "requirements": [],
+             "incompatibilities": []},
+        ])
+
+    def test_source_failure_does_not_write_a_partial_table(self):
+        for error in [ValueError("bad source"), requests.HTTPError("503")]:
+            with self.subTest(error=error), \
+                    patch.object(scraper, "fetch", side_effect=error), \
+                    patch.object(scraper, "update_compatibility_info") as update:
+                with self.assertRaises(type(error)):
+                    scraper.scrape()
+                update.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Kong Ingress Controller to the compatibility catalog, with a scraper, generated table, manifest registration and aggregate data. The table covers the seven controller minor families and Kubernetes versions explicitly listed in [Kong's compatibility documentation](https://developer.konghq.com/kubernetes-ingress-controller/version-compatibility/).

The scraper reads the Kubernetes table from [the documentation source](https://github.com/Kong/developer.konghq.com/blob/main/app/kubernetes-ingress-controller/version-compatibility.md). It maps controller versions to the recommended `ingress` Helm chart by reading the bundled controller image tag and applying parent-chart overrides. Chart `appVersion` describes Kong Gateway, so it cannot supply this mapping. Downloaded chart archives are checked against the official index digests.

Minor-wide compatibility is represented by `.0` boundaries, following the existing CloudNativePG scraper and Plural's version lookup. Floating controller image tags establish a minor family, not an exact patch pin.

Automatic discovery of the standard Kong chart deployments needs separate detector support: their workload labels identify `controller` and `gateway`, and their version labels contain the Gateway version. This contribution supplies the catalog data and its updater.

Related to #4129. I'd like to claim the contributor program's new-scraper reward if this is accepted; the payout-method question is in that issue.

## Test Plan

Local environment: Python 3.13 and Helm 4.2.4.

- Eight unit tests pass: Kubernetes-table selection, explicit compatibility pairs, malformed input, chart overrides, stable chart ordering, archive digests, missing mappings and failure before writes.
- Generated the table against live Kong documentation and chart archives, including Helm image inventories for all seven rows.
- A second live run produces byte-identical output.
- All 54 compatibility YAML files pass the repository's Draft-07 schema. Kong's manifest entry, per-app table and aggregate entry agree.
- `git diff --check` passes.

Run the focused tests from the repository root:

```sh
python -B -m unittest discover -s utils/compatibility/tests -p 'test_kong_ingress_controller.py' -v
```

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have included upstream documentation confirming the compatibility information.
- [x] I have added tests to cover my changes.
- [ ] Agent deployment verification: not applicable to this compatibility-data and scraper change.

Plural Flow: console
