### PR TITLE
feat: add Consul compatibility scraper

### DIFF
--- a/static/compatibilities/consul.yaml
+++ b/static/compatibilities/consul.yaml
@@ -1,0 +1,35 @@
+icon: https://raw.githubusercontent.com/hashicorp/consul-k8s/main/assets/icon.png
+git_url: https://github.com/hashicorp/consul
+release_url: https://github.com/hashicorp/consul/releases/tag/v{vsn}
+readme_url: https://developer.hashicorp.com/consul/docs/upgrade/k8s/compatibility
+helm_repository_url: https://helm.releases.hashicorp.com
+chart_name: consul
+versions:
+- version: 2.0.3
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.0.3
+  images: []
+- version: 1.22.7
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.9.11
+  images: []
+- version: 1.21.5
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.8.16
+  images: []
+- version: 1.17.3
+  kube: ['1.28', '1.27', '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.9
+  images: []

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -13,6 +13,7 @@ names:
 - coredns
 - cloudnative-pg
 - cluster-autoscaler
+- consul
 - descheduler
 - external-dns
 - external-secrets

--- a/utils/compatibility/scrapers/consul.py
+++ b/utils/compatibility/scrapers/consul.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import yaml
+from bs4 import BeautifulSoup
+from packaging.version import Version
+
+from utils import (
+    expand_kube_versions,
+    fetch_page,
+    print_error,
+    update_compatibility_info,
+    validate_semver,
+)
+
+APP_NAME = "consul"
+COMPATIBILITY_URL = (
+    "https://developer.hashicorp.com/consul/docs/upgrade/k8s/compatibility"
+)
+HELM_INDEX_URL = "https://helm.releases.hashicorp.com/index.yaml"
+TARGET_FILE = f"../../static/compatibilities/{APP_NAME}.yaml"
+FAMILY_RE = re.compile(r"(\d+)\.(\d+)\.x")
+KUBE_RANGE_RE = re.compile(
+    r"(\d+)\.(\d+)(?:\.x)?\s*(?:→|->|-|–|—)\s*(\d+)\.(\d+)(?:\.x)?"
+)
+
+
+def _cell_lines(cell) -> list[str]:
+    text = cell.get_text("\n", strip=True)
+    return [line.strip() for line in text.split("\n") if line.strip()]
+
+
+def _families(value: str) -> list[str]:
+    return [f"{major}.{minor}" for major, minor in FAMILY_RE.findall(value)]
+
+
+def parse_kube_versions(value: str) -> list[str]:
+    if not value:
+        return []
+    match = KUBE_RANGE_RE.search(value)
+    if not match:
+        return []
+    start = f"{match.group(1)}.{match.group(2)}"
+    end = f"{match.group(3)}.{match.group(4)}"
+    return expand_kube_versions(start, end)
+
+
+def find_standard_releases_table(soup: BeautifulSoup):
+    heading = soup.find(
+        lambda tag: tag.name in ("h2", "h3", "h4")
+        and tag.get_text(" ", strip=True) == "Standard releases"
+    )
+    if heading:
+        table = heading.find_next("table")
+        if table:
+            return table
+
+    for table in soup.find_all("table"):
+        headers = [th.get_text(" ", strip=True) for th in table.find_all("th")]
+        joined = " ".join(headers)
+        if "Compatible Kubernetes versions" not in joined or "consul-k8s" not in joined:
+            continue
+        body_rows = table.find_all("tr")[1:]
+        if not body_rows:
+            continue
+        first_cell = body_rows[0].find("td")
+        if first_cell and "ent" in first_cell.get_text(" ", strip=True).lower():
+            continue
+        return table
+    return None
+
+
+def parse_standard_matrix_pairings(html: str) -> list[dict[str, object]]:
+    soup = BeautifulSoup(html, "html.parser")
+    table = find_standard_releases_table(soup)
+    if table is None:
+        return []
+
+    pairings: list[dict[str, object]] = []
+    for row in table.find_all("tr")[1:]:
+        cells = row.find_all("td")
+        if len(cells) < 3:
+            continue
+
+        consul_text = cells[0].get_text(" ", strip=True)
+        if "ent" in consul_text.lower():
+            continue
+
+        consul_families = _families(consul_text)
+        if not consul_families:
+            continue
+        consul_family = consul_families[0]
+
+        chart_families = _families(" ".join(_cell_lines(cells[1])))
+        kube_lists = [
+            kube
+            for line in _cell_lines(cells[2])
+            for kube in [parse_kube_versions(line)]
+            if kube
+        ]
+        if not kube_lists:
+            kube_lists = [
+                parse_kube_versions(match.group(0))
+                for match in KUBE_RANGE_RE.finditer(cells[2].get_text(" ", strip=True))
+            ]
+            kube_lists = [kube for kube in kube_lists if kube]
+        if not chart_families or not kube_lists:
+            continue
+
+        for chart_family, kube in zip(chart_families, kube_lists):
+            pairings.append(
+                {
+                    "consul_family": consul_family,
+                    "chart_family": chart_family,
+                    "kube": kube,
+                }
+            )
+    return pairings
+
+
+def select_catalog_pairings(pairings: list[dict[str, object]]) -> list[dict[str, object]]:
+    # merge_versions keys catalog rows on Consul appVersion. Two consul-k8s
+    # families for the same Consul series (1.21.x → 1.8.x and 1.7.x) collapse,
+    # so keep the newest documented chart family per Consul series.
+    selected: dict[str, dict[str, object]] = {}
+    for pairing in pairings:
+        consul_family = str(pairing["consul_family"])
+        current = selected.get(consul_family)
+        if current is None or Version(str(pairing["chart_family"])) > Version(
+            str(current["chart_family"])
+        ):
+            selected[consul_family] = pairing
+    return list(selected.values())
+
+
+def parse_standard_matrix(html: str) -> list[dict[str, object]]:
+    return select_catalog_pairings(parse_standard_matrix_pairings(html))
+
+
+def latest_stable_charts(entries: list[dict]) -> dict[tuple[str, str], dict[str, str]]:
+    latest: dict[tuple[str, str], dict[str, object]] = {}
+    for entry in entries:
+        raw_chart = str(entry.get("version") or "").lstrip("v")
+        raw_app = str(entry.get("appVersion") or "").lstrip("v")
+        if not raw_chart or not raw_app or "-" in raw_chart or "-" in raw_app:
+            continue
+
+        chart_semver = validate_semver(raw_chart)
+        app_semver = validate_semver(raw_app)
+        if not chart_semver or not app_semver:
+            continue
+
+        key = (
+            f"{chart_semver.major}.{chart_semver.minor}",
+            f"{app_semver.major}.{app_semver.minor}",
+        )
+        current = latest.get(key)
+        if current is None or chart_semver > current["_chart"]:
+            latest[key] = {
+                "version": str(app_semver),
+                "chart_version": str(chart_semver),
+                "_chart": chart_semver,
+            }
+
+    return {
+        key: {"version": item["version"], "chart_version": item["chart_version"]}
+        for key, item in latest.items()
+    }
+
+
+def build_versions(
+    matrix_rows: list[dict[str, object]],
+    charts: dict[tuple[str, str], dict[str, str]],
+) -> list[OrderedDict]:
+    versions: list[OrderedDict] = []
+    for row in matrix_rows:
+        chart = charts.get((str(row["chart_family"]), str(row["consul_family"])))
+        kube = row.get("kube") or []
+        if not chart or not kube:
+            continue
+        versions.append(
+            OrderedDict(
+                [
+                    ("version", chart["version"]),
+                    ("kube", list(kube)),
+                    ("chart_version", chart["chart_version"]),
+                    ("images", []),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+    return versions
+
+
+def scrape() -> None:
+    page = fetch_page(COMPATIBILITY_URL)
+    if not page:
+        print_error("Failed to fetch Consul Kubernetes compatibility docs.")
+        return
+
+    html = (
+        page.decode("utf-8", errors="replace")
+        if isinstance(page, (bytes, bytearray))
+        else str(page)
+    )
+    matrix_rows = parse_standard_matrix(html)
+    if not matrix_rows:
+        print_error("Consul standard-release compatibility table not found.")
+        return
+
+    index_content = fetch_page(HELM_INDEX_URL)
+    if not index_content:
+        print_error("Failed to fetch HashiCorp Helm index.")
+        return
+
+    try:
+        index = yaml.safe_load(index_content)
+    except yaml.YAMLError as exc:
+        print_error(f"Failed to parse HashiCorp Helm index: {exc}")
+        return
+
+    entries = (index or {}).get("entries", {}).get(APP_NAME, [])
+    if not entries:
+        print_error("No consul chart entries found in HashiCorp Helm index.")
+        return
+
+    versions = build_versions(matrix_rows, latest_stable_charts(entries))
+    if not versions:
+        print_error("No Consul compatibility rows could be joined to Helm charts.")
+        return
+
+    update_compatibility_info(TARGET_FILE, versions)

--- a/utils/compatibility/tests/test_consul.py
+++ b/utils/compatibility/tests/test_consul.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scrapers.consul import (  # noqa: E402
+    build_versions,
+    latest_stable_charts,
+    parse_kube_versions,
+    parse_standard_matrix,
+    parse_standard_matrix_pairings,
+)
+
+STANDARD_TABLE = """
+<html><body>
+<h4>Standard releases</h4>
+<table>
+  <thead>
+    <tr>
+      <th>Consul version</th>
+      <th>Compatible consul-k8s versions</th>
+      <th>Compatible Kubernetes versions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>2.0.x</td>
+      <td>2.0.x</td>
+      <td>1.30.x - 1.35.x</td>
+    </tr>
+    <tr>
+      <td>1.22.x</td>
+      <td>1.9.x</td>
+      <td>1.30.x - 1.35.x</td>
+    </tr>
+    <tr>
+      <td>1.21.x</td>
+      <td>1.8.x<br/>1.7.x</td>
+      <td>1.30.x - 1.35.x<br/>1.30.x - 1.33.x</td>
+    </tr>
+    <tr>
+      <td>1.17.x</td>
+      <td>1.3.x</td>
+      <td>1.25.x - 1.28.x</td>
+    </tr>
+    <tr>
+      <td>1.21.x Ent</td>
+      <td>1.8.x</td>
+      <td>1.30.x - 1.35.x</td>
+    </tr>
+  </tbody>
+</table>
+<h4>Enterprise Long Term Support releases</h4>
+<table>
+  <tr>
+    <th>Consul version</th>
+    <th>Compatible consul-k8s versions</th>
+    <th>Compatible Kubernetes versions</th>
+  </tr>
+  <tr>
+    <td>1.18.x Ent</td>
+    <td>1.7.x</td>
+    <td>1.30.x - 1.33.x</td>
+  </tr>
+</table>
+</body></html>
+"""
+
+HELM_ENTRIES = [
+    {"version": "2.0.2-oss", "appVersion": "2.0.2"},
+    {"version": "2.0.3", "appVersion": "2.0.3"},
+    {"version": "2.0.0-rc1", "appVersion": "2.0.0-rc1"},
+    {"version": "1.9.11", "appVersion": "1.22.7"},
+    {"version": "1.9.10", "appVersion": "1.22.7"},
+    {"version": "1.8.16", "appVersion": "1.21.5"},
+    {"version": "1.8.15", "appVersion": "1.21.5"},
+    {"version": "1.7.13", "appVersion": "1.21.5"},
+    {"version": "1.3.9", "appVersion": "1.17.3"},
+]
+
+
+class ConsulScraperTests(unittest.TestCase):
+    def test_parses_standard_table_and_skips_enterprise(self):
+        pairings = parse_standard_matrix_pairings(STANDARD_TABLE)
+        self.assertEqual(
+            [(row["consul_family"], row["chart_family"], row["kube"][-1]) for row in pairings],
+            [
+                ("2.0", "2.0", "1.35"),
+                ("1.22", "1.9", "1.35"),
+                ("1.21", "1.8", "1.35"),
+                ("1.21", "1.7", "1.33"),
+                ("1.17", "1.3", "1.28"),
+            ],
+        )
+
+    def test_keeps_newest_chart_family_for_consul_1_21(self):
+        rows = parse_standard_matrix(STANDARD_TABLE)
+        self.assertEqual(
+            [(row["consul_family"], row["chart_family"], row["kube"][-1]) for row in rows],
+            [
+                ("2.0", "2.0", "1.35"),
+                ("1.22", "1.9", "1.35"),
+                ("1.21", "1.8", "1.35"),
+                ("1.17", "1.3", "1.28"),
+            ],
+        )
+
+    def test_parses_kube_ranges_with_or_without_x_suffix(self):
+        self.assertEqual(parse_kube_versions("1.30.x - 1.35.x")[0], "1.30")
+        self.assertEqual(parse_kube_versions("1.30.x - 1.35.x")[-1], "1.35")
+        self.assertEqual(parse_kube_versions("1.30 – 1.33")[-1], "1.33")
+
+    def test_ignores_prerelease_and_oss_chart_tags(self):
+        charts = latest_stable_charts(HELM_ENTRIES)
+        self.assertEqual(charts[("2.0", "2.0")]["chart_version"], "2.0.3")
+        self.assertEqual(charts[("2.0", "2.0")]["version"], "2.0.3")
+        self.assertEqual(charts[("1.9", "1.22")]["chart_version"], "1.9.11")
+        self.assertEqual(charts[("1.9", "1.22")]["version"], "1.22.7")
+        self.assertNotIn(("1.8", "1.22"), charts)
+
+    def test_joins_matching_consul_and_chart_families(self):
+        rows = parse_standard_matrix(STANDARD_TABLE)
+        versions = build_versions(rows, latest_stable_charts(HELM_ENTRIES))
+        self.assertEqual(
+            [(item["version"], item["chart_version"], item["kube"][-1]) for item in versions],
+            [
+                ("2.0.3", "2.0.3", "1.35"),
+                ("1.22.7", "1.9.11", "1.35"),
+                ("1.21.5", "1.8.16", "1.35"),
+                ("1.17.3", "1.3.9", "1.28"),
+            ],
+        )
+
+    def test_rejects_chart_family_with_mismatched_consul_appversion(self):
+        rows = parse_standard_matrix(STANDARD_TABLE)
+        versions = build_versions(
+            rows,
+            {
+                ("2.0", "2.0"): {"version": "2.0.3", "chart_version": "2.0.3"},
+                ("1.9", "1.21"): {"version": "1.21.5", "chart_version": "1.9.11"},
+                ("1.8", "1.21"): {"version": "1.21.5", "chart_version": "1.8.16"},
+            },
+        )
+        self.assertEqual(
+            [(item["version"], item["chart_version"]) for item in versions],
+            [("2.0.3", "2.0.3"), ("1.21.5", "1.8.16")],
+        )
+        self.assertTrue(
+            all(item["chart_version"] != "1.9.11" for item in versions)
+        )
+
+    def test_malformed_html_returns_no_rows(self):
+        self.assertEqual(parse_standard_matrix("<html><body>no table</body></html>"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add Consul Kubernetes compatibility data and metadata
- add a Consul compatibility scraper based on HashiCorp's compatibility matrix and Helm index
- add offline tests for matrix parsing, chart matching, and generated rows

## Validation

- `python utils\compatibility\tests\test_consul.py` (7 tests)
- `git diff --cached --check`