### PR TITLE
feat: add Redis Enterprise Operator compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -30910,3 +30910,51 @@ addons:
     chart_version: 0.1.1
     images: ['wiziopublic.azurecr.io/wiz-app/wiz-network-analyzer:0.1']
   name: wiz-network-analyzer
+- icon: https://avatars.githubusercontent.com/u/1991868?v=4
+  git_url: https://github.com/RedisLabs/redis-enterprise-k8s-docs
+  release_url: https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases
+  helm_repository_url: https://helm.redis.io
+  versions:
+  - version: 8.2.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 8.2.0-12
+    images: ['redislabs/operator:8.2.0-12']
+  - version: 8.0.18
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 8.0.18-11
+    images: ['redislabs/operator:8.0.18-11']
+  - version: 8.0.2
+    kube: ['1.34', '1.33', '1.32', '1.31']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 8.0.2-2
+    images: ['redislabs/operator:8.0.2-2']
+  - version: 7.22.0
+    kube: ['1.33', '1.32', '1.31', '1.30']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 7.22.0-15
+    images: ['redislabs/operator:7.22.0-15']
+  - version: 7.8.6
+    kube: ['1.32', '1.31', '1.30', '1.29', '1.28']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 7.8.6-1
+    images: ['redislabs/operator:7.8.6-1']
+  - version: 7.8.2
+    kube: ['1.31', '1.30', '1.29', '1.28']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 7.8.2-6
+    images: ['redislabs/operator:7.8.2-6']
+  name: redis-enterprise-operator

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -49,3 +49,4 @@ names:
 - wiz-sensor
 - wiz-admission-controller
 - wiz-network-analyzer
+- redis-enterprise-operator

--- a/static/compatibilities/redis-enterprise-operator.yaml
+++ b/static/compatibilities/redis-enterprise-operator.yaml
@@ -1,0 +1,48 @@
+icon: https://avatars.githubusercontent.com/u/1991868?v=4
+git_url: https://github.com/RedisLabs/redis-enterprise-k8s-docs
+release_url: https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases
+helm_repository_url: https://helm.redis.io
+versions:
+- version: 8.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 8.2.0-12
+  images: ['redislabs/operator:8.2.0-12']
+- version: 8.0.18
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 8.0.18-11
+  images: ['redislabs/operator:8.0.18-11']
+- version: 8.0.2
+  kube: ['1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 8.0.2-2
+  images: ['redislabs/operator:8.0.2-2']
+- version: 7.22.0
+  kube: ['1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 7.22.0-15
+  images: ['redislabs/operator:7.22.0-15']
+- version: 7.8.6
+  kube: ['1.32', '1.31', '1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 7.8.6-1
+  images: ['redislabs/operator:7.8.6-1']
+- version: 7.8.2
+  kube: ['1.31', '1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 7.8.2-6
+  images: ['redislabs/operator:7.8.2-6']
+name: redis-enterprise-operator

--- a/utils/compatibility/scrapers/redis-enterprise-operator.py
+++ b/utils/compatibility/scrapers/redis-enterprise-operator.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+app_name = "redis-enterprise-operator"
+compatibility_url = (
+    "https://raw.githubusercontent.com/redis/docs/main/"
+    "content/operate/kubernetes/reference/supported_k8s_distributions.md"
+)
+
+_VERSION_RE = re.compile(r"(?<![\d.])(\d+\.\d+\.\d+-\d+)(?!\d)")
+_KUBE_RE = re.compile(r"^1\.(\d+)$")
+
+
+def _split_markdown_row(line: str) -> list[str]:
+    cells = [cell.strip() for cell in line.strip().split("|")]
+    if cells and not cells[0]:
+        cells = cells[1:]
+    if cells and not cells[-1]:
+        cells = cells[:-1]
+    return cells
+
+
+def _extract_operator_versions(line: str) -> list[str]:
+    if "Redis operator" not in line:
+        raise ValueError("Redis operator version-history header not found")
+
+    versions = _VERSION_RE.findall(line)
+    if not versions:
+        raise ValueError("Redis operator version-history header has no versions")
+    if len(versions) != len(set(versions)):
+        raise ValueError("Duplicate Redis operator version in version-history header")
+    return versions
+
+
+def _split_operator_version(version: str) -> tuple[str, int]:
+    match = re.fullmatch(r"(\d+\.\d+\.\d+)-(\d+)", version)
+    if not match:
+        raise ValueError(f"Unsupported Redis operator version: {version!r}")
+    return match.group(1), int(match.group(2))
+
+
+def _status_supported(cell: str) -> bool:
+    if not cell:
+        return False
+    if 'title="Supported"' in cell:
+        return True
+    if 'title="Deprecation warning"' in cell:
+        # Redis explicitly documents Deprecated as still supported, with removal
+        # planned for a future release.
+        return True
+    if 'title="X icon"' in cell:
+        return False
+    raise ValueError(f"Unexpected Redis Kubernetes support marker: {cell!r}")
+
+
+def parse_support_matrix(
+    markdown: str, chart_versions: dict[str, str]
+) -> list[OrderedDict[str, object]]:
+    lines = markdown.splitlines()
+
+    header_index = next(
+        (i for i, line in enumerate(lines) if "Redis operator" in line and "<nobr>" in line),
+        None,
+    )
+    if header_index is None:
+        raise ValueError("Redis operator version-history header not found")
+
+    operator_versions = _extract_operator_versions(lines[header_index])
+
+    kube_header_index = next(
+        (
+            i
+            for i in range(header_index + 1, len(lines))
+            if re.fullmatch(
+                r"\s*\|\s*OpenShift\s*\|\s*Kubernetes\s*\|.*",
+                lines[i],
+                re.IGNORECASE,
+            )
+        ),
+        None,
+    )
+    if kube_header_index is None:
+        raise ValueError("Redis Kubernetes version-history rows not found")
+
+    kube_by_operator: dict[str, list[str]] = {version: [] for version in operator_versions}
+    parsed_kube_rows = 0
+
+    for line in lines[kube_header_index + 1 :]:
+        stripped = line.strip()
+        if stripped.startswith("{{<") or stripped.startswith("{{</"):
+            break
+        if not stripped:
+            if parsed_kube_rows:
+                break
+            continue
+        if not stripped.startswith("|"):
+            if parsed_kube_rows:
+                break
+            continue
+
+        cells = _split_markdown_row(stripped)
+        if len(cells) < 2:
+            raise ValueError("Malformed Redis compatibility table row")
+
+        kube = cells[1]
+        if not _KUBE_RE.fullmatch(kube):
+            if re.fullmatch(r":?-+:?", kube):
+                continue
+            raise ValueError(f"Unexpected Redis Kubernetes version: {kube!r}")
+
+        expected_cells = 2 + len(operator_versions)
+        if len(cells) != expected_cells:
+            raise ValueError(
+                "Redis compatibility row column count does not match operator header"
+            )
+
+        parsed_kube_rows += 1
+        for index, source_version in enumerate(operator_versions):
+            if _status_supported(cells[index + 2]):
+                kube_by_operator[source_version].append(kube)
+
+    if not parsed_kube_rows:
+        raise ValueError("Redis Kubernetes version-history table is empty")
+
+    # Redis versions use a fourth build component such as 8.2.0-12. Plural's
+    # shared compatibility reducer intentionally accepts stable semantic versions
+    # only, so expose 8.2.0 as the application version while retaining the exact
+    # Redis build in chart_version. If Redis documents multiple builds for the
+    # same semantic version, keep the newest documented build that also exists in
+    # the official Helm repository.
+    selected: dict[str, tuple[int, str, str, list[str]]] = {}
+    for source_version in operator_versions:
+        kube_versions = kube_by_operator[source_version]
+        if not kube_versions:
+            continue
+
+        chart_version = chart_versions.get(source_version)
+        if not chart_version:
+            # Never guess a chart/operator pairing. Only publish source releases
+            # that are present in Redis' official Helm repository.
+            continue
+
+        base_version, build = _split_operator_version(source_version)
+        current = selected.get(base_version)
+        if current is None or build > current[0]:
+            selected[base_version] = (
+                build,
+                source_version,
+                chart_version,
+                kube_versions,
+            )
+
+    if not selected:
+        raise ValueError("No Redis operator releases matched official Helm charts")
+
+    rows: list[OrderedDict[str, object]] = []
+    for base_version in sorted(
+        selected,
+        key=lambda value: tuple(int(part) for part in value.split(".")),
+        reverse=True,
+    ):
+        _, _, chart_version, kube_versions = selected[base_version]
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", base_version),
+                    (
+                        "kube",
+                        sorted(
+                            set(kube_versions),
+                            key=lambda item: int(item.split(".")[1]),
+                            reverse=True,
+                        ),
+                    ),
+                    ("chart_version", chart_version),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    return rows
+
+
+def scrape() -> None:
+    from utils import fetch_page, get_chart_versions, update_compatibility_info
+
+    page = fetch_page(compatibility_url)
+    if not page:
+        raise ValueError("Could not fetch Redis Kubernetes compatibility matrix")
+    if isinstance(page, bytes):
+        page = page.decode("utf-8")
+    elif not isinstance(page, str):
+        raise ValueError("Unexpected Redis compatibility payload type")
+
+    rows = parse_support_matrix(page, get_chart_versions(app_name))
+    update_compatibility_info(
+        f"../../static/compatibilities/{app_name}.yaml",
+        rows,
+    )

--- a/utils/compatibility/tests/test_redis_enterprise_operator.py
+++ b/utils/compatibility/tests/test_redis_enterprise_operator.py
@@ -1,0 +1,156 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "redis-enterprise-operator.py"
+spec = importlib.util.spec_from_file_location("redis_enterprise_operator", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+FIXTURE = """## Kubernetes version support
+
+### Version history
+
+{{<table-scrollable>}}|  | Redis operator | **<nobr>8.2.0-12</nobr>** | **<nobr>8.0.20-21</nobr>** | **<nobr>8.0.2-2</nobr>** | **<nobr>7.22.2-21</nobr>** | **<nobr>7.22.0-15</nobr>** | **<nobr>7.22.0-7</nobr>** |
+|---|---|---|---|---|---|---|---|
+|  |  | July 2026 | May 2026 | Oct 2025 | Oct 2025 | July 2025 | April 2025 |
+| OpenShift | Kubernetes |  |  |  |  |  |  |
+| &mdash; | 1.36 | <span title="Supported">&#x2705;</span> |  |  |  |  |  |
+| 4.22 | 1.35 | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |  |  |  |
+| 4.21 | 1.34 | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |  |  |
+| 4.20 | 1.33 | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |
+| 4.19 | 1.32 | <span title="Deprecation warning">&#x26a0;</span> | <span title="Deprecation warning">&#x26a0;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| 4.18 | 1.31 | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning">&#x26a0;</span> | <span title="Deprecation warning">&#x26a0;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| 4.17 | 1.30 |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning">&#x26a0;</span> | <span title="Deprecation warning">&#x26a0;</span> | <span title="Deprecation warning">&#x26a0;</span> |
+{{</table-scrollable>}}
+"""
+
+CHARTS = {
+    "8.2.0-12": "8.2.0-12",
+    "8.0.20-21": "8.0.20-21",
+    "8.0.2-2": "8.0.2-2",
+    "7.22.2-21": "7.22.2-21",
+    "7.22.0-15": "7.22.0-15",
+    "7.22.0-7": "7.22.0-7",
+}
+
+
+class RedisEnterpriseOperatorTests(unittest.TestCase):
+    def test_supported_and_deprecated_are_included_but_eol_is_not(self):
+        rows = scraper.parse_support_matrix(FIXTURE, CHARTS)
+        by_version = {row["version"]: row for row in rows}
+        self.assertEqual(
+            by_version["8.2.0"]["kube"],
+            ["1.36", "1.35", "1.34", "1.33", "1.32"],
+        )
+        self.assertNotIn("1.31", by_version["8.2.0"]["kube"])
+
+    def test_kubernetes_versions_are_sorted_descending(self):
+        rows = scraper.parse_support_matrix(FIXTURE, CHARTS)
+        by_version = {row["version"]: row for row in rows}
+        self.assertEqual(
+            by_version["7.22.2"]["kube"],
+            ["1.33", "1.32", "1.31", "1.30"],
+        )
+
+    def test_exact_chart_mapping_is_attached_while_app_version_is_stable_semver(self):
+        rows = scraper.parse_support_matrix(FIXTURE, CHARTS)
+        self.assertEqual(rows[0]["version"], "8.2.0")
+        self.assertEqual(rows[0]["chart_version"], "8.2.0-12")
+
+    def test_newest_documented_build_wins_for_same_semver(self):
+        rows = scraper.parse_support_matrix(FIXTURE, CHARTS)
+        by_version = {row["version"]: row for row in rows}
+        self.assertEqual(by_version["7.22.0"]["chart_version"], "7.22.0-15")
+        self.assertEqual(
+            by_version["7.22.0"]["kube"],
+            ["1.33", "1.32", "1.31", "1.30"],
+        )
+
+    def test_missing_newest_chart_falls_back_to_documented_older_build(self):
+        charts = dict(CHARTS)
+        del charts["7.22.0-15"]
+        rows = scraper.parse_support_matrix(FIXTURE, charts)
+        by_version = {row["version"]: row for row in rows}
+        self.assertEqual(by_version["7.22.0"]["chart_version"], "7.22.0-7")
+        self.assertEqual(
+            by_version["7.22.0"]["kube"],
+            ["1.32", "1.31", "1.30"],
+        )
+
+    def test_unpublished_chart_release_is_skipped(self):
+        charts = dict(CHARTS)
+        del charts["8.0.2-2"]
+        rows = scraper.parse_support_matrix(FIXTURE, charts)
+        self.assertNotIn("8.0.2", [row["version"] for row in rows])
+
+    def test_missing_version_history_header_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "header not found"):
+            scraper.parse_support_matrix("# no version history", CHARTS)
+
+    def test_missing_kubernetes_rows_fails_closed(self):
+        broken = FIXTURE.replace("| OpenShift | Kubernetes |", "| Platform | K8s |")
+        with self.assertRaisesRegex(ValueError, "rows not found"):
+            scraper.parse_support_matrix(broken, CHARTS)
+
+    def test_unknown_status_marker_fails_closed(self):
+        broken = FIXTURE.replace(
+            '<span title="Supported">&#x2705;</span>',
+            '<span title="Maybe">?</span>',
+            1,
+        )
+        with self.assertRaisesRegex(ValueError, "Unexpected Redis Kubernetes support"):
+            scraper.parse_support_matrix(broken, CHARTS)
+
+    def test_short_row_fails_closed(self):
+        original = '| 4.17 | 1.30 |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning">&#x26a0;</span> | <span title="Deprecation warning">&#x26a0;</span> | <span title="Deprecation warning">&#x26a0;</span> |'
+        broken = FIXTURE.replace(original, '| 4.17 | 1.30 |  |  |')
+        with self.assertRaisesRegex(ValueError, "column count"):
+            scraper.parse_support_matrix(broken, CHARTS)
+
+    def test_duplicate_operator_header_fails_closed(self):
+        broken = FIXTURE.replace(
+            "**<nobr>7.22.2-21</nobr>**",
+            "**<nobr>8.2.0-12</nobr>**",
+        )
+        with self.assertRaisesRegex(ValueError, "Duplicate Redis operator"):
+            scraper.parse_support_matrix(broken, CHARTS)
+
+    def test_no_chart_matches_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "matched official Helm"):
+            scraper.parse_support_matrix(FIXTURE, {})
+
+    def test_scrape_wires_official_source_and_shared_updater_without_module_leak(self):
+        helpers = ModuleType("utils")
+        helpers.fetch_page = Mock(return_value=FIXTURE.encode("utf-8"))
+        helpers.get_chart_versions = Mock(return_value=CHARTS)
+        helpers.update_compatibility_info = Mock()
+
+        previous = sys.modules.get("utils")
+        try:
+            with patch.dict(sys.modules, {"utils": helpers}):
+                scraper.scrape()
+        finally:
+            if previous is None:
+                sys.modules.pop("utils", None)
+            else:
+                sys.modules["utils"] = previous
+
+        helpers.fetch_page.assert_called_once_with(scraper.compatibility_url)
+        helpers.get_chart_versions.assert_called_once_with("redis-enterprise-operator")
+        path, rows = helpers.update_compatibility_info.call_args.args
+        self.assertEqual(
+            path,
+            "../../static/compatibilities/redis-enterprise-operator.yaml",
+        )
+        self.assertEqual(
+            [row["version"] for row in rows],
+            ["8.2.0", "8.0.20", "8.0.2", "7.22.2", "7.22.0"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Redis Enterprise Operator to Plural’s compatibility catalog with an automated compatibility scraper, generated compatibility data, manifest registration, aggregate compatibility data and focused regression tests.

Authoritative sources

* https://redis.io/docs/latest/operate/kubernetes/reference/supported_k8s_distributions/
* https://github.com/redis/docs/blob/main/content/operate/kubernetes/reference/supported_k8s_distributions.md
* https://helm.redis.io
* https://github.com/RedisLabs/redis-enterprise-helm

The scraper reads Redis’s official Kubernetes version-history compatibility matrix. It treats both Supported and Deprecated Kubernetes releases as currently supported, excludes End-of-Life entries, normalizes Redis build-style operator versions such as 8.2.0-12 to Plural-compatible application versions such as 8.2.0, and preserves the exact Redis build as the Helm chart version. Only releases present in Redis’s official Helm repository are emitted.

Testing

* 13 focused tests passed
* live scraper validation against the current Redis documentation passed
* official Helm chart mapping and image resolution passed
* Python compilation passed
* compatibility YAML and aggregate validation passed
* malformed, structurally changed or unknown support markers fail closed

No live Kubernetes cluster deployment was performed; this change validates compatibility metadata, parser behavior and official Helm resolution.

AI assistance disclosure: implemented and tested using OpenAI ChatGPT/Codex under the GitHub account owner’s authorization.

I would like this submission considered under the README Contributor Program’s advertised $300 reward for a new compatibility scraper, subject to maintainer review, merge and eligibility confirmation.

Plural Flow: console