### PR TITLE
fix(compatibility): refresh Kyverno v1.19 support

### DIFF
--- a/static/compatibilities/kyverno.yaml
+++ b/static/compatibilities/kyverno.yaml
@@ -4,6 +4,16 @@ release_url: https://github.com/kyverno/kyverno/releases/tag/v{vsn}
 helm_repository_url: https://kyverno.github.io/kyverno/
 eolApiSlug: kyverno
 versions:
+- version: 1.19.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.9.0
+  images: ['ghcr.io/kyverno/readiness-checker:latest', 'ghcr.io/kyverno/readiness-checker:v1.19.0',
+    'reg.kyverno.io/kyverno/background-controller:v1.19.0', 'reg.kyverno.io/kyverno/cleanup-controller:v1.19.0',
+    'reg.kyverno.io/kyverno/kyverno-cli:v1.19.0', 'reg.kyverno.io/kyverno/kyverno:v1.19.0',
+    'reg.kyverno.io/kyverno/kyvernopre:v1.19.0', 'reg.kyverno.io/kyverno/reports-controller:v1.19.0']
 - version: 1.16.0
   kube: ['1.34', '1.33', '1.32', '1.31']
   requirements: []

--- a/utils/compatibility/scrapers/kyverno.py
+++ b/utils/compatibility/scrapers/kyverno.py
@@ -8,75 +8,87 @@ from bs4 import BeautifulSoup
 from utils import (
     expand_kube_versions,
     fetch_page,
-    print_error,
-    read_yaml,
-    update_chart_versions,
-    update_compatibility_info,
     get_chart_versions,
+    print_error,
+    update_compatibility_info,
 )
 
 app_name = "kyverno"
-compatibility_url = "https://kyverno.io/docs/installation/"
+compatibility_url = "https://kyverno.io/docs/installation/releases/"
 
 
-def _find_compat_table(soup: BeautifulSoup):
-    # Look for the Compatibility Matrix section and grab the following table
-    h2 = soup.find("h2", id="compatibility-matrix")
-    if not h2:
-        # Fallback: search by heading text in case id changes
-        for candidate in soup.find_all("h2"):
-            if candidate.get_text(strip=True).lower() == "compatibility matrix":
-                h2 = candidate
-                break
-    if not h2:
+def _find_release_table(soup: BeautifulSoup):
+    """Find the current supported-release table in Kyverno's release docs."""
+    for table in soup.find_all("table"):
+        text = table.get_text(" ", strip=True).lower()
+        if (
+            "supported release:" in text
+            and "kubernetes versions supported:" in text
+        ):
+            return table
+    return None
+
+
+def _normalize_version(value: str) -> Optional[str]:
+    """Normalize release labels such as v1.19 or v1.19.0 to x.y.0."""
+    match = re.search(r"v?(\d+)\.(\d+)", value.strip())
+    if not match:
         return None
-    return h2.find_next("table")
-
-
-def _normalize_version(ver: str) -> Optional[str]:
-    # Accept formats like "1.13.x", "v1.13.x", or "1.13"
-    m = re.search(r"v?(\d+)\.(\d+)", ver.strip())
-    if not m:
-        return None
-    major, minor = m.groups()
+    major, minor = match.groups()
     return f"{major}.{minor}.0"
 
 
-def _parse_rows(table) -> list[OrderedDict[str, object]]:
-    rows: list[OrderedDict[str, object]] = []
-    tbody = table.find("tbody") or table
-    chart_versions = get_chart_versions(app_name)
-    for tr in tbody.find_all("tr"):
-        cols = [c.get_text(strip=True) for c in tr.find_all(["td", "th"])]
-        if len(cols) < 3:
-            continue
-        kyverno_ver_raw, kube_min_raw, kube_max_raw = cols[:3]
+def _parse_kube_range(value: str) -> list[str]:
+    """Parse the documented Kubernetes range, e.g. v1.33 - v1.35."""
+    cleaned = value.replace("–", "-").replace("—", "-")
+    match = re.search(
+        r"v?(\d+\.\d+)\s*-\s*v?(\d+\.\d+)",
+        cleaned,
+    )
+    if not match:
+        return []
+    start, end = match.groups()
+    return expand_kube_versions(start, end)
 
-        kyverno_version = _normalize_version(kyverno_ver_raw)
-        if not kyverno_version:
-            continue
 
-        kube_min = kube_min_raw.lstrip("v").strip()
-        kube_max = kube_max_raw.lstrip("v").strip()
-        if not kube_min or not kube_max:
+def _parse_release_table(table) -> list[OrderedDict[str, object]]:
+    values: dict[str, str] = {}
+    for row in table.find_all("tr"):
+        cells = [
+            cell.get_text(" ", strip=True)
+            for cell in row.find_all(["th", "td"])
+        ]
+        if len(cells) < 2:
             continue
+        key = cells[0].rstrip(":").strip().lower()
+        values[key] = cells[1].strip()
 
-        kube_versions = expand_kube_versions(kube_min, kube_max)
-        if not kube_versions:
-            continue
+    kyverno_version = _normalize_version(values.get("supported release", ""))
+    kube_versions = _parse_kube_range(
+        values.get("kubernetes versions supported", "")
+    )
+    if not kyverno_version or not kube_versions:
+        return []
 
-        version_info = OrderedDict(
+    chart_version = get_chart_versions(app_name).get(kyverno_version)
+    if not chart_version:
+        print_error(
+            f"No Kyverno Helm chart found for application {kyverno_version}"
+        )
+        return []
+
+    return [
+        OrderedDict(
             [
                 ("version", kyverno_version),
                 ("kube", kube_versions),
+                ("chart_version", chart_version),
+                ("images", []),
                 ("requirements", []),
                 ("incompatibilities", []),
-                ("chart_version", chart_versions.get(kyverno_version)),
             ]
         )
-        rows.append(version_info)
-
-    return rows
+    ]
 
 
 def scrape() -> None:
@@ -85,15 +97,17 @@ def scrape() -> None:
         return
 
     soup = BeautifulSoup(page_content, "html.parser")
-    table = _find_compat_table(soup)
+    table = _find_release_table(soup)
     if not table:
-        print_error("Kyverno compatibility matrix table not found")
+        print_error("Kyverno supported-release table not found")
         return
 
-    rows = _parse_rows(table)
+    rows = _parse_release_table(table)
     if not rows:
         print_error("No compatibility rows parsed for Kyverno")
         return
 
-    output_path = f"../../static/compatibilities/{app_name}.yaml"
-    update_compatibility_info(output_path, rows)
+    update_compatibility_info(
+        f"../../static/compatibilities/{app_name}.yaml",
+        rows,
+    )

--- a/utils/compatibility/scrapers/kyverno.py
+++ b/utils/compatibility/scrapers/kyverno.py
@@ -22,8 +22,8 @@ def _find_release_table(soup: BeautifulSoup):
     for table in soup.find_all("table"):
         text = table.get_text(" ", strip=True).lower()
         if (
-            "supported release:" in text
-            and "kubernetes versions supported:" in text
+            "supported release" in text
+            and "kubernetes versions supported" in text
         ):
             return table
     return None
@@ -73,7 +73,7 @@ def _parse_release_table(table) -> list[OrderedDict[str, object]]:
     chart_version = get_chart_versions(app_name).get(kyverno_version)
     if not chart_version:
         print_error(
-            f"No Kyverno Helm chart found for application {kyverno_version}"
+            f"No Kyverno Helm chart found for version {kyverno_version}"
         )
         return []
 

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -235,8 +235,9 @@ def find_nested_images(objs: Any) -> List[str]:
 
         if isinstance(x, dict):
             for k, v in x.items():
-                if k == "image":
-                    images.add(v)
+                if k == "image" and isinstance(v, str):
+                    if _looks_like_image(v):
+                        images.add(v)
                     continue
                 walk(v)
 


### PR DESCRIPTION
## Summary

- update the Kyverno compatibility scraper to the current Releases documentation page
- add Kyverno v1.19.0 compatibility for Kubernetes v1.33-v1.35 with Helm chart 3.9.0
- make chart image discovery ignore non-string `image` schema nodes instead of crashing on rendered CRDs

Sources:
- https://kyverno.io/docs/installation/releases/
- https://kyverno.github.io/kyverno/index.yaml
- https://github.com/kyverno/kyverno/releases/tag/v1.19.0

This is a compatibility-table update under the contributor program described in the repository README.

AI assistance disclosure: this contribution was prepared with OpenAI ChatGPT/Codex under the GitHub account owner's authorization. Review follow-up will be handled through this account.

## Test Plan

- live-parsed Kyverno's Releases page and asserted v1.19.0 / Kubernetes 1.33-1.35 / chart 3.9.0
- ran the actual Kyverno compatibility scraper successfully with `KUBE_VERSION=1.36` and Helm
- asserted the image extractor handles nested `image` schema objects and still returns real image strings
- validated `static/compatibilities/kyverno.yaml` against `static/compatibilities/schema.json`
- ran `python3 -m py_compile` and `git diff --check`
