### PR TITLE
Add ClickHouse Operator compatibility scraper

### DIFF
--- a/static/compatibilities/clickhouse-operator.yaml
+++ b/static/compatibilities/clickhouse-operator.yaml
@@ -1,0 +1,48 @@
+icon: https://avatars.githubusercontent.com/u/28471076?s=48&v=4
+git_url: https://github.com/Altinity/clickhouse-operator
+release_url: https://github.com/Altinity/clickhouse-operator/releases/tag/release-{vsn}
+helm_repository_url: https://altinity.github.io/helm-charts
+chart_name: altinity-clickhouse-operator
+versions:
+- version: 0.27.3
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.27.3
+- version: 0.27.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.27.0
+- version: 0.26.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.26.2
+- version: 0.26.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.26.0
+- version: 0.25.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.25.0
+- version: 0.24.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.24.1

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -9,6 +9,7 @@ names:
 - calico
 - cert-manager
 - cilium
+- clickhouse-operator
 - contour
 - coredns
 - cloudnative-pg

--- a/utils/compatibility/scrapers/clickhouse-operator.py
+++ b/utils/compatibility/scrapers/clickhouse-operator.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from typing import Optional
+
+from utils import (
+    expand_kube_versions,
+    fetch_page,
+    get_github_releases,
+    latest_kube_version,
+    print_error,
+    print_warning,
+    read_yaml,
+    update_chart_versions,
+    update_compatibility_info,
+    validate_semver,
+)
+
+app_name = "clickhouse-operator"
+
+REPO_OWNER = "Altinity"
+REPO_NAME = "clickhouse-operator"
+CHART_NAME = "altinity-clickhouse-operator"
+MAX_RELEASES = 20
+
+# Strict form: a line that states only the requirement, e.g.
+#   " * Kubernetes 1.25+"
+#   "- Kubernetes 1.19 or later"
+_STRICT_REQ_RE = re.compile(
+    r"(?im)^\s*(?:\*|-)?\s*Kubernetes\s+v?(1\.\d+)\s*(?:\+|or\s+(?:later|above|newer))?\s*$"
+)
+# Loose fallback: any "Kubernetes 1.25+" mention
+_LOOSE_REQ_RE = re.compile(r"(?i)kubernetes\s+v?(1\.\d+)\s*(?:\+|or\s+(?:later|above|newer))")
+
+
+def _release_versions() -> list[str]:
+    """Latest stable release versions, newest first (release-0.27.3 -> 0.27.3)."""
+    try:
+        tags = get_github_releases(REPO_OWNER, REPO_NAME)
+    except Exception as e:
+        print_error(f"Failed to fetch releases: {e}")
+        return []
+    seen = set()
+    versions = []
+    for tag in tags:
+        m = re.fullmatch(r"release-v?(\d+\.\d+\.\d+)", tag)
+        if not m or m.group(1) in seen:
+            continue
+        seen.add(m.group(1))
+        versions.append(m.group(1))
+    return versions[:MAX_RELEASES]
+
+
+def _kube_floor(version: str) -> Optional[str]:
+    """Read the minimum supported Kubernetes version from the release-tag README."""
+    url = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/release-{version}/README.md"
+    content = fetch_page(url)
+    if not content:
+        print_warning(f"No README found for release-{version}")
+        return None
+    text = content.decode("utf-8", errors="ignore")
+    m = _STRICT_REQ_RE.search(text) or _LOOSE_REQ_RE.search(text)
+    if not m:
+        print_warning(f"No Kubernetes requirement found in release-{version} README")
+        return None
+    v = validate_semver(m.group(1))
+    return f"{v.major}.{v.minor}" if v else None
+
+
+def scrape() -> None:
+    latest = latest_kube_version()
+    latest_minor = f"{latest.major}.{latest.minor}" if latest else None
+    if not latest_minor:
+        print_error("Could not determine the latest Kubernetes version")
+        return
+
+    rows: list[OrderedDict[str, object]] = []
+    for version in _release_versions():
+        floor = _kube_floor(version)
+        if not floor:
+            continue
+        floor_v = validate_semver(floor)
+        latest_v = validate_semver(latest_minor)
+        if floor_v and latest_v and floor_v > latest_v:
+            floor = latest_minor
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", version),
+                    ("kube", expand_kube_versions(floor, latest_minor)),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    if not rows:
+        print_error("No compatibility information found for ClickHouse Operator")
+        return
+
+    output_path = f"../../static/compatibilities/{app_name}.yaml"
+    update_compatibility_info(output_path, rows)
+
+    compatibility_yaml = read_yaml(output_path)
+    if compatibility_yaml and compatibility_yaml.get("helm_repository_url"):
+        update_chart_versions(app_name, CHART_NAME)


### PR DESCRIPTION
Adds compatibility data for the Altinity Kubernetes Operator for ClickHouse.

**Compatibility source**

Each ClickHouse Operator release documents the minimum supported Kubernetes
version in its release-tag README (e.g. release-0.27.3: `Kubernetes 1.25+`,
release-0.26.0: `Kubernetes 1.19+`). The scraper reads that requirement from
every stable release tag and expands it up to the latest stable Kubernetes
release, so each row reflects the documented support floor for that release:

- https://github.com/Altinity/clickhouse-operator/blob/release-0.27.3/README.md
- https://github.com/Altinity/clickhouse-operator/blob/release-0.26.0/README.md

**Chart versions** come from the official Altinity Helm index:
https://altinity.github.io/helm-charts (chart `altinity-clickhouse-operator`,
appVersion matches operator releases).

**Files**
- `static/compatibilities/clickhouse-operator.yaml` - new compatibility table
- `utils/compatibility/scrapers/clickhouse-operator.py` - scraper (follows the keda/dynatrace-operator scraper pattern; release-tag based, no release-date inference)
- `static/compatibilities/manifest.yaml` - register `clickhouse-operator`

## Test Plan
- Ran the scraper end-to-end: 6 version rows generated with correct floors (1.19+ pre-0.26.2, 1.25+ from 0.26.2 on) and chart versions filled from the Altinity index.
- Validated the generated YAML against `static/compatibilities/schema.json` (jsonschema draft-07): passes.
- Spot-checked floors against the release-tag READMEs.

## Checklist
- [x] If required, I have updated the Plural documentation

---
Note: this contribution was produced with AI coding-agent assistance.
Discord: zhangb06
