### PR TITLE
Fix CloudNativePG scraping and add 1.29/1.30 compatibility

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -15102,6 +15102,20 @@ addons:
   helm_repository_url: https://cloudnative-pg.github.io/charts
   chart_name: cloudnative-pg
   versions:
+  - version: 1.30.0
+    kube: ['1.36', '1.35', '1.34']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.29.0
+    images: ['ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0']
+  - version: 1.29.0
+    kube: ['1.35', '1.34', '1.33']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.28.0
+    images: ['ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0']
   - version: 1.28.0
     kube: ['1.34', '1.33', '1.32']
     requirements: []

--- a/static/compatibilities/cloudnative-pg.yaml
+++ b/static/compatibilities/cloudnative-pg.yaml
@@ -4,6 +4,20 @@ release_url: https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v{vsn
 helm_repository_url: https://cloudnative-pg.github.io/charts
 chart_name: cloudnative-pg
 versions:
+- version: 1.30.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.29.0
+  images: ['ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0']
+- version: 1.29.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.28.0
+  images: ['ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0']
 - version: 1.28.0
   kube: ['1.34', '1.33', '1.32']
   requirements: []

--- a/utils/compatibility/scrapers/cloudnative-pg.py
+++ b/utils/compatibility/scrapers/cloudnative-pg.py
@@ -7,6 +7,7 @@ from utils import (
     fetch_page,
     get_chart_versions,
     print_error,
+    read_yaml,
     update_compatibility_info,
     validate_semver,
 )
@@ -15,6 +16,7 @@ APP_NAME = "cloudnative-pg"
 DOCS_BASE = "https://cloudnative-pg.io"
 DOCS_ROOT = f"{DOCS_BASE}/docs"
 SUPPORTED_PATH = "supported_releases"
+RELEASE_DOCS = "https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg"
 TARGET_FILE = f"../../static/compatibilities/{APP_NAME}.yaml"
 
 
@@ -22,12 +24,12 @@ def normalize_version(label: str) -> str | None:
     text = str(label).strip().lower()
     if not text or text == "main":
         return None
-    text = text.lstrip("v")
-    # Match major.minor components
-    match = re.search(r"(\d+)\.(\d+)", text)
+    # Only release families or stable versions; never turn an RC into a GA release.
+    match = re.fullmatch(r"v?(\d+)\.(\d+)(?:\.(x|\d+))?", text)
     if not match:
         return None
-    version = f"{match.group(1)}.{match.group(2)}.0"
+    patch = match.group(3)
+    version = f"{match.group(1)}.{match.group(2)}.{patch if patch and patch != 'x' else '0'}"
     semver = validate_semver(version)
     return str(semver) if semver else None
 
@@ -36,11 +38,9 @@ def normalize_kube_list(cell_text: str) -> list[str]:
     values: list[str] = []
     for part in str(cell_text).split(","):
         item = part.strip()
-        if not item:
-            continue
-        match = re.search(r"(\d+)\.(\d+)", item)
+        match = re.fullmatch(r"v?(\d+)\.(\d+)", item)
         if not match:
-            continue
+            return []
         values.append(f"{match.group(1)}.{match.group(2)}")
     unique = sorted(
         set(values), key=lambda v: tuple(int(x) for x in v.split(".")), reverse=True
@@ -48,15 +48,15 @@ def normalize_kube_list(cell_text: str) -> list[str]:
     return unique
 
 
-def get_current_docs_version() -> str:
+def get_current_docs_version() -> str | None:
     landing = fetch_page(f"{DOCS_ROOT}/")
     if not landing:
-        return "devel"
+        return None
     html = landing.decode("utf-8", errors="replace")
     match = re.search(r"/docs/(\d+\.\d+)/", html)
     if match:
         return match.group(1)
-    return "devel"
+    return None
 
 
 def fetch_supported_page(path: str) -> bytes | None:
@@ -68,30 +68,48 @@ def find_table(soup: BeautifulSoup, heading_id: str):
     heading = soup.find(["h2", "h3"], id=heading_id)
     if not heading:
         return None
-    return heading.find_next("table")
+    table = heading.find_next("table")
+    if table and table.find_previous(["h2", "h3"]) is heading:
+        return table
+    return None
 
 
-def parse_table_rows(table, kube_index: int) -> list[OrderedDict]:
+def cell_text(cell) -> str:
+    # Docusaurus omits optional </th>/<td>/<tr> tags. html.parser nests those
+    # elements, so get_text() would include all subsequent cells and rows.
+    return " ".join(
+        text.strip() for text in cell.find_all(string=True)
+        if text.strip() and text.find_parent(["th", "td"]) is cell
+    )
+
+
+def parse_table_rows(table) -> list[OrderedDict]:
     if not table:
         return []
 
+    headers = [cell_text(cell) for cell in table.find_all("th")]
+    if "Supported Kubernetes versions" not in headers:
+        raise ValueError("CloudNativePG table has no supported Kubernetes column")
+    kube_index = headers.index("Supported Kubernetes versions")
     body = table.find("tbody")
     if not body:
         return []
 
     versions: list[OrderedDict] = []
     for row in body.find_all("tr"):
-        cells = [cell.get_text(" ", strip=True) for cell in row.find_all("td")]
-        if len(cells) <= kube_index:
+        cells = [cell_text(cell) for cell in row.find_all("td") if cell.find_parent("tr") is row]
+        if not cells:
             continue
 
         version = normalize_version(cells[0])
         if not version:
             continue
 
+        if len(cells) <= kube_index:
+            raise ValueError(f"Incomplete CloudNativePG row for {version}")
         kube_versions = normalize_kube_list(cells[kube_index])
         if not kube_versions:
-            continue
+            raise ValueError(f"Invalid supported Kubernetes list for {version}")
 
         versions.append(
             OrderedDict(
@@ -106,41 +124,90 @@ def parse_table_rows(table, kube_index: int) -> list[OrderedDict]:
     return versions
 
 
+def release_kube_versions(content: bytes, version: str) -> list[str]:
+    """Read the release's own matrix, before later patches extend its support."""
+    kube_index = None
+    for line in content.decode("utf-8").splitlines():
+        if not line.strip().startswith("|"):
+            kube_index = None
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if cells[0] == "Version":
+            kube_index = (
+                cells.index("Supported Kubernetes versions")
+                if "Supported Kubernetes versions" in cells else None
+            )
+        elif kube_index is not None and normalize_version(cells[0]) == version:
+            if len(cells) <= kube_index:
+                break
+            kube = normalize_kube_list(cells[kube_index])
+            if kube:
+                return kube
+            break
+    raise ValueError(f"No valid release-tag support matrix for CloudNativePG {version}")
+
+
 def scrape():
     current_version = get_current_docs_version()
-    sources = [
-        f"{current_version}/{SUPPORTED_PATH}",
-        f"devel/{SUPPORTED_PATH}",
-    ]
+    if not current_version:
+        print_error("Could not discover the stable CloudNativePG documentation version.")
+        return
+
+    existing = read_yaml(TARGET_FILE)
+    if not existing or not isinstance(existing.get("versions"), list):
+        print_error("Could not read existing CloudNativePG compatibility versions.")
+        return
+    existing_versions = {entry["version"] for entry in existing["versions"]}
 
     parsed_versions: OrderedDict[str, OrderedDict] = OrderedDict()
-
-    for path in sources:
+    try:
+        # Development docs may describe unreleased versions or override GA support.
+        path = f"{current_version}/{SUPPORTED_PATH}/"
         content = fetch_supported_page(path)
         if not content:
             print_error(f"Failed to download CloudNativePG page: {path}")
-            continue
+            return
 
         soup = BeautifulSoup(content, "html.parser")
         supported_table = find_table(soup, "support-status-of-cloudnativepg-releases")
         old_table = find_table(soup, "old-releases")
 
-        for entry in parse_table_rows(supported_table, 4):
+        if not supported_table:
+            raise ValueError("CloudNativePG supported release table not found")
+        for entry in parse_table_rows(supported_table):
             parsed_versions[entry["version"]] = entry
-        for entry in parse_table_rows(old_table, 3):
+        for entry in parse_table_rows(old_table):
             if entry["version"] not in parsed_versions:
                 parsed_versions[entry["version"]] = entry
-
-    versions = list(parsed_versions.values())
-    if not versions:
-        print_error("No CloudNativePG compatibility data extracted.")
+    except ValueError as error:
+        print_error(str(error))
         return
 
+    # Preserve recorded concrete releases: the moving .x table can gain support
+    # in a later patch (for example 1.28.4), which must not be assigned to .0.
+    versions = [entry for version, entry in parsed_versions.items() if version not in existing_versions]
+    if not versions:
+        return
     chart_versions = get_chart_versions(APP_NAME, chart_name="cloudnative-pg")
-    if chart_versions:
+    if not chart_versions:
+        print_error("No CloudNativePG chart versions found.")
+        return
+    released_versions = []
+    try:
         for entry in versions:
             chart_version = chart_versions.get(entry["version"])
-            if chart_version:
-                entry["chart_version"] = chart_version
-
-    update_compatibility_info(TARGET_FILE, versions)
+            if not chart_version or not validate_semver(chart_version):
+                continue
+            version = entry["version"]
+            url = f"{RELEASE_DOCS}/v{version}/docs/src/supported_releases.md"
+            content = fetch_page(url)
+            if not content:
+                raise ValueError(f"Could not fetch the release-tag matrix: {url}")
+            entry["kube"] = release_kube_versions(content, version)
+            entry["chart_version"] = chart_version
+            released_versions.append(entry)
+    except ValueError as error:
+        print_error(str(error))
+        return
+    if released_versions:
+        update_compatibility_info(TARGET_FILE, released_versions)

--- a/utils/compatibility/tests/fixtures/cloudnative-pg/release-1.29.0.md
+++ b/utils/compatibility/tests/fixtures/cloudnative-pg/release-1.29.0.md
@@ -1,0 +1,5 @@
+<!-- Matrix excerpt: https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.29.0/docs/src/supported_releases.md
+SPDX-License-Identifier: CC-BY-4.0 -->
+| Version | Currently supported | Release date | End of life | Supported Kubernetes versions | Tested, but not supported | Supported Postgres versions |
+|---------|---------------------|--------------|-------------|-------------------------------|---------------------------|-----------------------------|
+| 1.29.x | Yes | 31 Mar 2026 | Sep 2026 | 1.33, 1.34, 1.35 | 1.32, 1.31, 1.30, 1.29 | 14 - 18 |

--- a/utils/compatibility/tests/fixtures/cloudnative-pg/release-1.30.0.md
+++ b/utils/compatibility/tests/fixtures/cloudnative-pg/release-1.30.0.md
@@ -1,0 +1,5 @@
+<!-- Matrix excerpt: https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.30.0/docs/src/supported_releases.md
+SPDX-License-Identifier: CC-BY-4.0 -->
+| Version | Currently supported | Release date | End of life | Supported Kubernetes versions | Tested, but not supported | Supported Postgres versions |
+|---------|---------------------|--------------|-------------|-------------------------------|---------------------------|-----------------------------|
+| 1.30.x | Yes | 29 Jun 2026 | Dec 2026 | 1.34, 1.35, 1.36 | 1.33, 1.32, 1.31, 1.30 | 14 - 18 |

--- a/utils/compatibility/tests/fixtures/cloudnative-pg/supported.html
+++ b/utils/compatibility/tests/fixtures/cloudnative-pg/supported.html
@@ -1,0 +1,15 @@
+<!-- Reduced structural fixture based on https://cloudnative-pg.io/docs/1.30/supported_releases/.
+     The historical 1.28.x row deliberately includes support added after 1.28.0. -->
+<h2 id="support-status-of-cloudnativepg-releases">Support status</h2>
+<table><thead><tr><th>Version</th><th>Currently supported</th><th>Release date</th><th>End of life</th><th>Supported Kubernetes versions</th><th>Tested, but not supported</th></tr></thead>
+<tbody>
+<tr><td>1.30.x</td><td>Yes</td><td>29 Jun 2026</td><td>Dec 2026</td><td>1.34, 1.35, 1.36</td><td>1.33, 1.32, 1.31, 1.30</td></tr>
+<tr><td>1.29.x</td><td>Yes</td><td>31 Mar 2026</td><td>29 Sep 2026</td><td>1.33, 1.34, 1.35</td><td>1.36, 1.32, 1.31</td></tr>
+<tr><td>main</td><td>No, development only</td><td></td><td></td><td></td><td></td></tr>
+</tbody></table>
+<h2 id="upcoming-releases">Upcoming releases</h2>
+<table><thead><tr><th>Version</th><th>Release date</th><th>End of life</th></tr></thead>
+<tbody><tr><td>1.31.0</td><td>Sep 2026</td><td>Mar 2027</td></tr></tbody></table>
+<h2 id="old-releases">Old releases</h2>
+<table><thead><tr><th>Version</th><th>Release date</th><th>End of life</th><th>Supported Kubernetes versions</th></tr></thead>
+<tbody><tr><td>1.28.x</td><td>9 Dec 2025</td><td>30 Jun 2026</td><td>1.32, 1.33, 1.34, 1.35</td></tr></tbody></table>

--- a/utils/compatibility/tests/test_chart_images.py
+++ b/utils/compatibility/tests/test_chart_images.py
@@ -1,0 +1,36 @@
+"""Image extraction regressions from charts that also template CRD schemas."""
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import find_nested_images
+
+
+class ChartImageTests(unittest.TestCase):
+    def test_crd_image_schema_does_not_crash_or_hide_container_images(self):
+        manifests = [
+            {"kind": "CustomResourceDefinition", "spec": {"properties": {
+                "image": {"description": "Container image", "type": "string"},
+            }}},
+            {"kind": "Deployment", "spec": {"template": {"spec": {
+                "containers": [{"image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0"}],
+                "initContainers": [{"image": "busybox:1.36"}],
+            }}}},
+        ]
+        self.assertEqual(find_nested_images(manifests), [
+            "busybox:1.36", "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0",
+        ])
+
+    def test_non_image_values_are_ignored_and_references_deduplicated(self):
+        self.assertEqual(find_nested_images([
+            {"image": None}, {"image": 123}, {"image": "not an image"},
+            {"image": "registry.example:5000/operator:v1"},
+            {"image": "registry.example:5000/operator:v1"},
+            {"image": "registry.example/operator@sha256:" + "a" * 64},
+        ]), ["registry.example/operator@sha256:" + "a" * 64, "registry.example:5000/operator:v1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_cloudnative_pg.py
+++ b/utils/compatibility/tests/test_cloudnative_pg.py
@@ -1,0 +1,144 @@
+"""Offline regressions: python -m unittest discover -s tests -p 'test_cloudnative_pg.py'."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+from bs4 import BeautifulSoup
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+spec = importlib.util.spec_from_file_location(
+    "cloudnative_pg_scraper", COMPATIBILITY / "scrapers/cloudnative-pg.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+FIXTURES = Path(__file__).parent / "fixtures/cloudnative-pg"
+
+
+class CloudNativePGTests(unittest.TestCase):
+    def setUp(self):
+        self.html = (FIXTURES / "supported.html").read_bytes()
+        self.sources = {
+            f"{scraper.DOCS_ROOT}/": b'<link rel="canonical" href="/docs/1.30/">',
+            f"{scraper.DOCS_ROOT}/1.30/supported_releases/": self.html,
+            **{
+                f"{scraper.RELEASE_DOCS}/v{version}/docs/src/supported_releases.md":
+                (FIXTURES / f"release-{version}.md").read_bytes()
+                for version in ("1.29.0", "1.30.0")
+            },
+        }
+        self.existing = {"versions": [{"version": "1.28.0", "kube": ["1.34", "1.33", "1.32"]}]}
+        self.charts = {"1.30.0": "0.29.0", "1.29.0": "0.28.0", "1.28.0": "0.27.0"}
+
+    def run_scrape(self):
+        with patch.object(scraper, "fetch_page", side_effect=self.sources.get) as fetch, \
+                patch.object(scraper, "read_yaml", return_value=self.existing), \
+                patch.object(scraper, "get_chart_versions", return_value=self.charts), \
+                patch.object(scraper, "print_error"), \
+                patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+        return update, fetch
+
+    def test_versions_reject_prereleases_and_unrelated_text(self):
+        for value in ("main", "1.31.0-rc1", "next 1.31", "1.30.0+build", "v1.30.x extra"):
+            with self.subTest(value=value):
+                self.assertIsNone(scraper.normalize_version(value))
+        self.assertEqual(scraper.normalize_version("v1.30.x"), "1.30.0")
+        self.assertEqual(scraper.normalize_version("1.29.2"), "1.29.2")
+
+    def test_kubernetes_list_is_strict_and_deduplicated(self):
+        self.assertEqual(scraper.normalize_kube_list("1.35, v1.34, 1.35"), ["1.35", "1.34"])
+        for value in ("1.34+", "1.34, unknown", "1.34 - 1.36", "1.34,", "", "1.34.1"):
+            with self.subTest(value=value):
+                self.assertEqual(scraper.normalize_kube_list(value), [])
+
+    def test_header_selects_supported_column_after_reordering(self):
+        table = BeautifulSoup(
+            '<table><thead><tr><th>Version</th><th>Tested, but not supported</th>'
+            '<th>Supported Kubernetes versions</th></tr></thead><tbody><tr>'
+            '<td>1.30.x</td><td>1.33, 1.32</td><td>1.35, 1.36</td>'
+            '</tr></tbody></table>', "html.parser"
+        ).table
+        self.assertEqual(scraper.parse_table_rows(table)[0]["kube"], ["1.36", "1.35"])
+
+    def test_heading_cannot_capture_a_later_unrelated_table(self):
+        soup = BeautifulSoup('<h2 id="old-releases">Old</h2><h2>Upcoming</h2><table></table>', "html.parser")
+        self.assertIsNone(scraper.find_table(soup, "old-releases"))
+
+    def test_release_tag_selects_supported_instead_of_tested(self):
+        for version, expected in (("1.29.0", ["1.35", "1.34", "1.33"]), ("1.30.0", ["1.36", "1.35", "1.34"])):
+            content = (FIXTURES / f"release-{version}.md").read_bytes()
+            self.assertEqual(scraper.release_kube_versions(content, version), expected)
+
+    def test_invalid_release_tag_matrix_fails_closed(self):
+        source = (FIXTURES / "release-1.30.0.md").read_bytes()
+        for content in (b"# Missing", source.replace(b"1.34, 1.35, 1.36", b"1.34+"), source.replace(b"1.30.x", b"1.31.x")):
+            with self.subTest(content=content):
+                with self.assertRaises(ValueError):
+                    scraper.release_kube_versions(content, "1.30.0")
+
+    def test_scrape_adds_only_two_released_versions_with_exact_charts(self):
+        update, fetch = self.run_scrape()
+        update.assert_called_once()
+        versions = update.call_args.args[1]
+        self.assertEqual([v["version"] for v in versions], ["1.30.0", "1.29.0"])
+        self.assertEqual([v["chart_version"] for v in versions], ["0.29.0", "0.28.0"])
+        self.assertEqual(versions[1]["kube"], ["1.35", "1.34", "1.33"])
+        self.assertFalse(any("devel" in call.args[0] for call in fetch.call_args_list))
+        self.assertEqual(self.existing["versions"][0]["kube"], ["1.34", "1.33", "1.32"])
+
+    def test_release_tag_overrides_later_patch_support_in_moving_docs(self):
+        url = f"{scraper.DOCS_ROOT}/1.30/supported_releases/"
+        self.sources[url] = self.html.replace(b"1.33, 1.34, 1.35</td>", b"1.33, 1.34, 1.35, 1.36</td>")
+        update, _ = self.run_scrape()
+        self.assertEqual(update.call_args.args[1][1]["kube"], ["1.35", "1.34", "1.33"])
+
+    def test_docusaurus_omitted_optional_closing_tags(self):
+        minified = self.html
+        for tag in (b"</th>", b"</td>", b"</tr>", b"</thead>", b"</tbody>"):
+            minified = minified.replace(tag, b"")
+        self.sources[f"{scraper.DOCS_ROOT}/1.30/supported_releases/"] = minified
+        update, _ = self.run_scrape()
+        self.assertEqual([v["version"] for v in update.call_args.args[1]], ["1.30.0", "1.29.0"])
+
+    def test_discovery_failure_never_uses_development_or_writes(self):
+        self.sources[f"{scraper.DOCS_ROOT}/"] = b'<a href="/docs/devel/">Preview</a>'
+        update, fetch = self.run_scrape()
+        update.assert_not_called()
+        self.assertEqual(fetch.call_count, 1)
+
+    def test_missing_or_invalid_page_never_writes(self):
+        for source in (None, b"<html>No matrix</html>", self.html.replace(b"1.34, 1.35, 1.36", b"1.34+")):
+            with self.subTest(source=source):
+                self.sources[f"{scraper.DOCS_ROOT}/1.30/supported_releases/"] = source
+                update, _ = self.run_scrape()
+                update.assert_not_called()
+
+    def test_missing_release_tag_prevents_partial_batch_write(self):
+        self.sources[f"{scraper.RELEASE_DOCS}/v1.29.0/docs/src/supported_releases.md"] = None
+        update, _ = self.run_scrape()
+        update.assert_not_called()
+
+    def test_missing_or_prerelease_charts_cannot_create_ga_records(self):
+        for charts in ({}, {"1.30.0": "0.29.0-rc1", "1.29.1": "0.28.1"}):
+            with self.subTest(charts=charts):
+                self.charts = charts
+                update, _ = self.run_scrape()
+                update.assert_not_called()
+
+    def test_existing_versions_make_rerun_a_noop(self):
+        self.existing["versions"].extend([{"version": "1.29.0"}, {"version": "1.30.0"}])
+        update, _ = self.run_scrape()
+        update.assert_not_called()
+
+    def test_unreadable_existing_file_never_writes(self):
+        self.existing = None
+        update, _ = self.run_scrape()
+        update.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -235,7 +235,8 @@ def find_nested_images(objs: Any) -> List[str]:
 
         if isinstance(x, dict):
             for k, v in x.items():
-                if k == "image":
+                # CRD schemas also use "image" keys whose values are mappings.
+                if k == "image" and isinstance(v, str) and _looks_like_image(v):
                     images.add(v)
                     continue
                 walk(v)


### PR DESCRIPTION
The CloudNativePG scraper currently misreads compact Docusaurus tables and crashes while extracting images from charts containing CRD `image` schema mappings. This fixes both failures and adds compatibility for CloudNativePG 1.29.0 and 1.30.0.

Stable documentation discovers candidates; exact stable app/chart mappings gate them; each release tag's own support matrix supplies its Kubernetes versions. Development docs and tested-but-unsupported versions are excluded. All 14 existing version records remain unchanged, avoiding later patch support being assigned to an earlier `.0` release.

| Application | Kubernetes support at release | Helm chart | Rendered image |
|---|---|---|---|
| 1.29.0 | 1.33–1.35 | 0.28.0 | `ghcr.io/cloudnative-pg/cloudnative-pg:1.29.0` |
| 1.30.0 | 1.34–1.36 | 0.29.0 | `ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0` |

Primary evidence: [1.29.0 support matrix](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.29.0/docs/src/supported_releases.md), [1.30.0 support matrix](https://github.com/cloudnative-pg/cloudnative-pg/blob/v1.30.0/docs/src/supported_releases.md), [stable discovery page](https://cloudnative-pg.io/docs/1.30/supported_releases/), and [official chart index](https://cloudnative-pg.github.io/charts/index.yaml). The offline fixtures extract these source tables, retrieved September 8, 2026.

## Test Plan

- 17 offline unit tests pass, covering strict version/support parsing, reordered columns, omitted HTML closing tags, immutable support lookup, failed-source protection, exact chart gating, no-op reruns and CRD image extraction.
- Both new charts rendered successfully using Helm 4.2.4. Chart archive metadata and SHA256 digests independently match the official index.
- Both changed YAML documents pass the repository schema. Each adds 14 lines; all older CloudNativePG records and every other add-on are unchanged. A live rerun leaves the per-app file byte-identical.
- `git diff --check` passes. No clusters deployed or paid API calls used.

Run from `utils/compatibility` with existing runtime requirements: `python -m unittest discover -s tests -v`.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added tests to cover my changes.
- Documentation: source provenance is included above; no product documentation change needed.
- Agent deployment: not applicable; no agent code changed.

Submitted for contributor-program review; eligibility and rewards are subject to maintainer acceptance. AI-assisted implementation with independent source/code review. The small shared image-extraction correction is also needed by a separate Argo Rollouts update; both use identical code and regression tests.

Plural Flow: console
