### PR TITLE
Add Kueue compatibility scraper and chart image regression coverage

### DIFF
--- a/.github/workflows/compatibility-scraper-tests.yaml
+++ b/.github/workflows/compatibility-scraper-tests.yaml
@@ -19,14 +19,19 @@ jobs:
   test-compatibility-scrapers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.13'
           cache: pip
-          cache-dependency-path: utils/compatibility/requirements.txt
+          cache-dependency-path: |
+            utils/compatibility/requirements.txt
+            utils/compatibility/tests/constraints.txt
       - name: Install scraper dependencies
-        run: python -m pip install -r utils/compatibility/requirements.txt
+        run: >-
+          python -m pip install
+          -r utils/compatibility/requirements.txt
+          -c utils/compatibility/tests/constraints.txt
       - name: Run offline scraper tests
         working-directory: utils/compatibility
         run: python -m unittest discover -s tests -v

--- a/.github/workflows/compatibility-scraper-tests.yaml
+++ b/.github/workflows/compatibility-scraper-tests.yaml
@@ -1,0 +1,32 @@
+name: Test Compatibility Scrapers
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/compatibility-scraper-tests.yaml'
+      - 'utils/compatibility/**'
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/compatibility-scraper-tests.yaml'
+      - 'utils/compatibility/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test-compatibility-scrapers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: utils/compatibility/requirements.txt
+      - name: Install scraper dependencies
+        run: python -m pip install -r utils/compatibility/requirements.txt
+      - name: Run offline scraper tests
+        working-directory: utils/compatibility
+        run: python -m unittest discover -s tests -v

--- a/static/compatibilities/kueue.yaml
+++ b/static/compatibilities/kueue.yaml
@@ -1,0 +1,91 @@
+icon: https://raw.githubusercontent.com/kubernetes-sigs/kueue/main/site/static/images/logo.svg
+git_url: https://github.com/kubernetes-sigs/kueue
+release_url: https://github.com/kubernetes-sigs/kueue/releases/tag/v{vsn}
+readme_url: https://github.com/kubernetes-sigs/kueue/blob/main/README.md
+helm_repository_url: oci://registry.k8s.io/kueue/charts/kueue
+chart_name: kueue
+versions:
+- version: 0.19.3
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.19.3
+  images: ['registry.k8s.io/kueue/kueue:v0.19.3']
+- version: 0.19.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.19.0
+  images: ['registry.k8s.io/kueue/kueue:v0.19.0']
+- version: 0.18.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.18.0
+  images: ['registry.k8s.io/kueue/kueue:v0.18.0']
+- version: 0.17.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.0
+  images: ['registry.k8s.io/kueue/kueue:v0.17.0']
+- version: 0.16.0
+  kube: ['1.35', '1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.0
+  images: ['registry.k8s.io/kueue/kueue:v0.16.0']
+- version: 0.15.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.0
+  images: ['registry.k8s.io/kueue/kueue:v0.15.0']
+- version: 0.14.0
+  kube: ['1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.0
+  images: ['registry.k8s.io/kueue/kueue:v0.14.0']
+- version: 0.13.0
+  kube: ['1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.13.0
+  images: ['registry.k8s.io/kueue/kueue:v0.13.0']
+- version: 0.12.0
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.0
+  images: ['registry.k8s.io/kueue/kueue:v0.12.0']
+- version: 0.11.0
+  kube: ['1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.11.0
+  images: ['registry.k8s.io/kueue/kueue:v0.11.0']
+- version: 0.10.3
+  kube: ['1.31', '1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.3
+  images: ['registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0', 'registry.k8s.io/kueue/kueue:v0.10.3']
+- version: 0.9.5
+  kube: ['1.31', '1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.9.5
+  images: ['registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.16.0', 'registry.k8s.io/kueue/kueue:v0.9.5']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -23,6 +23,7 @@ names:
 - karpenter
 - keda
 - kube-prometheus-stack
+- kueue
 - kyverno
 - linkerd
 - longhorn

--- a/utils/compatibility/scrapers/kueue.py
+++ b/utils/compatibility/scrapers/kueue.py
@@ -1,0 +1,73 @@
+import re
+
+import requests
+
+from utils import update_compatibility_info
+
+
+CHART_TAGS_URL = "https://registry.k8s.io/v2/kueue/charts/kueue/tags/list"
+README_URL = "https://raw.githubusercontent.com/kubernetes-sigs/kueue/v{version}/README.md"
+COMPATIBILITY_FILE = "../../static/compatibilities/kueue.yaml"
+REQUEST_TIMEOUT = 30
+
+
+def stable_chart_versions(payload):
+    """OCI registries also list signature/attestation tags; accept releases only."""
+    tags = payload.get("tags") if isinstance(payload, dict) else None
+    if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+        raise ValueError("Kueue registry response must contain a list of tag strings")
+
+    number = r"(?:0|[1-9][0-9]*)"
+    versions = {tag for tag in tags if re.fullmatch(rf"{number}\.{number}\.{number}", tag)}
+    if not versions:
+        raise ValueError("No stable Kueue Helm chart versions found")
+    return sorted(versions, key=lambda value: tuple(map(int, value.split("."))), reverse=True)
+
+
+def tested_kube_versions(markdown):
+    """Use explicit E2E versions, not an unbounded installation minimum."""
+    section = re.search(
+        r"^## Production Readiness status\s*\n(.*?)(?=^## |\Z)",
+        markdown,
+        re.MULTILINE | re.DOTALL | re.IGNORECASE,
+    )
+    if not section:
+        raise ValueError("Kueue README has no production readiness section")
+
+    links = re.findall(
+        r"\[([0-9]+\.[0-9]+)\]\("
+        r"(https://testgrid\.k8s\.io/sig-scheduling#periodic-kueue-test-e2e-[^)]+)\)",
+        section.group(1),
+    )
+    versions = set()
+    for label, url in links:
+        target = re.search(r"-main-([0-9]+)-([0-9]+)$", url)
+        if not target or label != f"{target.group(1)}.{target.group(2)}":
+            raise ValueError(f"Kueue E2E link does not match Kubernetes {label}: {url}")
+        versions.add(label)
+
+    if not versions:
+        raise ValueError("No explicit Kubernetes E2E versions found in Kueue README")
+    return sorted(versions, key=lambda value: tuple(map(int, value.split("."))), reverse=True)
+
+
+def scrape():
+    response = requests.get(CHART_TAGS_URL, timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    versions = stable_chart_versions(response.json())
+
+    rows = []
+    for version in versions:
+        # Chart version and appVersion are set from the same release tag upstream.
+        # Pin the documentation to that tag so main cannot rewrite historical data.
+        url = README_URL.format(version=version)
+        response = requests.get(url, timeout=REQUEST_TIMEOUT)
+        response.raise_for_status()
+        try:
+            kube_versions = tested_kube_versions(response.text)
+        except ValueError as error:
+            raise ValueError(f"Invalid Kueue compatibility source {url}: {error}") from error
+        rows.append({"version": version, "kube": kube_versions, "chart_version": version})
+
+    # Fetch and validate every source before allowing the shared writer to change data.
+    update_compatibility_info(COMPATIBILITY_FILE, rows)

--- a/utils/compatibility/tests/README.md
+++ b/utils/compatibility/tests/README.md
@@ -1,0 +1,26 @@
+# Compatibility scraper tests
+
+From `utils/compatibility`, with `requirements.txt` installed:
+
+```sh
+python -m unittest discover -s tests -v
+```
+
+The tests run offline, with HTTP and Helm replaced at their external boundaries.
+The integration test uses the real YAML writer, version reducer, and image parser.
+It checks repeatable output and preservation of existing data on source failures.
+
+## Kueue sources
+
+Kueue publishes its Helm chart to
+`oci://registry.k8s.io/kueue/charts/kueue`. The scraper discovers stable chart tags
+from the registry and reads the README at each corresponding Git release tag.
+It records the Kubernetes versions explicitly linked from the release's E2E test
+coverage. An installation minimum such as "1.29 or newer" does not supply an
+upper bound, so the scraper does not expand it into a compatibility range.
+
+The fixtures are production-readiness excerpts from the Apache-2.0
+licensed [Kueue repository](https://github.com/kubernetes-sigs/kueue), with source
+URLs embedded at the top. They cover the original E2E layout (v0.9.5) and the
+baseline/extended suite layout (v0.19.3). Signature, attestation, and prerelease
+tags are excluded. Releases without a published Helm chart are not inferred.

--- a/utils/compatibility/tests/README.md
+++ b/utils/compatibility/tests/README.md
@@ -1,10 +1,17 @@
 # Compatibility scraper tests
 
-From `utils/compatibility`, with `requirements.txt` installed:
+From `utils/compatibility`, install the same constrained dependencies as CI:
 
 ```sh
+python -m pip install -r requirements.txt -c tests/constraints.txt
 python -m unittest discover -s tests -v
 ```
+
+`constraints.txt` pins the tested direct and transitive dependency versions for
+Python 3.13. To refresh it, install `requirements.txt` in a clean Python 3.13
+environment, run the tests, and regenerate it with `python -m pip freeze`.
+Review the version changes and rerun the tests using the new constraints before
+committing. These test constraints do not change the daily updater's dependencies.
 
 The tests run offline, with HTTP and Helm replaced at their external boundaries.
 The integration test uses the real YAML writer, version reducer, and image parser.

--- a/utils/compatibility/tests/constraints.txt
+++ b/utils/compatibility/tests/constraints.txt
@@ -1,0 +1,29 @@
+# CI dependency versions verified on Python 3.13, including transitive dependencies.
+# Use with ../requirements.txt; these constraints do not change the daily updater.
+annotated-types==0.8.0
+anyio==4.15.1
+beautifulsoup4==4.12.3
+certifi==2024.12.14
+charset-normalizer==3.3.2
+colorama==0.4.6
+distro==1.9.0
+exa-py==2.20.0
+h11==0.16.0
+httpcore==1.0.9
+httpx==0.28.1
+idna==3.15
+jiter==0.16.0
+openai==2.54.0
+packaging==24.1
+pydantic==2.13.5
+pydantic-core==2.46.5
+python-dotenv==1.2.3
+pyyaml==6.0.2
+requests==2.33.0
+semantic-version==2.10.0
+sniffio==1.3.1
+soupsieve==2.8.4
+tqdm==4.70.0
+typing-extensions==4.16.0
+typing-inspection==0.4.4
+urllib3==2.7.0

--- a/utils/compatibility/tests/fixtures/kueue/v0.19.3-README.md
+++ b/utils/compatibility/tests/fixtures/kueue/v0.19.3-README.md
@@ -1,0 +1,64 @@
+<!-- Source: https://raw.githubusercontent.com/kubernetes-sigs/kueue/v0.19.3/README.md -->
+## Production Readiness status
+
+- ✔️ API version: v1beta2, respecting [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/).
+- ✔️ Up-to-date [documentation](https://kueue.sigs.k8s.io/docs).
+- ✔️ Test coverage:
+  - ✔️ Unit test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-unit-main).
+  - ✔️ Integration tests:
+    - ✔️ Baseline suite
+      - ✔️ [shard-0](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-integration-shard-0-main)
+      - ✔️ [shard-1](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-integration-shard-1-main)
+      - ✔️ [shard-2](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-integration-shard-2-main)
+    - ✔️ MultiKueue suite [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-integration-multikueue-main).
+  - ✔️ E2E tests:
+    - ✔️ Baseline suites for Kubernetes
+      [1.34](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-baseline-main-1-34)
+      [1.35](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-baseline-main-1-35)
+      [1.36](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-baseline-main-1-36)
+      on Kind.
+    - ✔️ Extended suites for Kubernetes on Kind:
+      - ✔️ 1.34:
+        - ✔️ [shard-0](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-extended-shard-0-main-1-34)
+        - ✔️ [shard-1](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-extended-shard-1-main-1-34)
+        - ✔️ [shard-2](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-extended-shard-2-main-1-34)
+      - ✔️ 1.35:
+        - ✔️ [shard-0](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-extended-shard-0-main-1-35)
+        - ✔️ [shard-1](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-extended-shard-1-main-1-35)
+        - ✔️ [shard-2](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-extended-shard-2-main-1-35)
+      - ✔️ 1.36:
+        - ✔️ [shard-0](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-extended-shard-0-main-1-36)
+        - ✔️ [shard-1](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-extended-shard-1-main-1-36)
+        - ✔️ [shard-2](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-extended-shard-2-main-1-36)
+    - ✔️ TAS:
+      - ✔️ Baseline suite [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-tas-baseline-main).
+      - ✔️ Extended suite:
+        - ✔️ [shard-0](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-tas-extended-shard-0-main)
+        - ✔️ [shard-1](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-tas-extended-shard-1-main)
+    - ✔️ Sequential tests:
+      - ✔️ Baseline suites:
+        - ✔️ [shard-0](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-baseline-shard-0-main)
+        - ✔️ [shard-1](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-baseline-shard-1-main)
+      - ✔️ Extended suites:
+        - ✔️ [shard-0](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-extended-shard-0-main)
+        - ✔️ [shard-1](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-sequential-extended-shard-1-main)
+    - ✔️ E2E Cert Manager test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-certmanager-main).
+    - ✔️ DRA test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-dra-main).
+    - ✔️ MultiKueue:
+      - ✔️ Baseline suite [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-multikueue-baseline-main).
+      - ✔️ Extended suites:
+        - ✔️ [shard-0](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-multikueue-extended-shard-0-main)
+        - ✔️ [shard-1](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-multikueue-extended-shard-1-main)
+    - ✔️ MultiKueue DRA test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-multikueue-dra-main).
+  - ✔️ Scheduling performance tests:
+    - ✔️ Baseline suite [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-scheduling-perf-main).
+    - ✔️ TAS suite [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-tas-scheduling-perf-main).
+    - ✔️ Large-Scale suite [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-large-scale-scheduling-perf-main).
+- ✔️ Scalability verification via [performance tests](https://github.com/kubernetes-sigs/kueue/tree/main/test/performance).
+- ✔️ Monitoring via [metrics](https://kueue.sigs.k8s.io/docs/reference/metrics).
+- ✔️ Security: RBAC based accessibility.
+- ✔️ Stable [release](RELEASE.md) cycle (2-3 months).
+- ✔️ [Adopters](https://kueue.sigs.k8s.io/community/adopters/) running on production.
+
+  _Based on community feedback, we continue to simplify and evolve the API to
+  address new use cases_.

--- a/utils/compatibility/tests/fixtures/kueue/v0.9.5-README.md
+++ b/utils/compatibility/tests/fixtures/kueue/v0.9.5-README.md
@@ -1,0 +1,22 @@
+<!-- Source: https://raw.githubusercontent.com/kubernetes-sigs/kueue/v0.9.5/README.md -->
+## Production Readiness status
+
+- ✔️ API version: v1beta1, respecting [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
+- ✔️ Up-to-date [documentation](https://kueue.sigs.k8s.io/docs).
+- ✔️ Test Coverage:
+  - ✔️ Unit Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-unit-main).
+  - ✔️ Integration Test [testgrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-integration-main)
+  - ✔️ E2E Tests for Kubernetes
+    [1.28](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-28),
+    [1.29](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-29),
+    [1.30](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-30),
+    [1.31](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-31),
+    on Kind.
+- ✔️ Scalability verification via [performance tests](https://github.com/kubernetes-sigs/kueue/tree/main/test/performance).
+- ✔️ Monitoring via [metrics](https://kueue.sigs.k8s.io/docs/reference/metrics).
+- ✔️ Security: RBAC based accessibility.
+- ✔️ Stable release cycle(2-3 months) for new features, bugfixes, cleanups.
+- ✔️ [Adopters](https://kueue.sigs.k8s.io/docs/adopters/) running on production.
+
+  _Based on community feedback, we continue to simplify and evolve the API to
+  address new use cases_.

--- a/utils/compatibility/tests/test_chart_images.py
+++ b/utils/compatibility/tests/test_chart_images.py
@@ -1,0 +1,27 @@
+import unittest
+
+from utils import find_nested_images
+
+
+class ChartImageTests(unittest.TestCase):
+    def test_schema_image_properties_do_not_crash_extraction(self):
+        objects = [
+            {"schema": {"properties": {"image": {"type": "string"}}}},
+            {"spec": {"containers": [
+                {"image": "registry.k8s.io/kueue/kueue:v0.19.3"},
+                {"image": "registry.k8s.io/kueue/kueue:v0.19.3"},
+            ]}},
+        ]
+        self.assertEqual(find_nested_images(objects),
+                         ["registry.k8s.io/kueue/kueue:v0.19.3"])
+
+    def test_non_string_fields_are_traversed_without_becoming_image_references(self):
+        objects = [
+            {"image": None}, {"image": 42}, {"image": False},
+            {"image": [{"image": "example.com/controller:1.0"}]},
+        ]
+        self.assertEqual(find_nested_images(objects), ["example.com/controller:1.0"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_kueue.py
+++ b/utils/compatibility/tests/test_kueue.py
@@ -1,0 +1,169 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import requests
+import yaml
+
+from scrapers import kueue
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "kueue"
+
+
+def readme(version):
+    return (FIXTURES / f"v{version}-README.md").read_text()
+
+
+class ChartVersionTests(unittest.TestCase):
+    def test_stable_tags_are_deduplicated_and_sorted_numerically(self):
+        self.assertEqual(
+            kueue.stable_chart_versions({"tags": [
+                "0.19.3", "0.9.5", "0.13.9", "0.13.10", "0.13.10",
+                "0.20.0-rc.1", "0.19.3+build.1", "sha256-abc.sig",
+                "sha256-abc.att", "v0.19.3", "latest", "00.19.3",
+            ]}),
+            ["0.19.3", "0.13.10", "0.13.9", "0.9.5"],
+        )
+
+    def test_missing_or_invalid_registry_tags_fail_closed(self):
+        for payload in (None, [], {}, {"tags": None}, {"tags": "0.19.3"},
+                        {"tags": [None]}, {"tags": []}, {"tags": ["latest"]}):
+            with self.subTest(payload=payload), self.assertRaises(ValueError):
+                kueue.stable_chart_versions(payload)
+
+
+class TestedKubernetesVersionTests(unittest.TestCase):
+    def test_original_e2e_format_from_oldest_published_chart(self):
+        self.assertEqual(kueue.tested_kube_versions(readme("0.9.5")),
+                         ["1.31", "1.30", "1.29", "1.28"])
+
+    def test_baseline_format_ignores_shard_links(self):
+        self.assertEqual(kueue.tested_kube_versions(readme("0.19.3")),
+                         ["1.36", "1.35", "1.34"])
+
+    def test_does_not_expand_installation_minimum_or_include_other_sections(self):
+        markdown = readme("0.19.3") + """
+## Installation
+**Requires Kubernetes 1.29 or newer**.
+[1.37](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-37)
+"""
+        self.assertEqual(kueue.tested_kube_versions(markdown),
+                         ["1.36", "1.35", "1.34"])
+
+    def test_gaps_are_preserved_and_duplicate_links_are_deduplicated(self):
+        markdown = """## Production Readiness status
+[1.28](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-28)
+[1.31](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-31)
+[1.31](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-e2e-main-1-31)
+[1.99](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-unit-main-1-99)
+[1.42](https://example.com/sig-scheduling#periodic-kueue-test-e2e-main-1-42)
+"""
+        self.assertEqual(kueue.tested_kube_versions(markdown), ["1.31", "1.28"])
+
+    def test_changed_document_format_fails_closed(self):
+        for markdown in ("", "Requires Kubernetes 1.29 or newer",
+                         "## Production Readiness status\nNo version matrix."):
+            with self.subTest(markdown=markdown), self.assertRaises(ValueError):
+                kueue.tested_kube_versions(markdown)
+
+    def test_mismatched_version_label_fails_instead_of_writing_partial_data(self):
+        markdown = readme("0.19.3").replace("[1.36]", "[1.37]")
+        with self.assertRaises(ValueError):
+            kueue.tested_kube_versions(markdown)
+
+
+class ScrapeTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.output = Path(self.directory.name) / "kueue.yaml"
+        self.original = (
+            "icon: https://example.com/logo.svg\n"
+            "helm_repository_url: oci://registry.k8s.io/kueue/charts/kueue\n"
+            "chart_name: kueue\nversions: []\n"
+        )
+        self.output.write_text(self.original)
+        self.addCleanup(patch.stopall)
+        patch.object(kueue, "COMPATIBILITY_FILE", str(self.output)).start()
+        patch.dict(os.environ, {"OPENAI_API_KEY": "", "EXA_API_KEY": ""}).start()
+        self.sources = {
+            kueue.CHART_TAGS_URL: json.dumps({"tags": ["0.9.5", "0.19.3"]}),
+            kueue.README_URL.format(version="0.9.5"): readme("0.9.5"),
+            kueue.README_URL.format(version="0.19.3"): readme("0.19.3"),
+        }
+        patch("scrapers.kueue.requests.get", side_effect=self.response).start()
+
+    def response(self, url, *, timeout):
+        self.assertGreater(timeout, 0)
+        body = self.sources[url]
+        if isinstance(body, Exception):
+            raise body
+        response = requests.Response()
+        response.url = url
+        response.status_code = 200 if body is not None else 404
+        response._content = (body or "Not Found").encode()
+        return response
+
+    def test_scrape_writes_real_yaml_with_metadata_and_chart_images(self):
+        # Only external HTTP and Helm are replaced; the shared reducer/writer run.
+        manifest = """apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: registry.k8s.io/kueue/kueue:v0.19.3
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+spec:
+  versions:
+  - schema:
+      openAPIV3Schema:
+        properties:
+          image:
+            type: string
+            description: Container image name
+"""
+        helm = subprocess.CompletedProcess(args=[], returncode=0, stdout=manifest, stderr="")
+        with patch("utils.subprocess.run", return_value=helm):
+            kueue.scrape()
+            first_output = self.output.read_text()
+            kueue.scrape()
+        self.assertEqual(self.output.read_text(), first_output)
+        data = yaml.safe_load(first_output)
+        self.assertEqual(data["icon"], "https://example.com/logo.svg")
+        self.assertEqual([row["version"] for row in data["versions"]], ["0.19.3", "0.9.5"])
+        self.assertEqual(data["versions"][0]["kube"], ["1.36", "1.35", "1.34"])
+        self.assertEqual(data["versions"][1]["kube"], ["1.31", "1.30", "1.29", "1.28"])
+        self.assertEqual(data["versions"][0]["chart_version"], "0.19.3")
+        self.assertEqual(data["versions"][0]["images"],
+                         ["registry.k8s.io/kueue/kueue:v0.19.3"])
+
+    def test_unavailable_tagged_readme_preserves_existing_file(self):
+        self.sources[kueue.README_URL.format(version="0.9.5")] = None
+        with self.assertRaises(requests.HTTPError):
+            kueue.scrape()
+        self.assertEqual(self.output.read_text(), self.original)
+
+    def test_missing_test_versions_preserves_existing_file(self):
+        self.sources[kueue.README_URL.format(version="0.9.5")] = "Requires Kubernetes 1.25+"
+        with self.assertRaises(ValueError):
+            kueue.scrape()
+        self.assertEqual(self.output.read_text(), self.original)
+
+    def test_registry_timeout_preserves_existing_file(self):
+        self.sources[kueue.CHART_TAGS_URL] = requests.Timeout("Timed out")
+        with self.assertRaises(requests.Timeout):
+            kueue.scrape()
+        self.assertEqual(self.output.read_text(), self.original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -235,7 +235,7 @@ def find_nested_images(objs: Any) -> List[str]:
 
         if isinstance(x, dict):
             for k, v in x.items():
-                if k == "image":
+                if k == "image" and isinstance(v, str):
                     images.add(v)
                     continue
                 walk(v)


### PR DESCRIPTION
Kueue currently has no compatibility entry. This adds its metadata, manifest registration, a scraper, and a generated table covering published stable Helm charts from 0.9.5 through 0.19.3. The shared reducer retains 12 representative rows.

The scraper discovers stable tags from the official OCI registry, then reads each release's tagged README. Its `kube` values are the explicitly documented E2E test versions. It does not expand an open-ended installation minimum into assumed compatibility. For example, v0.19.3 records 1.34, 1.35, and 1.36, although its installation minimum is 1.29. Signature, attestation, build-metadata, and prerelease tags are excluded; a missing or changed source fails before writing.

Live Helm templating exposed an existing image-extraction crash on CRD schema properties named `image`. A one-line type guard handles those objects while preserving actual image strings; regression tests cover this path.

Sources:

- [Official Helm installation instructions](https://kueue.sigs.k8s.io/docs/getting-started/installation/)
- [Official chart registry tags](https://registry.k8s.io/v2/kueue/charts/kueue/tags/list)
- [v0.9.5 documented E2E versions](https://github.com/kubernetes-sigs/kueue/blob/v0.9.5/README.md#production-readiness-status)
- [v0.19.3 documented E2E versions](https://github.com/kubernetes-sigs/kueue/blob/v0.19.3/README.md#production-readiness-status)
- [v0.19.3 chart metadata](https://github.com/kubernetes-sigs/kueue/blob/v0.19.3/charts/kueue/Chart.yaml)

Related discussion: #4137. Maintainer confirmation is requested for the tested-minor interpretation and coverage before merging.

## Test Plan

- 14 offline unit/integration tests on Python 3.13.9, including old/new README layouts, numeric tag sorting, source failures, actual YAML writing/reduction, CRD image fields, and repeatable output.
- Live scraper generation and Helm 4.2.4 templating produced 12 rows with image references.
- Generated table and manifest pass the repository JSON schema.
- Scoped GitHub Actions workflow runs the offline tests using the existing scraper requirements.
- Kubernetes deployment testing is outside this data/scraper change; no live cluster was used.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code; not applicable).

Plural Flow: console

Could maintainers confirm eligibility for the advertised $300 new-scraper contributor reward and whether it can be paid through PayPal? I understand that a reward depends on your review and acceptance. Payment details can be provided privately after confirmation.
