### PR TITLE
Add KubeEdge compatibility scraper

### DIFF
--- a/static/compatibilities/kubeedge.yaml
+++ b/static/compatibilities/kubeedge.yaml
@@ -1,0 +1,30 @@
+icon: https://raw.githubusercontent.com/kubeedge/kubeedge/master/docs/images/logo/kubeedge-stacked-color.png
+git_url: https://github.com/kubeedge/kubeedge
+release_url: https://github.com/kubeedge/kubeedge/releases/tag/v{vsn}
+readme_url: https://github.com/kubeedge/kubeedge#kubernetes-compatibility
+versions:
+- version: 1.23.1
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 1.22.2
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 1.21.2
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 1.20.0
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 1.19.2
+  kube: ['1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -1,5 +1,6 @@
 names:
 - kubevirt
+- kubeedge
 - argo-rollouts
 - aws-ebs-csi-driver
 - aws-efs-csi-driver

--- a/utils/compatibility/scrapers/kubeedge.py
+++ b/utils/compatibility/scrapers/kubeedge.py
@@ -78,6 +78,9 @@ def latest_stable_release_by_minor():
             break
 
         for release in releases:
+            if release.get("draft") or release.get("prerelease"):
+                continue
+
             tag = release.get("tag_name", "").lstrip("v")
             if not re.match(r"^\d+\.\d+\.\d+$", tag):
                 continue
@@ -97,8 +100,11 @@ def parse_matrix(readme, release_versions):
         return []
 
     headers = [cell.strip() for cell in table[0].strip("|").split("|")]
-    kube_versions = [_version(header) for header in headers[1:]]
-    kube_versions = [version for version in kube_versions if version]
+    kube_columns = [
+        (index, version)
+        for index, header in enumerate(headers)
+        if index > 0 and (version := _version(header))
+    ]
     rows = []
 
     for line in table[2:]:
@@ -116,8 +122,8 @@ def parse_matrix(readme, release_versions):
 
         supported_kube_versions = [
             kube_version
-            for kube_version, value in zip(kube_versions, cells[1:])
-            if value == SUPPORTED_MARK
+            for column, kube_version in kube_columns
+            if column < len(cells) and cells[column] == SUPPORTED_MARK
         ]
         if not supported_kube_versions:
             continue

--- a/utils/compatibility/scrapers/kubeedge.py
+++ b/utils/compatibility/scrapers/kubeedge.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import requests
+from packaging.version import Version
+
+from utils import (
+    fetch_page,
+    print_error,
+    update_compatibility_info,
+)
+
+
+APP_NAME = "kubeedge"
+README_URL = "https://raw.githubusercontent.com/kubeedge/kubeedge/master/README.md"
+RELEASES_URL = "https://api.github.com/repos/kubeedge/kubeedge/releases"
+REQUEST_TIMEOUT = 30
+SUPPORTED_MARK = "✓"
+
+
+def _decode(content):
+    try:
+        return content.decode("utf-8") if isinstance(content, bytes) else content
+    except UnicodeDecodeError as exc:
+        print_error(f"Failed to decode KubeEdge README: {exc}")
+        return None
+
+
+def _version(value):
+    match = re.search(r"\d+\.\d+(?:\.\d+)?", value)
+    return match.group(0) if match else None
+
+
+def _minor(version):
+    parts = version.split(".")
+    if len(parts) < 2:
+        return None
+    return f"{parts[0]}.{parts[1]}"
+
+
+def _table_lines(readme):
+    lines = readme.splitlines()
+    table = []
+    found_heading = False
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "## Kubernetes compatibility":
+            found_heading = True
+            continue
+        if not found_heading:
+            continue
+
+        if stripped.startswith("|"):
+            table.append(stripped)
+        elif table:
+            break
+
+    return table
+
+
+def latest_stable_release_by_minor():
+    latest = {}
+
+    for page in range(1, 4):
+        response = requests.get(
+            RELEASES_URL,
+            params={"page": page, "per_page": 100},
+            timeout=REQUEST_TIMEOUT,
+        )
+        if response.status_code != 200:
+            raise Exception(f"Failed to fetch KubeEdge releases: {response.status_code}")
+
+        releases = response.json()
+        if not releases:
+            break
+
+        for release in releases:
+            tag = release.get("tag_name", "").lstrip("v")
+            if not re.match(r"^\d+\.\d+\.\d+$", tag):
+                continue
+
+            parsed = Version(tag)
+            minor = f"{parsed.major}.{parsed.minor}"
+            current = latest.get(minor)
+            if current is None or parsed > Version(current):
+                latest[minor] = tag
+
+    return latest
+
+
+def parse_matrix(readme, release_versions):
+    table = _table_lines(readme)
+    if len(table) < 3:
+        return []
+
+    headers = [cell.strip() for cell in table[0].strip("|").split("|")]
+    kube_versions = [_version(header) for header in headers[1:]]
+    kube_versions = [version for version in kube_versions if version]
+    rows = []
+
+    for line in table[2:]:
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+
+        kubeedge_minor = _version(cells[0])
+        if not kubeedge_minor:
+            continue
+
+        release_version = release_versions.get(_minor(kubeedge_minor))
+        if not release_version:
+            continue
+
+        supported_kube_versions = [
+            kube_version
+            for kube_version, value in zip(kube_versions, cells[1:])
+            if value == SUPPORTED_MARK
+        ]
+        if not supported_kube_versions:
+            continue
+
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", release_version),
+                    ("kube", supported_kube_versions),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    return rows
+
+
+def scrape():
+    content = fetch_page(README_URL)
+    if not content:
+        return
+
+    readme = _decode(content)
+    if not readme:
+        return
+
+    release_versions = latest_stable_release_by_minor()
+    rows = parse_matrix(readme, release_versions)
+    if not rows:
+        print_error("No compatibility information found for KubeEdge")
+        return
+
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", rows)

--- a/utils/compatibility/tests/test_kubeedge.py
+++ b/utils/compatibility/tests/test_kubeedge.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 COMPATIBILITY_DIR = Path(__file__).resolve().parents[1]
@@ -53,6 +54,47 @@ Key:
                 },
             ],
         )
+
+    def test_parse_matrix_preserves_columns_when_metadata_columns_are_present(self):
+        readme = """
+## Kubernetes compatibility
+
+|               | Notes | Kubernetes 1.27 | Kubernetes 1.28 |
+|---------------|-------|-----------------|-----------------|
+| KubeEdge 1.21 | LTS   | ✓               | -               |
+"""
+
+        rows = kubeedge.parse_matrix(readme, {"1.21": "1.21.2"})
+
+        self.assertEqual(rows[0]["kube"], ["1.27"])
+
+    def test_latest_stable_release_by_minor_skips_draft_and_prerelease_entries(self):
+        class Response:
+            status_code = 200
+
+            def __init__(self, releases):
+                self._releases = releases
+
+            def json(self):
+                return self._releases
+
+        responses = [
+            Response(
+                [
+                    {"tag_name": "v1.22.3", "draft": False, "prerelease": True},
+                    {"tag_name": "v1.22.2", "draft": False, "prerelease": False},
+                    {"tag_name": "v1.21.9", "draft": True, "prerelease": False},
+                    {"tag_name": "v1.21.2", "draft": False, "prerelease": False},
+                ]
+            ),
+            Response([]),
+        ]
+
+        with patch.object(kubeedge.requests, "get", side_effect=responses):
+            self.assertEqual(
+                kubeedge.latest_stable_release_by_minor(),
+                {"1.22": "1.22.2", "1.21": "1.21.2"},
+            )
 
     def test_parse_matrix_skips_missing_release_versions(self):
         readme = """

--- a/utils/compatibility/tests/test_kubeedge.py
+++ b/utils/compatibility/tests/test_kubeedge.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+COMPATIBILITY_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = COMPATIBILITY_DIR / "scrapers" / "kubeedge.py"
+sys.path.insert(0, str(COMPATIBILITY_DIR))
+
+spec = importlib.util.spec_from_file_location("kubeedge", MODULE_PATH)
+kubeedge = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(kubeedge)
+
+
+class KubeEdgeScraperTest(unittest.TestCase):
+    def test_parse_matrix_uses_exact_support_marks_only(self):
+        readme = """
+## Kubernetes compatibility
+
+|                        | Kubernetes 1.27 | Kubernetes 1.28 | Kubernetes 1.29 |
+|------------------------|-----------------|-----------------|-----------------|
+| KubeEdge 1.21          | +               | ✓               | ✓               |
+| KubeEdge 1.22          | +               | +               | ✓               |
+| KubeEdge HEAD (master) | +               | +               | ✓               |
+
+Key:
+* `✓` KubeEdge and the Kubernetes version are exactly compatible.
+* `+` KubeEdge has features or API objects that may not be present in the Kubernetes version.
+* `-` The Kubernetes version has features or API objects that KubeEdge can't use.
+"""
+
+        self.assertEqual(
+            kubeedge.parse_matrix(
+                readme,
+                {"1.21": "1.21.2", "1.22": "1.22.2"},
+            ),
+            [
+                {
+                    "version": "1.21.2",
+                    "kube": ["1.28", "1.29"],
+                    "requirements": [],
+                    "incompatibilities": [],
+                },
+                {
+                    "version": "1.22.2",
+                    "kube": ["1.29"],
+                    "requirements": [],
+                    "incompatibilities": [],
+                },
+            ],
+        )
+
+    def test_parse_matrix_skips_missing_release_versions(self):
+        readme = """
+## Kubernetes compatibility
+
+|               | Kubernetes 1.30 |
+|---------------|-----------------|
+| KubeEdge 1.24 | ✓               |
+"""
+
+        self.assertEqual(kubeedge.parse_matrix(readme, {}), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I added KubeEdge to the compatibility catalog.

The scraper reads the Kubernetes compatibility table from the KubeEdge README and maps each KubeEdge minor to the latest stable patch release from GitHub releases.

I treated only `✓` cells as supported. KubeEdge also marks some cells with `+`, but their own legend says those combinations may miss required KubeEdge features or API objects in that Kubernetes version. Since Plural stores a supported-version list, I left those caveated combinations out instead of overstating support.

Sources:
- https://github.com/kubeedge/kubeedge#kubernetes-compatibility
- https://api.github.com/repos/kubeedge/kubeedge/releases

I checked this locally: the scraper and test file compile, the matrix parser tests pass, a direct scraper run works against the live README and GitHub releases API, the generated YAML/manifest parse cleanly, and `git diff --check` passes.

Related to #4142.
