### PR TITLE
feat: add Portainer CE compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -49,3 +49,4 @@ names:
 - wiz-sensor
 - wiz-admission-controller
 - wiz-network-analyzer
+- portainer

--- a/static/compatibilities/portainer.yaml
+++ b/static/compatibilities/portainer.yaml
@@ -1,0 +1,186 @@
+icon: https://github.com/portainer/portainer/raw/develop/app/assets/ico/apple-touch-icon.png
+git_url: https://github.com/portainer/portainer
+release_url: https://github.com/portainer/portainer/releases/tag/{vsn}
+readme_url: https://docs.portainer.io/start/requirements-and-prerequisites
+helm_repository_url: https://portainer.github.io/k8s/
+versions:
+- version: 2.45.0
+  kube:
+  - '1.34'
+  - '1.35'
+  - '1.36'
+  requirements: []
+  incompatibilities: []
+  chart_version: 245.0.0
+- version: 2.44.0
+  kube:
+  - '1.34'
+  - '1.35'
+  - '1.36'
+  requirements: []
+  incompatibilities: []
+- version: 2.43.0
+  kube:
+  - '1.33'
+  - '1.34'
+  - '1.35'
+  requirements: []
+  incompatibilities: []
+- version: 2.42.0
+  kube:
+  - '1.33'
+  - '1.34'
+  - '1.35'
+  requirements: []
+  incompatibilities: []
+- version: 2.41.0
+  kube:
+  - '1.33'
+  - '1.34'
+  - '1.35'
+  requirements: []
+  incompatibilities: []
+- version: 2.40.0
+  kube:
+  - '1.33'
+  - '1.34'
+  - '1.35'
+  requirements: []
+  incompatibilities: []
+- version: 2.39.6
+  kube:
+  - '1.34'
+  - '1.35'
+  - '1.36'
+  requirements: []
+  incompatibilities: []
+  chart_version: 239.6.0
+- version: 2.39.5
+  kube:
+  - '1.34'
+  - '1.35'
+  - '1.36'
+  requirements: []
+  incompatibilities: []
+  chart_version: 239.5.0
+- version: 2.39.4
+  kube:
+  - '1.33'
+  - '1.34'
+  - '1.35'
+  requirements: []
+  incompatibilities: []
+  chart_version: 239.4.0
+- version: 2.39.3
+  kube:
+  - '1.33'
+  - '1.34'
+  - '1.35'
+  requirements: []
+  incompatibilities: []
+  chart_version: 239.3.1
+- version: 2.39.2
+  kube:
+  - '1.33'
+  - '1.34'
+  - '1.35'
+  requirements: []
+  incompatibilities: []
+  chart_version: 239.2.0
+- version: 2.39.1
+  kube:
+  - '1.33'
+  - '1.34'
+  - '1.35'
+  requirements: []
+  incompatibilities: []
+  chart_version: 239.1.0
+- version: 2.39.0
+  kube:
+  - '1.32'
+  - '1.33'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+  chart_version: 239.0.2
+- version: 2.38.1
+  kube:
+  - '1.32'
+  - '1.33'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+- version: 2.38.0
+  kube:
+  - '1.32'
+  - '1.33'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+- version: 2.37.0
+  kube:
+  - '1.32'
+  - '1.33'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+- version: 2.36.0
+  kube:
+  - '1.32'
+  - '1.33'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+- version: 2.35.0
+  kube:
+  - '1.31'
+  - '1.32'
+  - '1.33'
+  requirements: []
+  incompatibilities: []
+- version: 2.34.0
+  kube:
+  - '1.31'
+  - '1.32'
+  - '1.33'
+  requirements: []
+  incompatibilities: []
+- version: 2.33.5
+  kube:
+  - '1.32'
+  - '1.33'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.33.5
+- version: 2.33.4
+  kube:
+  - '1.32'
+  - '1.33'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.33.4
+- version: 2.33.3
+  kube:
+  - '1.32'
+  - '1.33'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.33.3
+- version: 2.33.2
+  kube:
+  - '1.31'
+  - '1.32'
+  - '1.33'
+  requirements: []
+  incompatibilities: []
+- version: 2.33.1
+  kube:
+  - '1.31'
+  - '1.32'
+  - '1.33'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.33.1

--- a/utils/compatibility/scrapers/portainer.py
+++ b/utils/compatibility/scrapers/portainer.py
@@ -77,11 +77,10 @@ def build_versions(markdown, chart_index, fetch):
         if not version.is_prerelease:
             entries.append((version, entry))
     for _, entry in sorted(entries, key=lambda item: item[0], reverse=True):
-        # appVersion contains both editions and sometimes a floating CE tag.
-        # It is only a candidate filter; the packaged CE default is authoritative.
-        candidates = set(re.findall(r"\d+\.\d+\.\d+", str(entry.get("appVersion", ""))))
-        if not (candidates & (compatibility.keys() - charts.keys())):
-            continue
+        # appVersion may be floating, absent, or describe only Business Edition.
+        # Only the packaged CE default can establish the mapping.
+        if compatibility.keys() <= charts.keys():
+            break
         archive = fetch(urljoin(CHART_URL, entry["urls"][0]))
         if archive is None:
             raise ValueError("Could not fetch Portainer chart")

--- a/utils/compatibility/scrapers/portainer.py
+++ b/utils/compatibility/scrapers/portainer.py
@@ -1,0 +1,109 @@
+"""Portainer CE's explicitly tested Kubernetes versions (not inferred ranges)."""
+
+import io
+import re
+import tarfile
+import warnings
+from urllib.parse import urljoin
+
+import yaml
+from packaging.version import Version, InvalidVersion
+
+app_name = "portainer"
+SOURCE_URL = "https://docs.portainer.io/start/requirements-and-prerequisites.md"
+CHART_URL = "https://portainer.github.io/k8s/"
+
+
+def parse_compatibility(markdown):
+    section = re.search(
+        r"^### Portainer Community Edition \(CE\)\s*$(.*?)(?=^#{1,3} |\Z)",
+        markdown, re.MULTILINE | re.DOTALL,
+    )
+    if not section:
+        raise ValueError("Portainer CE compatibility section missing")
+    versions = {}
+    columns = None
+    for line in section.group(1).splitlines():
+        if not line.strip().startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if "Portainer Version" in cells and "Kubernetes Version" in cells:
+            columns = (cells.index("Portainer Version"), cells.index("Kubernetes Version"))
+            continue
+        if columns is None or len(cells) <= max(columns):
+            continue
+        release = re.fullmatch(r"Community (\d+\.\d+\.\d+)(?: (?:LTS|STS))?", cells[columns[0]])
+        if not release:
+            continue
+        kube_cell = re.sub(r"<br\s*/?>", " ", cells[columns[1]], flags=re.IGNORECASE)
+        if not re.fullmatch(r"\s*1\.\d+(?:\s+1\.\d+)*\s*", kube_cell):
+            warnings.warn(f"Skipping {release.group(1)}: unexpected Kubernetes versions {kube_cell!r}")
+            continue
+        kube = sorted(set(kube_cell.split()), key=Version)
+        version = release.group(1)
+        if version in versions and versions[version] != kube:
+            raise ValueError(f"Conflicting compatibility rows for {version}")
+        versions[version] = kube
+    if not versions:
+        raise ValueError("No Portainer CE compatibility rows found")
+    return versions
+
+
+def chart_ce_version(archive):
+    # Inspect the package without extracting files or executing Helm templates.
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as chart:
+        stream = chart.extractfile("portainer/values.yaml")
+        if stream is None:
+            raise ValueError("Portainer chart values missing")
+        values = yaml.safe_load(stream)
+    if values.get("enterpriseEdition", {}).get("enabled", False):
+        return None
+    image = values.get("image", {})
+    if image.get("repository") != "portainer/portainer-ce":
+        return None
+    tag = str(image.get("tag", ""))
+    return tag if re.fullmatch(r"\d+\.\d+\.\d+", tag) else None
+
+
+def build_versions(markdown, chart_index, fetch):
+    compatibility = parse_compatibility(markdown)
+    charts = {}
+    entries = []
+    for entry in chart_index["entries"]["portainer"]:
+        try:
+            version = Version(str(entry["version"]))
+        except InvalidVersion:
+            continue
+        if not version.is_prerelease:
+            entries.append((version, entry))
+    for _, entry in sorted(entries, key=lambda item: item[0], reverse=True):
+        # appVersion contains both editions and sometimes a floating CE tag.
+        # It is only a candidate filter; the packaged CE default is authoritative.
+        candidates = set(re.findall(r"\d+\.\d+\.\d+", str(entry.get("appVersion", ""))))
+        if not (candidates & (compatibility.keys() - charts.keys())):
+            continue
+        archive = fetch(urljoin(CHART_URL, entry["urls"][0]))
+        if archive is None:
+            raise ValueError("Could not fetch Portainer chart")
+        ce_version = chart_ce_version(archive)
+        if ce_version in compatibility and ce_version not in charts:
+            charts[ce_version] = str(entry["version"])
+    versions = []
+    for version in sorted(compatibility, key=Version, reverse=True):
+        item = {"version": version, "kube": compatibility[version],
+                "requirements": [], "incompatibilities": []}
+        if version in charts:
+            item["chart_version"] = charts[version]
+        versions.append(item)
+    return versions
+
+
+def scrape():
+    from utils import fetch_page, update_compatibility_info
+
+    source = fetch_page(SOURCE_URL)
+    index = fetch_page(urljoin(CHART_URL, "index.yaml"))
+    if source is None or index is None:
+        raise ValueError("Could not fetch Portainer compatibility sources")
+    versions = build_versions(source.decode("utf-8"), yaml.safe_load(index), fetch_page)
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", versions)

--- a/utils/compatibility/tests/test_portainer.py
+++ b/utils/compatibility/tests/test_portainer.py
@@ -1,0 +1,82 @@
+import io
+import sys
+import tarfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scrapers.portainer import build_versions, chart_ce_version, parse_compatibility
+
+
+TABLE = """### Portainer Business Edition (BE)
+| Portainer Version | Kubernetes Version |
+| Business 2.45.0 LTS | 1.99 |
+### Portainer Community Edition (CE)
+| Portainer Version | Release Date | Kubernetes Version |
+| --- | --- | --- |
+| Community 2.45.0 LTS | August 27, 2026 | 1.34 1.36 |
+| Community 2.39.6 LTS | August 13, 2026 | 1.33 1.34 1.35 |
+### Other
+| Community 9.99.0 | today | 1.99 |
+"""
+
+
+def package(tag, enabled=False):
+    output = io.BytesIO()
+    values = f"enterpriseEdition:\n  enabled: {str(enabled).lower()}\nimage:\n  repository: portainer/portainer-ce\n  tag: {tag}\n".encode()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        member = tarfile.TarInfo("portainer/values.yaml")
+        member.size = len(values)
+        archive.addfile(member, io.BytesIO(values))
+    return output.getvalue()
+
+
+class PortainerTests(unittest.TestCase):
+    def test_ce_only_and_no_interpolated_kubernetes_minors(self):
+        self.assertEqual(parse_compatibility(TABLE), {
+            "2.45.0": ["1.34", "1.36"], "2.39.6": ["1.33", "1.34", "1.35"]})
+
+    def test_layout_change_fails(self):
+        for text in ["", TABLE.replace("Community 2.", "CE 2.")]:
+            with self.subTest(text=text), self.assertRaises(ValueError):
+                parse_compatibility(text)
+
+    def test_malformed_row_is_warned_and_skipped_without_guessing(self):
+        for malformed in ["1.34-1.36", "1.31 1.32 .133"]:
+            with self.assertWarns(UserWarning):
+                versions = parse_compatibility(TABLE.replace("1.34 1.36", malformed))
+            self.assertEqual(list(versions), ["2.39.6"])
+
+    def test_breaks_and_duplicate_versions(self):
+        self.assertEqual(parse_compatibility(TABLE.replace("1.34 1.36", "1.36<br/>1.34 1.34"))["2.45.0"], ["1.34", "1.36"])
+
+    def test_conflicting_rows_fail(self):
+        text = TABLE.replace("### Other", "| Community 2.45.0 LTS | today | 1.33 |\n### Other")
+        with self.assertRaises(ValueError):
+            parse_compatibility(text)
+
+    def test_chart_requires_pinned_ce_default(self):
+        self.assertEqual(chart_ce_version(package("2.45.0")), "2.45.0")
+        self.assertIsNone(chart_ce_version(package("latest")))
+        self.assertIsNone(chart_ce_version(package("2.45.0", enabled=True)))
+
+    def test_metadata_is_not_used_as_ce_version(self):
+        index = {"entries": {"portainer": [
+            {"version": "245.0.0", "appVersion": "ce-latest-ee-2.45.0", "urls": ["new.tgz"]},
+            {"version": "244.0.0", "appVersion": "ce-2.45.0-ee-2.45.0", "urls": ["old.tgz"]},
+        ]}}
+        def fetch(url):
+            return package("latest" if url.endswith("new.tgz") else "2.45.0")
+        versions = build_versions(TABLE, index, fetch)
+        self.assertEqual(versions[0]["chart_version"], "244.0.0")
+        self.assertNotIn("chart_version", versions[1])
+
+    def test_newest_stable_chart_selected_independent_of_index_order(self):
+        entries = [{"version": v, "appVersion": "2.45.0", "urls": [v + ".tgz"]}
+                   for v in ["244.0.0", "246.0.0-rc1", "245.0.0"]]
+        versions = build_versions(TABLE, {"entries": {"portainer": entries}}, lambda _: package("2.45.0"))
+        self.assertEqual(versions[0]["chart_version"], "245.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_portainer.py
+++ b/utils/compatibility/tests/test_portainer.py
@@ -77,6 +77,16 @@ class PortainerTests(unittest.TestCase):
         versions = build_versions(TABLE, {"entries": {"portainer": entries}}, lambda _: package("2.45.0"))
         self.assertEqual(versions[0]["chart_version"], "245.0.0")
 
+    def test_floating_missing_and_unrelated_metadata_do_not_hide_ce_tag(self):
+        for metadata in ["ce-latest", None, "ee-2.39.0"]:
+            with self.subTest(metadata=metadata):
+                entry = {"version": "245.0.0", "urls": ["chart.tgz"]}
+                if metadata is not None:
+                    entry["appVersion"] = metadata
+                versions = build_versions(TABLE, {"entries": {"portainer": [entry]}},
+                                          lambda _: package("2.45.0"))
+                self.assertEqual(versions[0]["chart_version"], "245.0.0")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Portainer CE is absent from the compatibility manifest. This adds a scraper and 24 release records using explicitly tested Kubernetes minors from the official requirements table, without inferring intervening versions.

The scraper separates CE from Business Edition and verifies Helm mappings against packaged Community image tags, since chart appVersion mixes editions and sometimes uses ce-latest. Twelve chart mappings were verified; remaining releases retain documented compatibility without an invented chart version. The malformed upstream 2.33.0 row (.133) is skipped with a warning.

Sources:
- https://docs.portainer.io/start/requirements-and-prerequisites
- https://docs.portainer.io/start/install-ce/server/kubernetes/baremetal
- https://portainer.github.io/k8s/index.yaml
- https://github.com/portainer/portainer

## Test plan

Eight local regression tests passed: edition separation, no interpolation, changed layouts, malformed rows, conflicting rows, pinned CE defaults, metadata mismatch, and stable chart selection. Live data produced 24 release records and 12 chart mappings checked from archives. Generated YAML passed the repository JSON schema; git diff --check passed.

Run: python -m unittest discover -s utils/compatibility/tests -p test_portainer.py -v

No Kubernetes deployment, Helm rendering, or full compatibility cron execution was performed.

## Contribution disclosure and reward question

Prepared by Codex, an AI coding assistant acting for Ultimate99. The tests and live-data checks above were executed locally. We are pursuing the documented $300 new-scraper reward. Please confirm whether this scope and AI-assisted contribution are eligible and whether an accepted reward can be paid via PayPal. Payment details will be supplied privately through an agreed claim channel.