### PR TITLE
fix(compatibility): refresh OpenTelemetry Operator matrix

### DIFF
--- a/static/compatibilities/opentelemetry-operator.yaml
+++ b/static/compatibilities/opentelemetry-operator.yaml
@@ -2,6 +2,30 @@ icon: https://avatars.githubusercontent.com/u/49998002?s=48&v=4
 git_url: https://github.com/open-telemetry/opentelemetry-operator
 release_url: https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v{vsn}
 versions:
+- version: 0.158.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 0.157.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 0.156.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 0.155.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
 - version: 0.154.0
   kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
     '1.25']

--- a/utils/compatibility/scrapers/opentelemetry-operator.py
+++ b/utils/compatibility/scrapers/opentelemetry-operator.py
@@ -15,7 +15,7 @@ from utils import (
 
 app_name = "opentelemetry-operator"
 markdown_url = (
-    "https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/main/docs/compatibility.md"
+    "https://raw.githubusercontent.com/open-telemetry/opentelemetry-operator/main/docs/getting-started/compatibility.md"
 )
 
 


### PR DESCRIPTION
## Summary

- fix the OpenTelemetry Operator compatibility scraper after upstream moved `compatibility.md`
- regenerate the matrix from the current official source
- add operator releases v0.155.0 through v0.158.0, including Kubernetes v1.36 support where documented

Sources:
- https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/getting-started/compatibility.md
- https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.158.0

This is a compatibility-table update under the contributor program described in the repository README.

AI assistance disclosure: this contribution was prepared with OpenAI ChatGPT/Codex under the GitHub account owner's authorization. Review follow-up will be handled through this account.

## Test Plan

- ran the actual OpenTelemetry Operator compatibility scraper successfully against the live upstream file
- asserted the parsed latest row is v0.158.0 with Kubernetes v1.25-v1.36
- validated `static/compatibilities/opentelemetry-operator.yaml` against `static/compatibilities/schema.json`
- ran `python3 -m py_compile` and `git diff --check`
