### PR TITLE
fix: refresh Argo Rollouts compatibility from release-tag CI

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -40,31 +40,27 @@ addons:
   release_url: https://github.com/argoproj/argo-rollouts/releases/tag/v{vsn}
   helm_repository_url: https://argoproj.github.io/argo-helm
   versions:
-  - version: 1.8.3
+  - version: 1.10.0
+    kube: ['1.35', '1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.43.0
+    images: ['quay.io/argoproj/argo-rollouts:v1.10.0']
+  - version: 1.9.1
+    kube: ['1.35', '1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.42.0
+    images: ['quay.io/argoproj/argo-rollouts:v1.9.1']
+  - version: 1.9.0
     kube: ['1.34', '1.33', '1.32', '1.31']
     requirements: []
     incompatibilities: []
-    summary:
-      helm_changes: ''
-      chart_updates: ["No Helm chart changelog was provided in the notes you pasted\
-          \ (only application GitHub release notes). Treat this as an application-only\
-          \ summary; verify the Helm chart version you\u2019ll deploy and diff `values.yaml`\
-          \ separately."]
-      features: ['Prometheus metric provider: adds range query support, enabling analyses
-          over a time range instead of single-point queries.', 'Analysis/New Relic:
-          can now set a timeout and the provider returns the resolved query as metadata
-          (useful for debugging/traceability).', 'Datadog metric provider: supports
-          multi-account configurations and adds support for providing credentials
-          to download plugins.', 'Controller: adds an (alpha) canary steps plugin
-          mechanism for extending canary step behavior.', 'Controller: canary ingress
-          support allows specifying full annotations for nginx canary ingresses (more
-          flexibility for NGINX users).', 'Controller: enables pprof profiling support
-          for debugging performance issues.', 'Analysis: adds ConsecutiveSuccessLimit
-          to Analysis (lets you require N consecutive successful measurements).',
-        'Metrics/observability: new Prometheus `build_info` metric is emitted.']
-      breaking_changes: []
-    chart_version: 2.40.5
-    images: ['quay.io/argoproj/argo-rollouts:v1.8.3']
+    summary: null
+    chart_version: 2.41.0
+    images: ['quay.io/argoproj/argo-rollouts:v1.9.0']
   - version: 1.8.0
     kube: ['1.31', '1.30', '1.29', '1.28']
     requirements: []

--- a/static/compatibilities/argo-rollouts.yaml
+++ b/static/compatibilities/argo-rollouts.yaml
@@ -3,31 +3,27 @@ git_url: https://github.com/argoproj/argo-rollouts
 release_url: https://github.com/argoproj/argo-rollouts/releases/tag/v{vsn}
 helm_repository_url: https://argoproj.github.io/argo-helm
 versions:
-- version: 1.8.3
+- version: 1.10.0
+  kube: ['1.35', '1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.43.0
+  images: ['quay.io/argoproj/argo-rollouts:v1.10.0']
+- version: 1.9.1
+  kube: ['1.35', '1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.42.0
+  images: ['quay.io/argoproj/argo-rollouts:v1.9.1']
+- version: 1.9.0
   kube: ['1.34', '1.33', '1.32', '1.31']
   requirements: []
   incompatibilities: []
-  summary:
-    helm_changes: ''
-    chart_updates: ["No Helm chart changelog was provided in the notes you pasted\
-        \ (only application GitHub release notes). Treat this as an application-only\
-        \ summary; verify the Helm chart version you\u2019ll deploy and diff `values.yaml`\
-        \ separately."]
-    features: ['Prometheus metric provider: adds range query support, enabling analyses
-        over a time range instead of single-point queries.', 'Analysis/New Relic:
-        can now set a timeout and the provider returns the resolved query as metadata
-        (useful for debugging/traceability).', 'Datadog metric provider: supports
-        multi-account configurations and adds support for providing credentials to
-        download plugins.', 'Controller: adds an (alpha) canary steps plugin mechanism
-        for extending canary step behavior.', 'Controller: canary ingress support
-        allows specifying full annotations for nginx canary ingresses (more flexibility
-        for NGINX users).', 'Controller: enables pprof profiling support for debugging
-        performance issues.', 'Analysis: adds ConsecutiveSuccessLimit to Analysis
-        (lets you require N consecutive successful measurements).', 'Metrics/observability:
-        new Prometheus `build_info` metric is emitted.']
-    breaking_changes: []
-  chart_version: 2.40.5
-  images: ['quay.io/argoproj/argo-rollouts:v1.8.3']
+  summary: null
+  chart_version: 2.41.0
+  images: ['quay.io/argoproj/argo-rollouts:v1.9.0']
 - version: 1.8.0
   kube: ['1.31', '1.30', '1.29', '1.28']
   requirements: []

--- a/utils/compatibility/scrapers/argo-rollouts.py
+++ b/utils/compatibility/scrapers/argo-rollouts.py
@@ -1,62 +1,90 @@
-# scrapers/cert_manager.py
+"""Read the Kubernetes e2e matrix from each stable Argo Rollouts release tag."""
 
+import re
 from collections import OrderedDict
 
 import requests
 import yaml
 
-from utils import (
-    print_error,
-    fetch_page,
-    update_compatibility_info,
-    get_chart_versions,
-    print_success,
-)
+from utils import get_chart_versions, print_success, update_compatibility_info
 
 app_name = "argo-rollouts"
 github_api_tags_url = "https://api.github.com/repos/argoproj/argo-rollouts/tags"
+workflow_url = (
+    "https://raw.githubusercontent.com/argoproj/argo-rollouts/"
+    "refs/tags/{tag}/.github/workflows/testing.yaml"
+)
+stable_version = re.compile(r"\d+\.\d+\.\d+")
 
 
 def fetch_github_tags():
-    response = requests.get(github_api_tags_url)
-    if response.status_code != 200:
-        print_error(
-            f"Failed to fetch GitHub tags. Status code: {response.status_code}"
+    tags = []
+    page = 1
+    while True:
+        response = requests.get(
+            github_api_tags_url, params={"per_page": 100, "page": page}, timeout=30
         )
-        return []
-    return [tag["name"] for tag in response.json()]
+        response.raise_for_status()
+        entries = response.json()
+        if not isinstance(entries, list) or any(
+            not isinstance(entry, dict) or not isinstance(entry.get("name"), str)
+            for entry in entries
+        ):
+            raise ValueError("Invalid Argo Rollouts tags response")
+        names = [entry["name"] for entry in entries]
+        if names and all(name in tags for name in names):
+            raise ValueError("Argo Rollouts tags pagination did not advance")
+        tags.extend(name for name in names if name not in tags)
+        if len(entries) < 100:
+            return tags
+        page += 1
+
+
+def parse_kube_versions(content):
+    matrix = yaml.safe_load(content)
+    for key in ("jobs", "test-e2e", "strategy", "matrix", "kubernetes"):
+        if not isinstance(matrix, dict) or key not in matrix:
+            raise ValueError("Argo Rollouts e2e Kubernetes matrix not found")
+        matrix = matrix[key]
+    if not isinstance(matrix, list) or not matrix:
+        raise ValueError("Argo Rollouts e2e Kubernetes matrix is empty or invalid")
+
+    versions = set()
+    for entry in matrix:
+        version = entry.get("version") if isinstance(entry, dict) else None
+        # Quoted minor versions are required: YAML turns unquoted 1.30 into 1.3.
+        if not isinstance(version, str) or not re.fullmatch(r"\d+\.\d+", version):
+            raise ValueError(f"Invalid Kubernetes matrix entry: {entry!r}")
+        versions.add(version)
+    return sorted(
+        versions, key=lambda version: tuple(map(int, version.split("."))), reverse=True
+    )
 
 
 def scrape():
     release_tags = fetch_github_tags()
     if not release_tags:
-        print_error("No release tags found.")
-        return
+        raise ValueError("No Argo Rollouts release tags found")
 
     chart_versions = get_chart_versions(app_name)
     rows = []
     for tag in release_tags:
-        tag_version = tag.lstrip("v")
+        tag_version = tag.removeprefix("v")
+        if not stable_version.fullmatch(tag_version):
+            continue
+        # The versioned testing.yaml workflow is available from 1.8 onward.
+        # Preserve older stored rows instead of replacing them with current CI data.
+        if tuple(map(int, tag_version.split("."))) < (1, 8, 0):
+            continue
         chart_version = chart_versions.get(tag_version)
-        # Skip if there's no chart version mapped
         if not chart_version:
             continue
+        if not stable_version.fullmatch(chart_version):
+            raise ValueError(f"Invalid stable Helm chart version: {chart_version!r}")
 
-        workflow_ref = "master" if tag_version == "1.8.3" else f"refs/tags/{tag}"
-        response = requests.get(
-            f"https://raw.githubusercontent.com/argoproj/argo-rollouts/{workflow_ref}/.github/workflows/testing.yaml"
-        )
-        if response.status_code != 200:
-            print_error(f"Failed to fetch compatibility info for tag {tag}. Status code: {response.status_code}")
-            continue
-
-        content = yaml.safe_load(response.text)
-        if not content:
-            print_error(f"Failed to parse compatibility info for {tag}")
-            return
-
-        matrix = content.get("jobs", {}).get("test-e2e", {}).get("strategy", {}).get("matrix", {}).get("kubernetes", [])
-        kube_versions = [str(entry["version"]) for entry in matrix]
+        response = requests.get(workflow_url.format(tag=tag), timeout=30)
+        response.raise_for_status()
+        kube_versions = parse_kube_versions(response.text)
         rows.append(OrderedDict(
             [
                 ("version", tag_version),
@@ -69,4 +97,7 @@ def scrape():
         ))
         print_success(f"Fetched compatibility info for tag: {tag}")
 
+    # Fetch and validate every candidate before changing the existing table.
+    if not rows:
+        raise ValueError("No chart-backed Argo Rollouts compatibility rows found")
     update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", rows)

--- a/utils/compatibility/tests/ARGO_ROLLOUTS.md
+++ b/utils/compatibility/tests/ARGO_ROLLOUTS.md
@@ -1,0 +1,11 @@
+# Argo Rollouts compatibility tests
+
+From the repository root, create a virtual environment and install the scraper dependencies plus the test runner:
+
+```sh
+python -m venv .venv
+.venv/bin/python -m pip install -r utils/compatibility/requirements.txt pytest==8.4.2
+env -u EXA_API_KEY -u OPENAI_API_KEY .venv/bin/python -m pytest utils/compatibility/tests/test_argo_rollouts.py utils/compatibility/tests/test_chart_images.py -q
+```
+
+The tests use release-tag matrix excerpts and mocked network responses; they do not call external APIs or Helm. Fixtures include their official upstream source URLs. A live scraper run separately verifies the current release tags, Helm index mapping, and rendered chart images.

--- a/utils/compatibility/tests/fixtures/argo-rollouts-v1.10.0-testing.yaml
+++ b/utils/compatibility/tests/fixtures/argo-rollouts-v1.10.0-testing.yaml
@@ -1,0 +1,20 @@
+# Matrix excerpt from the official release-tag workflow:
+# https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.10.0/.github/workflows/testing.yaml
+jobs:
+  test-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes:
+          - version: "1.32"
+            k3s_version: "1.32.12+k3s1"
+            latest: false
+          - version: "1.33"
+            k3s_version: "1.33.8+k3s1"
+            latest: false
+          - version: "1.34"
+            k3s_version: "1.34.4+k3s1"
+            latest: false
+          - version: "1.35"
+            k3s_version: "1.35.1+k3s1"
+            latest: true

--- a/utils/compatibility/tests/fixtures/argo-rollouts-v1.8.3-testing.yaml
+++ b/utils/compatibility/tests/fixtures/argo-rollouts-v1.8.3-testing.yaml
@@ -1,0 +1,16 @@
+# Matrix excerpt from the official release-tag workflow:
+# https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.8.3/.github/workflows/testing.yaml
+jobs:
+  test-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes:
+          - version: "1.28"
+            latest: false
+          - version: "1.29"
+            latest: false
+          - version: "1.30"
+            latest: false
+          - version: "1.31"
+            latest: true

--- a/utils/compatibility/tests/fixtures/argo-rollouts-v1.9.0-testing.yaml
+++ b/utils/compatibility/tests/fixtures/argo-rollouts-v1.9.0-testing.yaml
@@ -1,0 +1,16 @@
+# Matrix excerpt from the official release-tag workflow:
+# https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.9.0/.github/workflows/testing.yaml
+jobs:
+  test-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes:
+          - version: "1.31"
+            latest: false
+          - version: "1.32"
+            latest: false
+          - version: "1.33"
+            latest: false
+          - version: "1.34"
+            latest: true

--- a/utils/compatibility/tests/fixtures/argo-rollouts-v1.9.1-testing.yaml
+++ b/utils/compatibility/tests/fixtures/argo-rollouts-v1.9.1-testing.yaml
@@ -1,0 +1,20 @@
+# Matrix excerpt from the official release-tag workflow:
+# https://raw.githubusercontent.com/argoproj/argo-rollouts/v1.9.1/.github/workflows/testing.yaml
+jobs:
+  test-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes:
+          - version: "1.32"
+            k3s_version: "1.32.12+k3s1"
+            latest: false
+          - version: "1.33"
+            k3s_version: "1.33.8+k3s1"
+            latest: false
+          - version: "1.34"
+            k3s_version: "1.34.4+k3s1"
+            latest: false
+          - version: "1.35"
+            k3s_version: "1.35.1+k3s1"
+            latest: true

--- a/utils/compatibility/tests/test_argo_rollouts.py
+++ b/utils/compatibility/tests/test_argo_rollouts.py
@@ -1,0 +1,140 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+import yaml
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+spec = importlib.util.spec_from_file_location(
+    "argo_rollouts_scraper", COMPATIBILITY / "scrapers" / "argo-rollouts.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def fixture(version):
+    return (FIXTURES / f"argo-rollouts-v{version}-testing.yaml").read_text()
+
+
+def response(*, body=None, text="", error=None):
+    result = Mock(text=text)
+    result.json.return_value = body
+    result.raise_for_status.side_effect = error
+    return result
+
+
+@pytest.mark.parametrize("version,expected", [
+    ("1.8.3", ["1.31", "1.30", "1.29", "1.28"]),
+    ("1.9.0", ["1.34", "1.33", "1.32", "1.31"]),
+    ("1.9.1", ["1.35", "1.34", "1.33", "1.32"]),
+    ("1.10.0", ["1.35", "1.34", "1.33", "1.32"]),
+])
+def test_release_tag_matrix(version, expected):
+    assert scraper.parse_kube_versions(fixture(version)) == expected
+
+
+def test_matrix_deduplicates_without_inventing_untested_minors():
+    content = yaml.safe_dump({"jobs": {"test-e2e": {"strategy": {"matrix": {
+        "kubernetes": [{"version": "1.29"}, {"version": "1.31"}, {"version": "1.29"}]
+    }}}}})
+    assert scraper.parse_kube_versions(content) == ["1.31", "1.29"]
+
+
+@pytest.mark.parametrize("content", [
+    "", "[]", "jobs: []", "jobs: {test-e2e: {strategy: {matrix: {kubernetes: []}}}}",
+    "jobs: {test-e2e: {strategy: {matrix: {kubernetes: [1.30]}}}}",
+    "jobs: {test-e2e: {strategy: {matrix: {kubernetes: [{version: 1.30}]}}}}",
+    'jobs: {test-e2e: {strategy: {matrix: {kubernetes: [{version: "1.35.1+k3s1"}]}}}}',
+])
+def test_rejects_missing_or_malformed_matrix(content):
+    with pytest.raises(ValueError):
+        scraper.parse_kube_versions(content)
+
+
+def test_fetch_tags_paginates_and_uses_timeouts(monkeypatch):
+    first = [{"name": f"v1.8.{patch}"} for patch in range(100)]
+    get = Mock(side_effect=[response(body=first), response(body=[{"name": "v1.7.0"}])])
+    monkeypatch.setattr(scraper.requests, "get", get)
+    assert len(scraper.fetch_github_tags()) == 101
+    assert [call.kwargs for call in get.call_args_list] == [
+        {"params": {"per_page": 100, "page": 1}, "timeout": 30},
+        {"params": {"per_page": 100, "page": 2}, "timeout": 30},
+    ]
+
+
+@pytest.mark.parametrize("body", [{"message": "error"}, [None], [{}], [{"name": 123}]])
+def test_rejects_invalid_tag_response(monkeypatch, body):
+    monkeypatch.setattr(scraper.requests, "get", Mock(return_value=response(body=body)))
+    with pytest.raises(ValueError, match="tags response"):
+        scraper.fetch_github_tags()
+
+
+def test_rejects_repeated_tag_page(monkeypatch):
+    page = [{"name": f"v1.8.{patch}"} for patch in range(100)]
+    monkeypatch.setattr(scraper.requests, "get", Mock(return_value=response(body=page)))
+    with pytest.raises(ValueError, match="did not advance"):
+        scraper.fetch_github_tags()
+
+
+def test_scrape_uses_exact_tag_for_183_and_skips_prereleases_and_legacy(monkeypatch):
+    monkeypatch.setattr(scraper, "fetch_github_tags", lambda: [
+        "v1.10.0-rc1", "v1.10.0", "v1.8.3", "v1.7.0", "master", "v1.11.0",
+    ])
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: {
+        "1.10.0-rc1": "2.43.0-rc1", "1.10.0": "2.43.0", "1.8.3": "2.40.5", "1.7.0": "2.36.0",
+    })
+    get = Mock(side_effect=[response(text=fixture("1.10.0")), response(text=fixture("1.8.3"))])
+    monkeypatch.setattr(scraper.requests, "get", get)
+    update = Mock()
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+    scraper.scrape()
+    assert [call.args[0] for call in get.call_args_list] == [
+        scraper.workflow_url.format(tag="v1.10.0"),
+        scraper.workflow_url.format(tag="v1.8.3"),
+    ]
+    assert all(call.kwargs == {"timeout": 30} for call in get.call_args_list)
+    rows = update.call_args.args[1]
+    assert rows[0]["version"] == "1.10.0"
+    assert rows[0]["chart_version"] == "2.43.0"
+    assert rows[1]["kube"] == ["1.31", "1.30", "1.29", "1.28"]
+
+
+@pytest.mark.parametrize("failure", ["404", "503", "matrix"])
+def test_failed_release_does_not_partially_write(monkeypatch, failure):
+    failed = response(text="jobs: {}") if failure == "matrix" else response(error=requests.HTTPError(failure))
+    monkeypatch.setattr(scraper, "fetch_github_tags", lambda: ["v1.10.0", "v1.9.0"])
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: {"1.10.0": "2.43.0", "1.9.0": "2.41.0"})
+    monkeypatch.setattr(scraper.requests, "get", Mock(side_effect=[response(text=fixture("1.10.0")), failed]))
+    update = Mock()
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+    with pytest.raises((requests.HTTPError, ValueError)):
+        scraper.scrape()
+    update.assert_not_called()
+
+
+@pytest.mark.parametrize("tags,charts", [([], {}), (["v1.10.0"], {}), (["v1.10.0"], {"1.10.0": "2.43.0-rc1"})])
+def test_no_valid_candidate_does_not_write(monkeypatch, tags, charts):
+    monkeypatch.setattr(scraper, "fetch_github_tags", lambda: tags)
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: charts)
+    update = Mock()
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+    with pytest.raises(ValueError):
+        scraper.scrape()
+    update.assert_not_called()
+
+
+def test_static_rows_match_release_matrices_and_real_chart_versions():
+    root = COMPATIBILITY.parents[1]
+    addon = yaml.safe_load((root / "static/compatibilities/argo-rollouts.yaml").read_text())
+    versions = {row["version"]: row for row in addon["versions"]}
+    for version, chart in [("1.9.0", "2.41.0"), ("1.9.1", "2.42.0"), ("1.10.0", "2.43.0")]:
+        assert versions[version]["kube"] == scraper.parse_kube_versions(fixture(version))
+        assert versions[version]["chart_version"] == chart
+        assert versions[version]["images"] == [f"quay.io/argoproj/argo-rollouts:v{version}"]
+    aggregate = yaml.safe_load((root / "static/compatibilities.yaml").read_text())
+    assert next(row for row in aggregate["addons"] if row["name"] == "argo-rollouts") == {**addon, "name": "argo-rollouts"}

--- a/utils/compatibility/tests/test_chart_images.py
+++ b/utils/compatibility/tests/test_chart_images.py
@@ -1,0 +1,36 @@
+"""Image extraction regressions from charts that also template CRD schemas."""
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import find_nested_images
+
+
+class ChartImageTests(unittest.TestCase):
+    def test_crd_image_schema_does_not_crash_or_hide_container_images(self):
+        manifests = [
+            {"kind": "CustomResourceDefinition", "spec": {"properties": {
+                "image": {"description": "Container image", "type": "string"},
+            }}},
+            {"kind": "Deployment", "spec": {"template": {"spec": {
+                "containers": [{"image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0"}],
+                "initContainers": [{"image": "busybox:1.36"}],
+            }}}},
+        ]
+        self.assertEqual(find_nested_images(manifests), [
+            "busybox:1.36", "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0",
+        ])
+
+    def test_non_image_values_are_ignored_and_references_deduplicated(self):
+        self.assertEqual(find_nested_images([
+            {"image": None}, {"image": 123}, {"image": "not an image"},
+            {"image": "registry.example:5000/operator:v1"},
+            {"image": "registry.example:5000/operator:v1"},
+            {"image": "registry.example/operator@sha256:" + "a" * 64},
+        ]), ["registry.example/operator@sha256:" + "a" * 64, "registry.example:5000/operator:v1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -235,7 +235,8 @@ def find_nested_images(objs: Any) -> List[str]:
 
         if isinstance(x, dict):
             for k, v in x.items():
-                if k == "image":
+                # CRD schemas also use "image" keys whose values are mappings.
+                if k == "image" and isinstance(v, str) and _looks_like_image(v):
                     images.add(v)
                     continue
                 walk(v)


### PR DESCRIPTION
Argo Rollouts compatibility stops at 1.8.3, and that release is currently assigned Kubernetes versions from the mutable `master` workflow. Read each stable release's own e2e matrix and refresh the chart-backed compatibility boundaries:

| Argo Rollouts | Helm chart | Kubernetes minors in release CI |
| --- | --- | --- |
| 1.9.0 | 2.41.0 | 1.31, 1.32, 1.33, 1.34 |
| 1.9.1 | 2.42.0 | 1.32, 1.33, 1.34, 1.35 |
| 1.10.0 | 2.43.0 | 1.32, 1.33, 1.34, 1.35 |

The corrected 1.8.3 matrix matches 1.8.0, so the existing reducer removes its redundant boundary. Preserve older rows whose releases predate this workflow layout. Tag fetching now paginates, and the scraper validates all candidate matrices before writing, so a failed or malformed source cannot produce a partial refresh.

Rendering the current charts also exposed CRD schema mappings under `image` keys. Include the same small image-reference guard and regression tests as #4157; either PR can merge first. The per-app and aggregate compatibility records are synchronized, with unrelated app data unchanged.

Sources:

- [Official guidance on supported versions](https://argo-rollouts.readthedocs.io/en/stable/installation/#supported-versions) directs readers to each release tag's e2e workflow.
- [1.9.0 workflow](https://github.com/argoproj/argo-rollouts/blob/v1.9.0/.github/workflows/testing.yaml), [1.9.1 workflow](https://github.com/argoproj/argo-rollouts/blob/v1.9.1/.github/workflows/testing.yaml), [1.10.0 workflow](https://github.com/argoproj/argo-rollouts/blob/v1.10.0/.github/workflows/testing.yaml), and [1.8.3 workflow](https://github.com/argoproj/argo-rollouts/blob/v1.8.3/.github/workflows/testing.yaml).
- [Official Helm index](https://argoproj.github.io/argo-helm/index.yaml) maps app releases to the chart versions above.
- [Related shared image fix: #4157](https://github.com/pluralsh/console/pull/4157).

## Test Plan

- 28 focused offline tests passed, covering exact release matrices, pagination, malformed/empty input, no partial write, CRD image fields, and synchronized generated rows. Reproduction commands are in `utils/compatibility/tests/ARGO_ROLLOUTS.md`.
- Live release-tag and Helm-index refresh completed; eight retained chart versions rendered through Helm, including the three added boundaries with matching `quay.io/argoproj/argo-rollouts` image tags.
- Frozen matrix fixtures matched the official tag workflows. Both changed YAML files passed the repository's JSON schema. Unrelated addon records and existing Argo rows other than the corrected 1.8.3 boundary were preserved.
- `git diff --check` passed. Optional paid summarization was disabled. No Kubernetes cluster/e2e execution was performed; the table records upstream release CI coverage.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added tests to cover my changes.
- Documentation: test reproduction and fixture provenance included.
- Agent deployment: not applicable; no agent code changed.

AI-assisted implementation with independent code/source review. Submitted for contributor-program review; no reward is assumed.

Plural Flow: console
