### PR TITLE
Add MetalLB Helm compatibility scraper

### DIFF
--- a/.github/workflows/test-metallb-compatibility.yaml
+++ b/.github/workflows/test-metallb-compatibility.yaml
@@ -1,0 +1,35 @@
+name: Test MetalLB compatibility scraper
+on:
+  pull_request:
+    paths:
+      - 'utils/compatibility/scrapers/metallb.py'
+      - 'utils/compatibility/tests/test_metallb.py'
+      - 'utils/compatibility/utils.py'
+      - 'static/compatibilities/metallb.yaml'
+      - '.github/workflows/test-metallb-compatibility.yaml'
+  push:
+    branches: [master]
+    paths:
+      - 'utils/compatibility/scrapers/metallb.py'
+      - 'utils/compatibility/tests/test_metallb.py'
+      - 'utils/compatibility/utils.py'
+      - 'static/compatibilities/metallb.yaml'
+      - '.github/workflows/test-metallb-compatibility.yaml'
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Run scraper tests through the repository test entry point
+        env:
+          TEST_CMD: >-
+            apk add --no-cache python3 py3-pip &&
+            python3 -m venv /tmp/metallb-tests &&
+            /tmp/metallb-tests/bin/python -m pip install packaging==24.1 PyYAML==6.0.2 &&
+            /tmp/metallb-tests/bin/python -m unittest discover -s utils/compatibility/tests -p test_metallb.py -v
+        # Compose consumes CONSOLE_CMD and needs one argument for /bin/sh -c.
+        run: CONSOLE_CMD="\"$TEST_CMD\"" make test-full TEST_CMD="$TEST_CMD"
+

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -49,3 +49,4 @@ names:
 - wiz-sensor
 - wiz-admission-controller
 - wiz-network-analyzer
+- metallb

--- a/static/compatibilities/metallb.yaml
+++ b/static/compatibilities/metallb.yaml
@@ -1,0 +1,48 @@
+icon: https://metallb.io/images/logo/metallb-white.png
+git_url: https://github.com/metallb/metallb
+release_url: https://github.com/metallb/metallb/releases/tag/v{vsn}
+helm_repository_url: https://metallb.github.io/metallb
+helm_values: frr-k8s.prometheus.serviceMonitor.enabled=false,frr-k8s.prometheus.prometheusRule.enabled=false
+versions:
+- version: 0.16.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.1
+  images: ['quay.io/frrouting/frr:10.4.3', 'quay.io/metallb/controller:v0.16.1', 'quay.io/metallb/frr-k8s:v0.0.25',
+    'quay.io/metallb/speaker:v0.16.1']
+- version: 0.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.0
+  images: ['quay.io/frrouting/frr:10.4.3', 'quay.io/metallb/controller:v0.16.0', 'quay.io/metallb/frr-k8s:v0.0.25',
+    'quay.io/metallb/speaker:v0.16.0']
+- version: 0.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.0
+  images: ['quay.io/frrouting/frr:9.1.0', 'quay.io/metallb/controller:v0.15.0', 'quay.io/metallb/speaker:v0.15.0']
+- version: 0.14.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.2
+  images: ['quay.io/frrouting/frr:8.5.2', 'quay.io/metallb/controller:v0.14.2', 'quay.io/metallb/speaker:v0.14.2']
+- version: 0.13.9
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.13.9
+  images: ['quay.io/metallb/controller:v0.13.9', 'quay.io/metallb/speaker:v0.13.9']

--- a/utils/compatibility/scrapers/metallb.py
+++ b/utils/compatibility/scrapers/metallb.py
@@ -1,0 +1,79 @@
+"""MetalLB Helm compatibility from each published chart's kubeVersion."""
+
+import re
+from collections import OrderedDict
+
+import yaml
+from packaging.version import Version
+
+INDEX_URL = "https://metallb.github.io/metallb/index.yaml"
+FIRST_CONSTRAINED_RELEASE = Version("0.13.9")
+
+
+def stable_version(value):
+    if not isinstance(value, str) or not re.fullmatch(r"v?\d+\.\d+\.\d+", value):
+        return None
+    return value.removeprefix("v")
+
+
+def build_rows(index, current_kube):
+    """Encode chart install constraints, not a matrix of cluster test results.
+
+    Only the observed >= major.minor.0[-0] constraint is supported. A future
+    constraint change must be reviewed instead of silently widening support.
+    """
+    ceiling = re.fullmatch(r"1\.(\d+)", current_kube)
+    if not ceiling:
+        raise ValueError("Expected a Kubernetes 1.minor ceiling")
+    maximum = int(ceiling.group(1))
+    if not isinstance(index, dict) or not isinstance(index.get("entries"), dict):
+        raise ValueError("Missing Helm index entries")
+    entries = index["entries"].get("metallb")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Missing MetalLB chart entries")
+
+    selected = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Malformed MetalLB chart entry")
+        app = stable_version(entry.get("appVersion"))
+        chart = stable_version(entry.get("version"))
+        if not app or not chart or chart == "0.0.0":
+            continue  # The official index contains a development 0.0.0 chart.
+        if Version(app) < FIRST_CONSTRAINED_RELEASE:
+            continue  # Older official charts do not declare kubeVersion.
+        constraint = entry.get("kubeVersion")
+        match = re.fullmatch(r">=\s*1\.(\d+)\.0(?:-0)?", constraint or "")
+        if not match:
+            raise ValueError(f"Unsupported or missing kubeVersion for MetalLB {app}: {constraint!r}")
+        minimum = int(match.group(1))
+        if minimum > maximum:
+            raise ValueError(f"Kubernetes ceiling precedes the minimum for MetalLB {app}")
+        if app in selected:
+            previous_chart, previous_minimum = selected[app]
+            if chart == previous_chart and minimum != previous_minimum:
+                raise ValueError(f"Conflicting duplicate chart metadata for MetalLB {app}")
+            if Version(chart) <= Version(previous_chart):
+                continue
+        selected[app] = (chart, minimum)
+
+    if not selected:
+        raise ValueError("No stable MetalLB charts with supported constraints")
+    return [OrderedDict([
+        ("version", app),
+        ("kube", [f"1.{minor}" for minor in range(maximum, selected[app][1] - 1, -1)]),
+        ("chart_version", selected[app][0]),
+        ("images", []),
+        ("requirements", []),
+        ("incompatibilities", []),
+    ]) for app in sorted(selected, key=Version, reverse=True)]
+
+
+def scrape():
+    from utils import current_kube_version, fetch_page, update_compatibility_info
+
+    page = fetch_page(INDEX_URL)
+    if not page:
+        raise ValueError("Could not fetch the official MetalLB chart index")
+    rows = build_rows(yaml.safe_load(page), current_kube_version())
+    update_compatibility_info("../../static/compatibilities/metallb.yaml", rows)

--- a/utils/compatibility/tests/METALLB.md
+++ b/utils/compatibility/tests/METALLB.md
@@ -1,0 +1,72 @@
+# MetalLB Helm compatibility
+
+Source: the [official MetalLB Helm index](https://metallb.github.io/metallb/index.yaml),
+linked by the [official installation guide](https://metallb.io/installation/).
+The scraper reads the `metallb` chart's own `appVersion`, `version` and
+`kubeVersion` fields. It encodes Helm installation constraints, not results of
+testing every listed Kubernetes version with every networking configuration.
+
+The current stable charts from 0.13.9 through 0.16.1 declare `>= 1.19.0-0`.
+This is more restrictive than the website's generic Kubernetes 1.13 minimum.
+The chart constraint is used for these Helm installations. Earlier charts do
+not declare `kubeVersion` and are excluded. The index's development chart
+`0.0.0` (whose appVersion misleadingly names 0.14.1) and prereleases are also
+excluded. No missing release is synthesized.
+
+Each chart is considered independently. The highest stable chart version wins
+when multiple charts package the same application release. The current parser
+supports only an explicit `>= 1.minor.0` bound, optionally ending in `-0`.
+Missing or changed constraints in the supported release range abort the scrape
+before any shared update. A future upper bound or nonzero patch minimum needs
+review; it is never silently rounded or removed. The open upper bound expands
+only through the repository's current `KUBE_VERSION` (1.36).
+
+The shared updater reduces the result to representative version boundaries and
+resolves chart images with Helm. Chart 0.16.0 has a null FRR-K8s Prometheus
+configuration in its default values, causing a template nil-pointer error.
+The metadata's `helm_values` explicitly disables the optional FRR-K8s
+ServiceMonitor and PrometheusRule to render this release. It does not disable
+the FRR-K8s workload or replace its images. These two values are applied to all
+rendered releases for reproducibility.
+
+Cloud/network-addon compatibility,
+available address pools, speaker privileges, IPVS strict ARP, and BGP/L2 setup
+are still required as described by MetalLB's installation documentation. Helm
+version acceptance alone does not establish that those requirements are met.
+
+## Tests
+
+Use the repository test entry point from the repository root with Make and
+Docker Compose. The existing test image is Alpine-based and does not include
+Python. Install the test dependencies in its disposable container:
+
+```sh
+TEST_CMD='apk add --no-cache python3 py3-pip && python3 -m venv /tmp/metallb-tests && /tmp/metallb-tests/bin/python -m pip install packaging==24.1 PyYAML==6.0.2 && /tmp/metallb-tests/bin/python -m unittest discover -s utils/compatibility/tests -p test_metallb.py -v'
+CONSOLE_CMD="\"$TEST_CMD\"" make test-full TEST_CMD="$TEST_CMD"
+```
+
+Both variables are needed because the Compose file currently consumes
+`CONSOLE_CMD`, while the Makefile documents `TEST_CMD`. Embedded quotes preserve
+one command argument for `/bin/sh -c`. The Make target retains dependency startup,
+console exit-code propagation, and teardown. The focused workflow uses the same
+command and pins checkout to a full commit SHA.
+
+The six unit tests cover per-chart bounds, app/chart version separation,
+prerelease/development filtering, duplicate-chart selection and conflicts,
+unsupported/missing constraints, malformed sources and entry-point atomicity.
+They passed directly with Python 3.13 during development. The Windows host has
+no Make or Docker, so local verification does not establish that the Docker
+wrapper or hosted CI passed.
+
+## Regeneration
+
+With the repository compatibility Python environment and Helm 3 on PATH, run
+from `utils/compatibility`:
+
+```sh
+OPENAI_API_KEY= EXA_API_KEY= python -c 'from scrapers.metallb import scrape; scrape()'
+```
+
+This fetches public chart metadata and renders Helm templates locally to extract
+images. It does not install anything into a cluster. Optional paid summaries
+are disabled by the empty API keys.

--- a/utils/compatibility/tests/test_metallb.py
+++ b/utils/compatibility/tests/test_metallb.py
@@ -1,0 +1,86 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import unittest
+from unittest.mock import Mock, patch
+
+spec = importlib.util.spec_from_file_location(
+    "metallb", Path(__file__).parents[1] / "scrapers" / "metallb.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+def entry(app="v0.14.2", chart="0.14.2", constraint=">= 1.19.0-0"):
+    return {"appVersion": app, "version": chart, "kubeVersion": constraint}
+
+
+def index(*entries):
+    return {"entries": {"metallb": list(entries)}}
+
+
+class MetalLBTests(unittest.TestCase):
+    def test_uses_each_chart_constraint_and_app_version(self):
+        rows = scraper.build_rows(index(
+            entry(), entry("v0.15.0", "0.15.1", ">= 1.21.0"),
+        ), "1.22")
+        self.assertEqual([row["version"] for row in rows], ["0.15.0", "0.14.2"])
+        self.assertEqual(rows[0]["chart_version"], "0.15.1")
+        self.assertEqual(rows[0]["kube"], ["1.22", "1.21"])
+        self.assertEqual(rows[1]["kube"], ["1.22", "1.21", "1.20", "1.19"])
+
+    def test_filters_old_prerelease_and_development_charts(self):
+        rows = scraper.build_rows(index(
+            entry("v0.13.7", "0.13.7", None),
+            entry("v0.14.1", "0.0.0"),
+            entry("v0.17.0-rc.1", "0.17.0"),
+            entry("v0.17.0", "0.17.0-rc.1"), entry(),
+        ), "1.19")
+        self.assertEqual([row["version"] for row in rows], ["0.14.2"])
+
+    def test_chooses_highest_chart_for_an_app_independent_of_order(self):
+        entries = [entry(chart="0.14.9"), entry(chart="0.14.10", constraint=">= 1.20.0")]
+        a = scraper.build_rows(index(*entries), "1.21")
+        self.assertEqual(a, scraper.build_rows(index(*reversed(entries)), "1.21"))
+        self.assertEqual(a[0]["chart_version"], "0.14.10")
+        self.assertEqual(a[0]["kube"], ["1.21", "1.20"])
+        with self.assertRaises(ValueError):
+            scraper.build_rows(index(entry(), entry(constraint=">= 1.20.0")), "1.21")
+
+    def test_rejects_unsupported_constraints_instead_of_widening(self):
+        for value in [None, "", ">=1.19.1", ">=1.19.0 <1.25.0", "^1.19.0", ">=2.0.0"]:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                scraper.build_rows(index(entry(constraint=value)), "1.36")
+
+    def test_rejects_missing_data_and_invalid_bounds(self):
+        for data in [None, {}, {"entries": []}, index(), index(None)]:
+            with self.subTest(data=data), self.assertRaises(ValueError):
+                scraper.build_rows(data, "1.36")
+        for bound in ["1.18", "1.19.0", "2.0"]:
+            with self.subTest(bound=bound), self.assertRaises(ValueError):
+                scraper.build_rows(index(entry()), bound)
+
+    def test_scrape_updates_once_and_never_writes_partial_rows(self):
+        utilities = ModuleType("utils")
+        utilities.current_kube_version = Mock(return_value="1.20")
+        utilities.fetch_page = Mock(return_value=scraper.yaml.safe_dump(index(entry())))
+        utilities.update_compatibility_info = Mock()
+        with patch.dict("sys.modules", {"utils": utilities}):
+            scraper.scrape()
+            utilities.fetch_page.assert_called_once_with(scraper.INDEX_URL)
+            utilities.update_compatibility_info.assert_called_once_with(
+                "../../static/compatibilities/metallb.yaml",
+                scraper.build_rows(index(entry()), "1.20"),
+            )
+            for page in [None, b"", b"entries: [", scraper.yaml.safe_dump(index(
+                entry(), entry("v0.15.0", "0.15.0", None),
+            ))]:
+                utilities.fetch_page.return_value = page
+                utilities.update_compatibility_info.reset_mock()
+                with self.assertRaises((ValueError, scraper.yaml.YAMLError)):
+                    scraper.scrape()
+                utilities.update_compatibility_info.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
MetalLB is missing from the compatibility registry. This adds a scraper that maps each stable official Helm chart's `appVersion` to its own `kubeVersion` constraint, together with generated metadata and a registry entry.

The source is the [official chart index](https://metallb.github.io/metallb/index.yaml), linked by the [installation guide](https://metallb.io/installation/). Charts from 0.13.9 through 0.16.1 explicitly declare `>= 1.19.0-0`. This is stricter than the website's generic 1.13 minimum and is the relevant constraint for these Helm installations. Older charts without the field, prereleases, and the development `0.0.0` chart are excluded. No missing release is synthesized.

The supported open lower-bound constraint expands through the repository's current `KUBE_VERSION` (1.36). This encodes chart installation requirements, not a claim of testing every Kubernetes/network combination. Unsupported or missing constraints in the included release range abort before the shared update. If multiple charts package one application release, the highest stable chart version is selected independently of index order.

Real Helm rendering exposed a default-value nil-pointer error in chart 0.16.0's FRR-K8s ServiceMonitor template. The metadata explicitly disables the optional FRR-K8s ServiceMonitor and PrometheusRule via `helm_values`; the workload remains enabled and its images are retained. The workaround and network/privilege prerequisites are documented in `utils/compatibility/tests/METALLB.md`.

Validation:
- Six focused unit tests pass locally with Python 3.13, including per-chart version bounds, filtering, duplicate selection/conflicts, invalid metadata and entry-point failure atomicity.
- Actual fetch and Helm 3.18.6 rendering completed after the documented values override. The shared reducer retained five representative rows (0.13.9, 0.14.2, 0.15.0, 0.16.0, 0.16.1), all with resolved images.
- The generated table and manifest pass the repository JSON Schema; the registry contains one MetalLB entry. Workflow YAML/command argument checks and `git diff --check` pass.
- The focused workflow uses `make test-full`, with both `TEST_CMD` and the actual Compose `CONSOLE_CMD` override, and a pinned checkout action. The Windows development host has neither Make nor Docker, so the Docker wrapper and hosted CI have not been validated locally.

Please consider this submission under the README Contributor Program for new compatibility scrapers. Eligibility remains subject to maintainer review and merge.
