### PR TITLE
feat: add Node Feature Discovery compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -27,6 +27,7 @@ names:
 - linkerd
 - longhorn
 - metrics-server
+- node-feature-discovery
 - opentelemetry-operator
 - rook
 - strimzi-kafka

--- a/static/compatibilities/node-feature-discovery.yaml
+++ b/static/compatibilities/node-feature-discovery.yaml
@@ -1,0 +1,61 @@
+icon: https://kubernetes-sigs.github.io/node-feature-discovery/v0.19/assets/images/nfd/favicon.svg
+git_url: https://github.com/kubernetes-sigs/node-feature-discovery
+release_url: https://github.com/kubernetes-sigs/node-feature-discovery/releases/tag/v{vsn}
+helm_repository_url: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+versions:
+- version: 0.19.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.19.0
+  images: ['registry.k8s.io/nfd/node-feature-discovery:v0.19.0']
+- version: 0.18.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.18.0
+  images: ['registry.k8s.io/nfd/node-feature-discovery:v0.18.0']
+- version: 0.17.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.0
+  images: ['registry.k8s.io/nfd/node-feature-discovery:v0.17.0']
+- version: 0.16.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.2
+  images: ['registry.k8s.io/nfd/node-feature-discovery:v0.16.2']
+- version: 0.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.0
+  images: ['registry.k8s.io/nfd/node-feature-discovery:v0.16.0']
+- version: 0.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.0
+  images: ['registry.k8s.io/nfd/node-feature-discovery:v0.15.0']
+- version: 0.14.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.0
+  images: ['registry.k8s.io/nfd/node-feature-discovery:v0.14.0']

--- a/utils/compatibility/scrapers/node-feature-discovery.py
+++ b/utils/compatibility/scrapers/node-feature-discovery.py
@@ -1,0 +1,55 @@
+import re
+
+from utils import (
+    current_kube_version,
+    fetch_page,
+    get_chart_versions,
+    print_warning,
+    update_compatibility_info,
+    validate_semver,
+)
+
+app_name = "node-feature-discovery"
+deployment_url = (
+    "https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/"
+    "v{version}/docs/deployment/index.md"
+)
+
+
+def documented_versions(page, current):
+    """Expand the tagged deployment minimum, bounded by Plural's KUBE_VERSION."""
+    text = page.decode("utf-8") if isinstance(page, bytes) else page
+    match = re.search(
+        r"Node Feature Discovery can be deployed on any recent version of "
+        r"Kubernetes\s+\(v(\d+\.\d+)\+\)", text
+    )
+    if not match:
+        return []
+    minimum = match.group(1)
+    if not re.fullmatch(r"1\.\d+", current) or not minimum.startswith("1."):
+        raise ValueError("Unsupported Kubernetes major version")
+    start, end = int(minimum.split(".")[1]), int(current.split(".")[1])
+    if start > end:
+        raise ValueError(f"NFD minimum {minimum} is newer than Plural {current}")
+    return [f"1.{minor}" for minor in range(end, start - 1, -1)]
+
+
+def scrape():
+    current = current_kube_version()
+    if not current:
+        raise ValueError("Plural current Kubernetes version is unavailable")
+    versions = []
+    for version, chart in get_chart_versions(app_name).items():
+        if not validate_semver(version) or not validate_semver(chart):
+            continue
+        page = fetch_page(deployment_url.format(version=version))
+        kube = documented_versions(page, current) if page else []
+        if not kube:
+            print_warning(f"Skipping NFD {version}: no tagged Kubernetes minimum")
+            continue
+        versions.append({"version": version, "kube": kube, "chart_version": chart})
+    if not versions:
+        raise ValueError("No documented Node Feature Discovery releases found")
+    update_compatibility_info(
+        f"../../static/compatibilities/{app_name}.yaml", versions
+    )

--- a/utils/compatibility/tests/test_node_feature_discovery.py
+++ b/utils/compatibility/tests/test_node_feature_discovery.py
@@ -1,0 +1,70 @@
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+spec = importlib.util.spec_from_file_location(
+    "node_feature_discovery",
+    Path(__file__).parents[1] / "scrapers" / "node-feature-discovery.py",
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+def documentation(minimum):
+    return (
+        "Node Feature Discovery can be deployed on any recent version of Kubernetes\n"
+        f"(v{minimum}+)."
+    ).encode()
+
+
+class NodeFeatureDiscoveryTests(unittest.TestCase):
+    def test_documented_range_and_boundaries(self):
+        self.assertEqual(scraper.documented_versions(documentation("1.24"), "1.26"),
+                         ["1.26", "1.25", "1.24"])
+        self.assertEqual(scraper.documented_versions(documentation("1.24"), "1.24"),
+                         ["1.24"])
+        for minimum, current in [("1.27", "1.26"), ("2.0", "2.1"), ("1.24", "invalid")]:
+            with self.subTest(minimum=minimum, current=current), self.assertRaises(ValueError):
+                scraper.documented_versions(documentation(minimum), current)
+
+    def test_undocumented_or_unrelated_version_is_not_evidence(self):
+        self.assertEqual(scraper.documented_versions("Use Kubernetes v1.24+", "1.26"), [])
+        with self.assertRaises(UnicodeDecodeError):
+            scraper.documented_versions(b"\xff", "1.26")
+
+    def test_tagged_patch_minimum_and_chart_pairing(self):
+        charts = {"0.16.1": "0.16.1", "0.16.2": "0.16.2", "0.13.6": "0.13.6",
+                  "0.11.3": "0.11.3", "0.20.0-rc.1": "0.20.0-rc.1",
+                  "0.20.0": "0.20.0-rc.2"}
+        docs = {scraper.deployment_url.format(version="0.16.1"): documentation("1.21"),
+                scraper.deployment_url.format(version="0.16.2"): documentation("1.24"),
+                scraper.deployment_url.format(version="0.13.6"): b"# Deployment"}
+        with patch.object(scraper, "get_chart_versions", return_value=charts), \
+             patch.object(scraper, "current_kube_version", return_value="1.26"), \
+             patch.object(scraper, "fetch_page", side_effect=docs.get) as fetch, \
+             patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+        path, rows = update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/node-feature-discovery.yaml")
+        self.assertEqual([r["version"] for r in rows], ["0.16.1", "0.16.2"])
+        self.assertEqual([r["chart_version"] for r in rows], ["0.16.1", "0.16.2"])
+        self.assertEqual([r["kube"][-1] for r in rows], ["1.21", "1.24"])
+        self.assertEqual(fetch.call_count, 4)
+
+    def test_source_failure_preserves_existing_file(self):
+        for charts in [{}, {"0.19.0": "0.19.0"}]:
+            with self.subTest(charts=charts), \
+                 patch.object(scraper, "get_chart_versions", return_value=charts), \
+                 patch.object(scraper, "current_kube_version", return_value="1.26"), \
+                 patch.object(scraper, "fetch_page", return_value=None), \
+                 patch.object(scraper, "update_compatibility_info") as update:
+                with self.assertRaisesRegex(ValueError, "No documented"):
+                    scraper.scrape()
+                update.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Node Feature Discovery is missing from the compatibility catalog. This adds its scraper, metadata and manifest entry, with seven generated rows through v0.19.0 using the existing reduction and chart-image pipeline.

The scraper reads the official Helm index through `get_chart_versions` and checks each stable application release's tagged deployment page. It preserves the minimum-version change within the 0.16 series: v0.16.1 declares Kubernetes 1.21+, while v0.16.2 declares 1.24+. Earlier releases whose deployment page is absent or omits a minimum are skipped with a warning; no compatibility is inferred from release dates or dependencies. Complete source failure prevents an update.

Sources:
- [Official Helm index](https://kubernetes-sigs.github.io/node-feature-discovery/charts/index.yaml) and [Helm installation guide documenting the legacy HTTP repository](https://github.com/kubernetes-sigs/node-feature-discovery/blob/v0.19.0/docs/deployment/helm.md).
- Tagged deployment requirements for [v0.14.0](https://github.com/kubernetes-sigs/node-feature-discovery/blob/v0.14.0/docs/deployment/index.md), [v0.16.1](https://github.com/kubernetes-sigs/node-feature-discovery/blob/v0.16.1/docs/deployment/index.md), [v0.16.2](https://github.com/kubernetes-sigs/node-feature-discovery/blob/v0.16.2/docs/deployment/index.md), and [v0.19.0](https://github.com/kubernetes-sigs/node-feature-discovery/blob/v0.19.0/docs/deployment/index.md).

Validation:
- All 32 compatibility tests pass, including four new regression tests covering tagged patch differences, stable release filtering, exact chart pairing, boundaries and source-failure preservation.
- Live schema validation; all seven retained rows checked against their own tagged documentation and exact chart/application pairing. All seven chart archive SHA256 digests match the official index.
- Helm 3.19.0 renders all seven retained charts and populates their image references. A second live generation is byte-identical. Icon URL returns HTTP 200; `git diff --check` passes.

The Kubernetes ranges represent upstream's declared minimum through this repository's `KUBE_VERSION` ceiling (currently 1.36). No Kubernetes cluster tests were performed. Paid summarization was disabled during generation.

Submitted under the README contributor program. My Discord handle is `bengdk.`; the earlier eligibility/payout-process inquiry is in the contributor-program channel. Reward remains subject to maintainer acceptance.

I have read the September 8 README update limiting awards to one per contributor per calendar month. I understand my Plural submissions cannot be counted as separate awards within that month.
