### PR TITLE
Restore Strimzi scraping and add four tested compatibility releases

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -23160,7 +23160,37 @@ addons:
 - icon: https://avatars.githubusercontent.com/u/34767428?s=48&v=4
   git_url: https://github.com/strimzi/strimzi-kafka-operator
   release_url: https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{vsn}
+  helm_repository_url: https://strimzi.io/charts
+  chart_name: strimzi-kafka-operator
   versions:
+  - version: 1.2.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.2.0
+    images: ['quay.io/strimzi/operator:1.2.0']
+  - version: 1.1.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.1.0
+    images: ['quay.io/strimzi/operator:1.1.0']
+  - version: 1.0.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.0
+    images: ['quay.io/strimzi/operator:1.0.0']
+  - version: 0.51.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.51.0
+    images: ['quay.io/strimzi/operator:0.51.0']
   - version: 0.50.0
     kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
     requirements: []

--- a/static/compatibilities/strimzi-kafka.yaml
+++ b/static/compatibilities/strimzi-kafka.yaml
@@ -1,7 +1,37 @@
 icon: https://avatars.githubusercontent.com/u/34767428?s=48&v=4
 git_url: https://github.com/strimzi/strimzi-kafka-operator
 release_url: https://github.com/strimzi/strimzi-kafka-operator/releases/tag/{vsn}
+helm_repository_url: https://strimzi.io/charts
+chart_name: strimzi-kafka-operator
 versions:
+- version: 1.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.0
+  images: ['quay.io/strimzi/operator:1.2.0']
+- version: 1.1.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.0
+  images: ['quay.io/strimzi/operator:1.1.0']
+- version: 1.0.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.0
+  images: ['quay.io/strimzi/operator:1.0.0']
+- version: 0.51.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.51.0
+  images: ['quay.io/strimzi/operator:0.51.0']
 - version: 0.50.0
   kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
   requirements: []

--- a/utils/compatibility/scrapers/strimzi-kafka.py
+++ b/utils/compatibility/scrapers/strimzi-kafka.py
@@ -163,13 +163,6 @@ def scrape() -> None:
         if validate_semver(row["version"]) > legacy_version_cutoff
         and row["version"] not in recorded_versions
     ]
-    # Consider the complete version sequence, not just releases newer than its
-    # maximum. A delayed chart or changed-support backport can fill an older gap.
-    # Pre-reduction also avoids repeatedly reprocessing unchanged patch releases.
-    retained_versions = {
-        row["version"] for row in reduce_versions(deepcopy(existing["versions"]) + rows)
-    }
-    rows = [row for row in rows if row["version"] in retained_versions]
     if not rows:
         return
     charts = get_chart_versions(app_name, chart_name=chart_name)
@@ -182,5 +175,12 @@ def scrape() -> None:
         if chart and validate_semver(chart):
             row["chart_version"] = chart
             released_rows.append(row)
+    # Reduce only chart-backed candidates. An unavailable .0 chart must not
+    # hide a usable patch with the same compatibility window. Including existing
+    # rows preserves delayed/backport boundaries and makes unchanged patches no-ops.
+    retained_versions = {
+        row["version"] for row in reduce_versions(deepcopy(existing["versions"]) + released_rows)
+    }
+    released_rows = [row for row in released_rows if row["version"] in retained_versions]
     if released_rows:
         update_compatibility_info(target_file, released_rows)

--- a/utils/compatibility/scrapers/strimzi-kafka.py
+++ b/utils/compatibility/scrapers/strimzi-kafka.py
@@ -6,56 +6,78 @@ from collections import OrderedDict
 from bs4 import BeautifulSoup
 from utils import (
     current_kube_version,
-    expand_kube_versions,
     fetch_page,
-    latest_kube_version,
+    get_chart_versions,
     print_error,
+    read_yaml,
     update_compatibility_info,
+    validate_semver,
 )
 
 app_name = "strimzi-kafka"
 downloads_url = "https://strimzi.io/downloads/"
+target_file = f"../../static/compatibilities/{app_name}.yaml"
+chart_name = "strimzi-kafka-operator"
+kube_headers = {"kubernetes versions", "tested kubernetes versions"}
 
 
 def _latest_minor() -> str | None:
     cur = current_kube_version()
-    if cur:
+    if cur and re.fullmatch(r"\d+\.\d+", cur):
         return cur
-    latest = latest_kube_version()
-    if not latest:
-        return None
-    return f"{latest.major}.{latest.minor}"
+    return None
+
+
+def _expand_range(start: str, end: str) -> list[str]:
+    start_major, start_minor = map(int, start.split("."))
+    end_major, end_minor = map(int, end.split("."))
+    if start_major != end_major or start_minor > end_minor:
+        return []
+    return [f"{start_major}.{minor}" for minor in range(start_minor, end_minor + 1)]
 
 
 def _parse_kube_cell(text: str) -> list[str]:
-    # Normalize whitespace and remove footnote numbers
+    # Only the compatibility matrix supplies these values, never a dependency floor.
     cleaned = re.sub(r"\s+", " ", text).strip()
-    cleaned = re.sub(r"\s*\[[^\]]*\]", "", cleaned)  # strip bracket notes if any
 
-    # Patterns: "1.27+", "v1.27+", "1.23+ 2", "1.21 - 1.25"
-    m_plus = re.search(r"v?(\d+\.\d+)\s*\+", cleaned)
+    # Patterns: "1.27+", "v1.27+", "1.21 - 1.25" (footnotes removed in _cell_text).
+    m_plus = re.fullmatch(r"v?(\d+\.\d+)\s*\+", cleaned)
     if m_plus:
         start = m_plus.group(1)
         latest_minor = _latest_minor()
         if not latest_minor:
             return []
-        return expand_kube_versions(start, latest_minor)
+        return _expand_range(start, latest_minor)
 
-    m_range = re.search(r"v?(\d+\.\d+)\s*-\s*v?(\d+\.\d+)", cleaned)
+    m_range = re.fullmatch(r"v?(\d+\.\d+)\s*[-–—]\s*v?(\d+\.\d+)", cleaned)
     if m_range:
         start, end = m_range.groups()
-        return expand_kube_versions(start, end)
+        return _expand_range(start, end)
 
     # Fallback: try comma separated explicit minors
     parts = [p.strip().lstrip("v") for p in cleaned.split(",")]
-    return [p for p in parts if re.match(r"^\d+\.\d+$", p)]
+    if not all(re.fullmatch(r"\d+\.\d+", p) for p in parts):
+        return []
+    return list(dict.fromkeys(parts))
+
+
+def _cell_text(cell) -> str:
+    # Footnote markers are presentation, not part of a version or header label.
+    return " ".join(
+        text.strip() for text in cell.find_all(string=True)
+        if text.strip() and text.find_parent("sup") is None
+    )
+
+
+def _headers(table) -> list[str]:
+    return [_cell_text(th).lower() for th in table.find_all("th")]
 
 
 def _find_supported_versions_table(soup: BeautifulSoup):
-    # Look for a table which has a header cell "Kubernetes versions"
+    # The current page labels its finite verified window "Tested Kubernetes versions".
     for table in soup.find_all("table"):
-        ths = [th.get_text(strip=True).lower() for th in table.find_all("th")]
-        if any("kubernetes versions" == th for th in ths):
+        ths = _headers(table)
+        if "operators" in ths and any(th in kube_headers for th in ths):
             return table
     return None
 
@@ -64,31 +86,31 @@ def _parse_rows(table) -> list[OrderedDict[str, object]]:
     rows: list[OrderedDict[str, object]] = []
     tbody = table.find("tbody") or table
     # Identify column indices based on header labels
-    header_cells = [th.get_text(strip=True).lower() for th in table.find_all("th")]
+    header_cells = _headers(table)
     try:
         op_idx = header_cells.index("operators")
-        k8s_idx = header_cells.index("kubernetes versions")
-    except ValueError:
-        # Fallback to assumed positions: operators at 0, k8s at last
-        op_idx = 0
-        k8s_idx = -1
+        k8s_idx = next(i for i, label in enumerate(header_cells) if label in kube_headers)
+    except (ValueError, StopIteration):
+        raise ValueError("Strimzi compatibility table is missing required headers")
 
     for tr in tbody.find_all("tr"):
         cells = tr.find_all("td")
-        if len(cells) < max(op_idx, k8s_idx if k8s_idx >= 0 else 0) + 1:
+        if not cells:
             continue
-        op_text = cells[op_idx].get_text(strip=True)
-        k8s_text = cells[k8s_idx].get_text(" ", strip=True) if k8s_idx >= 0 else ""
+        if len(cells) <= max(op_idx, k8s_idx):
+            raise ValueError("Incomplete Strimzi compatibility row")
+        op_text = _cell_text(cells[op_idx])
+        k8s_text = _cell_text(cells[k8s_idx])
 
         # Parse Strimzi operator version
-        m = re.search(r"(\d+\.\d+\.\d+)", op_text)
+        m = re.fullmatch(r"v?(\d+\.\d+\.\d+)", op_text)
         if not m:
             continue
         operator_version = m.group(1)
 
         kube_versions = _parse_kube_cell(k8s_text)
         if not kube_versions:
-            continue
+            raise ValueError(f"Invalid Strimzi Kubernetes compatibility for {operator_version}")
 
         rows.append(
             OrderedDict(
@@ -116,11 +138,34 @@ def scrape() -> None:
         print_error("Strimzi supported versions table not found")
         return
 
-    rows = _parse_rows(table)
+    try:
+        rows = _parse_rows(table)
+    except ValueError as error:
+        print_error(str(error))
+        return
     if not rows:
         print_error("No Strimzi compatibility rows parsed")
         return
 
-    update_compatibility_info(
-        f"../../static/compatibilities/{app_name}.yaml", rows
-    )
+    existing = read_yaml(target_file)
+    if not existing or not existing.get("versions"):
+        print_error("Could not read existing Strimzi compatibility versions")
+        return
+    latest_recorded = max(validate_semver(row["version"]) for row in existing["versions"])
+    # Historical rows were generated from older support policies. Keep them intact;
+    # this update adds released versions after the last recorded boundary only.
+    rows = [row for row in rows if validate_semver(row["version"]) > latest_recorded]
+    if not rows:
+        return
+    charts = get_chart_versions(app_name, chart_name=chart_name)
+    if not charts:
+        print_error("Could not read official Strimzi chart versions")
+        return
+    released_rows = []
+    for row in rows:
+        chart = charts.get(row["version"])
+        if chart and validate_semver(chart):
+            row["chart_version"] = chart
+            released_rows.append(row)
+    if released_rows:
+        update_compatibility_info(target_file, released_rows)

--- a/utils/compatibility/scrapers/strimzi-kafka.py
+++ b/utils/compatibility/scrapers/strimzi-kafka.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import re
 from collections import OrderedDict
+from copy import deepcopy
 
 from bs4 import BeautifulSoup
 from utils import (
     current_kube_version,
+    ensure_keys,
     fetch_page,
     get_chart_versions,
     print_error,
     read_yaml,
+    reduce_versions,
     update_compatibility_info,
     validate_semver,
 )
@@ -19,6 +22,9 @@ downloads_url = "https://strimzi.io/downloads/"
 target_file = f"../../static/compatibilities/{app_name}.yaml"
 chart_name = "strimzi-kafka-operator"
 kube_headers = {"kubernetes versions", "tested kubernetes versions"}
+# Records through 0.50.0 predate the finite tested-version matrix migration.
+# Freeze that legacy history, but allow later missing releases and backports.
+legacy_version_cutoff = validate_semver("0.50.0")
 
 
 def _latest_minor() -> str | None:
@@ -151,10 +157,19 @@ def scrape() -> None:
     if not existing or not existing.get("versions"):
         print_error("Could not read existing Strimzi compatibility versions")
         return
-    latest_recorded = max(validate_semver(row["version"]) for row in existing["versions"])
-    # Historical rows were generated from older support policies. Keep them intact;
-    # this update adds released versions after the last recorded boundary only.
-    rows = [row for row in rows if validate_semver(row["version"]) > latest_recorded]
+    recorded_versions = {row["version"] for row in existing["versions"]}
+    rows = [
+        ensure_keys(row) for row in rows
+        if validate_semver(row["version"]) > legacy_version_cutoff
+        and row["version"] not in recorded_versions
+    ]
+    # Consider the complete version sequence, not just releases newer than its
+    # maximum. A delayed chart or changed-support backport can fill an older gap.
+    # Pre-reduction also avoids repeatedly reprocessing unchanged patch releases.
+    retained_versions = {
+        row["version"] for row in reduce_versions(deepcopy(existing["versions"]) + rows)
+    }
+    rows = [row for row in rows if row["version"] in retained_versions]
     if not rows:
         return
     charts = get_chart_versions(app_name, chart_name=chart_name)

--- a/utils/compatibility/tests/fixtures/strimzi-kafka/downloads.html
+++ b/utils/compatibility/tests/fixtures/strimzi-kafka/downloads.html
@@ -1,0 +1,18 @@
+<!-- Reduced fixture from https://strimzi.io/downloads/, retrieved 2026-09-08.
+     Retains the live header wrappers, footnotes, and current release rows. -->
+<h3>Supported versions</h3>
+<table class="tg">
+<tr>
+  <th><div class="supported-component">Operators<span class="release-date"></span></div></th>
+  <th>Strimzi HTTP Bridge</th><th>Strimzi OAuth</th><th>Kafka versions</th>
+  <th><div class="supported-component">Tested Kubernetes versions <sup><a href="#support-footnotes">1</a></sup><span class="release-date"></span></div></th>
+</tr>
+<tr><td><a href="https://github.com/strimzi/strimzi-kafka-operator/releases/tag/1.2.0">1.2.0</a></td><td>1.1.0</td><td>0.18.0</td><td>4.2.0, 4.2.1, 4.3.0, 4.3.1</td><td>1.30 - 1.36</td></tr>
+<tr><td>1.1.0</td><td>1.0.0</td><td>0.17.1</td><td>4.2.0, 4.2.1, 4.3.0</td><td>1.30 - 1.36</td></tr>
+<tr><td>1.0.1</td><td>1.0.0</td><td>0.17.1</td><td>4.1.0, 4.1.1, 4.1.2, 4.2.0</td><td>1.30 - 1.36</td></tr>
+<tr><td>1.0.0</td><td>1.0.0</td><td>0.17.1</td><td>4.1.0, 4.1.1, 4.1.2, 4.2.0</td><td>1.30 - 1.36</td></tr>
+<tr><td>0.51.0</td><td>0.33.1</td><td>0.17.1</td><td>4.1.0, 4.1.1, 4.2.0</td><td>1.30 - 1.35</td></tr>
+<tr><td>0.50.1</td><td>0.33.1</td><td>0.17.1</td><td>4.0.0, 4.0.1, 4.1.0, 4.1.1</td><td>1.27 - 1.35</td></tr>
+<tr><td>0.50.0</td><td>0.33.1</td><td>0.17.1</td><td>4.0.0, 4.0.1, 4.1.0, 4.1.1</td><td>1.27 - 1.35</td></tr>
+<tr><td>0.49.0</td><td>0.33.1</td><td>0.17.1</td><td>4.0.0, 4.0.1, 4.1.0, 4.1.1</td><td>1.27 - 1.34</td></tr>
+</table>

--- a/utils/compatibility/tests/test_strimzi_kafka.py
+++ b/utils/compatibility/tests/test_strimzi_kafka.py
@@ -132,6 +132,21 @@ class StrimziKafkaTests(unittest.TestCase):
         second.assert_called_once()
         self.assertEqual([row["version"] for row in second.call_args.args[1]], ["1.1.0"])
 
+    def test_missing_baseline_chart_does_not_hide_available_patch(self):
+        del self.charts["1.0.0"]
+        original = deepcopy(self.existing)
+        first = self.run_scrape()
+        first.assert_called_once()
+        rows = first.call_args.args[1]
+        self.assertEqual([row["version"] for row in rows], ["1.2.0", "1.1.0", "1.0.1", "0.51.0"])
+        patch_row = next(row for row in rows if row["version"] == "1.0.1")
+        self.assertEqual(patch_row["chart_version"], "1.0.1")
+        self.assertEqual(patch_row["kube"], [f"1.{v}" for v in range(36, 29, -1)])
+        self.assertEqual(self.existing, original)
+        self.existing["versions"].extend(deepcopy(rows))
+        # A complete chart-backed sequence must not repeatedly rewrite itself.
+        self.run_scrape().assert_not_called()
+
     def test_changed_support_backport_is_added_below_latest_saved_minor(self):
         first = self.run_scrape()
         self.existing["versions"].extend(deepcopy(first.call_args.args[1]))

--- a/utils/compatibility/tests/test_strimzi_kafka.py
+++ b/utils/compatibility/tests/test_strimzi_kafka.py
@@ -93,8 +93,6 @@ class StrimziKafkaTests(unittest.TestCase):
         self.assertNotIn("0.50.0", [row["version"] for row in rows])
         self.assertNotIn("0.49.0", [row["version"] for row in rows])
         # Same-compatibility patches do not create extra boundary records.
-        for row in rows:
-            row["kube"].reverse()
         reduced = reduce_versions(sort_versions(rows + self.existing["versions"]))
         self.assertEqual([row["version"] for row in reduced], ["1.2.0", "1.1.0", "1.0.0", "0.51.0", "0.50.0"])
         self.assertEqual(self.existing, original)
@@ -118,8 +116,35 @@ class StrimziKafkaTests(unittest.TestCase):
         self.run_scrape().assert_not_called()
 
     def test_current_records_make_rerun_a_noop(self):
-        self.existing["versions"].append({"version": "1.2.0"})
+        first = self.run_scrape()
+        self.existing["versions"].extend(deepcopy(first.call_args.args[1]))
         self.run_scrape().assert_not_called()
+
+    def test_delayed_older_chart_is_backfilled_after_newer_version_was_saved(self):
+        del self.charts["1.1.0"]
+        first = self.run_scrape()
+        first_rows = first.call_args.args[1]
+        self.assertIn("1.2.0", [row["version"] for row in first_rows])
+        self.assertNotIn("1.1.0", [row["version"] for row in first_rows])
+        self.existing["versions"].extend(deepcopy(first_rows))
+        self.charts["1.1.0"] = "1.1.0"
+        second = self.run_scrape()
+        second.assert_called_once()
+        self.assertEqual([row["version"] for row in second.call_args.args[1]], ["1.1.0"])
+
+    def test_changed_support_backport_is_added_below_latest_saved_minor(self):
+        first = self.run_scrape()
+        self.existing["versions"].extend(deepcopy(first.call_args.args[1]))
+        original = deepcopy(self.existing)
+        # Synthetic future backport, with an explicit changed matrix window.
+        backport = b'<tr><td>1.1.1</td><td>1.0.0</td><td>0.17.1</td><td>4.3.0</td><td>1.30 - 1.37</td></tr>'
+        self.html = self.html.replace(b"</table>", backport + b"</table>")
+        self.charts["1.1.1"] = "1.1.1"
+        second = self.run_scrape()
+        second.assert_called_once()
+        self.assertEqual([row["version"] for row in second.call_args.args[1]], ["1.1.1"])
+        self.assertEqual(second.call_args.args[1][0]["kube"], [f"1.{v}" for v in range(37, 29, -1)])
+        self.assertEqual(self.existing, original)
 
 
 if __name__ == "__main__":

--- a/utils/compatibility/tests/test_strimzi_kafka.py
+++ b/utils/compatibility/tests/test_strimzi_kafka.py
@@ -1,0 +1,126 @@
+"""Offline regressions: python -m unittest discover -s tests -p 'test_strimzi_kafka.py'."""
+
+from copy import deepcopy
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+from bs4 import BeautifulSoup
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+spec = importlib.util.spec_from_file_location("strimzi_scraper", COMPATIBILITY / "scrapers/strimzi-kafka.py")
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+from utils import reduce_versions, sort_versions
+
+FIXTURE = Path(__file__).parent / "fixtures/strimzi-kafka/downloads.html"
+
+
+class StrimziKafkaTests(unittest.TestCase):
+    def setUp(self):
+        self.html = FIXTURE.read_bytes()
+        self.existing = {"versions": [{
+            "version": "0.50.0", "kube": [f"1.{v}" for v in range(35, 26, -1)],
+            "requirements": [], "incompatibilities": [], "summary": None,
+        }]}
+        self.charts = {version: version for version in ("1.2.0", "1.1.0", "1.0.1", "1.0.0", "0.51.0", "0.50.1")}
+
+    def table(self, html=None):
+        return scraper._find_supported_versions_table(BeautifulSoup(html or self.html, "html.parser"))
+
+    def run_scrape(self):
+        with patch.object(scraper, "fetch_page", return_value=self.html), \
+                patch.object(scraper, "read_yaml", return_value=self.existing), \
+                patch.object(scraper, "get_chart_versions", return_value=self.charts), \
+                patch.object(scraper, "print_error"), \
+                patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+        return update
+
+    def test_current_tested_header_and_nested_footnote_are_recognized(self):
+        rows = scraper._parse_rows(self.table())
+        self.assertEqual(rows[0]["version"], "1.2.0")
+        self.assertEqual(rows[0]["kube"], [f"1.{v}" for v in range(30, 37)])
+        self.assertEqual(next(row["kube"] for row in rows if row["version"] == "0.51.0"), [f"1.{v}" for v in range(30, 36)])
+
+    def test_legacy_header_still_works(self):
+        self.html = self.html.replace(b"Tested Kubernetes versions", b"Kubernetes versions")
+        self.assertEqual(scraper._parse_rows(self.table())[0]["version"], "1.2.0")
+
+    def test_columns_are_selected_by_header_not_position(self):
+        html = '<table><tr><th>Kafka versions</th><th>Tested Kubernetes versions</th><th>Operators</th></tr>'
+        html += '<tr><td>4.3.1</td><td>1.35 - 1.36</td><td>1.2.0</td></tr></table>'
+        self.assertEqual(scraper._parse_rows(self.table(html))[0]["kube"], ["1.35", "1.36"])
+
+    def test_unrelated_table_is_not_treated_as_operator_support(self):
+        self.assertIsNone(self.table('<table><tr><th>Kafka versions</th><th>Kubernetes versions</th></tr></table>'))
+
+    def test_prerelease_and_unrelated_operator_labels_are_ignored(self):
+        self.html = self.html.replace(b">1.2.0</a>", b">1.2.0-rc1</a>")
+        self.assertNotIn("1.2.0", [row["version"] for row in scraper._parse_rows(self.table())])
+
+    def test_equal_and_reversed_ranges_terminate(self):
+        self.assertEqual(scraper._parse_kube_cell("v1.35 - v1.35"), ["1.35"])
+        for value in ("1.36 - 1.30", "1.35 - 2.0"):
+            self.assertEqual(scraper._parse_kube_cell(value), [])
+
+    def test_range_and_list_parsing_rejects_partial_values(self):
+        for value in ("1.30 - 1.36 TBD", "1.30, invalid", "1.36,", "1.35.1", "unknown", ""):
+            with self.subTest(value=value):
+                self.assertEqual(scraper._parse_kube_cell(value), [])
+        self.assertEqual(scraper._parse_kube_cell("1.34, v1.35, 1.34"), ["1.34", "1.35"])
+
+    def test_published_plus_range_is_bounded_by_cached_kubernetes_version(self):
+        with patch.object(scraper, "current_kube_version", return_value="1.36"):
+            self.assertEqual(scraper._parse_kube_cell("1.35+"), ["1.35", "1.36"])
+            self.assertEqual(scraper._parse_kube_cell("1.37+"), [])
+        with patch.object(scraper, "current_kube_version", return_value=None):
+            self.assertEqual(scraper._parse_kube_cell("1.35+"), [])
+
+    def test_superscript_footnote_is_removed_from_cell(self):
+        soup = BeautifulSoup('<td>1.30 - 1.36<sup><a href="#note">1</a></sup></td>', "html.parser")
+        self.assertEqual(scraper._cell_text(soup.td), "1.30 - 1.36")
+
+    def test_new_boundaries_have_exact_charts_and_old_records_are_preserved(self):
+        original = deepcopy(self.existing)
+        update = self.run_scrape()
+        update.assert_called_once()
+        rows = update.call_args.args[1]
+        self.assertTrue(all(row["chart_version"] == row["version"] for row in rows))
+        self.assertNotIn("0.50.0", [row["version"] for row in rows])
+        self.assertNotIn("0.49.0", [row["version"] for row in rows])
+        # Same-compatibility patches do not create extra boundary records.
+        for row in rows:
+            row["kube"].reverse()
+        reduced = reduce_versions(sort_versions(rows + self.existing["versions"]))
+        self.assertEqual([row["version"] for row in reduced], ["1.2.0", "1.1.0", "1.0.0", "0.51.0", "0.50.0"])
+        self.assertEqual(self.existing, original)
+
+    def test_missing_or_prerelease_charts_do_not_create_ga_records(self):
+        for charts in ({}, {"1.2.0": "1.2.0-rc1"}):
+            self.charts = charts
+            self.run_scrape().assert_not_called()
+
+    def test_failed_or_malformed_source_never_writes(self):
+        for content in (None, b"<html>No table</html>", self.html.replace(b"1.30 - 1.36", b"1.36 - 1.30")):
+            self.html = content
+            self.run_scrape().assert_not_called()
+
+    def test_missing_required_cell_never_writes(self):
+        self.html = self.html.replace(b"<td>1.30 - 1.36</td>", b"", 1)
+        self.run_scrape().assert_not_called()
+
+    def test_missing_existing_records_never_writes(self):
+        self.existing = None
+        self.run_scrape().assert_not_called()
+
+    def test_current_records_make_rerun_a_noop(self):
+        self.existing["versions"].append({"version": "1.2.0"})
+        self.run_scrape().assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Strimzi's downloads table now labels its compatibility column `Tested Kubernetes versions` and includes a superscript footnote. The scraper still expects the old exact header, so the generated data stops at 0.50.0. Recognize both header formats and refresh four missing stable minor releases from the official matrix:

| Strimzi / official Helm chart | Tested Kubernetes minors |
| --- | --- |
| 0.51.0 | 1.30–1.35 |
| 1.0.0 | 1.30–1.36 |
| 1.1.0 | 1.30–1.36 |
| 1.2.0 | 1.30–1.36 |

These are the finite windows explicitly published as tested by Strimzi. Add the official Helm repository and chart name, resolve exact stable application/chart mappings, and retain all 39 historical records unchanged. Per-app and aggregate data are synchronized; unrelated add-ons are unchanged.

Parsing selects columns by their labels, removes footnote markup, and rejects malformed versions or ranges before writing. Historical explicit `+` ranges use the repository's cached Kubernetes minor without a new network lookup. Preserve the documented baseline through 0.50.0 while allowing missing later releases and changed-support backports below the newest saved version. Resolve charts before reducing compatibility boundaries so an unavailable baseline chart cannot hide a usable patch.

Sources: [official downloads matrix](https://strimzi.io/downloads/) and [official Helm index](https://strimzi.io/charts/index.yaml). Release pages: [0.51.0](https://github.com/strimzi/strimzi-kafka-operator/releases/tag/0.51.0), [1.0.0](https://github.com/strimzi/strimzi-kafka-operator/releases/tag/1.0.0), [1.1.0](https://github.com/strimzi/strimzi-kafka-operator/releases/tag/1.1.0), [1.2.0](https://github.com/strimzi/strimzi-kafka-operator/releases/tag/1.2.0).

## Test Plan

- 18 offline tests pass from `utils/compatibility` with `python -m unittest discover -s tests -v`. They cover current/legacy headers, nested footnotes, reordered columns, strict range parsing, malformed source, chart failure, delayed chart availability, backport boundaries, chart-before-reduction ordering and no-op reruns.
- Live refresh rendered all four official charts with Helm v4.2.4. Their actual default images are `quay.io/strimzi/operator:<version>`. Each archive's SHA256 matches the official index, and internal chart/application metadata matches the recorded version.
- Both generated YAML documents pass `static/compatibilities/schema.json`; all 39 historical Strimzi records and every unrelated add-on are preserved.
- A second live refresh is byte-identical. After the final ordering fix, the live source/index still selects exactly these four candidates from the old baseline; with them saved, the writer is not called.
- `git diff --check` passes. Optional paid summarization was disabled. No Kubernetes cluster execution was performed; the table records upstream-published tested coverage.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added tests to cover my changes.
- Documentation: source provenance and reproduction command included above.
- Agent deployment: not applicable; no agent code changed.

AI-assisted implementation with independent code/source review. Submitted for contributor-program review; no reward is assumed.

Plural Flow: console
