### PR TITLE
Add Antrea compatibility scraper

### DIFF
--- a/.github/workflows/test-antrea-compatibility.yaml
+++ b/.github/workflows/test-antrea-compatibility.yaml
@@ -20,10 +20,15 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-      - run: python -m pip install packaging==24.1
-      - run: python -m unittest discover -s utils/compatibility/tests -p test_antrea.py -v
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Run scraper tests through the repository test entry point
+        env:
+          TEST_CMD: >-
+            apk add --no-cache python3 py3-pip &&
+            python3 -m venv /tmp/antrea-tests &&
+            /tmp/antrea-tests/bin/python -m pip install packaging==24.1 &&
+            /tmp/antrea-tests/bin/python -m unittest discover -s utils/compatibility/tests -p test_antrea.py -v
+        # Compose consumes CONSOLE_CMD and needs one argument for /bin/sh -c.
+        run: CONSOLE_CMD="\"$TEST_CMD\"" make test-full TEST_CMD="$TEST_CMD"

--- a/.github/workflows/test-antrea-compatibility.yaml
+++ b/.github/workflows/test-antrea-compatibility.yaml
@@ -1,0 +1,29 @@
+name: Test Antrea compatibility scraper
+on:
+  pull_request:
+    paths:
+      - 'utils/compatibility/scrapers/antrea.py'
+      - 'utils/compatibility/tests/test_antrea.py'
+      - 'utils/compatibility/utils.py'
+      - 'static/compatibilities/antrea.yaml'
+      - '.github/workflows/test-antrea-compatibility.yaml'
+  push:
+    branches: [master]
+    paths:
+      - 'utils/compatibility/scrapers/antrea.py'
+      - 'utils/compatibility/tests/test_antrea.py'
+      - 'utils/compatibility/utils.py'
+      - 'static/compatibilities/antrea.yaml'
+      - '.github/workflows/test-antrea-compatibility.yaml'
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - run: python -m pip install packaging==24.1
+      - run: python -m unittest discover -s utils/compatibility/tests -p test_antrea.py -v

--- a/static/compatibilities/antrea.yaml
+++ b/static/compatibilities/antrea.yaml
@@ -1,0 +1,141 @@
+icon: https://raw.githubusercontent.com/antrea-io/antrea/main/docs/assets/logo/antrea_logo.svg
+git_url: https://github.com/antrea-io/antrea
+release_url: https://github.com/antrea-io/antrea/releases/tag/v{vsn}
+helm_repository_url: https://charts.antrea.io
+versions:
+- version: 2.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.7.0
+  images: ['antrea/antrea-agent-ubuntu:v2.7.0', 'antrea/antrea-controller-ubuntu:v2.7.0']
+- version: 2.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.6.0
+  images: ['antrea/antrea-agent-ubuntu:v2.6.0', 'antrea/antrea-controller-ubuntu:v2.6.0']
+- version: 2.5.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.5.0
+  images: ['antrea/antrea-agent-ubuntu:v2.5.0', 'antrea/antrea-controller-ubuntu:v2.5.0']
+- version: 2.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.4.0
+  images: ['antrea/antrea-agent-ubuntu:v2.4.0', 'antrea/antrea-controller-ubuntu:v2.4.0']
+- version: 2.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.3.0
+  images: ['antrea/antrea-agent-ubuntu:v2.3.0', 'antrea/antrea-controller-ubuntu:v2.3.0']
+- version: 2.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.2.0
+  images: ['antrea/antrea-agent-ubuntu:v2.2.0', 'antrea/antrea-controller-ubuntu:v2.2.0']
+- version: 2.1.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.1.0
+  images: ['antrea/antrea-agent-ubuntu:v2.1.0', 'antrea/antrea-controller-ubuntu:v2.1.0']
+- version: 2.0.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.0.0
+  images: ['antrea/antrea-agent-ubuntu:v2.0.0', 'antrea/antrea-controller-ubuntu:v2.0.0']
+- version: 1.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.15.0
+  images: ['projects.registry.vmware.com/antrea/antrea-agent-ubuntu:v1.15.0', 'projects.registry.vmware.com/antrea/antrea-controller-ubuntu:v1.15.0']
+- version: 1.14.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.14.0
+  images: ['projects.registry.vmware.com/antrea/antrea-ubuntu:v1.14.0']
+- version: 1.13.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.13.0
+  images: ['projects.registry.vmware.com/antrea/antrea-ubuntu:v1.13.0']
+- version: 1.12.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.12.0
+  images: ['projects.registry.vmware.com/antrea/antrea-ubuntu:v1.12.0']
+- version: 1.11.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.11.0
+  images: ['projects.registry.vmware.com/antrea/antrea-ubuntu:v1.11.0']
+- version: 1.10.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.10.0
+  images: ['projects.registry.vmware.com/antrea/antrea-ubuntu:v1.10.0']
+- version: 1.9.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.9.0
+  images: ['projects.registry.vmware.com/antrea/antrea-ubuntu:v1.9.0']
+- version: 1.8.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.8.0
+  images: ['projects.registry.vmware.com/antrea/antrea-ubuntu:v1.8.0']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -49,3 +49,4 @@ names:
 - wiz-sensor
 - wiz-admission-controller
 - wiz-network-analyzer
+- antrea

--- a/utils/compatibility/scrapers/antrea.py
+++ b/utils/compatibility/scrapers/antrea.py
@@ -1,0 +1,66 @@
+"""Antrea prerequisites from the README at each released application tag."""
+
+import re
+from collections import OrderedDict
+
+from packaging.version import Version
+
+README_URL = "https://raw.githubusercontent.com/antrea-io/antrea/v{version}/README.md"
+
+
+def parse_minimum(markdown):
+    section = re.search(r"^## Prerequisites\s*$(.*?)(?=^## |\Z)", markdown, re.M | re.S)
+    if not section:
+        raise ValueError("Antrea Prerequisites section not found")
+    matches = re.findall(
+        r"Antrea has been tested with Kubernetes clusters running version\s+1\.(\d+) or later\.",
+        section.group(1),
+    )
+    if len(matches) != 1:
+        raise ValueError("Expected one explicit Antrea Kubernetes minimum")
+    return int(matches[0])
+
+
+def build_rows(chart_versions, current_kube, fetch_readme):
+    """Map chart appVersions to their own release's documented lower bound.
+
+    The open upper bound is expanded only through the repository's KUBE_VERSION.
+    This encodes upstream's 'or later' policy, not additional local cluster tests.
+    """
+    ceiling = re.fullmatch(r"1\.(\d+)", current_kube)
+    if not ceiling:
+        raise ValueError(f"Unsupported Kubernetes upper bound: {current_kube}")
+    latest_minor = int(ceiling.group(1))
+    rows = []
+    for app, chart in chart_versions.items():
+        if not re.fullmatch(r"\d+\.\d+\.\d+", app):
+            continue
+        if Version(app) < Version("1.8.0"):
+            continue  # Official Helm distribution starts at v1.8.
+        if not re.fullmatch(r"\d+\.\d+\.\d+", chart):
+            continue
+        url = README_URL.format(version=app)
+        page = fetch_readme(url)
+        if not page:
+            raise ValueError(f"Could not fetch Antrea prerequisites: {url}")
+        minimum = parse_minimum(page.decode("utf-8"))
+        if minimum > latest_minor:
+            raise ValueError(f"Kubernetes upper bound precedes minimum for Antrea {app}")
+        rows.append(OrderedDict([
+            ("version", app),
+            ("kube", [f"1.{minor}" for minor in range(latest_minor, minimum - 1, -1)]),
+            ("chart_version", chart),
+            ("images", []),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ]))
+    if not rows:
+        raise ValueError("No stable Antrea Helm releases found")
+    return sorted(rows, key=lambda row: Version(row["version"]), reverse=True)
+
+
+def scrape():
+    from utils import fetch_page, get_chart_versions, current_kube_version, update_compatibility_info
+
+    rows = build_rows(get_chart_versions("antrea"), current_kube_version(), fetch_page)
+    update_compatibility_info("../../static/compatibilities/antrea.yaml", rows)

--- a/utils/compatibility/tests/ANTREA.md
+++ b/utils/compatibility/tests/ANTREA.md
@@ -28,12 +28,23 @@ included. The scraper does not install a cluster or change a live cluster.
 
 ## Unit tests
 
-From the repository root, with Python 3.13:
+From the repository root, with Make and Docker Compose available, use the
+repository's required test entry point. The current test image is Alpine-based;
+the command installs Python and an isolated dependency environment in that
+disposable container:
 
 ```sh
-python -m pip install packaging==24.1
-python -m unittest discover -s utils/compatibility/tests -p test_antrea.py -v
+TEST_CMD='apk add --no-cache python3 py3-pip && python3 -m venv /tmp/antrea-tests && /tmp/antrea-tests/bin/python -m pip install packaging==24.1 && /tmp/antrea-tests/bin/python -m unittest discover -s utils/compatibility/tests -p test_antrea.py -v'
+CONSOLE_CMD="\"$TEST_CMD\"" make test-full TEST_CMD="$TEST_CMD"
 ```
+
+Both variables are supplied because `docker-compose.test.yml` currently reads
+`CONSOLE_CMD`, while the Makefile documents `TEST_CMD`. The embedded quotes keep
+the command as one argument to the container's `/bin/sh -c`. The Make target retains
+its existing dependency startup, console exit-code propagation and teardown.
+The six tests were also checked directly with Python 3.13 during development;
+the Docker wrapper has not been run on the Windows development host, which has
+neither Make nor Docker. Hosted workflow execution requires maintainer approval.
 
 The tests cover per-tag source selection, appVersion versus chart version,
 patch-level prerequisite changes, prerelease/pre-Helm filtering, malformed and

--- a/utils/compatibility/tests/ANTREA.md
+++ b/utils/compatibility/tests/ANTREA.md
@@ -1,0 +1,54 @@
+# Antrea compatibility scraper
+
+The official [Helm installation guide](https://github.com/antrea-io/antrea/blob/main/docs/helm.md)
+identifies `https://charts.antrea.io` and states that Helm distribution starts at
+Antrea v1.8. The scraper reads only the `antrea` chart's stable appVersions;
+flow-aggregator, theia, pre-Helm releases and prereleases are not substituted for
+Antrea releases.
+
+Each application version gets its own tagged README, rather than reusing main's
+current prerequisites for historical releases. For example:
+
+- [v1.15.2](https://github.com/antrea-io/antrea/blob/v1.15.2/README.md#prerequisites): Kubernetes 1.16 or later.
+- [v2.0.0](https://github.com/antrea-io/antrea/blob/v2.0.0/README.md#prerequisites): Kubernetes 1.19 or later.
+- [v2.7.0](https://github.com/antrea-io/antrea/blob/v2.7.0/README.md#prerequisites): Kubernetes 1.23 or later.
+
+The generated `kube` array expands that explicit `or later` lower bound through
+the repository's `KUBE_VERSION`, currently 1.36. It encodes the upstream statement;
+it does not claim this contribution ran Antrea on every Kubernetes version.
+NodeIPAM, Open vSwitch, OS-specific and optional feature requirements remain as
+described in upstream's installation documentation.
+
+All stable chart versions are considered independently, including patch releases
+with changed prerequisites. Missing or ambiguous tagged documentation aborts
+before calling the shared updater. That updater retains representative version
+boundaries using the repository's existing reduction policy, and resolves images
+through Helm rendering. Older releases without an official Helm chart are not
+included. The scraper does not install a cluster or change a live cluster.
+
+## Unit tests
+
+From the repository root, with Python 3.13:
+
+```sh
+python -m pip install packaging==24.1
+python -m unittest discover -s utils/compatibility/tests -p test_antrea.py -v
+```
+
+The tests cover per-tag source selection, appVersion versus chart version,
+patch-level prerequisite changes, prerelease/pre-Helm filtering, malformed and
+missing sources, invalid Kubernetes bounds and entry-point failure atomicity.
+
+## Regenerate from upstream
+
+Use the compatibility tool's Python environment and Helm 3 on PATH. From
+`utils/compatibility`, run:
+
+```sh
+OPENAI_API_KEY= EXA_API_KEY= python -c 'from scrapers.antrea import scrape; scrape()'
+```
+
+This fetches the official chart index and tagged READMEs, renders charts locally
+to extract image references and updates only `static/compatibilities/antrea.yaml`.
+The command disables optional paid summary generation. It requires network access
+and may update the local Helm repository cache.

--- a/utils/compatibility/tests/test_antrea.py
+++ b/utils/compatibility/tests/test_antrea.py
@@ -1,0 +1,95 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import unittest
+from unittest.mock import Mock, patch
+
+spec = importlib.util.spec_from_file_location(
+    "antrea", Path(__file__).parents[1] / "scrapers" / "antrea.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+def readme(minimum):
+    return (
+        "# Antrea\n\n## Prerequisites\n\n"
+        f"Antrea has been tested with Kubernetes clusters running version 1.{minimum} or later.\n"
+        "\n## Getting Started\nOther requirements follow.\n"
+    ).encode("utf-8")
+
+
+class AntreaTests(unittest.TestCase):
+    def test_each_app_uses_its_tag_not_chart_or_main(self):
+        pages = {
+            scraper.README_URL.format(version="1.15.2"): readme(16),
+            scraper.README_URL.format(version="2.0.0"): readme(19),
+            scraper.README_URL.format(version="2.7.0"): readme(23),
+        }
+        fetch = Mock(side_effect=pages.__getitem__)
+        rows = scraper.build_rows(
+            {"1.15.2": "9.0.0", "2.0.0": "9.1.0", "2.7.0": "9.2.0"}, "1.24", fetch
+        )
+        self.assertEqual([r["version"] for r in rows], ["2.7.0", "2.0.0", "1.15.2"])
+        self.assertEqual([r["chart_version"] for r in rows], ["9.2.0", "9.1.0", "9.0.0"])
+        self.assertEqual(rows[0]["kube"], ["1.24", "1.23"])
+        self.assertEqual(rows[1]["kube"][-1], "1.19")
+        self.assertEqual(rows[2]["kube"][-1], "1.16")
+        self.assertEqual(fetch.call_count, 3)
+
+    def test_skips_prereleases_and_pre_helm_versions(self):
+        fetch = Mock(return_value=readme(16))
+        rows = scraper.build_rows({
+            "1.7.3": "1.7.3", "2.2.0-alpha.1": "2.2.0-alpha.1",
+            "main": "9.0.0", "2.0.0": "2.0.0-beta.1", "1.8.0": "1.8.0",
+        }, "1.16", fetch)
+        self.assertEqual([r["version"] for r in rows], ["1.8.0"])
+        self.assertEqual(rows[0]["kube"], ["1.16"])
+        fetch.assert_called_once_with(scraper.README_URL.format(version="1.8.0"))
+
+    def test_patch_releases_can_change_the_minimum(self):
+        fetch = Mock(side_effect=[readme(19), readme(23)])
+        rows = scraper.build_rows({"2.1.0": "2.1.0", "2.1.1": "2.1.1"}, "1.24", fetch)
+        self.assertEqual([r["version"] for r in rows], ["2.1.1", "2.1.0"])
+        self.assertEqual([r["kube"][-1] for r in rows], ["1.23", "1.19"])
+
+    def test_rejects_missing_ambiguous_or_out_of_section_minimum(self):
+        sentence = readme(23).decode().splitlines()[4]
+        for text in ["no prerequisites", "## Prerequisites\nNo numeric policy.\n",
+                     "## Prerequisites\n\n## Elsewhere\n" + sentence,
+                     "## Prerequisites\n" + sentence + "\n" + sentence]:
+            with self.subTest(text=text), self.assertRaises(ValueError):
+                scraper.parse_minimum(text)
+
+    def test_rejects_empty_sources_and_invalid_bounds(self):
+        for page in [None, b"", b"bad document", b"\xff"]:
+            with self.subTest(page=page), self.assertRaises(ValueError):
+                scraper.build_rows({"2.7.0": "2.7.0"}, "1.24", Mock(return_value=page))
+        for ceiling in ["2.0", "1.24.1", "1.22"]:
+            with self.subTest(ceiling=ceiling), self.assertRaises(ValueError):
+                scraper.build_rows({"2.7.0": "2.7.0"}, ceiling, Mock(return_value=readme(23)))
+        with self.assertRaises(ValueError):
+            scraper.build_rows({}, "1.24", Mock())
+
+    def test_scrape_wiring_and_no_partial_update(self):
+        helpers = ModuleType("utils")
+        helpers.get_chart_versions = Mock(return_value={"1.15.2": "1.15.2", "2.7.0": "2.7.0"})
+        helpers.current_kube_version = Mock(return_value="1.24")
+        helpers.fetch_page = Mock(side_effect=[readme(16), None])
+        helpers.update_compatibility_info = Mock()
+        with patch.dict("sys.modules", {"utils": helpers}), self.assertRaises(ValueError):
+            scraper.scrape()
+        helpers.update_compatibility_info.assert_not_called()
+        helpers.fetch_page = Mock(side_effect=[readme(16), readme(23)])
+        with patch.dict("sys.modules", {"utils": helpers}):
+            scraper.scrape()
+        helpers.get_chart_versions.assert_called_with("antrea")
+        path, rows = helpers.update_compatibility_info.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/antrea.yaml")
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0]["version"], "2.7.0")
+        self.assertEqual(rows[0]["kube"], ["1.24", "1.23"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Antrea is missing from Console's compatibility registry. This adds a scraper and generated table that match each stable `antrea` Helm appVersion to the Kubernetes minimum documented in that application's tagged README, preserving historical changes instead of applying today's prerequisites to every release.

Sources:
- [Official Helm installation guide](https://github.com/antrea-io/antrea/blob/main/docs/helm.md) and [chart index](https://charts.antrea.io/index.yaml): Helm releases start at v1.8.
- Tagged prerequisites: [v1.15.2 requires 1.16 or later](https://github.com/antrea-io/antrea/blob/v1.15.2/README.md#prerequisites), [v2.0.0 requires 1.19 or later](https://github.com/antrea-io/antrea/blob/v2.0.0/README.md#prerequisites), and [v2.7.0 requires 1.23 or later](https://github.com/antrea-io/antrea/blob/v2.7.0/README.md#prerequisites).

The explicit `or later` policy is expanded through the repository's current `KUBE_VERSION` (1.36). This represents upstream's documented policy; it is not a claim that I ran Antrea across all those cluster versions. NodeIPAM, Open vSwitch, OS-specific and optional-feature prerequisites still apply as documented upstream. Pre-Helm versions and prereleases are excluded. A missing or ambiguous tagged README aborts before writing any partial update.

Validation completed locally:
- Six unit tests pass, covering appVersion/tag selection, patch-level prerequisite changes, version filtering, invalid/missing sources, bounds and the scrape entry point's failure atomicity.
- A real scrape and Helm 3.18.6 render completed. The shared updater's existing reduction policy produced 16 representative version rows (v1.8.0 through v2.7.0), all with image references.
- The generated table and manifest pass the repository's JSON Schema. The registry contains exactly one Antrea entry; `git diff --check` is clean.

A focused GitHub Actions workflow runs the unit tests, and `utils/compatibility/tests/ANTREA.md` documents sources, limitations and reproduction. No hosted CI result is claimed yet.

Please consider this submission under the README Contributor Program for new compatibility scrapers. Reward eligibility remains subject to maintainer review and merge.
