### PR TITLE
feat: add kube-state-metrics compatibility scraper

### DIFF
--- a/static/compatibilities/kube-state-metrics.yaml
+++ b/static/compatibilities/kube-state-metrics.yaml
@@ -1,0 +1,41 @@
+name: kube-state-metrics
+icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/kubernetes/icon/color/kubernetes-icon-color.svg
+git_url: https://github.com/kubernetes/kube-state-metrics
+release_url: https://github.com/kubernetes/kube-state-metrics/releases/tag/v{vsn}
+helm_repository_url: https://prometheus-community.github.io/helm-charts
+versions:
+- version: 2.20.0
+  kube: ['1.36']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 8.4.2
+  images: ['registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.20.0']
+- version: 2.19.0
+  kube: ['1.35']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 7.4.0
+  images: ['registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.0']
+- version: 2.18.0
+  kube: ['1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 7.3.0
+  images: ['registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0']
+- version: 2.17.0
+  kube: ['1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 7.0.1
+  images: ['registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.17.0']
+- version: 2.16.0
+  kube: ['1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 6.1.5
+  images: ['registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.16.0']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -23,6 +23,7 @@ names:
 - karpenter
 - keda
 - kube-prometheus-stack
+- kube-state-metrics
 - kyverno
 - linkerd
 - longhorn

--- a/utils/compatibility/scrapers/kube-state-metrics.py
+++ b/utils/compatibility/scrapers/kube-state-metrics.py
@@ -1,0 +1,57 @@
+import re
+
+from utils import (
+    fetch_page,
+    get_chart_versions,
+    print_error,
+    update_compatibility_info,
+    validate_semver,
+)
+
+APP_NAME = "kube-state-metrics"
+MATRIX_URL = "https://raw.githubusercontent.com/kubernetes/kube-state-metrics/main/README.md"
+
+
+def parse_matrix(content, chart_versions):
+    text = content.decode("utf-8") if isinstance(content, bytes) else content
+    in_matrix = False
+    versions = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line == "#### Compatibility matrix":
+            in_matrix = True
+            continue
+        if not in_matrix:
+            continue
+        if line.startswith("#"):
+            break
+        cells = [cell.strip().strip("*`") for cell in line.strip("|").split("|")]
+        if len(cells) != 2:
+            continue
+        app_version = validate_semver(cells[0].lstrip("v"))
+        kube_match = re.fullmatch(r"v?(\d+\.\d+)", cells[1])
+        if not app_version or not kube_match:
+            continue
+        chart_version = validate_semver(chart_versions.get(str(app_version), ""))
+        if not chart_version:
+            continue
+        # Record the documented client-go pairing; broader compatibility is best effort.
+        versions.append({
+            "version": str(app_version),
+            "kube": [kube_match.group(1)],
+            "chart_version": str(chart_version),
+            "requirements": [],
+            "incompatibilities": [],
+        })
+    return versions
+
+
+def scrape():
+    content = fetch_page(MATRIX_URL)
+    if not content:
+        return
+    versions = parse_matrix(content, get_chart_versions(APP_NAME))
+    if not versions:
+        print_error("No kube-state-metrics compatibility rows with stable Helm charts found.")
+        return
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", versions)

--- a/utils/compatibility/tests/test_kube_state_metrics.py
+++ b/utils/compatibility/tests/test_kube_state_metrics.py
@@ -1,0 +1,58 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+scraper = importlib.import_module("scrapers.kube-state-metrics")
+MATRIX = """#### Compatibility matrix
+
+| kube-state-metrics | Kubernetes client-go Version |
+|--------------------|:----------------------------:|
+| **v2.19.0** | v1.35 |
+| **v2.20.0** | v1.36 |
+| **main** | v1.36 |
+"""
+
+
+class KubeStateMetricsTests(unittest.TestCase):
+    def test_exact_documented_pairs_and_chart_versions(self):
+        rows = scraper.parse_matrix(MATRIX.encode(), {"2.19.0": "7.4.0", "2.20.0": "8.4.2"})
+        self.assertEqual(rows, [
+            {"version": "2.19.0", "kube": ["1.35"], "chart_version": "7.4.0",
+             "requirements": [], "incompatibilities": []},
+            {"version": "2.20.0", "kube": ["1.36"], "chart_version": "8.4.2",
+             "requirements": [], "incompatibilities": []},
+        ])
+
+    def test_unrelated_tables_are_ignored(self):
+        unrelated = "| **v2.18.0** | v1.34 |\n"
+        content = unrelated + MATRIX + "#### Other section\n" + unrelated
+        rows = scraper.parse_matrix(content, {"2.18.0": "7.3.0", "2.20.0": "8.4.2"})
+        self.assertEqual([r["version"] for r in rows], ["2.20.0"])
+
+    def test_missing_or_unstable_versions_are_not_inferred(self):
+        content = MATRIX + "| **v2.21.0-rc.0** | v1.37 |\n| **v2.22.0** | unknown |"
+        rows = scraper.parse_matrix(content, {"2.20.0": "8.5.0-rc.0",
+                                             "2.21.0-rc.0": "9.0.0", "2.22.0": "10.0.0"})
+        self.assertEqual(rows, [])
+
+    def test_fetch_or_parse_failure_preserves_existing_data(self):
+        for content in (None, "# New README without a compatibility matrix"):
+            with self.subTest(content=content), \
+                 patch.object(scraper, "fetch_page", return_value=content), \
+                 patch.object(scraper, "get_chart_versions", return_value={}), \
+                 patch.object(scraper, "update_compatibility_info") as update:
+                scraper.scrape()
+                update.assert_not_called()
+
+    def test_scrape_uses_shared_chart_and_update_helpers(self):
+        with patch.object(scraper, "fetch_page", return_value=MATRIX), \
+             patch.object(scraper, "get_chart_versions", return_value={"2.20.0": "8.4.2"}) as charts, \
+             patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+            charts.assert_called_once_with("kube-state-metrics")
+            self.assertEqual(update.call_args.args[0], "../../static/compatibilities/kube-state-metrics.yaml")
+            self.assertEqual(update.call_args.args[1][0]["kube"], ["1.36"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
kube-state-metrics has no entry in the compatibility catalog. This adds its scraper, metadata and manifest entry, with five generated release rows from v2.16.0 through v2.20.0.

The scraper reads the upstream [compatibility matrix](https://github.com/kubernetes/kube-state-metrics#compatibility-matrix) and records only its exact application/client-go Kubernetes pairings. Upstream describes other compatibility as best effort and only supports its latest release; these historical pairings do not imply ongoing upstream support or compatibility with every newer cluster. The `main` row is excluded.

Chart versions come from the existing `get_chart_versions` helper and the [Prometheus Community Helm index](https://prometheus-community.github.io/helm-charts/index.yaml). The existing update pipeline renders charts to extract images and preserves older entries as the upstream matrix rolls forward. There are no new dependencies.

## Test Plan

Local environment: Python 3.11 and Helm 3.19.0 on macOS arm64.

- `cd utils/compatibility && python -m unittest discover -s tests -p test_kube_state_metrics.py -v`: 5 passing checks for exact pairings, table boundaries, unstable/missing versions and preserving data when sources are unavailable.
- Ran `importlib.import_module('scrapers.kube-state-metrics').scrape()` twice with summarization disabled. All five Helm charts rendered and the generated YAML was byte-for-byte identical on the second run.
- Validated both changed YAML files against `static/compatibilities/schema.json`. Independently checked each application/Kubernetes/chart tuple and exact image reference against the live sources. Icon and release links return HTTP 200.
- `git diff --check` passes. No cluster deployment or frontend behavior change is claimed.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added tests to cover my changes.
- Documentation and agent deployment: not applicable to this catalog addition.

Submitted under the README's new compatibility scraper contributor program. My Discord handle is `bengdk.` for account verification.

Plural Flow: console
