### PR TITLE
feat: add MongoDB Kubernetes Operator compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31041,3 +31041,93 @@ addons:
     chart_version: 0.4.0
     images: ['kuberay/operator:v0.4.0']
   name: kuberay-operator
+- icon: https://mongodb-images-new.s3.eu-west-1.amazonaws.com/leaf-green-dark.png
+  git_url: https://github.com/mongodb/mongodb-kubernetes
+  release_url: https://github.com/mongodb/mongodb-kubernetes/releases/tag/{vsn}
+  helm_repository_url: https://mongodb.github.io/helm-charts
+  versions:
+  - version: 1.11.0
+    kube: ['1.36', '1.35', '1.34']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.11.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.11.0']
+  - version: 1.10.0
+    kube: ['1.36', '1.35', '1.34']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.10.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.10.0']
+  - version: 1.9.0
+    kube: ['1.36', '1.35', '1.34']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.9.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.9.0']
+  - version: 1.8.0
+    kube: ['1.35', '1.34', '1.33']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.8.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.8.0']
+  - version: 1.7.0
+    kube: ['1.35', '1.34', '1.33']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.7.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.7.0']
+  - version: 1.6.0
+    kube: ['1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.6.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.6.0']
+  - version: 1.5.0
+    kube: ['1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.5.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.5.0']
+  - version: 1.4.0
+    kube: ['1.33', '1.32', '1.31']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.4.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.4.0']
+  - version: 1.3.0
+    kube: ['1.33', '1.32', '1.31']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.3.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.3.0']
+  - version: 1.2.0
+    kube: ['1.31', '1.30', '1.29']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.2.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.2.0']
+  - version: 1.1.0
+    kube: ['1.31', '1.30', '1.29']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.1.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.1.0']
+  - version: 1.0.0
+    kube: ['1.31', '1.30', '1.29']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.0
+    images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
+  name: mongodb-kubernetes

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -50,3 +50,4 @@ names:
 - wiz-admission-controller
 - wiz-network-analyzer
 - kuberay-operator
+- mongodb-kubernetes

--- a/static/compatibilities/mongodb-kubernetes.yaml
+++ b/static/compatibilities/mongodb-kubernetes.yaml
@@ -1,0 +1,90 @@
+icon: https://mongodb-images-new.s3.eu-west-1.amazonaws.com/leaf-green-dark.png
+git_url: https://github.com/mongodb/mongodb-kubernetes
+release_url: https://github.com/mongodb/mongodb-kubernetes/releases/tag/{vsn}
+helm_repository_url: https://mongodb.github.io/helm-charts
+versions:
+- version: 1.11.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.11.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.11.0']
+- version: 1.10.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.10.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.10.0']
+- version: 1.9.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.9.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.9.0']
+- version: 1.8.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.8.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.8.0']
+- version: 1.7.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.7.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.7.0']
+- version: 1.6.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.6.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.6.0']
+- version: 1.5.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.5.0']
+- version: 1.4.0
+  kube: ['1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.4.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.4.0']
+- version: 1.3.0
+  kube: ['1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.3.0']
+- version: 1.2.0
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.2.0']
+- version: 1.1.0
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.1.0']
+- version: 1.0.0
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.0
+  images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
+name: mongodb-kubernetes

--- a/utils/compatibility/scrapers/mongodb-kubernetes.py
+++ b/utils/compatibility/scrapers/mongodb-kubernetes.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import yaml
+from bs4 import BeautifulSoup
+from packaging.version import InvalidVersion, Version
+
+from utils import fetch_page, update_compatibility_info
+
+app_name = "mongodb-kubernetes"
+compatibility_url = (
+    "https://www.mongodb.com/docs/kubernetes/current/tutorial/"
+    "plan-k8s-op-compatibility/"
+)
+chart_index_url = "https://mongodb.github.io/helm-charts/index.yaml"
+chart_name = "mongodb-kubernetes"
+
+
+def _decode(content: bytes | str, source: str) -> str:
+    if isinstance(content, str):
+        return content
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"Could not decode {source} as UTF-8") from exc
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip().lower()
+
+
+def parse_chart_versions(content: bytes | str) -> dict[str, str]:
+    try:
+        parsed = yaml.safe_load(_decode(content, "MongoDB Helm index"))
+    except yaml.YAMLError as exc:
+        raise ValueError("Could not parse MongoDB Helm index") from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError("MongoDB Helm index is empty or malformed")
+
+    entries = parsed.get("entries", {}).get(chart_name)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError(f"MongoDB Helm index has no {chart_name!r} chart entries")
+
+    versions: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        raw = str(entry.get("version", "")).lstrip("v")
+        try:
+            parsed_version = Version(raw)
+        except InvalidVersion:
+            continue
+        if parsed_version.is_prerelease or parsed_version.is_devrelease:
+            continue
+        versions.setdefault(raw, raw)
+
+    if not versions:
+        raise ValueError("MongoDB Helm index contains no stable chart versions")
+    return versions
+
+
+def _find_compatibility_table(soup: BeautifulSoup):
+    for table in soup.find_all("table"):
+        headers = [_normalize(cell.get_text(" ", strip=True)) for cell in table.find_all("th")]
+        if not headers:
+            continue
+        if any("kubernetes operator release series" in header for header in headers) and any(
+            header == "kubernetes version" for header in headers
+        ):
+            return table, headers
+    raise ValueError("MongoDB Kubernetes compatibility table not found")
+
+
+def _extract_release(value: str) -> str:
+    match = re.search(r"(?<!\d)(\d+\.\d+\.\d+)(?!\d)", value)
+    if not match:
+        raise ValueError(f"Unsupported MongoDB Operator release cell: {value!r}")
+    version = match.group(1)
+    try:
+        parsed = Version(version)
+    except InvalidVersion as exc:
+        raise ValueError(f"Invalid MongoDB Operator release: {version!r}") from exc
+    if parsed.is_prerelease or parsed.is_devrelease:
+        raise ValueError(f"Unsupported pre-release MongoDB Operator version: {version!r}")
+    return version
+
+
+def _extract_kube_versions(value: str) -> list[str]:
+    versions = re.findall(r"(?<!\d)(1\.\d+)(?!\d)", value)
+    if not versions:
+        raise ValueError(f"No Kubernetes versions found in compatibility cell: {value!r}")
+
+    unique = {version for version in versions}
+    return sorted(unique, key=lambda item: int(item.split(".")[1]), reverse=True)
+
+
+def parse_compatibility_page(
+    content: bytes | str, chart_versions: dict[str, str]
+) -> list[OrderedDict[str, object]]:
+    html = _decode(content, "MongoDB compatibility page")
+    soup = BeautifulSoup(html, "html.parser")
+    table, headers = _find_compatibility_table(soup)
+
+    try:
+        release_idx = next(
+            i for i, header in enumerate(headers) if "kubernetes operator release series" in header
+        )
+        kube_idx = headers.index("kubernetes version")
+    except (StopIteration, ValueError) as exc:
+        raise ValueError("Unexpected MongoDB compatibility table columns") from exc
+
+    rows: list[OrderedDict[str, object]] = []
+    seen: set[str] = set()
+
+    for tr in table.find_all("tr"):
+        cells = tr.find_all("td")
+        if not cells:
+            continue
+        if len(cells) <= max(release_idx, kube_idx):
+            raise ValueError("Malformed MongoDB compatibility table row")
+
+        version = _extract_release(cells[release_idx].get_text(" ", strip=True))
+        if version in seen:
+            raise ValueError(f"Duplicate MongoDB Operator compatibility row: {version}")
+        seen.add(version)
+
+        chart_version = chart_versions.get(version)
+        if not chart_version:
+            # Do not invent an operator/chart pairing that MongoDB has not
+            # published in its official Helm repository.
+            continue
+
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", version),
+                    ("kube", _extract_kube_versions(cells[kube_idx].get_text(" ", strip=True))),
+                    ("chart_version", chart_version),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    if not rows:
+        raise ValueError("No MongoDB Operator releases matched official Helm charts")
+
+    return sorted(rows, key=lambda row: Version(str(row["version"])), reverse=True)
+
+
+def scrape() -> None:
+    index = fetch_page(chart_index_url)
+    if not index:
+        raise ValueError("Could not fetch MongoDB Helm index")
+    chart_versions = parse_chart_versions(index)
+
+    page = fetch_page(compatibility_url)
+    if not page:
+        raise ValueError("Could not fetch MongoDB Kubernetes compatibility page")
+
+    rows = parse_compatibility_page(page, chart_versions)
+    update_compatibility_info(
+        f"../../static/compatibilities/{app_name}.yaml",
+        rows,
+    )

--- a/utils/compatibility/tests/test_mongodb_kubernetes.py
+++ b/utils/compatibility/tests/test_mongodb_kubernetes.py
@@ -1,0 +1,131 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+helpers = ModuleType("utils")
+helpers.fetch_page = Mock()
+helpers.update_compatibility_info = Mock()
+
+_original_utils = sys.modules.get("utils")
+sys.modules["utils"] = helpers
+try:
+    SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "mongodb-kubernetes.py"
+    spec = importlib.util.spec_from_file_location("mongodb_kubernetes", SCRAPER_PATH)
+    scraper = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scraper)
+finally:
+    if _original_utils is None:
+        sys.modules.pop("utils", None)
+    else:
+        sys.modules["utils"] = _original_utils
+
+
+def table(rows: str, headers=None) -> bytes:
+    headers = headers or [
+        "Kubernetes Operator Release Series",
+        "Release Date",
+        "EOL date",
+        "Kubernetes Version",
+        "OpenShift Version",
+    ]
+    th = "".join(f"<th>{header}</th>" for header in headers)
+    return f"<html><body><table><thead><tr>{th}</tr></thead><tbody>{rows}</tbody></table></body></html>".encode()
+
+
+def row(version: str, kube: str) -> str:
+    return (
+        f"<tr><td>{version}</td><td>August 26, 2026</td><td>to be determined</td>"
+        f"<td>{kube}</td><td>4.22</td></tr>"
+    )
+
+
+class MongoDbKubernetesTests(unittest.TestCase):
+    def test_parses_compatibility_table_and_sorts_versions(self):
+        html = table(row("1.10.0", "1.34, 1.35, 1.36") + row("1.11.0", "1.34, 1.35, 1.36"))
+        rows = scraper.parse_compatibility_page(
+            html,
+            {"1.10.0": "1.10.0", "1.11.0": "1.11.0"},
+        )
+        self.assertEqual([item["version"] for item in rows], ["1.11.0", "1.10.0"])
+        self.assertEqual(rows[0]["kube"], ["1.36", "1.35", "1.34"])
+        self.assertEqual(rows[0]["chart_version"], "1.11.0")
+
+    def test_skips_release_without_official_chart(self):
+        html = table(row("1.12.0", "1.35, 1.36") + row("1.11.0", "1.34, 1.35, 1.36"))
+        rows = scraper.parse_compatibility_page(html, {"1.11.0": "1.11.0"})
+        self.assertEqual([item["version"] for item in rows], ["1.11.0"])
+
+    def test_missing_compatibility_table_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "compatibility table not found"):
+            scraper.parse_compatibility_page(b"<html><table><th>Other</th></table></html>", {"1.11.0": "1.11.0"})
+
+    def test_unexpected_headers_fail_closed(self):
+        html = table(row("1.11.0", "1.34, 1.35, 1.36"), headers=["Kubernetes Operator Release Series", "Other"])
+        with self.assertRaisesRegex(ValueError, "compatibility table not found"):
+            scraper.parse_compatibility_page(html, {"1.11.0": "1.11.0"})
+
+    def test_malformed_release_fails_closed(self):
+        html = table(row("release-eleven", "1.34, 1.35, 1.36"))
+        with self.assertRaisesRegex(ValueError, "Unsupported MongoDB Operator release"):
+            scraper.parse_compatibility_page(html, {"1.11.0": "1.11.0"})
+
+    def test_missing_kubernetes_versions_fail_closed(self):
+        html = table(row("1.11.0", "not documented"))
+        with self.assertRaisesRegex(ValueError, "No Kubernetes versions"):
+            scraper.parse_compatibility_page(html, {"1.11.0": "1.11.0"})
+
+    def test_duplicate_release_fails_closed(self):
+        html = table(row("1.11.0", "1.34, 1.35") + row("1.11.0", "1.34, 1.35"))
+        with self.assertRaisesRegex(ValueError, "Duplicate MongoDB Operator"):
+            scraper.parse_compatibility_page(html, {"1.11.0": "1.11.0"})
+
+    def test_chart_index_uses_stable_mongodb_kubernetes_versions(self):
+        index = b"""
+entries:
+  mongodb-kubernetes:
+    - version: 1.12.0
+    - version: 1.11.0
+    - version: 1.13.0-rc.1
+    - version: nonsense
+"""
+        self.assertEqual(
+            scraper.parse_chart_versions(index),
+            {"1.12.0": "1.12.0", "1.11.0": "1.11.0"},
+        )
+
+    def test_missing_chart_entries_fail_closed(self):
+        with self.assertRaisesRegex(ValueError, "has no 'mongodb-kubernetes' chart entries"):
+            scraper.parse_chart_versions(b"entries: {}\n")
+
+    def test_invalid_utf8_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Could not decode"):
+            scraper.parse_compatibility_page(b"\xff", {"1.11.0": "1.11.0"})
+
+    def test_scrape_wires_official_sources_to_updater(self):
+        index = b"entries:\n  mongodb-kubernetes:\n    - version: 1.11.0\n"
+        html = table(row("1.11.0", "1.34, 1.35, 1.36"))
+
+        def fetch(url):
+            if url == scraper.chart_index_url:
+                return index
+            if url == scraper.compatibility_url:
+                return html
+            self.fail(f"unexpected URL: {url}")
+
+        with (
+            patch.object(scraper, "fetch_page", side_effect=fetch),
+            patch.object(scraper, "update_compatibility_info") as update,
+        ):
+            scraper.scrape()
+
+        path, rows = update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/mongodb-kubernetes.yaml")
+        self.assertEqual(rows[0]["version"], "1.11.0")
+        self.assertEqual(rows[0]["kube"], ["1.36", "1.35", "1.34"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds MongoDB Controllers for Kubernetes Operator to Plural’s compatibility catalog with an automated compatibility scraper, generated compatibility data, manifest registration, aggregate compatibility data and focused regression tests.

## Authoritative sources

- https://www.mongodb.com/docs/kubernetes/current/tutorial/plan-k8s-op-compatibility/
- https://github.com/mongodb/mongodb-kubernetes
- https://mongodb.github.io/helm-charts

The scraper reads MongoDB’s official Kubernetes compatibility table and maps documented operator releases to stable versions published in MongoDB’s official Helm repository.

It fails closed when the compatibility table, release data or Kubernetes version information cannot be verified, and it does not invent mappings for operator versions without a corresponding official Helm chart.

## Testing

- 11 focused tests passed
- Live scraper validation against MongoDB’s official compatibility documentation passed
- Official MongoDB Helm repository resolution passed
- Operator container image resolution passed
- Python compilation passed
- Generated compatibility YAML validation passed
- Manifest and aggregate compatibility validation passed
- Malformed, missing or structurally changed upstream data fails closed

No live Kubernetes cluster deployment was performed; this change validates upstream-declared compatibility metadata, parser behavior and official Helm resolution.

AI assistance disclosure: implemented and tested using OpenAI ChatGPT/Codex under the GitHub account owner’s authorization.

I would like this submission considered under the README Contributor Program’s advertised $300 reward for a new compatibility scraper, subject to maintainer review, merge and eligibility confirmation.

Plural Flow: console