### PR TITLE
feat: add KubeRay Operator compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -30910,3 +30910,97 @@ addons:
     chart_version: 0.1.1
     images: ['wiziopublic.azurecr.io/wiz-app/wiz-network-analyzer:0.1']
   name: wiz-network-analyzer
+- icon: https://raw.githubusercontent.com/ray-project/ray/master/doc/source/images/ray_header_logo.png
+  git_url: https://github.com/ray-project/kuberay
+  release_url: https://github.com/ray-project/kuberay/releases/tag/v{vsn}
+  helm_repository_url: https://ray-project.github.io/kuberay-helm
+  versions:
+  - version: 1.7.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.7.0
+    images: ['quay.io/kuberay/operator:v1.7.0']
+  - version: 1.6.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.6.2
+    images: ['quay.io/kuberay/operator:v1.6.2']
+  - version: 1.5.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.5.2
+    images: ['quay.io/kuberay/operator:v1.5.2']
+  - version: 1.4.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.4.2
+    images: ['quay.io/kuberay/operator:v1.4.2']
+  - version: 1.3.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.3.2
+    images: ['quay.io/kuberay/operator:v1.3.2']
+  - version: 1.2.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.2.2
+    images: ['quay.io/kuberay/operator:v1.2.2']
+  - version: 1.1.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.1.1
+    images: ['quay.io/kuberay/operator:v1.1.1']
+  - version: 1.0.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.0
+    images: ['kuberay/operator:v1.0.0']
+  - version: 0.6.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.6.0
+    images: ['kuberay/operator:v0.6.0']
+  - version: 0.5.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.5.2
+    images: ['kuberay/operator:v0.5.2']
+  - version: 0.4.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.4.0
+    images: ['kuberay/operator:v0.4.0']
+  name: kuberay-operator

--- a/static/compatibilities/kuberay-operator.yaml
+++ b/static/compatibilities/kuberay-operator.yaml
@@ -1,0 +1,94 @@
+icon: https://raw.githubusercontent.com/ray-project/ray/master/doc/source/images/ray_header_logo.png
+git_url: https://github.com/ray-project/kuberay
+release_url: https://github.com/ray-project/kuberay/releases/tag/v{vsn}
+helm_repository_url: https://ray-project.github.io/kuberay-helm
+versions:
+- version: 1.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.7.0
+  images: ['quay.io/kuberay/operator:v1.7.0']
+- version: 1.6.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.6.2
+  images: ['quay.io/kuberay/operator:v1.6.2']
+- version: 1.5.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.2
+  images: ['quay.io/kuberay/operator:v1.5.2']
+- version: 1.4.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.4.2
+  images: ['quay.io/kuberay/operator:v1.4.2']
+- version: 1.3.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.2
+  images: ['quay.io/kuberay/operator:v1.3.2']
+- version: 1.2.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.2
+  images: ['quay.io/kuberay/operator:v1.2.2']
+- version: 1.1.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.1
+  images: ['quay.io/kuberay/operator:v1.1.1']
+- version: 1.0.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.0
+  images: ['kuberay/operator:v1.0.0']
+- version: 0.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.6.0
+  images: ['kuberay/operator:v0.6.0']
+- version: 0.5.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.5.2
+  images: ['kuberay/operator:v0.5.2']
+- version: 0.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.4.0
+  images: ['kuberay/operator:v0.4.0']
+name: kuberay-operator

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -49,3 +49,4 @@ names:
 - wiz-sensor
 - wiz-admission-controller
 - wiz-network-analyzer
+- kuberay-operator

--- a/utils/compatibility/scrapers/kuberay-operator.py
+++ b/utils/compatibility/scrapers/kuberay-operator.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import yaml
+from packaging.version import InvalidVersion, Version
+
+app_name = "kuberay-operator"
+helm_index_url = (
+    "https://raw.githubusercontent.com/ray-project/kuberay-helm/"
+    "gh-pages/index.yaml"
+)
+installation_url = (
+    "https://raw.githubusercontent.com/ray-project/kuberay/"
+    "v{version}/docs/deploy/installation.md"
+)
+MIN_CHART_VERSION = Version("0.4.0")
+
+_MIN_KUBE_RE = re.compile(
+    r"Kubernetes\s+cluster\s+and\s+Kubectl\s+are\s+both\s+at\s+version\s+at\s+least\s+"
+    r"(1\.\d+)",
+    re.IGNORECASE,
+)
+
+
+def _decode_text(payload: bytes | str, source: str) -> str:
+    if isinstance(payload, bytes):
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"Could not decode {source}") from exc
+    if isinstance(payload, str):
+        return payload
+    raise ValueError(f"Unexpected {source} payload type")
+
+
+def parse_min_kubernetes(markdown: str) -> str:
+    match = _MIN_KUBE_RE.search(markdown)
+    if not match:
+        raise ValueError("KubeRay minimum Kubernetes version not found")
+    return match.group(1)
+
+
+def _parse_kube_minor(version: str) -> int:
+    match = re.fullmatch(r"1\.(\d+)", version.strip())
+    if not match:
+        raise ValueError(f"Unsupported Kubernetes version: {version!r}")
+    return int(match.group(1))
+
+
+def expand_minimum(minimum: str, current: str) -> list[str]:
+    start = _parse_kube_minor(minimum)
+    end = _parse_kube_minor(current)
+    if start > end:
+        raise ValueError(
+            f"KubeRay minimum Kubernetes {minimum} is newer than Plural {current}"
+        )
+    return [f"1.{minor}" for minor in range(end, start - 1, -1)]
+
+
+def stable_charts_by_minor(
+    index_payload: bytes | str,
+) -> list[list[tuple[str, str]]]:
+    """Return stable chart releases grouped by minor, newest first.
+
+    Some historical Helm chart releases do not have the installation document
+    at the corresponding Git tag. Keeping every stable patch in a minor lets
+    build_rows fall back to the newest exact release that has authoritative
+    tagged documentation instead of guessing compatibility for an undocumented
+    chart release.
+    """
+    index_text = _decode_text(index_payload, "KubeRay Helm index")
+    try:
+        index = yaml.safe_load(index_text)
+    except yaml.YAMLError as exc:
+        raise ValueError("Could not parse KubeRay Helm index") from exc
+
+    if not isinstance(index, dict):
+        raise ValueError("Unexpected KubeRay Helm index structure")
+
+    entries = index.get("entries", {}).get(app_name)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("KubeRay operator chart entries not found")
+
+    grouped: dict[tuple[int, int], list[tuple[Version, str]]] = {}
+    seen: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Malformed KubeRay operator chart entry")
+
+        raw_version = str(entry.get("version", "")).strip().lstrip("v")
+        if not raw_version or raw_version in seen:
+            continue
+        try:
+            parsed = Version(raw_version)
+        except InvalidVersion:
+            continue
+
+        if (
+            parsed.is_prerelease
+            or parsed.is_devrelease
+            or parsed < MIN_CHART_VERSION
+        ):
+            continue
+
+        seen.add(raw_version)
+        grouped.setdefault((parsed.major, parsed.minor), []).append(
+            (parsed, raw_version)
+        )
+
+    if not grouped:
+        raise ValueError("No stable supported KubeRay operator charts found")
+
+    result: list[list[tuple[str, str]]] = []
+    for key in sorted(grouped, reverse=True):
+        candidates = sorted(grouped[key], key=lambda item: item[0], reverse=True)
+        result.append([(str(parsed), chart_version) for parsed, chart_version in candidates])
+    return result
+
+
+def build_rows(
+    index_payload: bytes | str,
+    current_kube: str,
+    fetcher,
+) -> list[OrderedDict[str, object]]:
+    rows: list[OrderedDict[str, object]] = []
+
+    for candidates in stable_charts_by_minor(index_payload):
+        documented: tuple[str, str, str] | None = None
+        for version, chart_version in candidates:
+            url = installation_url.format(version=version)
+            page = fetcher(url)
+            if not page:
+                # A missing tagged document is not evidence for this release.
+                # Try an older stable patch in the same minor instead.
+                continue
+            markdown = _decode_text(
+                page, f"KubeRay {version} installation documentation"
+            )
+            minimum = parse_min_kubernetes(markdown)
+            documented = (version, chart_version, minimum)
+            break
+
+        if documented is None:
+            # Do not manufacture compatibility for a minor with no tagged
+            # installation documentation at any published stable chart release.
+            continue
+
+        version, chart_version, minimum = documented
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", version),
+                    ("kube", expand_minimum(minimum, current_kube)),
+                    ("chart_version", chart_version),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    if not rows:
+        raise ValueError("No documented KubeRay compatibility rows generated")
+    return rows
+
+
+def scrape() -> None:
+    from utils import current_kube_version, fetch_page, update_compatibility_info
+
+    index = fetch_page(helm_index_url)
+    if not index:
+        raise ValueError("Could not fetch official KubeRay Helm index")
+
+    current = current_kube_version()
+    if not current:
+        raise ValueError("Plural current Kubernetes version is unavailable")
+
+    rows = build_rows(index, current, fetch_page)
+    update_compatibility_info(
+        f"../../static/compatibilities/{app_name}.yaml",
+        rows,
+    )

--- a/utils/compatibility/tests/test_kuberay_operator.py
+++ b/utils/compatibility/tests/test_kuberay_operator.py
@@ -1,0 +1,171 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "kuberay-operator.py"
+spec = importlib.util.spec_from_file_location("kuberay_operator", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+INDEX = """apiVersion: v1
+entries:
+  kuberay-operator:
+  - version: 1.7.0
+  - version: 1.6.1
+  - version: 1.6.2
+  - version: 1.6.0-rc.0
+  - version: 1.0.0
+  - version: 0.6.0
+  - version: 0.6.1
+  - version: 0.4.0
+  - version: 0.3.0
+  - version: garbage
+"""
+
+DOC_123 = """# Installation
+
+Make sure your Kubernetes cluster and Kubectl are both at version at least 1.23.
+"""
+
+DOC_119 = """## Installation
+
+Make sure your Kubernetes cluster and Kubectl are both at version at least 1.19.
+"""
+
+
+class KubeRayOperatorTests(unittest.TestCase):
+    def test_parses_tagged_minimum_kubernetes_version(self):
+        self.assertEqual(scraper.parse_min_kubernetes(DOC_123), "1.23")
+
+    def test_missing_minimum_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "minimum Kubernetes version not found"):
+            scraper.parse_min_kubernetes("# Installation\nUse Kubernetes.")
+
+    def test_expands_minimum_through_plural_current_version(self):
+        self.assertEqual(
+            scraper.expand_minimum("1.23", "1.26"),
+            ["1.26", "1.25", "1.24", "1.23"],
+        )
+
+    def test_future_minimum_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "newer than Plural"):
+            scraper.expand_minimum("1.27", "1.26")
+
+    def test_groups_stable_charts_by_minor_newest_first(self):
+        self.assertEqual(
+            scraper.stable_charts_by_minor(INDEX),
+            [
+                [("1.7.0", "1.7.0")],
+                [("1.6.2", "1.6.2"), ("1.6.1", "1.6.1")],
+                [("1.0.0", "1.0.0")],
+                [("0.6.1", "0.6.1"), ("0.6.0", "0.6.0")],
+                [("0.4.0", "0.4.0")],
+            ],
+        )
+
+    def test_missing_operator_entries_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "chart entries not found"):
+            scraper.stable_charts_by_minor("entries: {}")
+
+    def test_build_rows_uses_each_release_tag_documentation(self):
+        docs = {
+            scraper.installation_url.format(version="1.7.0"): DOC_123.encode(),
+            scraper.installation_url.format(version="1.6.2"): DOC_123.encode(),
+            scraper.installation_url.format(version="1.0.0"): DOC_119.encode(),
+            scraper.installation_url.format(version="0.6.1"): DOC_119.encode(),
+            scraper.installation_url.format(version="0.4.0"): DOC_119.encode(),
+        }
+
+        rows = scraper.build_rows(INDEX, "1.26", docs.get)
+        by_version = {row["version"]: row for row in rows}
+
+        self.assertEqual(
+            by_version["1.7.0"]["kube"],
+            ["1.26", "1.25", "1.24", "1.23"],
+        )
+        self.assertEqual(
+            by_version["1.0.0"]["kube"],
+            ["1.26", "1.25", "1.24", "1.23", "1.22", "1.21", "1.20", "1.19"],
+        )
+        self.assertEqual(by_version["1.6.2"]["chart_version"], "1.6.2")
+
+    def test_missing_latest_patch_falls_back_to_documented_patch_same_minor(self):
+        docs = {
+            scraper.installation_url.format(version="1.7.0"): DOC_123,
+            scraper.installation_url.format(version="1.6.2"): DOC_123,
+            scraper.installation_url.format(version="1.0.0"): DOC_119,
+            # 0.6.1 intentionally absent; 0.6.0 is authoritative fallback.
+            scraper.installation_url.format(version="0.6.0"): DOC_119,
+            scraper.installation_url.format(version="0.4.0"): DOC_119,
+        }
+        rows = scraper.build_rows(INDEX, "1.26", docs.get)
+        by_version = {row["version"]: row for row in rows}
+        self.assertIn("0.6.0", by_version)
+        self.assertNotIn("0.6.1", by_version)
+        self.assertEqual(by_version["0.6.0"]["chart_version"], "0.6.0")
+
+    def test_minor_without_any_tagged_documentation_is_skipped(self):
+        docs = {
+            scraper.installation_url.format(version="1.7.0"): DOC_123,
+        }
+        rows = scraper.build_rows(INDEX, "1.26", docs.get)
+        self.assertEqual([row["version"] for row in rows], ["1.7.0"])
+
+    def test_all_tagged_documentation_missing_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "No documented KubeRay"):
+            scraper.build_rows(INDEX, "1.26", lambda _: None)
+
+    def test_invalid_utf8_existing_document_fails_closed(self):
+        def fetcher(url):
+            if url.endswith("v1.7.0/docs/deploy/installation.md"):
+                return b"\xff"
+            return None
+
+        with self.assertRaisesRegex(ValueError, "Could not decode"):
+            scraper.build_rows(INDEX, "1.26", fetcher)
+
+    def test_scrape_wires_official_sources_without_module_leak(self):
+        reduced_index = """entries:
+  kuberay-operator:
+  - version: 1.7.0
+"""
+        helpers = ModuleType("utils")
+        helpers.fetch_page = Mock(
+            side_effect=lambda url: (
+                reduced_index.encode()
+                if url == scraper.helm_index_url
+                else DOC_123.encode()
+            )
+        )
+        helpers.current_kube_version = Mock(return_value="1.26")
+        helpers.update_compatibility_info = Mock()
+
+        previous = sys.modules.get("utils")
+        try:
+            with patch.dict(sys.modules, {"utils": helpers}):
+                scraper.scrape()
+        finally:
+            if previous is None:
+                sys.modules.pop("utils", None)
+            else:
+                sys.modules["utils"] = previous
+
+        helpers.current_kube_version.assert_called_once_with()
+        path, rows = helpers.update_compatibility_info.call_args.args
+        self.assertEqual(
+            path,
+            "../../static/compatibilities/kuberay-operator.yaml",
+        )
+        self.assertEqual(rows[0]["version"], "1.7.0")
+        self.assertEqual(rows[0]["chart_version"], "1.7.0")
+
+    def test_bad_index_payload_type_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Unexpected KubeRay Helm index"):
+            scraper.stable_charts_by_minor(object())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds KubeRay Operator to Plural’s compatibility catalog with an automated compatibility scraper, generated compatibility data, manifest registration, aggregate compatibility data and focused regression tests.

## Authoritative sources

- https://github.com/ray-project/kuberay
- https://github.com/ray-project/kuberay/releases
- https://ray-project.github.io/kuberay-helm/
- https://github.com/ray-project/kuberay-helm

The scraper reads the minimum Kubernetes version documented in KubeRay’s tagged installation guides and expands that lower bound only through Plural’s current Kubernetes version.

It maps operator releases to the official KubeRay Helm repository and keeps stable, documented release mappings.

Some historical Helm patch releases do not have matching tagged installation documentation. The scraper never guesses across release families: when a patch tag lacks documentation, it falls back only to another stable documented patch within the same operator minor. If an entire minor has no usable tagged compatibility source, that minor is skipped.

## Testing

- 13 focused tests passed
- Live scraper validation against official KubeRay sources passed
- Official Helm chart and image resolution passed
- Python compilation passed
- Generated compatibility YAML validation passed
- Manifest and aggregate compatibility validation passed
- Malformed, missing or structurally changed source data fails closed

No live Kubernetes cluster deployment was performed; this change validates upstream-declared compatibility metadata, parser behavior and official Helm chart resolution.

AI assistance disclosure: implemented and tested using OpenAI ChatGPT/Codex under the GitHub account owner’s authorization.

I would like this submission considered under the README Contributor Program’s advertised $300 reward for a new compatibility scraper, subject to maintainer review, merge and eligibility confirmation.

Plural Flow: console