### PR TITLE
feat: add trust-manager compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -8,6 +8,7 @@ names:
 - amazon-vpc-cni-k8s
 - calico
 - cert-manager
+- trust-manager
 - cilium
 - contour
 - coredns

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -8,7 +8,6 @@ names:
 - amazon-vpc-cni-k8s
 - calico
 - cert-manager
-- trust-manager
 - cilium
 - contour
 - coredns
@@ -32,6 +31,7 @@ names:
 - rook
 - strimzi-kafka
 - traefik
+- trust-manager
 - velero
 - vitess
 - gatekeeper

--- a/static/compatibilities/trust-manager.yaml
+++ b/static/compatibilities/trust-manager.yaml
@@ -1,0 +1,174 @@
+name: trust-manager
+icon: https://raw.githubusercontent.com/cert-manager/community/4d35a69437d21b76322157e6284be4cd64e6d2b7/logo/logo-small.png
+git_url: https://github.com/cert-manager/trust-manager
+release_url: https://github.com/cert-manager/trust-manager/releases/tag/v{vsn}
+helm_repository_url: https://charts.jetstack.io
+versions:
+- version: 0.24.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.24.0
+  images: ['quay.io/jetstack/trust-manager:v0.24.0', 'quay.io/jetstack/trust-pkg-debian-trixie:20250419.1']
+- version: 0.23.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.23.0
+  images: ['quay.io/jetstack/trust-manager:v0.23.0', 'quay.io/jetstack/trust-pkg-debian-trixie:20250419.1']
+- version: 0.22.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.22.0
+  images: ['quay.io/jetstack/trust-manager:v0.22.0', 'quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.5']
+- version: 0.21.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.21.0
+  images: ['quay.io/jetstack/trust-manager:v0.21.0', 'quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.4']
+- version: 0.20.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.20.0
+  images: ['quay.io/jetstack/trust-manager:v0.20.0', 'quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.1']
+- version: 0.19.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.19.0
+  images: ['quay.io/jetstack/trust-manager:v0.19.0', 'quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.0']
+- version: 0.18.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.18.0
+  images: ['quay.io/jetstack/trust-manager:v0.18.0', 'quay.io/jetstack/trust-pkg-debian-bookworm:20230311.0']
+- version: 0.17.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.0
+  images: ['quay.io/jetstack/trust-manager:v0.17.0', 'quay.io/jetstack/trust-pkg-debian-bookworm:20230311.0']
+- version: 0.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.0
+  images: ['quay.io/jetstack/trust-manager:v0.16.0', 'quay.io/jetstack/trust-pkg-debian-bookworm:20230311.0']
+- version: 0.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.15.0']
+- version: 0.14.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.14.0']
+- version: 0.13.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.13.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.13.0']
+- version: 0.12.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.12.0']
+- version: 0.11.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.11.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.11.0']
+- version: 0.10.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.10.0']
+- version: 0.9.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.9.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.9.0']
+- version: 0.8.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.8.0']
+- version: 0.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.7.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.7.0']
+- version: 0.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.6.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.6.0']
+- version: 0.5.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.5.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.5.0']
+- version: 0.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.4.0
+  images: ['quay.io/jetstack/cert-manager-package-debian:20210119.0', 'quay.io/jetstack/trust-manager:v0.4.0']

--- a/utils/compatibility/scrapers/trust-manager.py
+++ b/utils/compatibility/scrapers/trust-manager.py
@@ -20,6 +20,8 @@ def parse_index(content, latest_kube):
     index = yaml.safe_load(content)
     entries = index.get("entries", {}).get(APP_NAME, [])
     latest = Version.coerce(latest_kube)
+    if latest.major != 1:
+        raise ValueError("Kubernetes major changed; update release history before scraping.")
     kube_releases = [
         Version(major=latest.major, minor=minor, patch=0)
         for minor in range(latest.minor + 1)

--- a/utils/compatibility/scrapers/trust-manager.py
+++ b/utils/compatibility/scrapers/trust-manager.py
@@ -1,0 +1,67 @@
+import re
+
+import yaml
+from semantic_version import NpmSpec, Version
+
+from utils import (
+    current_kube_version,
+    fetch_page,
+    print_error,
+    sort_versions,
+    update_compatibility_info,
+    validate_semver,
+)
+
+APP_NAME = "trust-manager"
+INDEX_URL = "https://charts.jetstack.io/index.yaml"
+
+
+def parse_index(content, latest_kube):
+    index = yaml.safe_load(content)
+    entries = index.get("entries", {}).get(APP_NAME, [])
+    latest = Version.coerce(latest_kube)
+    kube_releases = [
+        Version(major=latest.major, minor=minor, patch=0)
+        for minor in range(latest.minor + 1)
+    ]
+    versions = []
+    for entry in entries:
+        app_version = validate_semver(entry.get("appVersion", "").lstrip("v"))
+        chart_version = validate_semver(entry.get("version", "").lstrip("v"))
+        constraint = entry.get("kubeVersion")
+        # Older charts without a declared constraint do not establish compatibility.
+        if not app_version or not chart_version or not constraint:
+            continue
+        spec = NpmSpec(re.sub(r"([<>=~^]+)\s+", r"\1", constraint))
+        kube = [f"{v.major}.{v.minor}" for v in kube_releases if spec.match(v)]
+        if kube:
+            versions.append({
+                "version": str(app_version),
+                "kube": kube,
+                "chart_version": str(chart_version),
+                "requirements": [],
+                "incompatibilities": [],
+            })
+
+    # Index order is not guaranteed; prefer the newest stable chart per app version.
+    result = {}
+    for version in sort_versions(versions):
+        result.setdefault(version["version"], version)
+    return list(result.values())
+
+
+def scrape():
+    latest_kube = current_kube_version()
+    if not latest_kube:
+        print_error("Could not determine current Kubernetes version from KUBE_VERSION.")
+        return
+    content = fetch_page(INDEX_URL)
+    if not content:
+        return
+    versions = parse_index(content, latest_kube)
+    if not versions:
+        print_error("No declared Kubernetes compatibility found for trust-manager.")
+        return
+    update_compatibility_info(
+        f"../../static/compatibilities/{APP_NAME}.yaml", versions
+    )

--- a/utils/compatibility/tests/test_trust_manager.py
+++ b/utils/compatibility/tests/test_trust_manager.py
@@ -1,0 +1,73 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+import yaml
+
+scraper = importlib.import_module("scrapers.trust-manager")
+
+
+def chart(app="v0.24.0", version="v0.24.0", kube=">= 1.25.0-0"):
+    return {"appVersion": app, "version": version, "kubeVersion": kube}
+
+
+def index(*entries):
+    return yaml.safe_dump({"entries": {"trust-manager": list(entries)}})
+
+
+class TrustManagerTests(unittest.TestCase):
+    def test_declared_minimum_is_bounded_by_current_kubernetes(self):
+        rows = scraper.parse_index(index(chart()), "1.27")
+        self.assertEqual(rows, [{
+            "version": "0.24.0", "chart_version": "0.24.0",
+            "kube": ["1.25", "1.26", "1.27"],
+            "requirements": [], "incompatibilities": [],
+        }])
+
+    def test_upper_bounds_are_respected(self):
+        rows = scraper.parse_index(index(chart(kube=">= 1.25.0-0 < 1.27.0")), "1.36")
+        self.assertEqual(rows[0]["kube"], ["1.25", "1.26"])
+
+    def test_unknown_future_and_prerelease_entries_are_not_reported(self):
+        entries = [chart(kube=None), chart(kube=">=1.40.0"),
+                   chart(app="v0.25.0-alpha.0"), chart(version="v0.25.0-rc.1")]
+        self.assertEqual(scraper.parse_index(index(*entries), "1.36"), [])
+
+    def test_latest_chart_wins_regardless_of_index_order(self):
+        rows = scraper.parse_index(index(
+            chart(version="v0.24.1"), chart(version="v0.24.3"),
+            chart(version="v0.24.2")), "1.26")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["chart_version"], "0.24.3")
+
+    def test_invalid_constraint_does_not_write_partial_data(self):
+        with patch.object(scraper, "current_kube_version", return_value="1.36"), \
+             patch.object(scraper, "fetch_page", return_value=index(
+                 chart(), chart(app="v0.20.0", kube="not-a-version"))), \
+             patch.object(scraper, "update_compatibility_info") as update:
+            with self.assertRaises(ValueError):
+                scraper.scrape()
+            update.assert_not_called()
+
+    def test_scrape_uses_existing_update_pipeline(self):
+        with patch.object(scraper, "current_kube_version", return_value="1.26"), \
+             patch.object(scraper, "fetch_page", return_value=index(chart())) as fetch, \
+             patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+            fetch.assert_called_once_with(scraper.INDEX_URL)
+            self.assertEqual(update.call_args.args[0],
+                             "../../static/compatibilities/trust-manager.yaml")
+            self.assertEqual(update.call_args.args[1][0]["kube"], ["1.25", "1.26"])
+
+    def test_unavailable_or_empty_index_does_not_overwrite_data(self):
+        for content in (None, index(), index(chart(kube=None))):
+            with self.subTest(content=content), \
+                 patch.object(scraper, "current_kube_version", return_value="1.36"), \
+                 patch.object(scraper, "fetch_page", return_value=content), \
+                 patch.object(scraper, "update_compatibility_info") as update:
+                scraper.scrape()
+                update.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_trust_manager.py
+++ b/utils/compatibility/tests/test_trust_manager.py
@@ -68,6 +68,14 @@ class TrustManagerTests(unittest.TestCase):
                 scraper.scrape()
                 update.assert_not_called()
 
+    def test_major_transition_preserves_existing_data(self):
+        with patch.object(scraper, "current_kube_version", return_value="2.0"), \
+             patch.object(scraper, "fetch_page", return_value=index(chart())), \
+             patch.object(scraper, "update_compatibility_info") as update:
+            with self.assertRaisesRegex(ValueError, "Kubernetes major changed"):
+                scraper.scrape()
+            update.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
trust-manager is missing from the compatibility catalog. This adds its scraper and metadata, registers it in the manifest, and generates 21 release rows through v0.24.0 using the existing reduction and Helm image extraction pipeline.

The source is the official [Jetstack Helm index](https://charts.jetstack.io/index.yaml), specifically each stable chart's `appVersion`, `version` and `kubeVersion`. The current [Chart.yaml](https://github.com/cert-manager/trust-manager/blob/v0.24.0/deploy/charts/trust-manager/Chart.yaml) declares `>= 1.25.0-0`. The scraper evaluates declared constraints through the repository's `KUBE_VERSION` (currently 1.36), excludes prereleases, and selects the newest stable chart for each app version. v0.3.0 has no declared constraint, so it is omitted.

These rows describe Helm-declared installation compatibility; they are not a claim that every application/Kubernetes combination was tested on a cluster. The [installation documentation](https://cert-manager.io/docs/trust/trust-manager/installation/) describes cert-manager as optional when using a Helm-generated certificate; this change does not invent a cert-manager version requirement.

## Test Plan

Local environment: Python 3.11 and Helm 3.19.0 on macOS arm64.

- `cd utils/compatibility && python -m unittest discover -s tests -p test_trust_manager.py -v`: 8 passing checks covering bounds, spaced constraints, prereleases, duplicate charts and preserving data on unavailable or malformed input and unsupported Kubernetes major transitions.
- Ran `importlib.import_module('scrapers.trust-manager').scrape()` twice against the live index with summarization disabled. All 21 retained charts rendered successfully and produced image references; the second run was byte-for-byte identical.
- Cross-checked all 33 stable source entries with declared constraints against their minimum Kubernetes versions; verified the 21 reduced rows and validated the new YAML and manifest against `static/compatibilities/schema.json`.
- `git diff --check` passes. No agent or frontend code changed; no cluster deployment was performed.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added tests to cover my changes.
- Documentation and agent deployment: not applicable to this catalog addition.

I'm submitting this under the README's new compatibility scraper contributor program. My Discord handle is `bengdk.` for account verification.

Plural Flow: console
