### PR TITLE
Add draft OpenKruise compatibility scraper and offline tests

### DIFF
--- a/static/compatibilities/kruise.yaml
+++ b/static/compatibilities/kruise.yaml
@@ -1,0 +1,146 @@
+# Sources: https://openkruise.io/docs/installation and https://openkruise.github.io/charts/index.yaml
+# Conservative API-match mapping pending console#4169; +, -, ? are not classified.
+icon: https://avatars.githubusercontent.com/u/49735278?v=4
+git_url: https://github.com/openkruise/kruise
+release_url: https://github.com/openkruise/kruise/releases/tag/v{vsn}
+helm_repository_url: https://openkruise.github.io/charts
+chart_name: kruise
+versions:
+- version: 1.9.1
+  kube:
+  - '1.32'
+  chart_version: 1.9.1
+  requirements: []
+  incompatibilities: []
+- version: 1.9.0
+  kube:
+  - '1.32'
+  chart_version: 1.9.0
+  requirements: []
+  incompatibilities: []
+- version: 1.8.3
+  kube:
+  - '1.30'
+  chart_version: 1.8.3
+  requirements: []
+  incompatibilities: []
+- version: 1.8.0
+  kube:
+  - '1.30'
+  chart_version: 1.8.0
+  requirements: []
+  incompatibilities: []
+- version: 1.7.5
+  kube:
+  - '1.28'
+  chart_version: 1.7.5
+  requirements: []
+  incompatibilities: []
+- version: 1.7.3
+  kube:
+  - '1.28'
+  chart_version: 1.7.3
+  requirements: []
+  incompatibilities: []
+- version: 1.7.2
+  kube:
+  - '1.28'
+  chart_version: 1.7.2
+  requirements: []
+  incompatibilities: []
+- version: 1.7.1
+  kube:
+  - '1.28'
+  chart_version: 1.7.1
+  requirements: []
+  incompatibilities: []
+- version: 1.7.0
+  kube:
+  - '1.28'
+  chart_version: 1.7.0
+  requirements: []
+  incompatibilities: []
+- version: 1.6.4
+  kube:
+  - '1.26'
+  chart_version: 1.6.4
+  requirements: []
+  incompatibilities: []
+- version: 1.6.3
+  kube:
+  - '1.26'
+  chart_version: 1.6.3
+  requirements: []
+  incompatibilities: []
+- version: 1.6.2
+  kube:
+  - '1.26'
+  chart_version: 1.6.2
+  requirements: []
+  incompatibilities: []
+- version: 1.6.1
+  kube:
+  - '1.26'
+  chart_version: 1.6.1
+  requirements: []
+  incompatibilities: []
+- version: 1.6.0
+  kube:
+  - '1.26'
+  chart_version: 1.6.0
+  requirements: []
+  incompatibilities: []
+- version: 1.5.5
+  kube:
+  - '1.24'
+  chart_version: 1.5.5
+  requirements: []
+  incompatibilities: []
+- version: 1.5.4
+  kube:
+  - '1.24'
+  chart_version: 1.5.4
+  requirements: []
+  incompatibilities: []
+- version: 1.5.3
+  kube:
+  - '1.24'
+  chart_version: 1.5.3
+  requirements: []
+  incompatibilities: []
+- version: 1.5.2
+  kube:
+  - '1.24'
+  chart_version: 1.5.2
+  requirements: []
+  incompatibilities: []
+- version: 1.5.1
+  kube:
+  - '1.24'
+  chart_version: 1.5.1
+  requirements: []
+  incompatibilities: []
+- version: 1.5.0
+  kube:
+  - '1.24'
+  chart_version: 1.5.0
+  requirements: []
+  incompatibilities: []
+- version: 1.4.2
+  kube:
+  - '1.22'
+  chart_version: 1.4.2
+  requirements: []
+  incompatibilities: []
+- version: 1.4.1
+  kube:
+  - '1.22'
+  chart_version: 1.4.1
+  requirements: []
+  incompatibilities: []
+- version: 1.4.0
+  kube:
+  - '1.22'
+  chart_version: 1.4.0
+  requirements: []
+  incompatibilities: []

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -22,6 +22,7 @@ names:
 - jaeger
 - karpenter
 - keda
+- kruise
 - kube-prometheus-stack
 - kyverno
 - linkerd

--- a/utils/compatibility/scrapers/kruise.py
+++ b/utils/compatibility/scrapers/kruise.py
@@ -1,0 +1,118 @@
+"""OpenKruise's explicit API-match matrix, joined to stable Helm releases.
+
+Source: https://openkruise.io/docs/installation
+Only checkmarks are mapped to `kube`. The + and - cells describe API overlap,
+not exact matches; ? is untested. Never interpolate missing Kubernetes minors.
+This conservative mapping is awaiting maintainer agreement in console#4169.
+"""
+
+import re
+
+from bs4 import BeautifulSoup
+import yaml
+
+app_name = "kruise"
+compatibility_url = "https://openkruise.io/docs/installation"
+chart_index_url = "https://openkruise.github.io/charts/index.yaml"
+
+
+def _stable_version(value):
+    if not isinstance(value, str):
+        return None
+    match = re.fullmatch(r"v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", value)
+    return tuple(map(int, match.groups())) if match else None
+
+
+def parse_matrix(content):
+    """Return minor-version tuples mapped to explicit Kubernetes API matches.
+
+    Fail closed when the table shape or vocabulary changes, so a scheduled
+    scrape cannot replace stored data with guessed or misaligned columns.
+    """
+    soup = BeautifulSoup(content, "html.parser")
+    candidates = []
+    for table in soup.find_all("table"):
+        first_row = table.find("tr")
+        if first_row:
+            cells = first_row.find_all(["td", "th"])
+            if cells and cells[0].get_text(" ", strip=True).lower() == "kruise version":
+                candidates.append(table)
+    if len(candidates) != 1:
+        raise ValueError("Expected exactly one Kruise compatibility matrix")
+
+    rows = candidates[0].find_all("tr")
+    headers = [cell.get_text(" ", strip=True) for cell in rows[0].find_all(["th", "td"])]
+    kube = headers[1:]
+    if not kube or any(not re.fullmatch(r"1\.\d+", version) for version in kube):
+        raise ValueError("Invalid Kubernetes column labels")
+    if len(set(kube)) != len(kube):
+        raise ValueError("Duplicate Kubernetes columns")
+
+    matrix = {}
+    for row in rows[1:]:
+        cells = [cell.get_text(" ", strip=True) for cell in row.find_all(["th", "td"])]
+        if len(cells) != len(headers):
+            raise ValueError("Kruise matrix row width changed")
+        match = re.fullmatch(r"(\d+)\.(\d+)\.x", cells[0])
+        if not match:
+            raise ValueError("Invalid Kruise minor-version label")
+        minor = tuple(map(int, match.groups()))
+        if minor in matrix:
+            raise ValueError("Duplicate Kruise minor-version row")
+        if any(symbol not in {"✓", "+", "-", "?"} for symbol in cells[1:]):
+            raise ValueError("Unknown Kruise compatibility symbol")
+        matrix[minor] = [version for version, symbol in zip(kube, cells[1:]) if symbol == "✓"]
+    if not matrix or not any(matrix.values()):
+        raise ValueError("No explicit Kruise API matches found")
+    return matrix
+
+
+def build_rows(page_content, index_content):
+    matrix = parse_matrix(page_content)
+    index = yaml.safe_load(index_content)
+    chart_groups = index.get("entries") if isinstance(index, dict) else None
+    entries = chart_groups.get(app_name) if isinstance(chart_groups, dict) else None
+    if not isinstance(entries, list):
+        raise ValueError("Missing Kruise chart entries")
+
+    charts = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Invalid Kruise chart entry")
+        version = _stable_version(entry.get("appVersion"))
+        chart = _stable_version(entry.get("version"))
+        if version is None or chart is None or not matrix.get(version[:2]):
+            continue
+        # Do not rely on Helm index ordering or confuse app and chart versions.
+        if version not in charts or chart > charts[version][0]:
+            charts[version] = (chart, entry["version"])
+    if not charts:
+        raise ValueError("No stable charts match documented Kruise versions")
+
+    return [
+        {
+            "version": ".".join(map(str, version)),
+            "kube": sorted(matrix[version[:2]], key=lambda value: tuple(map(int, value.split("."))), reverse=True),
+            "chart_version": charts[version][1],
+            "requirements": [],
+            "incompatibilities": [],
+        }
+        for version in sorted(charts, reverse=True)
+    ]
+
+
+def scrape():
+    # Keep pure parsers importable without loading the network/AI/Helm helpers.
+    from utils import fetch_page, print_error, update_compatibility_info
+
+    page = fetch_page(compatibility_url)
+    index = fetch_page(chart_index_url)
+    if not page or not index:
+        print_error("Failed to fetch Kruise compatibility sources; leaving data unchanged")
+        return
+    try:
+        rows = build_rows(page, index)
+    except (ValueError, yaml.YAMLError) as error:
+        print_error(f"Cannot parse Kruise compatibility sources: {error}")
+        return
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", rows)

--- a/utils/compatibility/tests/test_kruise.py
+++ b/utils/compatibility/tests/test_kruise.py
@@ -1,0 +1,105 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scrapers import kruise
+
+
+MATRIX = """
+<table><tr><th>Unrelated</th></tr><tr><td>1.99</td></tr></table>
+<table><thead><tr><th>Kruise Version</th><th>1.24</th><th>1.26</th>
+<th>1.28</th><th>1.30</th><th>1.32</th></tr></thead><tbody>
+<tr><td>1.8.x</td><td>+</td><td>+</td><td>+</td><td>✓</td><td>?</td></tr>
+<tr><td>1.9.x</td><td>?</td><td>-</td><td>+</td><td>+</td><td>✓</td></tr>
+</tbody></table>
+"""
+
+
+def chart_index(entries):
+    return yaml.safe_dump({"entries": {"kruise": entries}})
+
+
+class KruiseTests(unittest.TestCase):
+    def test_only_explicit_matches_without_interpolating_minors(self):
+        self.assertEqual(kruise.parse_matrix(MATRIX), {(1, 8): ["1.30"], (1, 9): ["1.32"]})
+
+    def test_preserves_multiple_explicit_matches(self):
+        page = MATRIX.replace("<td>-</td>", "<td>✓</td>")
+        self.assertEqual(kruise.parse_matrix(page)[(1, 9)], ["1.26", "1.32"])
+
+    def test_rejects_changed_table_shape_and_symbols(self):
+        cases = ["<p>No table</p>", MATRIX + MATRIX,
+                 MATRIX.replace("<th>1.24</th>", "<th>1.26</th>"),
+                 MATRIX.replace("<th>1.24</th>", "<th>latest</th>"),
+                 MATRIX.replace("<td>?</td>", ""),
+                 MATRIX.replace("<td>?</td>", "<td>supported</td>"),
+                 MATRIX.replace("1.9.x", "1.8.x"),
+                 MATRIX.replace("1.9.x", "latest"),
+                 MATRIX.replace("✓", "?")]
+        for page in cases:
+            with self.subTest(page=page), self.assertRaises(ValueError):
+                kruise.parse_matrix(page)
+
+    def test_stable_chart_join_and_semantic_order(self):
+        entries = [
+            {"appVersion": "v1.9.0", "version": "1.9.2"},
+            {"appVersion": "1.8.10", "version": "1.8.10"},
+            {"appVersion": "1.8.2", "version": "1.8.2"},
+            {"appVersion": "v1.9.0", "version": "1.9.10"},
+            {"appVersion": "1.9.0-rc.1", "version": "1.9.11"},
+            {"appVersion": "1.9.0", "version": "1.9.12-rc.1"},
+            {"appVersion": "1.10.0", "version": "1.10.0"},
+            {"appVersion": 1.9, "version": "1.9.0"},
+            {"version": "1.9.0"},
+        ]
+        rows = kruise.build_rows(MATRIX, chart_index(entries))
+        self.assertEqual([row["version"] for row in rows], ["1.9.0", "1.8.10", "1.8.2"])
+        self.assertEqual(rows[0]["chart_version"], "1.9.10")
+        self.assertEqual(rows[0]["kube"], ["1.32"])
+        self.assertEqual(rows, kruise.build_rows(MATRIX, chart_index(list(reversed(entries)))))
+        self.assertEqual(set(rows[0]), {"version", "kube", "chart_version", "requirements", "incompatibilities"})
+
+    def test_missing_or_unusable_chart_data_fails(self):
+        for index in ["null", "{}", "entries: null", "entries: []", chart_index([]), chart_index([None]),
+                      chart_index([{"appVersion": "9.0.0", "version": "9.0.0"}])]:
+            with self.subTest(index=index), self.assertRaises(ValueError):
+                kruise.build_rows(MATRIX, index)
+
+    def test_checked_in_metadata_and_manifest(self):
+        directory = Path(__file__).resolve().parents[3] / "static" / "compatibilities"
+        data = yaml.safe_load((directory / "kruise.yaml").read_text())
+        manifest = yaml.safe_load((directory / "manifest.yaml").read_text())
+        self.assertEqual(manifest["names"].count("kruise"), 1)
+        for key in ["icon", "git_url", "release_url", "helm_repository_url"]:
+            self.assertTrue(data[key].startswith("https://"))
+        self.assertEqual(data["chart_name"], "kruise")
+        self.assertTrue(data["versions"])
+        self.assertEqual(len({row["version"] for row in data["versions"]}), len(data["versions"]))
+        for row in data["versions"]:
+            self.assertIsNotNone(kruise._stable_version(row["version"]))
+            self.assertIsNotNone(kruise._stable_version(row["chart_version"]))
+            self.assertTrue(row["kube"])
+            self.assertEqual(row["requirements"], [])
+            self.assertEqual(row["incompatibilities"], [])
+
+    def test_scrape_calls_existing_writer_only_after_valid_sources(self):
+        index = chart_index([{"appVersion": "v1.9.0", "version": "1.9.0"}])
+        for page, payload, writes in [(MATRIX, index, 1), (None, index, 0),
+                                      (MATRIX, None, 0), ("bad", index, 0), (MATRIX, "[", 0)]:
+            helpers = SimpleNamespace(fetch_page=Mock(side_effect=[page, payload]),
+                                      print_error=Mock(), update_compatibility_info=Mock())
+            with self.subTest(page=page, payload=payload), patch.dict(sys.modules, {"utils": helpers}):
+                kruise.scrape()
+                self.assertEqual(helpers.update_compatibility_info.call_count, writes)
+                if writes:
+                    self.assertEqual(helpers.update_compatibility_info.call_args.args[0],
+                                     "../../static/compatibilities/kruise.yaml")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_kruise_writer.py
+++ b/utils/compatibility/tests/test_kruise_writer.py
@@ -1,0 +1,51 @@
+"""Offline integration with the real compatibility writer; no Helm or AI calls."""
+
+import contextlib
+import copy
+import io
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import utils
+
+
+class KruiseWriterTests(unittest.TestCase):
+    def test_real_writer_preserves_metadata_and_is_idempotent(self):
+        source = Path(__file__).resolve().parents[3] / "static/compatibilities/kruise.yaml"
+        metadata = yaml.safe_load(source.read_text())
+        rows = copy.deepcopy(metadata["versions"])
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "kruise.yaml"
+            output.write_text(source.read_text())
+            with patch.object(utils, "get_chart_images", return_value=[]) as images, \
+                 patch.object(utils, "summarization_enabled", return_value=False), \
+                 patch.object(utils, "helm_summary", side_effect=AssertionError("AI call forbidden")), \
+                 patch.object(utils.traceback, "print_exc", side_effect=AssertionError("Writer failed")), \
+                 patch("subprocess.run", side_effect=AssertionError("Subprocess forbidden")), \
+                 patch("requests.sessions.Session.request", side_effect=AssertionError("Network forbidden")), \
+                 contextlib.redirect_stdout(io.StringIO()):
+                utils.update_compatibility_info(str(output), copy.deepcopy(rows))
+                first = yaml.safe_load(output.read_text())
+                utils.update_compatibility_info(str(output), copy.deepcopy(rows))
+                second = yaml.safe_load(output.read_text())
+            self.assertEqual(first, second)
+            self.assertGreater(images.call_count, 0)
+            for key in ("icon", "git_url", "release_url", "helm_repository_url", "chart_name"):
+                self.assertEqual(first[key], metadata[key])
+            self.assertEqual(first["versions"][0]["version"], rows[0]["version"])
+            original = {row["version"]: row for row in rows}
+            self.assertEqual({row["version"].rsplit(".", 1)[0] for row in first["versions"]},
+                             {row["version"].rsplit(".", 1)[0] for row in rows})
+            for row in first["versions"]:
+                self.assertEqual(row["kube"], original[row["version"]]["kube"])
+                self.assertEqual(row["chart_version"], original[row["version"]]["chart_version"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Draft for discussion; relates to #4169. Adds OpenKruise compatibility metadata, a scraper, manifest registration, and offline tests.

The scraper joins the [official installation matrix](https://openkruise.io/docs/installation) to stable application/chart releases in the [official Helm index](https://openkruise.github.io/charts/index.yaml). The initial data contains 23 stable application versions across 1.4.x–1.9.x.

**Representation needs maintainer agreement before merge:** only explicit checkmarks become `kube` entries. The source's `+` and `-` cells describe API overlap; they are not interpreted as unsupported, and undocumented Kubernetes minors are not interpolated. This is a conservative API-match subset, not a complete list of usable cluster configurations. Please advise whether this belongs in the compatibility schema or requires a different representation.

Malformed or ambiguous matrix input aborts before calling the writer. Stable application and chart versions are joined independently of index ordering; prereleases and undocumented application minors are omitted.

This contribution was generated and tested with OpenAI Codex. Contributor-program eligibility and scope remain unconfirmed in #4169; this draft makes no claim to an awarded bounty.

## Test Plan

Local Python 3.13 environment, rebased onto current upstream master:

- `python -m unittest discover -s utils/compatibility/tests -v`: **36 tests passed**, including eight new OpenKruise tests and the existing Istio/KubeRay tests.
- `git diff origin/master...HEAD --check`: passed.
- Local `jsonschema` 4.23.0 Draft 7 validation against `static/compatibilities/schema.json`: all 54 `static/compatibilities/*.yaml` files pass, including the new Kruise data and modified manifest. This checks schema structure, not agreement on compatibility semantics. Remote validation workflows currently report `action_required`; this is not a claim that GitHub CI passed.
- The pure parser was also checked against both live official sources and produced the 23 recorded rows.
- Offline writer integration exercises the real compatibility writer twice against a temporary file, checking metadata, retained version families, application/chart mappings and idempotence. Chart-image extraction is mocked, AI summaries disabled, and network/subprocess calls blocked. The existing writer's version reduction is preserved.

No Helm rendering, cluster deployment, paid AI calls, full Console application suite, or production writer run was performed. There is no deployed test environment for this Python-only change.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [ ] If required, I have updated the Plural documentation accordingly. (Schema interpretation is pending.)
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (not applicable: no agent-code changes).

Plural Flow: console
