### PR TITLE
Add Falco Operator compatibility scraper

### DIFF
--- a/static/compatibilities/falco-operator.yaml
+++ b/static/compatibilities/falco-operator.yaml
@@ -1,0 +1,34 @@
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/falco/horizontal/color/falco-horizontal-color.svg
+git_url: https://github.com/falcosecurity/falco-operator
+release_url: https://github.com/falcosecurity/falco-operator/releases/tag/v{vsn}
+helm_repository_url: https://falcosecurity.github.io/charts
+readme_url: https://github.com/falcosecurity/falco-operator/blob/main/docs/installation.md
+versions:
+- version: 0.4.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.3.1
+  images: ['falcosecurity/falco-operator:0.4.1']
+- version: 0.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.3.0
+  images: ['falcosecurity/falco-operator:0.4.0']
+- version: 0.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.2.0
+  images: ['falcosecurity/falco-operator:0.3.0']
+- version: 0.2.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.1.0
+  images: ['falcosecurity/falco-operator:0.2.2']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -16,6 +16,7 @@ names:
 - descheduler
 - external-dns
 - external-secrets
+- falco-operator
 - flux
 - ingress-nginx
 - istio

--- a/utils/compatibility/scrapers/falco-operator.py
+++ b/utils/compatibility/scrapers/falco-operator.py
@@ -1,0 +1,95 @@
+"""Read each charted operator release's own Kubernetes prerequisite."""
+
+import re
+from collections import OrderedDict
+
+from packaging.version import Version
+
+from utils import (
+    current_kube_version,
+    fetch_page,
+    get_chart_versions,
+    update_compatibility_info,
+)
+
+
+APP_NAME = "falco-operator"
+INSTALLATION_URL = (
+    "https://raw.githubusercontent.com/falcosecurity/falco-operator/"
+    "v{version}/docs/installation.md"
+)
+
+
+def parse_minimum_kube_version(content):
+    """Do not infer historical requirements from the unversioned docs."""
+    if isinstance(content, bytes):
+        content = content.decode("utf-8")
+    if not isinstance(content, str):
+        raise ValueError("Missing Falco Operator installation documentation")
+
+    sections = re.findall(
+        r"^## Prerequisites\s*\n(.*?)(?=^## |\Z)",
+        content,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if len(sections) != 1:
+        raise ValueError("Expected one Falco Operator prerequisites section")
+    versions = re.findall(
+        r"^- \*\*Kubernetes (\d+\.\d+)\+\*\*", sections[0], flags=re.MULTILINE
+    )
+    if len(versions) != 1:
+        raise ValueError("Expected one explicit Kubernetes minimum version")
+    return versions[0]
+
+
+def kube_versions_from_minimum(minimum, latest):
+    """Expand the documented lower bound only to the catalog's current minor."""
+    if not isinstance(latest, str) or not re.fullmatch(r"\d+\.\d+", latest):
+        raise ValueError("Missing or invalid catalog Kubernetes version")
+    start_major, start_minor = map(int, minimum.split("."))
+    end_major, end_minor = map(int, latest.split("."))
+    if start_major != end_major:
+        raise ValueError("Cannot extrapolate requirements across Kubernetes majors")
+    return [f"{start_major}.{minor}" for minor in range(start_minor, end_minor + 1)]
+
+
+def extract_table_data(chart_versions, latest_kube, fetch_document):
+    rows = []
+    stable_versions = [
+        (app_version, chart_version)
+        for app_version, chart_version in chart_versions.items()
+        if isinstance(app_version, str)
+        and isinstance(chart_version, str)
+        and re.fullmatch(r"\d+\.\d+\.\d+", app_version)
+        and re.fullmatch(r"\d+\.\d+\.\d+", chart_version)
+    ]
+    for app_version, chart_version in sorted(
+        stable_versions, key=lambda pair: Version(pair[0]), reverse=True
+    ):
+        url = INSTALLATION_URL.format(version=app_version)
+        minimum = parse_minimum_kube_version(fetch_document(url))
+        kube_versions = kube_versions_from_minimum(minimum, latest_kube)
+        if not kube_versions:
+            continue
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", app_version),
+                    ("kube", kube_versions),
+                    ("chart_version", chart_version),
+                    ("images", []),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+    if not rows:
+        raise ValueError("No documented stable Falco Operator chart versions found")
+    return rows
+
+
+def scrape():
+    rows = extract_table_data(
+        get_chart_versions(APP_NAME), current_kube_version(), fetch_page
+    )
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", rows)

--- a/utils/compatibility/tests/test_falco_operator.py
+++ b/utils/compatibility/tests/test_falco_operator.py
@@ -1,0 +1,118 @@
+import importlib
+import unittest
+from unittest.mock import Mock, patch
+
+
+scraper = importlib.import_module("scrapers.falco-operator")
+
+
+def documentation(minimum="1.29"):
+    return (
+        "# Installation\n\n"
+        "## Contents\nKubernetes 1.10+\n\n"
+        "## Prerequisites\n\n"
+        f"- **Kubernetes {minimum}+** — native sidecar support required.\n"
+        "- **Helm 3.x** — only for Helm installation.\n\n"
+        "## Install with Helm\nKubernetes 1.20+\n"
+    )
+
+
+class FalcoOperatorTests(unittest.TestCase):
+    def test_reads_only_explicit_prerequisite(self):
+        self.assertEqual(scraper.parse_minimum_kube_version(documentation()), "1.29")
+        self.assertEqual(
+            scraper.parse_minimum_kube_version(documentation().encode("utf-8")),
+            "1.29",
+        )
+
+    def test_missing_ambiguous_or_changed_documentation_fails(self):
+        for text in (
+            None,
+            "",
+            "# Error\nKubernetes 1.29+",
+            documentation().replace("## Prerequisites", "## Requirements"),
+            documentation().replace("1.29+", "1.29–1.35"),
+            documentation().replace(
+                "- **Helm 3.x**", "- **Kubernetes 1.30+**\n- **Helm 3.x**"
+            ),
+            documentation() + "\n## Prerequisites\n- **Kubernetes 1.29+**\n",
+        ):
+            with self.subTest(text=text), self.assertRaises(ValueError):
+                scraper.parse_minimum_kube_version(text)
+
+    def test_version_expansion_has_no_off_by_one_or_future_minor(self):
+        self.assertEqual(scraper.kube_versions_from_minimum("1.29", "1.29"), ["1.29"])
+        self.assertEqual(
+            scraper.kube_versions_from_minimum("1.29", "1.31"),
+            ["1.29", "1.30", "1.31"],
+        )
+        self.assertEqual(scraper.kube_versions_from_minimum("1.37", "1.36"), [])
+
+    def test_invalid_catalog_version_fails(self):
+        for latest in (None, "", "1.36.0", "next", "2.0"):
+            with self.subTest(latest=latest), self.assertRaises(ValueError):
+                scraper.kube_versions_from_minimum("1.29", latest)
+
+    def test_app_version_selects_docs_and_chart_version_stays_separate(self):
+        fetch = Mock(side_effect=[documentation("1.30"), documentation("1.29")])
+        rows = scraper.extract_table_data(
+            {"0.3.0": "0.2.0", "0.4.1": "0.3.1"}, "1.31", fetch
+        )
+        self.assertEqual([r["version"] for r in rows], ["0.4.1", "0.3.0"])
+        self.assertEqual([r["chart_version"] for r in rows], ["0.3.1", "0.2.0"])
+        self.assertEqual(rows[0]["kube"], ["1.30", "1.31"])
+        self.assertEqual(rows[1]["kube"], ["1.29", "1.30", "1.31"])
+        self.assertEqual(
+            [call.args[0] for call in fetch.call_args_list],
+            [scraper.INSTALLATION_URL.format(version=v) for v in ("0.4.1", "0.3.0")],
+        )
+
+    def test_prerelease_and_malformed_versions_are_not_requested(self):
+        fetch = Mock(return_value=documentation())
+        rows = scraper.extract_table_data(
+            {
+                "0.5.0-rc1": "0.4.0-rc1",
+                "0.4.2": "0.3.2-rc1",
+                "0.4.1": "0.3.1",
+                "0.4": "0.3.0",
+                "../../main": "0.1.0",
+                "0.3.0": None,
+            },
+            "1.36",
+            fetch,
+        )
+        self.assertEqual([r["version"] for r in rows], ["0.4.1"])
+        fetch.assert_called_once_with(scraper.INSTALLATION_URL.format(version="0.4.1"))
+
+    def test_no_matching_stable_version_fails(self):
+        with self.assertRaises(ValueError):
+            scraper.extract_table_data({"0.5.0-rc1": "0.4.0-rc1"}, "1.36", Mock())
+
+    def test_missing_later_document_does_not_write_partial_results(self):
+        with (
+            patch.object(scraper, "get_chart_versions", return_value={"0.4.1": "0.3.1", "0.3.0": "0.2.0"}),
+            patch.object(scraper, "current_kube_version", return_value="1.36"),
+            patch.object(scraper, "fetch_page", side_effect=[documentation(), None]),
+            patch.object(scraper, "update_compatibility_info") as update,
+            self.assertRaises(ValueError),
+        ):
+            scraper.scrape()
+        update.assert_not_called()
+
+    def test_scrape_uses_standard_update_pipeline(self):
+        with (
+            patch.object(scraper, "get_chart_versions", return_value={"0.4.1": "0.3.1"}) as charts,
+            patch.object(scraper, "current_kube_version", return_value="1.36"),
+            patch.object(scraper, "fetch_page", return_value=documentation()),
+            patch.object(scraper, "update_compatibility_info") as update,
+        ):
+            scraper.scrape()
+        charts.assert_called_once_with("falco-operator")
+        path, rows = update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/falco-operator.yaml")
+        self.assertEqual(rows[0]["kube"], [f"1.{n}" for n in range(29, 37)])
+        self.assertEqual(rows[0]["requirements"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Falco Operator is missing from the add-on compatibility catalog. This adds its metadata, manifest registration, generated table and a scraper that reads the Kubernetes prerequisite from each operator release's own installation guide.

The official chart index currently maps operator versions 0.2.2, 0.3.0, 0.4.0 and 0.4.1 to chart versions 0.1.0, 0.2.0, 0.3.0 and 0.3.1 respectively. The scraper keeps those identities separate and excludes prerelease operator/chart versions.

Each of those tagged guides documents Kubernetes 1.29+ for native sidecar support. The table expands that prerequisite only through the repository's `KUBE_VERSION` (currently 1.36), following the catalog's lower-bound convention. This records documented installation compatibility; it does not claim that every pairing was deployed or tested on a live cluster. The existing update pipeline renders the Helm charts to collect images.

Missing or ambiguous release documentation aborts the scrape before any partial table is written. Historical requirements are never copied from the latest documentation.

Sources:
- [Official chart index](https://falcosecurity.github.io/charts/index.yaml)
- Tagged prerequisites: [0.2.2](https://github.com/falcosecurity/falco-operator/blob/v0.2.2/docs/installation.md#prerequisites), [0.3.0](https://github.com/falcosecurity/falco-operator/blob/v0.3.0/docs/installation.md#prerequisites), [0.4.0](https://github.com/falcosecurity/falco-operator/blob/v0.4.0/docs/installation.md#prerequisites), [0.4.1](https://github.com/falcosecurity/falco-operator/blob/v0.4.1/docs/installation.md#prerequisites)

## Test Plan

Python 3.12.14 and Helm 3.21.4 on Windows:
- From `utils/compatibility`: `python -m unittest discover -s tests -p test_falco_operator.py -v` — 9 tests passed.
- Ran `importlib.import_module("scrapers.falco-operator").scrape()` against the official index and tagged docs, using local Helm rendering. The generated rows contain the four correct operator/chart/image mappings.
- Validated the generated add-on and manifest against `static/compatibilities/schema.json`.
- Repeated generation produced a byte-identical table.
- `git diff --check` passed.

No cluster was deployed. Optional model-based release summarization was disabled during verification.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly (source links and catalog metadata included).
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (not applicable: no agent code changed).

Plural Flow: console

Prepared with OpenAI Codex on behalf of @CocoRbt; implementation and verification were agent-run. Please consider this contribution under the published contributor program for new compatibility scrapers (advertised $300). No reward has been assumed or claimed as paid.
