### PR TITLE
fix: update Istio compatibility for 1.31 and its chart repository migration

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -18357,10 +18357,17 @@ addons:
 - icon: https://raw.githubusercontent.com/pluralsh/plural-artifacts/main/istio/plural/icons/istio.png?raw=true
   git_url: https://github.com/istio/istio
   release_url: https://github.com/istio/istio/releases/tag/{vsn}
-  helm_repository_url: https://istio-release.storage.googleapis.com/charts
+  helm_repository_url: https://blob.istio.io/istio-release/charts
   chart_name: istiod
   eolApiSlug: istio
   versions:
+  - version: 1.31.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.31.0
+    images: ['docker.io/istio/pilot:1.31.0']
   - version: 1.30.0
     kube: ['1.36', '1.35', '1.34', '1.33', '1.32']
     requirements: []

--- a/static/compatibilities/istio.yaml
+++ b/static/compatibilities/istio.yaml
@@ -1,10 +1,17 @@
 icon: https://raw.githubusercontent.com/pluralsh/plural-artifacts/main/istio/plural/icons/istio.png?raw=true
 git_url: https://github.com/istio/istio
 release_url: https://github.com/istio/istio/releases/tag/{vsn}
-helm_repository_url: https://istio-release.storage.googleapis.com/charts
+helm_repository_url: https://blob.istio.io/istio-release/charts
 chart_name: istiod
 eolApiSlug: istio
 versions:
+- version: 1.31.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.31.0
+  images: ['docker.io/istio/pilot:1.31.0']
 - version: 1.30.0
   kube: ['1.36', '1.35', '1.34', '1.33', '1.32']
   requirements: []

--- a/utils/compatibility/scrapers/istio.py
+++ b/utils/compatibility/scrapers/istio.py
@@ -1,80 +1,122 @@
-# scrapers/cert_manager.py
+"""Resolve supported Istio series against the official released istiod charts."""
+
+from collections import OrderedDict
+from copy import deepcopy
+import re
 
 from bs4 import BeautifulSoup
-from collections import OrderedDict
-from utils import (
-    print_error,
-    fetch_page,
-    update_compatibility_info,
-    get_chart_versions,
-    validate_semver,
-)
+import requests
+import yaml
+
+from utils import print_error, read_yaml, reduce_versions, update_compatibility_info
 
 app_name = "istio"
 compatibility_url = "https://istio.io/latest/docs/releases/supported-releases/"
+# Starting with 1.31, Istio no longer publishes releases to the GCP repository.
+chart_repository_url = "https://blob.istio.io/istio-release/charts"
+chart_index_url = f"{chart_repository_url}/index.yaml"
+target_file = f"../../static/compatibilities/{app_name}.yaml"
 
 
-def parse_page(content):
+def parse_support_table(content):
     soup = BeautifulSoup(content, "html.parser")
-    sections = soup.find_all("h2")
-    return sections
+    required = ("Version", "Currently Supported", "Supported Kubernetes Versions")
+    supported = {}
+    for table in soup.find_all("table"):
+        headers = [cell.get_text(" ", strip=True) for cell in table.find_all("th")
+                   if cell.find_parent("table") is table]
+        if not all(name in headers for name in required):
+            continue
+        if any(headers.count(name) != 1 for name in required):
+            raise ValueError("Ambiguous Istio support table headers")
+        version_index, status_index, kube_index = (headers.index(name) for name in required)
+        for row in table.find_all("tr"):
+            if row.find_parent("table") is not table:
+                continue
+            cells = [cell.get_text(" ", strip=True) for cell in row.find_all("td", recursive=False)]
+            if not cells:
+                continue
+            if len(cells) != len(headers):
+                raise ValueError("Incomplete Istio support row")
+            if cells[status_index].lower() != "yes":
+                continue
+            minor = cells[version_index]
+            if not re.fullmatch(r"\d+\.\d+", minor):
+                raise ValueError(f"Invalid supported Istio series: {minor!r}")
+            kube = [value.strip() for value in cells[kube_index].split(",")]
+            if not all(re.fullmatch(r"\d+\.\d+", value) for value in kube):
+                raise ValueError(f"Invalid supported Kubernetes list for Istio {minor}")
+            kube = sorted(set(kube), key=lambda value: tuple(map(int, value.split("."))), reverse=True)
+            series = tuple(map(int, minor.split(".")))
+            if series in supported and supported[series] != kube:
+                raise ValueError(f"Conflicting support rows for Istio {minor}")
+            supported[series] = kube
+    if not supported:
+        raise ValueError("No supported Istio series found")
+    return supported
 
 
-def find_target_tables(sections):
-    target_tables = []
-    for section in sections:
-        if section.get_text(strip=True) in [
-            "Support status of Istio releases",
-        ]:
-            table = section.find_next("table")
-            if table:
-                target_tables.append(table)
-    return target_tables
+def _stable_version(value):
+    if not isinstance(value, str) or not re.fullmatch(r"\d+\.\d+\.\d+", value):
+        return None
+    return tuple(map(int, value.split(".")))
 
 
-def extract_table_data(target_tables, chart_versions):
+def parse_chart_index(content):
+    index = yaml.safe_load(content)
+    entries = index.get("entries") if isinstance(index, dict) else None
+    charts = entries.get("istiod") if isinstance(entries, dict) else None
+    if not isinstance(charts, list) or not charts:
+        raise ValueError("No istiod charts found in the official index")
+    versions = {}
+    for entry in charts:
+        if not isinstance(entry, dict):
+            raise ValueError("Malformed istiod chart entry")
+        app, chart = _stable_version(entry.get("appVersion")), _stable_version(entry.get("version"))
+        if app is None or chart is None or entry.get("deprecated"):
+            continue
+        if app not in versions or chart > versions[app]:
+            versions[app] = chart
+    if not versions:
+        raise ValueError("No stable istiod charts found")
+    return versions
+
+
+def build_rows(supported, charts, existing):
+    recorded = {row["version"] for row in existing}
     rows = []
-    table = target_tables[0]
-    for row in table.find_all("tr")[1:]:  # Skip the header row
-        columns = row.find_all("td")
-        if len(columns) >= 6:  # Ensure there are enough columns
-            istio_version = validate_semver(columns[0].text)
-            kube_versions = columns[4].text.split(", ")
-            is_supported = columns[1].text
-            if istio_version and is_supported.lower() == "yes":
-                ver = str(istio_version)
-                chart_version = chart_versions.get(ver)
-                if not chart_version:
-                    continue
-                version_info = OrderedDict(
-                    [
-                        ("version", str(istio_version)),
-                        ("kube", kube_versions),
-                        ("chart_version", chart_version),
-                        ("images", []),
-                        ("requirements", []),
-                        ("incompatibilities", []),
-                    ]
-                )
-                rows.append(version_info)
+    for app, chart in charts.items():
+        version = ".".join(map(str, app))
+        if version in recorded or app[:2] not in supported:
+            continue
+        rows.append(OrderedDict([
+            ("version", version), ("kube", supported[app[:2]]),
+            ("chart_version", ".".join(map(str, chart))),
+            ("requirements", []), ("incompatibilities", []),
+        ]))
+    # Resolve real chart releases before reducing minor boundaries and patches.
+    # Preserve existing metadata as the live support table moves forward.
+    retained = {row["version"] for row in reduce_versions(deepcopy(existing) + rows)}
+    return [row for row in rows if row["version"] in retained]
 
-    return rows
+
+def _fetch(url):
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.content
 
 
 def scrape():
-
-    page_content = fetch_page(compatibility_url)
-    if not page_content:
+    existing = read_yaml(target_file)
+    if not isinstance(existing, dict) or not isinstance(existing.get("versions"), list):
+        print_error("Existing Istio compatibility data is missing or invalid")
         return
-
-    sections = parse_page(page_content)
-    target_tables = find_target_tables(sections)
-    if target_tables.__len__() >= 1:
-        chart_versions = get_chart_versions(app_name, "base")
-        rows = extract_table_data(target_tables, chart_versions)
-        update_compatibility_info(
-            f"../../static/compatibilities/{app_name}.yaml", rows
-        )
-    else:
-        print_error("No compatibility information found.")
-
+    try:
+        supported = parse_support_table(_fetch(compatibility_url))
+        charts = parse_chart_index(_fetch(chart_index_url))
+        rows = build_rows(supported, charts, existing["versions"])
+    except (requests.RequestException, ValueError, yaml.YAMLError) as error:
+        print_error(f"Cannot update Istio compatibility: {error}")
+        return
+    if rows:
+        update_compatibility_info(target_file, rows)

--- a/utils/compatibility/tests/ISTIO.md
+++ b/utils/compatibility/tests/ISTIO.md
@@ -1,0 +1,34 @@
+# Istio 1.31 chart repository migration
+
+The official [1.31 announcement](https://istio.io/latest/news/releases/1.31.x/announcing-1.31/)
+states that 1.31.0 supports Kubernetes 1.32–1.36 and that new charts move from
+`istio-release.storage.googleapis.com` to `blob.istio.io/istio-release/charts`.
+The old repository has 1.31 prereleases but no stable 1.31.0 chart.
+
+The scraper joins the **Supported Kubernetes Versions** column of the official
+[support table](https://istio.io/latest/docs/releases/supported-releases/) to exact
+stable application/chart versions in the replacement repository's
+[istiod index](https://blob.istio.io/istio-release/charts/index.yaml). The separate
+“Tested, but not supported” column is excluded. A documented minor series is never
+turned into an invented `.0` chart; only actual chart releases can become records.
+The repository's usual minor-boundary/latest-patch reduction still applies.
+
+Fixtures retain source URLs and retrieval dates. Offline tests cover reordered
+columns, unsupported rows, malformed/conflicting data, an empty first table,
+prereleases, exact chart mappings, delayed boundary charts, metadata retention,
+no-op repeats, and failure before writing. Run from `utils/compatibility`:
+
+```sh
+env -u OPENAI_API_KEY -u EXA_API_KEY python -m unittest discover -s tests -p 'test_istio.py' -v
+```
+
+Live validation on 2026-09-08 verified the 1.31.0 chart archive's SHA-256 against
+the index and its `Chart.yaml` (`name: istiod`, application/chart version 1.31.0).
+All 18 chart-bearing records, including all 17 historical charts, rendered using
+the replacement repository in isolated Helm directories. Existing version
+records remain unchanged, including their `eolAt` fields; the shared reducer now
+preserves those dates. No new EOL date is inferred from an approximate date in the
+support table. The new image is `docker.io/istio/pilot:1.31.0`.
+
+This verifies compatibility data and chart rendering; it is not a deployed
+Kubernetes integration test.

--- a/utils/compatibility/tests/fixtures/istio/index.yaml
+++ b/utils/compatibility/tests/fixtures/istio/index.yaml
@@ -1,0 +1,52 @@
+# Source: https://blob.istio.io/istio-release/charts/index.yaml; retrieved 2026-09-08. Exact representative chart entries.
+apiVersion: v1
+entries:
+  istiod:
+  - apiVersion: v2
+    appVersion: 1.31.0
+    created: '2026-08-31T13:15:04.686641609Z'
+    description: Helm chart for istio control plane
+    digest: df73f8fba27f2ae51c90f9483c5298e164b5241fcd349a04375df32d7f9fe2e7
+    icon: https://istio.io/latest/favicons/android-192x192.png
+    keywords:
+    - istio
+    - istiod
+    - istio-discovery
+    name: istiod
+    sources:
+    - https://github.com/istio/istio
+    urls:
+    - https://blob.istio.io/istio-release/charts/istiod-1.31.0.tgz
+    version: 1.31.0
+  - apiVersion: v2
+    appVersion: 1.31.0-rc.0
+    created: '2026-08-19T12:43:06.491753858Z'
+    description: Helm chart for istio control plane
+    digest: 34d7b6807439a6376b5821afb803912cf5c23d2b90267603dca3c1981bd83d22
+    icon: https://istio.io/latest/favicons/android-192x192.png
+    keywords:
+    - istio
+    - istiod
+    - istio-discovery
+    name: istiod
+    sources:
+    - https://github.com/istio/istio
+    urls:
+    - https://blob.istio.io/istio-release/charts/istiod-1.31.0-rc.0.tgz
+    version: 1.31.0-rc.0
+  - apiVersion: v2
+    appVersion: 1.30.0
+    created: '2026-05-18T18:06:02.13491212Z'
+    description: Helm chart for istio control plane
+    digest: 7a34c7688da34107841e9585b226b94357769749f82502fdc4fb43a6bc3db320
+    icon: https://istio.io/latest/favicons/android-192x192.png
+    keywords:
+    - istio
+    - istiod
+    - istio-discovery
+    name: istiod
+    sources:
+    - https://github.com/istio/istio
+    urls:
+    - https://blob.istio.io/istio-release/charts/istiod-1.30.0.tgz
+    version: 1.30.0

--- a/utils/compatibility/tests/fixtures/istio/support.html
+++ b/utils/compatibility/tests/fixtures/istio/support.html
@@ -1,0 +1,125 @@
+<!-- Source: https://istio.io/latest/docs/releases/supported-releases/; retrieved 2026-09-08. Exact current and preceding unsupported rows. -->
+<table>
+ <thead>
+  <tr>
+   <th>
+    Version
+   </th>
+   <th>
+    Currently Supported
+   </th>
+   <th>
+    Release Date
+   </th>
+   <th>
+    End of Life
+   </th>
+   <th>
+    Supported Kubernetes Versions
+   </th>
+   <th>
+    Tested, but not supported
+   </th>
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td>
+    master
+   </td>
+   <td>
+    No, development only
+   </td>
+   <td>
+   </td>
+   <td>
+   </td>
+   <td>
+    1.32, 1.33, 1.34, 1.35, 1.36
+   </td>
+   <td>
+    1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.30
+   </td>
+  </tr>
+  <tr>
+   <td>
+    1.31
+   </td>
+   <td>
+    Yes
+   </td>
+   <td>
+    Aug 27, 2026
+   </td>
+   <td>
+    ~Feb 2027 (Expected)
+   </td>
+   <td>
+    1.32, 1.33, 1.34, 1.35, 1.36
+   </td>
+   <td>
+    1.27, 1.28, 1.29, 1.30, 1.31
+   </td>
+  </tr>
+  <tr>
+   <td>
+    1.30
+   </td>
+   <td>
+    Yes
+   </td>
+   <td>
+    May 14, 2026
+   </td>
+   <td>
+    ~Dec 2026 (Expected)
+   </td>
+   <td>
+    1.32, 1.33, 1.34, 1.35, 1.36
+   </td>
+   <td>
+    1.27, 1.28, 1.29, 1.30, 1.31
+   </td>
+  </tr>
+  <tr>
+   <td>
+    1.29
+   </td>
+   <td>
+    Yes
+   </td>
+   <td>
+    Feb 16, 2026
+   </td>
+   <td>
+    ~Oct 2026 (Expected)
+   </td>
+   <td>
+    1.31, 1.32, 1.33, 1.34, 1.35
+   </td>
+   <td>
+    1.26, 1.27, 1.28, 1.29, 1.30
+   </td>
+  </tr>
+  <tr>
+   <td>
+    1.28
+   </td>
+   <td>
+    No
+   </td>
+   <td>
+    Nov 05, 2025
+   </td>
+   <td>
+    Jul 1, 2026
+   </td>
+   <td>
+    1.30, 1.31, 1.32, 1.33, 1.34
+   </td>
+   <td>
+    1.25, 1.26, 1.27, 1.28, 1.29
+   </td>
+  </tr>
+ </tbody>
+</table>

--- a/utils/compatibility/tests/test_istio.py
+++ b/utils/compatibility/tests/test_istio.py
@@ -1,0 +1,147 @@
+"""Offline coverage for the Istio repository migration and supported release join."""
+
+from copy import deepcopy
+import importlib
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+import requests
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import reduce_versions
+
+scraper = importlib.import_module("scrapers.istio")
+FIXTURES = Path(__file__).parent / "fixtures/istio"
+SUPPORT = (FIXTURES / "support.html").read_bytes()
+INDEX = (FIXTURES / "index.yaml").read_bytes()
+
+
+def table(rows, headers=None):
+    headers = headers or ["Version", "Currently Supported", "Supported Kubernetes Versions"]
+    return "<table><tr>" + "".join(f"<th>{header}</th>" for header in headers) + "</tr>" + "".join(
+        "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>" for row in rows
+    ) + "</table>"
+
+
+def historical(version):
+    return {"version": version, "kube": ["1.36", "1.35", "1.34", "1.33", "1.32"],
+            "chart_version": version, "requirements": [{"name": "existing", "version": ">=1.0.0"}],
+            "incompatibilities": [], "summary": "Preserved history", "images": [f"istio/pilot:{version}"],
+            "eolAt": "2026-12-31"}
+
+
+class IstioTests(unittest.TestCase):
+    def test_official_table_uses_supported_not_merely_tested_column(self):
+        supported = scraper.parse_support_table(SUPPORT)
+        self.assertEqual(set(supported), {(1, 31), (1, 30), (1, 29)})
+        self.assertEqual(supported[(1, 31)], ["1.36", "1.35", "1.34", "1.33", "1.32"])
+        self.assertNotIn("1.31", supported[(1, 31)])
+
+    def test_columns_are_selected_by_label_and_whitespace_is_normalized(self):
+        html = table([["1.35, 1.36,1.35", "<span>1.31</span>", "YES"]],
+                     ["Supported Kubernetes Versions", "Version", "Currently Supported"])
+        self.assertEqual(scraper.parse_support_table(html), {(1, 31): ["1.36", "1.35"]})
+
+    def test_empty_matching_table_does_not_hide_later_source(self):
+        self.assertEqual(scraper.parse_support_table(table([]) + table([["1.31", "Yes", "1.36"]])),
+                         {(1, 31): ["1.36"]})
+
+    def test_malformed_ambiguous_or_missing_support_aborts(self):
+        sources = ["<p>Missing table</p>", table([]), table([["1.31", "Yes"]]),
+                   table([["1.31", "Yes", "1.36+"]]), table([["1.31", "Yes", "1.32–1.36"]]),
+                   table([["1.31.0-rc.0", "Yes", "1.36"]]),
+                   table([["1.31", "Yes", "1.36"], ["1.31", "Yes", "1.35"]]),
+                   table([["1.31", "Yes", "1.36", "1.35"]],
+                         ["Version", "Currently Supported", "Supported Kubernetes Versions", "Supported Kubernetes Versions"])]
+        for source in sources:
+            with self.subTest(source=source), self.assertRaises(ValueError):
+                scraper.parse_support_table(source)
+
+    def test_official_index_contains_released_istiod_chart(self):
+        charts = scraper.parse_chart_index(INDEX)
+        self.assertEqual(charts, {(1, 31, 0): (1, 31, 0), (1, 30, 0): (1, 30, 0)})
+
+    def test_exact_app_and_chart_versions_are_separate_and_stable(self):
+        entries = [{"appVersion": "1.31.0", "version": "2.0.0"},
+                   {"appVersion": "1.31.0", "version": "2.0.1"},
+                   {"appVersion": "1.31.0", "version": "2.1.0-rc.1"},
+                   {"appVersion": "1.32.0-rc.0", "version": "3.0.0"},
+                   {"appVersion": "1.32.0", "version": "3.0.0", "deprecated": True},
+                   {"appVersion": "1.31", "version": "1.31.0"}]
+        charts = scraper.parse_chart_index(yaml.safe_dump({"entries": {"istiod": entries}}))
+        self.assertEqual(charts, {(1, 31, 0): (2, 0, 1)})
+
+    def test_missing_or_invalid_index_aborts(self):
+        for source in ["null", "entries: []", "entries: {}", "entries: {istiod: []}",
+                       "entries: {istiod: [null]}",
+                       "entries: {istiod: [{appVersion: 1.31.0-rc.0, version: 1.31.0-rc.0}]}"]:
+            with self.subTest(source=source), self.assertRaises(ValueError):
+                scraper.parse_chart_index(source)
+
+    def test_chart_gate_does_not_invent_zero_patch_or_future_series(self):
+        rows = scraper.build_rows(scraper.parse_support_table(SUPPORT),
+                                  {(1, 31, 1): (1, 31, 1), (1, 32, 0): (1, 32, 0)}, [])
+        self.assertEqual([row["version"] for row in rows], ["1.31.1"])
+
+    def test_new_boundary_preserves_all_historical_metadata(self):
+        existing = [historical("1.30.0")]
+        before = deepcopy(existing)
+        rows = scraper.build_rows(scraper.parse_support_table(SUPPORT), scraper.parse_chart_index(INDEX), existing)
+        self.assertEqual([row["version"] for row in rows], ["1.31.0"])
+        self.assertEqual(existing, before)
+        reduced = reduce_versions(deepcopy(existing) + rows)
+        self.assertEqual(reduced[-1], before[0])
+
+    def test_redundant_patches_make_completed_rerun_a_noop(self):
+        charts = {(1, 31, patch): (1, 31, patch) for patch in range(3)}
+        supported = scraper.parse_support_table(SUPPORT)
+        rows = scraper.build_rows(supported, charts, [historical("1.30.0")])
+        self.assertEqual([row["version"] for row in rows], ["1.31.0", "1.31.2"])
+        reduced = reduce_versions([historical("1.30.0")] + rows)
+        self.assertEqual(scraper.build_rows(supported, charts, reduced), [])
+
+    def test_late_chart_can_backfill_missing_boundary(self):
+        existing = [historical("1.31.2")]
+        rows = scraper.build_rows(scraper.parse_support_table(SUPPORT),
+                                  {(1, 31, 0): (1, 31, 0), (1, 31, 2): (1, 31, 2)}, existing)
+        self.assertEqual([row["version"] for row in rows], ["1.31.0"])
+
+    def test_http_failure_or_changed_source_does_not_partially_write(self):
+        for failure in [requests.Timeout("timeout"), requests.HTTPError("unavailable"),
+                        [SUPPORT, b"entries: {}"], [b"<p>Missing table</p>"]]:
+            with self.subTest(failure=failure), patch.object(scraper, "read_yaml", return_value={"versions": []}), \
+                    patch.object(scraper, "_fetch", side_effect=failure), patch.object(scraper, "print_error"), \
+                    patch.object(scraper, "update_compatibility_info") as write:
+                scraper.scrape()
+                write.assert_not_called()
+
+    def test_invalid_existing_data_does_not_fetch_or_write(self):
+        for existing in [None, [], {}, {"versions": None}]:
+            with self.subTest(existing=existing), patch.object(scraper, "read_yaml", return_value=existing), \
+                    patch.object(scraper, "_fetch") as fetch, patch.object(scraper, "print_error"), \
+                    patch.object(scraper, "update_compatibility_info") as write:
+                scraper.scrape()
+                fetch.assert_not_called()
+                write.assert_not_called()
+
+    def test_scrape_uses_migrated_repository_and_only_writes_new_rows(self):
+        with patch.object(scraper, "read_yaml", return_value={"versions": [historical("1.30.0")]}), \
+                patch.object(scraper, "_fetch", side_effect=[SUPPORT, INDEX]) as fetch, \
+                patch.object(scraper, "update_compatibility_info") as write:
+            scraper.scrape()
+            self.assertEqual(fetch.call_args_list[1].args[0], "https://blob.istio.io/istio-release/charts/index.yaml")
+            self.assertEqual([row["version"] for row in write.call_args.args[1]], ["1.31.0"])
+
+    def test_requests_have_timeout_and_raise_for_status(self):
+        with patch.object(scraper.requests, "get") as get:
+            get.return_value.content = b"fixture"
+            self.assertEqual(scraper._fetch(scraper.chart_index_url), b"fixture")
+            get.assert_called_once_with(scraper.chart_index_url, timeout=30)
+            get.return_value.raise_for_status.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -490,6 +490,8 @@ def reduce_versions(versions):
             if "chart_version" in data:
                 version_info["chart_version"] = data["chart_version"]
                 version_info["images"] = data.get("images", [])
+            if "eolAt" in data:
+                version_info["eolAt"] = data["eolAt"]
 
             reduced_versions.append(version_info)
 


### PR DESCRIPTION
Istio 1.31 moved Helm charts from `istio-release.storage.googleapis.com` to `blob.istio.io/istio-release/charts`. The old chart index includes 1.31 prereleases but no GA chart, so the current scraper misses the released 1.31.0 compatibility boundary.

This switches the Istio chart repository to the official replacement, joins the supported-release matrix to exact stable `istiod` application/chart versions, and adds 1.31.0 with Kubernetes 1.32–1.36. The separate “Tested, but not supported” column is excluded. Existing records are preserved as the support table changes; the shared reducer now retains existing `eolAt` metadata. All 22 historical version records remain unchanged.

Sources:

- [Istio 1.31 announcement and repository migration](https://istio.io/latest/news/releases/1.31.x/announcing-1.31/)
- [Official supported-release matrix](https://istio.io/latest/docs/releases/supported-releases/)
- [Stable 1.31.0 release](https://github.com/istio/istio/releases/tag/1.31.0)
- [Replacement chart index](https://blob.istio.io/istio-release/charts/index.yaml)

## Test Plan

- 15 offline tests pass, covering support-column selection, malformed sources, exact stable chart mapping, delayed charts, historical metadata, no-op repeats and failures before writing.
- Rendered all 18 chart-bearing records against the replacement repository, including all 17 historical charts; every retained chart is present and reachable there.
- Verified the new chart archive's digest against the index and its internal `Chart.yaml` app/chart version 1.31.0.
- Per-app and aggregate schemas pass; aggregate matches the per-app file, and every other add-on remains unchanged.
- A live repeat calls no writer and leaves the data byte-identical. No Kubernetes deployment was performed.

Reproduction steps and validation scope are documented in `utils/compatibility/tests/ISTIO.md`.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly. Scraper validation documentation is included.
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code). Not applicable: no agent code changed.

Prepared with AI assistance and independently reviewed. Paid summarization APIs were disabled for all scraping and rendering.

Plural Flow: console
