### PR TITLE
Add Chaos Mesh compatibility scraper

### DIFF
--- a/static/compatibilities/chaos-mesh.yaml
+++ b/static/compatibilities/chaos-mesh.yaml
@@ -1,0 +1,106 @@
+icon: https://raw.githubusercontent.com/chaos-mesh/chaos-mesh/master/static/logo.svg
+git_url: https://github.com/chaos-mesh/chaos-mesh
+release_url: https://github.com/chaos-mesh/chaos-mesh/releases/tag/v{vsn}
+helm_repository_url: https://charts.chaos-mesh.org
+chart_name: chaos-mesh
+versions:
+- version: 2.8.4
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.8.4
+  images: ['ghcr.io/chaos-mesh/chaos-coredns:v0.2.8', 'ghcr.io/chaos-mesh/chaos-daemon:v2.8.4',
+    'ghcr.io/chaos-mesh/chaos-dashboard:v2.8.4', 'ghcr.io/chaos-mesh/chaos-mesh:v2.8.4']
+- version: 2.8.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.8.0
+  images: ['ghcr.io/chaos-mesh/chaos-coredns:v0.2.6', 'ghcr.io/chaos-mesh/chaos-daemon:v2.8.0',
+    'ghcr.io/chaos-mesh/chaos-dashboard:v2.8.0', 'ghcr.io/chaos-mesh/chaos-mesh:v2.8.0']
+- version: 2.7.0
+  kube: ['1.28', '1.27', '1.26']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.7.0
+  images: ['ghcr.io/chaos-mesh/chaos-coredns:v0.2.6', 'ghcr.io/chaos-mesh/chaos-daemon:v2.7.0',
+    'ghcr.io/chaos-mesh/chaos-dashboard:v2.7.0', 'ghcr.io/chaos-mesh/chaos-mesh:v2.7.0']
+- version: 2.6.0
+  kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.6.0
+  images: ['ghcr.io/chaos-mesh/chaos-coredns:v0.2.6', 'ghcr.io/chaos-mesh/chaos-daemon:v2.6.0',
+    'ghcr.io/chaos-mesh/chaos-dashboard:v2.6.0', 'ghcr.io/chaos-mesh/chaos-mesh:v2.6.0']
+- version: 2.5.0
+  kube: ['1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.5.0
+  images: ['ghcr.io/chaos-mesh/chaos-daemon:v2.5.0', 'ghcr.io/chaos-mesh/chaos-dashboard:v2.5.0',
+    'ghcr.io/chaos-mesh/chaos-mesh:v2.5.0']
+- version: 2.4.0
+  kube: ['1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.4.0
+  images: ['ghcr.io/chaos-mesh/chaos-daemon:v2.4.0', 'ghcr.io/chaos-mesh/chaos-dashboard:v2.4.0',
+    'ghcr.io/chaos-mesh/chaos-mesh:v2.4.0']
+- version: 2.3.0
+  kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.3.0
+  images: ['ghcr.io/chaos-mesh/chaos-daemon:v2.3.0', 'ghcr.io/chaos-mesh/chaos-dashboard:v2.3.0',
+    'ghcr.io/chaos-mesh/chaos-mesh:v2.3.0']
+- version: 2.2.0
+  kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.2.0
+  images: ['ghcr.io/chaos-mesh/chaos-daemon:v2.2.0', 'ghcr.io/chaos-mesh/chaos-dashboard:v2.2.0',
+    'ghcr.io/chaos-mesh/chaos-mesh:v2.2.0']
+- version: 2.1.0
+  kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.1.0
+  images: ['ghcr.io/chaos-mesh/chaos-daemon:v2.1.0', 'ghcr.io/chaos-mesh/chaos-dashboard:v2.1.0',
+    'ghcr.io/chaos-mesh/chaos-mesh:v2.1.0']
+- version: 2.0.0
+  kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16', '1.15']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.0.0
+  images: ['pingcap/chaos-daemon:v2.0.0', 'pingcap/chaos-dashboard:v2.0.0', 'pingcap/chaos-mesh:v2.0.0']
+- version: 1.2.0
+  kube: ['1.15', '1.14', '1.13', '1.12']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.5.0
+  images: ['pingcap/chaos-daemon:v1.2.0', 'pingcap/chaos-dashboard:v1.2.0', 'pingcap/chaos-mesh:v1.2.0']
+- version: 1.1.0
+  kube: ['1.15', '1.14', '1.13', '1.12']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.4.0
+  images: ['pingcap/chaos-daemon:v1.1.0', 'pingcap/chaos-mesh:v1.1.0']
+- version: 1.0.0
+  kube: ['1.15', '1.14', '1.13', '1.12']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.3.0
+  images: ['pingcap/chaos-daemon:v1.0.0', 'pingcap/chaos-mesh:v1.0.0']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -9,6 +9,7 @@ names:
 - calico
 - cert-manager
 - cilium
+- chaos-mesh
 - contour
 - coredns
 - cloudnative-pg

--- a/utils/compatibility/scrapers/chaos-mesh.py
+++ b/utils/compatibility/scrapers/chaos-mesh.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+from bs4 import BeautifulSoup
+
+from utils import (
+    fetch_page,
+    get_chart_versions,
+    print_error,
+    update_compatibility_info,
+    validate_semver,
+)
+
+
+APP_NAME = "chaos-mesh"
+CHART_NAME = "chaos-mesh"
+SUPPORTED_RELEASES_URL = "https://chaos-mesh.org/supported-releases/"
+
+
+def _decode(content):
+    return content.decode("utf-8") if isinstance(content, bytes) else content
+
+
+def _minor(version):
+    parsed = validate_semver(str(version).strip().lstrip("v"))
+    if not parsed:
+        return None
+    return f"{parsed.major}.{parsed.minor}"
+
+
+def _kube_versions(text):
+    versions = re.findall(r"\b\d+\.\d+\b", text)
+    return [version for version in versions if validate_semver(version)]
+
+
+def _column(headers, name):
+    for index, header in enumerate(headers):
+        if header == name:
+            return index
+    return None
+
+
+def _strip_cell(cell_html):
+    return BeautifulSoup(cell_html, "html.parser").get_text(" ", strip=True)
+
+
+def _cells(row_html):
+    return [
+        _strip_cell(match.group(1))
+        for match in re.finditer(
+            r"<t[dh]\b[^>]*>(.*?)(?=<t[dh]\b[^>]*>|<tr|</tr|</thead|</tbody|</table)",
+            row_html,
+            re.IGNORECASE | re.DOTALL,
+        )
+    ]
+
+
+def _tables(content):
+    return re.findall(
+        r"<table[^>]*>.*?</table>",
+        _decode(content),
+        re.IGNORECASE | re.DOTALL,
+    )
+
+
+def parse_support_matrix(content):
+    matrix = {}
+
+    for table in _tables(content):
+        cells = _cells(table)
+        headers = [cell.lower() for cell in cells]
+        version_column = _column(headers, "version")
+        kube_column = _column(headers, "supported kubernetes versions")
+        if version_column is None or kube_column is None:
+            continue
+
+        column_count = kube_column + 1
+        if column_count < 2:
+            continue
+
+        for index in range(column_count, len(cells), column_count):
+            row = cells[index:index + column_count]
+            if len(row) <= max(version_column, kube_column):
+                continue
+
+            release = row[version_column]
+            if release.lower() == "master":
+                continue
+
+            minor = _minor(release)
+            kube = _kube_versions(row[kube_column])
+            if minor and kube:
+                matrix[minor] = kube
+
+    return matrix
+
+
+def build_rows(chart_versions, support_matrix):
+    rows = []
+
+    for app_version, chart_version in chart_versions.items():
+        parsed = validate_semver(app_version)
+        if not parsed:
+            continue
+
+        kube = support_matrix.get(f"{parsed.major}.{parsed.minor}")
+        if not kube:
+            continue
+
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", str(parsed)),
+                    ("kube", kube),
+                    ("chart_version", chart_version),
+                    ("images", []),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    return rows
+
+
+def scrape():
+    content = fetch_page(SUPPORTED_RELEASES_URL)
+    if not content:
+        print_error("Failed to fetch Chaos Mesh supported releases")
+        return
+
+    support_matrix = parse_support_matrix(content)
+    if not support_matrix:
+        print_error("No Chaos Mesh Kubernetes support matrix found")
+        return
+
+    chart_versions = get_chart_versions(APP_NAME, CHART_NAME)
+    if not chart_versions:
+        print_error("No Chaos Mesh chart versions found")
+        return
+
+    rows = build_rows(chart_versions, support_matrix)
+    if not rows:
+        print_error("No Chaos Mesh compatibility rows generated")
+        return
+
+    update_compatibility_info(
+        f"../../static/compatibilities/{APP_NAME}.yaml",
+        rows,
+    )

--- a/utils/compatibility/scrapers/chaos-mesh.py
+++ b/utils/compatibility/scrapers/chaos-mesh.py
@@ -46,14 +46,26 @@ def _strip_cell(cell_html):
     return BeautifulSoup(cell_html, "html.parser").get_text(" ", strip=True)
 
 
-def _cells(row_html):
+def _row_cells(row_html):
     return [
         _strip_cell(match.group(1))
         for match in re.finditer(
-            r"<t[dh]\b[^>]*>(.*?)(?=<t[dh]\b[^>]*>|<tr|</tr|</thead|</tbody|</table)",
+            r"<t[dh]\b[^>]*>(.*?)(?=</t[dh]>|<t[dh]\b|</tr|$)",
             row_html,
             re.IGNORECASE | re.DOTALL,
         )
+    ]
+
+
+def _table_rows(table_html):
+    return [
+        cells
+        for row_html in re.findall(
+            r"<tr\b[^>]*>(.*?)(?=<tr\b|</thead|</tbody|</table)",
+            table_html,
+            re.IGNORECASE | re.DOTALL,
+        )
+        if (cells := _row_cells(row_html))
     ]
 
 
@@ -69,19 +81,23 @@ def parse_support_matrix(content):
     matrix = {}
 
     for table in _tables(content):
-        cells = _cells(table)
-        headers = [cell.lower() for cell in cells]
-        version_column = _column(headers, "version")
-        kube_column = _column(headers, "supported kubernetes versions")
-        if version_column is None or kube_column is None:
+        rows = _table_rows(table)
+        header_index = None
+        version_column = None
+        kube_column = None
+
+        for index, row in enumerate(rows):
+            headers = [cell.lower() for cell in row]
+            version_column = _column(headers, "version")
+            kube_column = _column(headers, "supported kubernetes versions")
+            if version_column is not None and kube_column is not None:
+                header_index = index
+                break
+
+        if header_index is None:
             continue
 
-        column_count = kube_column + 1
-        if column_count < 2:
-            continue
-
-        for index in range(column_count, len(cells), column_count):
-            row = cells[index:index + column_count]
+        for row in rows[header_index + 1:]:
             if len(row) <= max(version_column, kube_column):
                 continue
 

--- a/utils/compatibility/tests/test_chaos_mesh.py
+++ b/utils/compatibility/tests/test_chaos_mesh.py
@@ -36,6 +36,24 @@ class ChaosMeshScraperTest(unittest.TestCase):
             },
         )
 
+
+    def test_parse_support_matrix_does_not_require_kubernetes_column_to_be_last(self):
+        content = """
+<table>
+  <thead><tr>
+    <th>Version</th><th>Supported Kubernetes versions</th><th>Notes</th>
+  </tr></thead>
+  <tbody>
+    <tr><td>2.8</td><td>1.30, 1.31, 1.32</td><td>current</td></tr>
+  </tbody>
+</table>
+"""
+
+        self.assertEqual(
+            chaos_mesh.parse_support_matrix(content),
+            {"2.8": ["1.30", "1.31", "1.32"]},
+        )
+
     def test_parse_support_matrix_ignores_the_e2e_test_table(self):
         content = """
 <table>

--- a/utils/compatibility/tests/test_chaos_mesh.py
+++ b/utils/compatibility/tests/test_chaos_mesh.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+COMPATIBILITY_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = COMPATIBILITY_DIR / "scrapers" / "chaos-mesh.py"
+sys.path.insert(0, str(COMPATIBILITY_DIR))
+
+spec = importlib.util.spec_from_file_location("chaos_mesh", MODULE_PATH)
+chaos_mesh = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(chaos_mesh)
+
+
+class ChaosMeshScraperTest(unittest.TestCase):
+    def test_parse_support_matrix_reads_the_supported_release_table(self):
+        content = """
+<table><thead><tr>
+  <th>Version<th>Currently Supported<th>Release Date<th>End of Life<th>Supported Kubernetes versions
+<tbody>
+  <tr><td>master<td>No<td>-<td>-<td>1.33, 1.34
+  <tr><td>2.8<td><code>Yes</code><td>Oct 01, 2025<td>-<td>1.30, 1.31, 1.32
+  <tr><td>2.7<td><code>Yes</code><td>Sep 20, 2024<td>-<td>1.26, 1.27, 1.28
+</table>
+"""
+
+        self.assertEqual(
+            chaos_mesh.parse_support_matrix(content),
+            {
+                "2.8": ["1.30", "1.31", "1.32"],
+                "2.7": ["1.26", "1.27", "1.28"],
+            },
+        )
+
+    def test_parse_support_matrix_ignores_the_e2e_test_table(self):
+        content = """
+<table>
+  <thead><tr><th>Version</th><th>Tested kubernetes Versions</th></tr></thead>
+  <tbody><tr><td>2.8</td><td>1.33.9, 1.34.5</td></tr></tbody>
+</table>
+"""
+
+        self.assertEqual(chaos_mesh.parse_support_matrix(content), {})
+
+    def test_build_rows_maps_chart_patches_to_their_release_minor(self):
+        rows = chaos_mesh.build_rows(
+            {
+                "2.8.4": "2.8.4",
+                "2.7.3": "2.7.3",
+                "3.0.0-alpha.1": "3.0.0-alpha.1",
+            },
+            {
+                "2.8": ["1.30", "1.31", "1.32"],
+                "2.7": ["1.26", "1.27", "1.28"],
+            },
+        )
+
+        self.assertEqual(rows[0]["version"], "2.8.4")
+        self.assertEqual(rows[0]["kube"], ["1.30", "1.31", "1.32"])
+        self.assertEqual(rows[0]["chart_version"], "2.8.4")
+        self.assertEqual(rows[1]["version"], "2.7.3")
+        self.assertEqual(rows[1]["kube"], ["1.26", "1.27", "1.28"])
+        self.assertEqual(len(rows), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I added Chaos Mesh to the compatibility catalog.

The scraper reads the official supported-releases page, then joins each Chaos Mesh minor with the chart/app versions from the Helm index. I used the support table rather than the E2E table because the docs treat those as different signals: one is the supported Kubernetes range, the other is the exact patch versions used in test jobs.

Sources:
- https://chaos-mesh.org/supported-releases/
- https://charts.chaos-mesh.org/index.yaml

I checked this locally with Python 3.13 and portable Helm: the scraper and test file compile, the parser/chart mapping tests pass, a direct live scraper run renders images through Helm, the generated YAML and manifest parse cleanly, and `git diff --check` passes.

Related to #4136.
