### PR TITLE
feat: add Dapr release-tagged compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31011,3 +31011,50 @@ addons:
     chart_version: 0.4.0
     images: ['kuberay/operator:v0.4.0']
   name: kuberay-operator
+- icon: https://avatars.githubusercontent.com/u/51932459?s=48&v=4
+  git_url: https://github.com/dapr/dapr
+  release_url: https://github.com/dapr/dapr/releases/tag/v{vsn}
+  helm_repository_url: https://dapr.github.io/helm-charts
+  readme_url: https://docs.dapr.io/operations/support/support-release-policy/
+  versions:
+  - version: 1.18.3
+    kube: ['1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.18.3
+    images: ['ghcr.io/dapr/injector:1.18.3', 'ghcr.io/dapr/operator:1.18.3', 'ghcr.io/dapr/placement:1.18.3',
+      'ghcr.io/dapr/scheduler:1.18.3', 'ghcr.io/dapr/sentry:1.18.3']
+  - version: 1.18.0
+    kube: ['1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.18.0
+    images: ['ghcr.io/dapr/injector:1.18.0', 'ghcr.io/dapr/operator:1.18.0', 'ghcr.io/dapr/placement:1.18.0',
+      'ghcr.io/dapr/scheduler:1.18.0', 'ghcr.io/dapr/sentry:1.18.0']
+  - version: 1.17.0
+    kube: ['1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.17.0
+    images: ['ghcr.io/dapr/injector:1.17.0', 'ghcr.io/dapr/operator:1.17.0', 'ghcr.io/dapr/placement:1.17.0',
+      'ghcr.io/dapr/scheduler:1.17.0', 'ghcr.io/dapr/sentry:1.17.0']
+  - version: 1.16.4
+    kube: ['1.34', '1.33', '1.32']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.16.4
+    images: ['ghcr.io/dapr/injector:1.16.4', 'ghcr.io/dapr/operator:1.16.4', 'ghcr.io/dapr/placement:1.16.4',
+      'ghcr.io/dapr/scheduler:1.16.4', 'ghcr.io/dapr/sentry:1.16.4']
+  - version: 1.16.0
+    kube: ['1.31', '1.30', '1.29']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.16.0
+    images: ['ghcr.io/dapr/injector:1.16.0', 'ghcr.io/dapr/operator:1.16.0', 'ghcr.io/dapr/placement:1.16.0',
+      'ghcr.io/dapr/scheduler:1.16.0', 'ghcr.io/dapr/sentry:1.16.0']
+  name: dapr

--- a/static/compatibilities/dapr.yaml
+++ b/static/compatibilities/dapr.yaml
@@ -1,0 +1,46 @@
+icon: https://avatars.githubusercontent.com/u/51932459?s=48&v=4
+git_url: https://github.com/dapr/dapr
+release_url: https://github.com/dapr/dapr/releases/tag/v{vsn}
+helm_repository_url: https://dapr.github.io/helm-charts
+readme_url: https://docs.dapr.io/operations/support/support-release-policy/
+versions:
+- version: 1.18.3
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.18.3
+  images: ['ghcr.io/dapr/injector:1.18.3', 'ghcr.io/dapr/operator:1.18.3', 'ghcr.io/dapr/placement:1.18.3',
+    'ghcr.io/dapr/scheduler:1.18.3', 'ghcr.io/dapr/sentry:1.18.3']
+- version: 1.18.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.18.0
+  images: ['ghcr.io/dapr/injector:1.18.0', 'ghcr.io/dapr/operator:1.18.0', 'ghcr.io/dapr/placement:1.18.0',
+    'ghcr.io/dapr/scheduler:1.18.0', 'ghcr.io/dapr/sentry:1.18.0']
+- version: 1.17.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.17.0
+  images: ['ghcr.io/dapr/injector:1.17.0', 'ghcr.io/dapr/operator:1.17.0', 'ghcr.io/dapr/placement:1.17.0',
+    'ghcr.io/dapr/scheduler:1.17.0', 'ghcr.io/dapr/sentry:1.17.0']
+- version: 1.16.4
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.16.4
+  images: ['ghcr.io/dapr/injector:1.16.4', 'ghcr.io/dapr/operator:1.16.4', 'ghcr.io/dapr/placement:1.16.4',
+    'ghcr.io/dapr/scheduler:1.16.4', 'ghcr.io/dapr/sentry:1.16.4']
+- version: 1.16.0
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.16.0
+  images: ['ghcr.io/dapr/injector:1.16.0', 'ghcr.io/dapr/operator:1.16.0', 'ghcr.io/dapr/placement:1.16.0',
+    'ghcr.io/dapr/scheduler:1.16.0', 'ghcr.io/dapr/sentry:1.16.0']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -50,3 +50,4 @@ names:
 - wiz-admission-controller
 - wiz-network-analyzer
 - kuberay-operator
+- dapr

--- a/utils/compatibility/scrapers/dapr.py
+++ b/utils/compatibility/scrapers/dapr.py
@@ -1,0 +1,158 @@
+"""Record release-tagged Linux KinD E2E targets, not a full support window."""
+
+from collections import OrderedDict
+from copy import deepcopy
+import re
+
+import requests
+import yaml
+
+from utils import print_error, read_yaml, reduce_versions, update_compatibility_info
+
+APP_NAME = "dapr"
+INDEX_URL = "https://dapr.github.io/helm-charts/index.yaml"
+WORKFLOW_URL = "https://raw.githubusercontent.com/dapr/dapr/v{version}/.github/workflows/kind-e2e.yaml"
+TARGET_FILE = "../../static/compatibilities/dapr.yaml"
+# Dapr documents support for its current and two preceding minor releases.
+SUPPORTED_MINOR_COUNT = 3
+
+
+class UniqueLoader(yaml.SafeLoader):
+    """Reject ambiguous source mappings instead of silently keeping the last key."""
+
+
+def _unique_mapping(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if not isinstance(key, (str, int, float, bool)) or key in mapping:
+            raise ValueError(f"Invalid or duplicate YAML key: {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _unique_mapping)
+
+
+def _version(value):
+    if not isinstance(value, str) or not re.fullmatch(r"v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)", value):
+        return None
+    return tuple(map(int, value.lstrip("v").split(".")))
+
+
+def parse_charts(content):
+    data = yaml.load(content, Loader=UniqueLoader)
+    entries = data.get("entries") if isinstance(data, dict) else None
+    entries = entries.get(APP_NAME) if isinstance(entries, dict) else None
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Dapr Helm index has no chart entries")
+    charts, app_by_chart = {}, {}
+    for entry in entries:
+        if not isinstance(entry, dict) or entry.get("name") != APP_NAME:
+            raise ValueError("Invalid Dapr Helm chart entry")
+        app, chart = _version(entry.get("appVersion")), _version(entry.get("version"))
+        if app is None or chart is None or entry.get("deprecated"):
+            continue
+        if chart in app_by_chart and app_by_chart[chart] != app:
+            raise ValueError("Dapr chart version maps to conflicting application versions")
+        app_by_chart[chart] = app
+        if app not in charts or chart > charts[app]:
+            charts[app] = chart
+    if not charts:
+        raise ValueError("Dapr Helm index has no stable application/chart pairs")
+    minors = sorted({app[:2] for app in charts})[-SUPPORTED_MINOR_COUNT:]
+    return {".".join(map(str, app)): ".".join(map(str, chart))
+            for app, chart in charts.items() if app[:2] in minors}
+
+
+def parse_kubernetes_targets(content):
+    data = yaml.load(content, Loader=UniqueLoader)
+    jobs = data.get("jobs") if isinstance(data, dict) else None
+    job = jobs.get("e2e") if isinstance(jobs, dict) else None
+    strategy = job.get("strategy") if isinstance(job, dict) else None
+    matrix = strategy.get("matrix") if isinstance(strategy, dict) else None
+    if not isinstance(matrix, dict) or "if" in job or not str(job.get("runs-on", "")).startswith("ubuntu-"):
+        raise ValueError("Dapr workflow has no unconditional finite e2e matrix")
+    if set(matrix) - {"k8s-version", "mode", "include", "exclude"} or matrix.get("exclude"):
+        raise ValueError("Unsupported Dapr matrix axes or exclusions")
+    versions, modes, includes = matrix.get("k8s-version"), matrix.get("mode"), matrix.get("include")
+    if not isinstance(versions, list) or not versions or any(_version(v) is None for v in versions):
+        raise ValueError("Dapr Kubernetes targets must be explicit stable patch versions")
+    if len(set(versions)) != len(versions):
+        raise ValueError("Duplicate Dapr Kubernetes targets")
+    if not isinstance(modes, list) or not modes or any(not isinstance(m, str) or not m for m in modes):
+        raise ValueError("Dapr matrix must declare finite deployment modes")
+    if not isinstance(includes, list) or not includes:
+        raise ValueError("Dapr matrix must pin each KinD node image")
+    pins = {}
+    for entry in includes:
+        if not isinstance(entry, dict) or entry.get("k8s-version") not in versions or "mode" in entry:
+            raise ValueError("Unsupported Dapr matrix include combination")
+        version = entry["k8s-version"]
+        if _version(entry.get("kind-version")) is None or not re.fullmatch(r"sha256:[a-f0-9]{64}", str(entry.get("kind-image-sha", ""))):
+            raise ValueError("Dapr KinD version or node image digest is invalid")
+        if version in pins and pins[version] != entry:
+            raise ValueError("Conflicting Dapr matrix include entries")
+        pins[version] = entry
+    if set(pins) != set(versions):
+        raise ValueError("Dapr matrix has an unpinned Kubernetes target")
+    steps = job.get("steps")
+    if not isinstance(steps, list) or any(not isinstance(step, dict) for step in steps):
+        raise ValueError("Invalid Dapr E2E workflow steps")
+    scripts = [step.get("run", "") for step in steps if isinstance(step.get("run", ""), str) and "if" not in step]
+    lines = [line.strip() for script in scripts for line in script.splitlines()]
+    if "image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}" not in lines:
+        raise ValueError("Dapr workflow does not use the pinned Kubernetes matrix")
+    checkouts = [step for step in steps if str(step.get("uses", "")).startswith("actions/checkout@")]
+    checkout_options = (checkouts[0].get("with") or {}) if len(checkouts) == 1 else None
+    if not isinstance(checkout_options, dict) or checkout_options.get("ref"):
+        raise ValueError("Dapr workflow must check out its own runtime revision")
+    for target in ("build-linux", "docker-build", "docker-deploy-k8s", "test-e2e-all"):
+        if not any(re.fullmatch(r"make\s+" + target + r"\s*(?:#.*)?", line) for line in lines):
+            raise ValueError(f"Dapr workflow does not run make {target}")
+    return sorted({".".join(map(str, _version(v)[:2])) for v in versions},
+                  key=lambda value: tuple(map(int, value.split("."))), reverse=True)
+
+
+def _fetch(url):
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
+def build_updates(charts, existing, fetch_workflow):
+    recorded = {row["version"]: row for row in existing}
+    updates = []
+    for version, chart in sorted(charts.items(), key=lambda pair: _version(pair[0]), reverse=True):
+        previous = recorded.get(version)
+        if previous and previous.get("chart_version"):
+            continue
+        if previous:
+            row = deepcopy(previous)
+            row["chart_version"] = chart
+        else:
+            kube = parse_kubernetes_targets(fetch_workflow(WORKFLOW_URL.format(version=version)))
+            row = OrderedDict([
+                ("version", version), ("kube", kube), ("requirements", []),
+                ("incompatibilities", []), ("chart_version", chart),
+            ])
+        updates.append(row)
+    combined = deepcopy(recorded)
+    combined.update({row["version"]: row for row in updates})
+    retained = {row["version"] for row in reduce_versions(list(combined.values()))}
+    return [row for row in updates if row["version"] in retained]
+
+
+def scrape():
+    existing = read_yaml(TARGET_FILE)
+    if not isinstance(existing, dict) or not isinstance(existing.get("versions"), list):
+        print_error("Existing Dapr compatibility metadata is missing or invalid")
+        return
+    try:
+        charts = parse_charts(_fetch(INDEX_URL))
+        updates = build_updates(charts, existing["versions"], _fetch)
+    except (requests.RequestException, ValueError, yaml.YAMLError) as error:
+        print_error(f"Cannot refresh Dapr compatibility: {error}")
+        return
+    if updates:
+        update_compatibility_info(TARGET_FILE, updates)

--- a/utils/compatibility/tests/DAPR.md
+++ b/utils/compatibility/tests/DAPR.md
@@ -1,0 +1,75 @@
+# Dapr release-tagged CI targets
+
+This scraper records the finite Kubernetes targets configured in each released
+Dapr tag's Linux KinD E2E workflow. These are **configured test targets**, not a
+universal Kubernetes support window, proof that historical CI runs passed, or a
+locally executed cluster matrix. The chart metadata identifies released artifacts;
+it is not used to infer Kubernetes compatibility.
+
+The [Dapr support policy](https://docs.dapr.io/operations/support/support-release-policy/)
+describes a rolling current-and-two-previous minor window. Discovery therefore
+starts with stable chart-backed releases in the newest three minor series. In
+this snapshot those are 1.16, 1.17 and 1.18. Already-recorded older series remain
+available when that discovery window advances. The SDK compatibility and upgrade
+path tables are not Kubernetes compatibility evidence.
+
+The source for each candidate is:
+`https://raw.githubusercontent.com/dapr/dapr/v{version}/.github/workflows/kind-e2e.yaml`.
+It explicitly declares `k8s-version` and deployment-mode axes, pins KinD node image
+digests, builds the checked-out runtime, deploys it and runs `make test-e2e-all`.
+Only those listed Kubernetes minors are recorded. Dynamic matrices, new axes,
+nonempty exclusions, conflicting/unpinned includes and inactive or commented-out
+build/deploy/test commands fail closed for review instead of being guessed.
+
+The [official Helm index](https://dapr.github.io/helm-charts/index.yaml) maps stable
+application and chart versions separately. It is resolved before applying the
+repository's reducer. Every candidate's own tagged workflow is checked, including
+patches; no patch inherits a different tag's target matrix. Reduction retains the
+first minor release, target changes and the overall latest patch:
+
+| Dapr / chart | Configured Kubernetes targets |
+| --- | --- |
+| 1.18.3 | 1.34, 1.33, 1.32 |
+| 1.18.0 | 1.34, 1.33, 1.32 |
+| 1.17.0 | 1.34, 1.33, 1.32 |
+| 1.16.4 | 1.34, 1.33, 1.32 |
+| 1.16.0 | 1.31, 1.30, 1.29 |
+
+The target change occurs at 1.16.4. The five default Helm renders provide the
+operator, injector, placement, scheduler and sentry images stored in the YAML.
+Sidecar images injected into application deployments are not fabricated from
+release names. No historical support dates are inferred.
+
+## Offline verification
+
+From the repository root:
+
+```sh
+python3 -m venv .venv
+.venv/bin/python -m pip install -r utils/compatibility/requirements.txt
+env -u EXA_API_KEY -u OPENAI_API_KEY .venv/bin/python -m unittest discover -s utils/compatibility/tests -p 'test_dapr.py' -v
+```
+
+The 23 tests cover strict chart/version matching, finite matrices, source changes,
+commented or disabled test commands, patch target changes, history preservation,
+delayed charts, no-op updates and manifest/aggregate consistency. Fixture source
+URLs and retrieval dates are embedded in each YAML file. Workflow fixtures contain
+the exact `e2e` job extracted from their identified release tags; the index fixture
+contains exact representative entries. They perform no network requests.
+
+## Live refresh
+
+Install Helm and use isolated Helm configuration/cache/data directories and an
+empty Docker configuration if the host has unrelated credential helpers. Then:
+
+```sh
+cd utils/compatibility
+env -u EXA_API_KEY -u OPENAI_API_KEY ../../.venv/bin/python -c 'import importlib; importlib.import_module("scrapers.dapr").scrape()'
+```
+
+This updates the per-app YAML; synchronize its aggregate entry before submitting.
+The submitted data was validated against the repository schema. The five chart
+archive digests and internal Chart.yaml app/chart versions were checked against
+the official index, all five charts rendered, and an unchanged repeat scrape
+preserved the YAML byte-for-byte. No paid summarization or Kubernetes deployment
+was used for this contribution.

--- a/utils/compatibility/tests/fixtures/dapr/index.yaml
+++ b/utils/compatibility/tests/fixtures/dapr/index.yaml
@@ -1,0 +1,292 @@
+# Exact representative entries from https://dapr.github.io/helm-charts/index.yaml; retrieved 2026-09-08.
+apiVersion: v1
+entries:
+  dapr:
+  - apiVersion: v2
+    appVersion: 1.18.3
+    created: '2026-09-02T18:05:24.212880355Z'
+    dependencies:
+    - name: dapr_rbac
+      repository: file://dapr_rbac
+      version: 1.18.3
+    - name: dapr_operator
+      repository: file://dapr_operator
+      version: 1.18.3
+    - name: dapr_placement
+      repository: file://dapr_placement
+      version: 1.18.3
+    - name: dapr_sidecar_injector
+      repository: file://dapr_sidecar_injector
+      version: 1.18.3
+    - name: dapr_sentry
+      repository: file://dapr_sentry
+      version: 1.18.3
+    - name: dapr_scheduler
+      repository: file://dapr_scheduler
+      version: 1.18.3
+    - name: dapr_config
+      repository: file://dapr_config
+      version: 1.18.3
+    description: A Helm chart for Dapr on Kubernetes
+    digest: ace724ac2f5911df9932424fb7664304c28aa5b43714a2324d2b3dc6900d355d
+    icon: https://dapr.io/images/dapr.svg
+    name: dapr
+    urls:
+    - https://dapr.github.io/helm-charts/dapr-1.18.3.tgz
+    version: 1.18.3
+  - apiVersion: v2
+    appVersion: 1.18.2
+    created: '2026-09-02T18:05:24.205168651Z'
+    dependencies:
+    - name: dapr_rbac
+      repository: file://dapr_rbac
+      version: 1.18.2
+    - name: dapr_operator
+      repository: file://dapr_operator
+      version: 1.18.2
+    - name: dapr_placement
+      repository: file://dapr_placement
+      version: 1.18.2
+    - name: dapr_sidecar_injector
+      repository: file://dapr_sidecar_injector
+      version: 1.18.2
+    - name: dapr_sentry
+      repository: file://dapr_sentry
+      version: 1.18.2
+    - name: dapr_scheduler
+      repository: file://dapr_scheduler
+      version: 1.18.2
+    - name: dapr_config
+      repository: file://dapr_config
+      version: 1.18.2
+    description: A Helm chart for Dapr on Kubernetes
+    digest: 9f587be1bb06bf5bd73effc6810f662aa9255f869b0e060c7966484a964d7057
+    icon: https://dapr.io/images/dapr.svg
+    name: dapr
+    urls:
+    - https://dapr.github.io/helm-charts/dapr-1.18.2.tgz
+    version: 1.18.2
+  - apiVersion: v2
+    appVersion: 1.18.0
+    created: '2026-09-02T18:05:24.190168226Z'
+    dependencies:
+    - name: dapr_rbac
+      repository: file://dapr_rbac
+      version: 1.18.0
+    - name: dapr_operator
+      repository: file://dapr_operator
+      version: 1.18.0
+    - name: dapr_placement
+      repository: file://dapr_placement
+      version: 1.18.0
+    - name: dapr_sidecar_injector
+      repository: file://dapr_sidecar_injector
+      version: 1.18.0
+    - name: dapr_sentry
+      repository: file://dapr_sentry
+      version: 1.18.0
+    - name: dapr_scheduler
+      repository: file://dapr_scheduler
+      version: 1.18.0
+    - name: dapr_config
+      repository: file://dapr_config
+      version: 1.18.0
+    description: A Helm chart for Dapr on Kubernetes
+    digest: 7c7e4dd396923ad7d6cc84753603c6d3737500f511a8747204b7249908033255
+    icon: https://dapr.io/images/dapr.svg
+    name: dapr
+    urls:
+    - https://dapr.github.io/helm-charts/dapr-1.18.0.tgz
+    version: 1.18.0
+  - apiVersion: v2
+    appVersion: 1.17.13
+    created: '2026-09-02T18:05:24.128800482Z'
+    dependencies:
+    - name: dapr_rbac
+      repository: file://dapr_rbac
+      version: 1.17.13
+    - name: dapr_operator
+      repository: file://dapr_operator
+      version: 1.17.13
+    - name: dapr_placement
+      repository: file://dapr_placement
+      version: 1.17.13
+    - name: dapr_sidecar_injector
+      repository: file://dapr_sidecar_injector
+      version: 1.17.13
+    - name: dapr_sentry
+      repository: file://dapr_sentry
+      version: 1.17.13
+    - name: dapr_scheduler
+      repository: file://dapr_scheduler
+      version: 1.17.13
+    - name: dapr_config
+      repository: file://dapr_config
+      version: 1.17.13
+    description: A Helm chart for Dapr on Kubernetes
+    digest: 39ab16a639fb4c1648f2efc9a7584e8940bb1c08a7cae4ae1249dcc73e2e10ff
+    icon: https://dapr.io/images/dapr.svg
+    name: dapr
+    urls:
+    - https://dapr.github.io/helm-charts/dapr-1.17.13.tgz
+    version: 1.17.13
+  - apiVersion: v2
+    appVersion: 1.17.0
+    created: '2026-09-02T18:05:24.111534938Z'
+    dependencies:
+    - name: dapr_rbac
+      repository: file://dapr_rbac
+      version: 1.17.0
+    - name: dapr_operator
+      repository: file://dapr_operator
+      version: 1.17.0
+    - name: dapr_placement
+      repository: file://dapr_placement
+      version: 1.17.0
+    - name: dapr_sidecar_injector
+      repository: file://dapr_sidecar_injector
+      version: 1.17.0
+    - name: dapr_sentry
+      repository: file://dapr_sentry
+      version: 1.17.0
+    - name: dapr_scheduler
+      repository: file://dapr_scheduler
+      version: 1.17.0
+    - name: dapr_config
+      repository: file://dapr_config
+      version: 1.17.0
+    description: A Helm chart for Dapr on Kubernetes
+    digest: b4c5dac689e79a66ca149ea3d539c19a103ac7267cd3327f5f6b5d19c4d177b7
+    icon: https://dapr.io/images/dapr.svg
+    name: dapr
+    urls:
+    - https://dapr.github.io/helm-charts/dapr-1.17.0.tgz
+    version: 1.17.0
+  - apiVersion: v2
+    appVersion: 1.16.19
+    created: '2026-09-02T18:05:24.052315307Z'
+    dependencies:
+    - name: dapr_rbac
+      repository: file://dapr_rbac
+      version: 1.16.19
+    - name: dapr_operator
+      repository: file://dapr_operator
+      version: 1.16.19
+    - name: dapr_placement
+      repository: file://dapr_placement
+      version: 1.16.19
+    - name: dapr_sidecar_injector
+      repository: file://dapr_sidecar_injector
+      version: 1.16.19
+    - name: dapr_sentry
+      repository: file://dapr_sentry
+      version: 1.16.19
+    - name: dapr_scheduler
+      repository: file://dapr_scheduler
+      version: 1.16.19
+    - name: dapr_config
+      repository: file://dapr_config
+      version: 1.16.19
+    description: A Helm chart for Dapr on Kubernetes
+    digest: 852f142d362608d5498fe812e5503b26f7de042da0111e8562cdeba36a9f9715
+    icon: https://dapr.io/images/dapr.svg
+    name: dapr
+    urls:
+    - https://dapr.github.io/helm-charts/dapr-1.16.19.tgz
+    version: 1.16.19
+  - apiVersion: v2
+    appVersion: 1.16.4
+    created: '2026-09-02T18:05:24.068355912Z'
+    dependencies:
+    - name: dapr_rbac
+      repository: file://dapr_rbac
+      version: 1.16.4
+    - name: dapr_operator
+      repository: file://dapr_operator
+      version: 1.16.4
+    - name: dapr_placement
+      repository: file://dapr_placement
+      version: 1.16.4
+    - name: dapr_sidecar_injector
+      repository: file://dapr_sidecar_injector
+      version: 1.16.4
+    - name: dapr_sentry
+      repository: file://dapr_sentry
+      version: 1.16.4
+    - name: dapr_scheduler
+      repository: file://dapr_scheduler
+      version: 1.16.4
+    - name: dapr_config
+      repository: file://dapr_config
+      version: 1.16.4
+    description: A Helm chart for Dapr on Kubernetes
+    digest: ac755ff3f156009c2b73761e9948e700027744cee468e6ce2cc6b6ec351c2186
+    icon: https://dapr.io/images/dapr.svg
+    name: dapr
+    urls:
+    - https://dapr.github.io/helm-charts/dapr-1.16.4.tgz
+    version: 1.16.4
+  - apiVersion: v2
+    appVersion: 1.16.3
+    created: '2026-09-02T18:05:24.065635888Z'
+    dependencies:
+    - name: dapr_rbac
+      repository: file://dapr_rbac
+      version: 1.16.3
+    - name: dapr_operator
+      repository: file://dapr_operator
+      version: 1.16.3
+    - name: dapr_placement
+      repository: file://dapr_placement
+      version: 1.16.3
+    - name: dapr_sidecar_injector
+      repository: file://dapr_sidecar_injector
+      version: 1.16.3
+    - name: dapr_sentry
+      repository: file://dapr_sentry
+      version: 1.16.3
+    - name: dapr_scheduler
+      repository: file://dapr_scheduler
+      version: 1.16.3
+    - name: dapr_config
+      repository: file://dapr_config
+      version: 1.16.3
+    description: A Helm chart for Dapr on Kubernetes
+    digest: 53f27f6b457c124c62050976d388e4697b20d229bde08969f58d74a577ed03df
+    icon: https://dapr.io/images/dapr.svg
+    name: dapr
+    urls:
+    - https://dapr.github.io/helm-charts/dapr-1.16.3.tgz
+    version: 1.16.3
+  - apiVersion: v2
+    appVersion: 1.16.0
+    created: '2026-09-02T18:05:24.005395351Z'
+    dependencies:
+    - name: dapr_rbac
+      repository: file://dapr_rbac
+      version: 1.16.0
+    - name: dapr_operator
+      repository: file://dapr_operator
+      version: 1.16.0
+    - name: dapr_placement
+      repository: file://dapr_placement
+      version: 1.16.0
+    - name: dapr_sidecar_injector
+      repository: file://dapr_sidecar_injector
+      version: 1.16.0
+    - name: dapr_sentry
+      repository: file://dapr_sentry
+      version: 1.16.0
+    - name: dapr_scheduler
+      repository: file://dapr_scheduler
+      version: 1.16.0
+    - name: dapr_config
+      repository: file://dapr_config
+      version: 1.16.0
+    description: A Helm chart for Dapr on Kubernetes
+    digest: affb2be7985a86795b58239f785edc396da7ba32cdbd21227d1090a8324e8aea
+    icon: https://dapr.io/images/dapr.svg
+    name: dapr
+    urls:
+    - https://dapr.github.io/helm-charts/dapr-1.16.0.tgz
+    version: 1.16.0

--- a/utils/compatibility/tests/fixtures/dapr/kind-1.16.0.yaml
+++ b/utils/compatibility/tests/fixtures/dapr/kind-1.16.0.yaml
@@ -1,0 +1,184 @@
+# Exact e2e job from https://raw.githubusercontent.com/dapr/dapr/v1.16.0/.github/workflows/kind-e2e.yaml; retrieved 2026-09-08.
+name: E2E tests on KinD
+jobs:
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      REGISTRY_PORT: 5000
+      REGISTRY_NAME: kind-registry
+      DAPR_REGISTRY: localhost:5000/dapr
+      DAPR_TAG: dev
+      DAPR_NAMESPACE: dapr-tests
+      DAPR_TEST_N_MINUS_1_IMAGE: ghcr.io/dapr/daprd:1.14.5
+      DAPR_TEST_N_MINUS_2_IMAGE: ghcr.io/dapr/daprd:1.13.6
+      DAPR_CACHE_REGISTRY: dapre2eacr.azurecr.io
+      PULL_POLICY: IfNotPresent
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version:
+        - v1.31.0
+        - v1.30.4
+        - v1.29.8
+        mode:
+        - ha
+        - non-ha
+        include:
+        - k8s-version: v1.31.0
+          kind-version: v0.24.0
+          kind-image-sha: sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
+          dapr-test-config-store: postgres
+        - k8s-version: v1.30.4
+          kind-version: v0.24.0
+          kind-image-sha: sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114
+          dapr-test-config-store: redis
+        - k8s-version: v1.29.8
+          kind-version: v0.24.0
+          kind-image-sha: sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa
+          dapr-test-config-store: redis
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Set up Go
+      id: setup-go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Configure KinD
+      run: "cat > kind.yaml <<EOF\napiVersion: kind.x-k8s.io/v1alpha4\nkind: Cluster\n\
+        nodes:\n- role: control-plane\n  image: kindest/node:${{ matrix.k8s-version\
+        \ }}@${{ matrix.kind-image-sha }}\n- role: worker\n  image: kindest/node:${{\
+        \ matrix.k8s-version }}@${{ matrix.kind-image-sha }}\n- role: worker\n  image:\
+        \ kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}\n- role:\
+        \ worker\n  image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha\
+        \ }}\ncontainerdConfigPatches:\n- |-\n  [plugins.\"io.containerd.grpc.v1.cri\"\
+        .registry.mirrors.\"localhost:$REGISTRY_PORT\"]\n    endpoint = [\"http://$REGISTRY_NAME:$REGISTRY_PORT\"\
+        ]\nEOF\n\n# Log the generated kind.yaml for easy reference.\ncat kind.yaml\n\
+        \n# Set log target directories\necho \"DAPR_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/container_logs/${{\
+        \ matrix.k8s-version }}_${{ matrix.mode }}\" >> $GITHUB_ENV\necho \"DAPR_TEST_LOG_PATH=$GITHUB_WORKSPACE/test_logs/${{\
+        \ matrix.k8s-version }}_${{ matrix.mode }}\" >> $GITHUB_ENV\n"
+    - name: Create KinD Cluster
+      uses: helm/kind-action@v1.10.0
+      with:
+        config: kind.yaml
+        cluster_name: kind
+        version: ${{ matrix.kind-version }}
+    - name: Get KinD info
+      run: "kubectl cluster-info --context kind-kind\nNODE_IP=$(kubectl get nodes\
+        \ \\\n          -lkubernetes.io/hostname!=kind-control-plane \\\n        \
+        \  -ojsonpath='{.items[0].status.addresses[?(@.type==\"InternalIP\")].address}')\n\
+        echo \"MINIKUBE_NODE_IP=$NODE_IP\" >> $GITHUB_ENV\n"
+    - name: Setup test output
+      shell: bash
+      run: 'export TEST_OUTPUT_FILE_PREFIX=$GITHUB_WORKSPACE/test_report
+
+        echo "TEST_OUTPUT_FILE_PREFIX=$TEST_OUTPUT_FILE_PREFIX" >> $GITHUB_ENV
+
+        '
+    - name: Setup local registry
+      run: "# Run a registry.\ndocker run -d --restart=always \\\n  -p $REGISTRY_PORT:$REGISTRY_PORT\
+        \ --name $REGISTRY_NAME registry:2\n# Connect the registry to the KinD network.\n\
+        docker network connect \"kind\" $REGISTRY_NAME\n"
+    - name: Setup Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.3.4
+    - name: Build and push Dapr
+      run: 'make build-linux
+
+        make docker-build
+
+        make docker-push
+
+        '
+    - name: Build and push test apps
+      run: 'make build-push-e2e-app-all
+
+        '
+    - name: Setup Dapr
+      run: "make setup-helm-init\nmake create-test-namespace\nexport ADDITIONAL_HELM_SET=\"\
+        dapr_operator.logLevel=debug,dapr_operator.watchInterval=20s\"\nif [[ \"${{\
+        \ matrix.mode }}\" == \"ha\" ]]; then\n  export HA_MODE=true\nelse\n  export\
+        \ HA_MODE=false\nfi\nmake docker-deploy-k8s\n"
+    - name: Setup Redis
+      run: 'make setup-test-env-redis
+
+        '
+    - name: Setup Kafka
+      run: 'make setup-test-env-kafka
+
+        '
+    - name: Setup Zipkin
+      run: 'make setup-test-env-zipkin
+
+        '
+    - name: Setup postgres
+      run: 'make setup-test-env-postgres
+
+        '
+    - name: Setup test components
+      run: 'make setup-test-components
+
+        '
+      env:
+        DAPR_TEST_CONFIG_STORE: ${{ matrix.dapr-test-config-store }}
+    - name: Free up some diskspace
+      run: "docker image prune -a -f\n# Clean up some more\necho \"Listing 100 largest\
+        \ packages\"\ndpkg-query -Wf '${Installed-Size}\\t${Package}\\n' | sort -n\
+        \ | tail -n 100\ndf -h\necho \"Removing large packages\"\nsudo apt-get update\n\
+        \n# check if pkgs exist before removing them\nif dpkg -l | grep -q '^dotnet-.*';\
+        \ then\n  sudo apt-get remove -y '^dotnet-.*'\nfi\n\nif dpkg -l | grep -q\
+        \ '^llvm-.*'; then\n  sudo apt-get remove -y '^llvm-.*'\nfi\n\nif dpkg -l\
+        \ | grep -q 'php.*'; then\n  sudo apt-get remove -y 'php.*'\nfi\n\nif dpkg\
+        \ -l | grep -q 'temurin-*'; then\n  sudo apt-get remove -y 'temurin-*'\nfi\n\
+        \nif dpkg -l | grep -q 'microsoft-edge-stable'; then\n  sudo apt-get remove\
+        \ -y microsoft-edge-stable\nfi\n\nif dpkg -l | grep -q 'azure-cli'; then\n\
+        \  sudo apt-get remove -y azure-cli\nfi\n\nif dpkg -l | grep -q 'google-chrome-stable';\
+        \ then\n  sudo apt-get remove -y google-chrome-stable\nfi\n\nif dpkg -l |\
+        \ grep -q 'firefox'; then\n  sudo apt-get remove -y firefox\nfi\n\nif dpkg\
+        \ -l | grep -q '^powershell'; then\n  sudo apt-get remove -y powershell\n\
+        fi\n\nif dpkg -l | grep -q 'mono-devel'; then\n  sudo apt-get remove -y mono-devel\n\
+        fi\n\nsudo apt-get autoremove -y\nsudo apt-get clean\ndf -h\n\necho \"Removing\
+        \ large directories\"\n# deleting 15GB\nrm -rf /usr/share/dotnet/\ndf -h\n"
+    - name: Run tests
+      run: 'make test-e2e-all
+
+        '
+      env:
+        DAPR_TEST_CONFIG_STORE: ${{ matrix.dapr-test-config-store }}
+    - name: Save control plane logs
+      if: always()
+      run: 'make save-dapr-control-plane-k8s-logs
+
+        '
+    - name: Compress logs
+      if: always()
+      run: 'gzip --fast -r ${{ env.DAPR_CONTAINER_LOG_PATH }}
+
+        gzip --fast -r ${{ env.DAPR_TEST_LOG_PATH }}
+
+        '
+      shell: bash
+    - name: Upload container logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.k8s-version }}_${{ matrix.mode}}_container_logs
+        path: ${{ env.DAPR_CONTAINER_LOG_PATH }}
+        compression-level: 0
+    - name: Upload test logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.k8s-version }}_${{ matrix.mode}}_test_logs
+        path: ${{ env.DAPR_TEST_LOG_PATH }}
+        compression-level: 0
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.k8s-version }}_${{ matrix.mode }}_test_e2e.json
+        path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_e2e.*

--- a/utils/compatibility/tests/fixtures/dapr/kind-1.16.4.yaml
+++ b/utils/compatibility/tests/fixtures/dapr/kind-1.16.4.yaml
@@ -1,0 +1,188 @@
+# Exact e2e job from https://raw.githubusercontent.com/dapr/dapr/v1.16.4/.github/workflows/kind-e2e.yaml; retrieved 2026-09-08.
+name: E2E tests on KinD
+jobs:
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      REGISTRY_PORT: 5000
+      REGISTRY_NAME: kind-registry
+      DAPR_REGISTRY: localhost:5000/dapr
+      DAPR_TAG: dev
+      DAPR_NAMESPACE: dapr-tests
+      DAPR_TEST_N_MINUS_1_IMAGE: ghcr.io/dapr/daprd:1.14.5
+      DAPR_TEST_N_MINUS_2_IMAGE: ghcr.io/dapr/daprd:1.13.6
+      DAPR_CACHE_REGISTRY: dapre2eacr.azurecr.io
+      PULL_POLICY: IfNotPresent
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version:
+        - v1.34.0
+        - v1.33.4
+        - v1.32.8
+        mode:
+        - ha
+        - non-ha
+        include:
+        - k8s-version: v1.34.0
+          kind-version: v0.30.0
+          kind-image-sha: sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+          dapr-test-config-store: postgres
+        - k8s-version: v1.33.4
+          kind-version: v0.30.0
+          kind-image-sha: sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
+          dapr-test-config-store: redis
+        - k8s-version: v1.32.8
+          kind-version: v0.30.0
+          kind-image-sha: sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
+          dapr-test-config-store: redis
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Set up Go
+      id: setup-go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: Configure KinD
+      run: "cat > kind.yaml <<EOF\napiVersion: kind.x-k8s.io/v1alpha4\nkind: Cluster\n\
+        nodes:\n- role: control-plane\n  image: kindest/node:${{ matrix.k8s-version\
+        \ }}@${{ matrix.kind-image-sha }}\n- role: worker\n  image: kindest/node:${{\
+        \ matrix.k8s-version }}@${{ matrix.kind-image-sha }}\n- role: worker\n  image:\
+        \ kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}\n- role:\
+        \ worker\n  image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha\
+        \ }}\ncontainerdConfigPatches:\n- |-\n  [plugins.\"io.containerd.grpc.v1.cri\"\
+        .registry.mirrors.\"localhost:$REGISTRY_PORT\"]\n    endpoint = [\"http://$REGISTRY_NAME:$REGISTRY_PORT\"\
+        ]\nEOF\n\n# Log the generated kind.yaml for easy reference.\ncat kind.yaml\n\
+        \n# Set log target directories\necho \"DAPR_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/container_logs/${{\
+        \ matrix.k8s-version }}_${{ matrix.mode }}\" >> $GITHUB_ENV\necho \"DAPR_TEST_LOG_PATH=$GITHUB_WORKSPACE/test_logs/${{\
+        \ matrix.k8s-version }}_${{ matrix.mode }}\" >> $GITHUB_ENV\n"
+    - name: Create KinD Cluster
+      uses: helm/kind-action@v1.13.0
+      with:
+        config: kind.yaml
+        cluster_name: kind
+        version: ${{ matrix.kind-version }}
+    - name: Get KinD info
+      run: "kubectl cluster-info --context kind-kind\nNODE_IP=$(kubectl get nodes\
+        \ \\\n          -lkubernetes.io/hostname!=kind-control-plane \\\n        \
+        \  -ojsonpath='{.items[0].status.addresses[?(@.type==\"InternalIP\")].address}')\n\
+        echo \"MINIKUBE_NODE_IP=$NODE_IP\" >> $GITHUB_ENV\n"
+    - name: Setup test output
+      shell: bash
+      run: 'export TEST_OUTPUT_FILE_PREFIX=$GITHUB_WORKSPACE/test_report
+
+        echo "TEST_OUTPUT_FILE_PREFIX=$TEST_OUTPUT_FILE_PREFIX" >> $GITHUB_ENV
+
+        '
+    - name: Setup local registry
+      run: "# Run a registry.\ndocker run -d --restart=always \\\n  -p $REGISTRY_PORT:$REGISTRY_PORT\
+        \ --name $REGISTRY_NAME registry:2\n# Connect the registry to the KinD network.\n\
+        docker network connect \"kind\" $REGISTRY_NAME\n"
+    - name: Setup Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.3.4
+    - name: Free disk space
+      run: 'df -h
+
+        docker system prune -af || true
+
+        docker volume prune -f || true
+
+        sudo rm -rf /usr/local/lib/android || true
+
+        sudo rm -rf /opt/ghc || true
+
+        sudo rm -rf /usr/share/dotnet || true
+
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+
+        sudo apt-get clean
+
+        sudo rm -rf /var/lib/apt/lists/* || true
+
+        df -h
+
+        '
+    - name: Build and push Dapr
+      run: 'make build-linux
+
+        make docker-build
+
+        make docker-push
+
+        '
+    - name: Build and push test apps
+      run: 'make build-push-e2e-app-all
+
+        '
+    - name: Setup Dapr
+      run: "make setup-helm-init\nmake create-test-namespace\nexport ADDITIONAL_HELM_SET=\"\
+        dapr_operator.logLevel=debug,dapr_operator.watchInterval=20s\"\nif [[ \"${{\
+        \ matrix.mode }}\" == \"ha\" ]]; then\n  export HA_MODE=true\nelse\n  export\
+        \ HA_MODE=false\nfi\nmake docker-deploy-k8s\n"
+    - name: Setup Redis
+      run: 'make setup-test-env-redis
+
+        '
+    - name: Setup Kafka
+      run: 'make setup-test-env-kafka
+
+        '
+    - name: Setup Zipkin
+      run: 'make setup-test-env-zipkin
+
+        '
+    - name: Setup postgres
+      run: 'make setup-test-env-postgres
+
+        '
+    - name: Setup test components
+      run: 'make setup-test-components
+
+        '
+      env:
+        DAPR_TEST_CONFIG_STORE: ${{ matrix.dapr-test-config-store }}
+    - name: Run tests
+      run: 'make test-e2e-all
+
+        '
+      env:
+        DAPR_TEST_CONFIG_STORE: ${{ matrix.dapr-test-config-store }}
+    - name: Save control plane logs
+      if: always()
+      run: 'make save-dapr-control-plane-k8s-logs
+
+        '
+    - name: Compress logs
+      if: always()
+      run: 'gzip --fast -r ${{ env.DAPR_CONTAINER_LOG_PATH }}
+
+        gzip --fast -r ${{ env.DAPR_TEST_LOG_PATH }}
+
+        '
+      shell: bash
+    - name: Upload container logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.k8s-version }}_${{ matrix.mode}}_container_logs
+        path: ${{ env.DAPR_CONTAINER_LOG_PATH }}
+        compression-level: 0
+    - name: Upload test logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.k8s-version }}_${{ matrix.mode}}_test_logs
+        path: ${{ env.DAPR_TEST_LOG_PATH }}
+        compression-level: 0
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.k8s-version }}_${{ matrix.mode }}_test_e2e.json
+        path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_e2e.*

--- a/utils/compatibility/tests/fixtures/dapr/kind-1.18.3.yaml
+++ b/utils/compatibility/tests/fixtures/dapr/kind-1.18.3.yaml
@@ -1,0 +1,188 @@
+# Exact e2e job from https://raw.githubusercontent.com/dapr/dapr/v1.18.3/.github/workflows/kind-e2e.yaml; retrieved 2026-09-08.
+name: E2E tests on KinD
+jobs:
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      REGISTRY_PORT: 5000
+      REGISTRY_NAME: kind-registry
+      DAPR_REGISTRY: localhost:5000/dapr
+      DAPR_TAG: dev
+      DAPR_NAMESPACE: dapr-tests
+      DAPR_TEST_N_MINUS_1_IMAGE: ghcr.io/dapr/daprd:1.16.8
+      DAPR_TEST_N_MINUS_2_IMAGE: ghcr.io/dapr/daprd:1.15.13
+      DAPR_CACHE_REGISTRY: dapre2eacr.azurecr.io
+      PULL_POLICY: IfNotPresent
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version:
+        - v1.34.0
+        - v1.33.4
+        - v1.32.8
+        mode:
+        - ha
+        - non-ha
+        include:
+        - k8s-version: v1.34.0
+          kind-version: v0.30.0
+          kind-image-sha: sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+          dapr-test-config-store: postgres
+        - k8s-version: v1.33.4
+          kind-version: v0.30.0
+          kind-image-sha: sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
+          dapr-test-config-store: redis
+        - k8s-version: v1.32.8
+          kind-version: v0.30.0
+          kind-image-sha: sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
+          dapr-test-config-store: redis
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+    - name: Set up Go
+      id: setup-go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
+    - name: Configure KinD
+      run: "cat > kind.yaml <<EOF\napiVersion: kind.x-k8s.io/v1alpha4\nkind: Cluster\n\
+        nodes:\n- role: control-plane\n  image: kindest/node:${{ matrix.k8s-version\
+        \ }}@${{ matrix.kind-image-sha }}\n- role: worker\n  image: kindest/node:${{\
+        \ matrix.k8s-version }}@${{ matrix.kind-image-sha }}\n- role: worker\n  image:\
+        \ kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha }}\n- role:\
+        \ worker\n  image: kindest/node:${{ matrix.k8s-version }}@${{ matrix.kind-image-sha\
+        \ }}\ncontainerdConfigPatches:\n- |-\n  [plugins.\"io.containerd.grpc.v1.cri\"\
+        .registry.mirrors.\"localhost:$REGISTRY_PORT\"]\n    endpoint = [\"http://$REGISTRY_NAME:$REGISTRY_PORT\"\
+        ]\nEOF\n\n# Log the generated kind.yaml for easy reference.\ncat kind.yaml\n\
+        \n# Set log target directories\necho \"DAPR_CONTAINER_LOG_PATH=$GITHUB_WORKSPACE/container_logs/${{\
+        \ matrix.k8s-version }}_${{ matrix.mode }}\" >> $GITHUB_ENV\necho \"DAPR_TEST_LOG_PATH=$GITHUB_WORKSPACE/test_logs/${{\
+        \ matrix.k8s-version }}_${{ matrix.mode }}\" >> $GITHUB_ENV\n"
+    - name: Create KinD Cluster
+      uses: helm/kind-action@v1.13.0
+      with:
+        config: kind.yaml
+        cluster_name: kind
+        version: ${{ matrix.kind-version }}
+    - name: Get KinD info
+      run: "kubectl cluster-info --context kind-kind\nNODE_IP=$(kubectl get nodes\
+        \ \\\n          -lkubernetes.io/hostname!=kind-control-plane \\\n        \
+        \  -ojsonpath='{.items[0].status.addresses[?(@.type==\"InternalIP\")].address}')\n\
+        echo \"MINIKUBE_NODE_IP=$NODE_IP\" >> $GITHUB_ENV\n"
+    - name: Setup test output
+      shell: bash
+      run: 'export TEST_OUTPUT_FILE_PREFIX=$GITHUB_WORKSPACE/test_report
+
+        echo "TEST_OUTPUT_FILE_PREFIX=$TEST_OUTPUT_FILE_PREFIX" >> $GITHUB_ENV
+
+        '
+    - name: Setup local registry
+      run: "# Run a registry.\ndocker run -d --restart=always \\\n  -p $REGISTRY_PORT:$REGISTRY_PORT\
+        \ --name $REGISTRY_NAME registry:2\n# Connect the registry to the KinD network.\n\
+        docker network connect \"kind\" $REGISTRY_NAME\n"
+    - name: Setup Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.3.4
+    - name: Free disk space
+      run: 'df -h
+
+        docker system prune -af || true
+
+        docker volume prune -f || true
+
+        sudo rm -rf /usr/local/lib/android || true
+
+        sudo rm -rf /opt/ghc || true
+
+        sudo rm -rf /usr/share/dotnet || true
+
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+
+        sudo apt-get clean
+
+        sudo rm -rf /var/lib/apt/lists/* || true
+
+        df -h
+
+        '
+    - name: Build and push Dapr
+      run: 'make build-linux
+
+        make docker-build
+
+        make docker-push-retry
+
+        '
+    - name: Build and push test apps
+      run: 'make build-push-e2e-app-all
+
+        '
+    - name: Setup Dapr
+      run: "make setup-helm-init\nmake create-test-namespace\nexport ADDITIONAL_HELM_SET=\"\
+        dapr_operator.logLevel=debug,dapr_operator.watchInterval=20s\"\nif [[ \"${{\
+        \ matrix.mode }}\" == \"ha\" ]]; then\n  export HA_MODE=true\nelse\n  export\
+        \ HA_MODE=false\nfi\nmake docker-deploy-k8s\n"
+    - name: Setup Redis
+      run: 'make setup-test-env-redis
+
+        '
+    - name: Setup Kafka
+      run: 'make setup-test-env-kafka
+
+        '
+    - name: Setup Zipkin
+      run: 'make setup-test-env-zipkin
+
+        '
+    - name: Setup postgres
+      run: 'make setup-test-env-postgres
+
+        '
+    - name: Setup test components
+      run: 'make setup-test-components
+
+        '
+      env:
+        DAPR_TEST_CONFIG_STORE: ${{ matrix.dapr-test-config-store }}
+    - name: Run tests
+      run: 'make test-e2e-all
+
+        '
+      env:
+        DAPR_TEST_CONFIG_STORE: ${{ matrix.dapr-test-config-store }}
+    - name: Save control plane logs
+      if: always()
+      run: 'make save-dapr-control-plane-k8s-logs
+
+        '
+    - name: Compress logs
+      if: always()
+      run: 'gzip --fast -r ${{ env.DAPR_CONTAINER_LOG_PATH }}
+
+        gzip --fast -r ${{ env.DAPR_TEST_LOG_PATH }}
+
+        '
+      shell: bash
+    - name: Upload container logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.k8s-version }}_${{ matrix.mode}}_container_logs
+        path: ${{ env.DAPR_CONTAINER_LOG_PATH }}
+        compression-level: 0
+    - name: Upload test logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.k8s-version }}_${{ matrix.mode}}_test_logs
+        path: ${{ env.DAPR_TEST_LOG_PATH }}
+        compression-level: 0
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.k8s-version }}_${{ matrix.mode }}_test_e2e.json
+        path: ${{ env.TEST_OUTPUT_FILE_PREFIX }}_e2e.*

--- a/utils/compatibility/tests/test_dapr.py
+++ b/utils/compatibility/tests/test_dapr.py
@@ -1,0 +1,226 @@
+"""Offline regressions for exact Dapr release/CI target provenance."""
+
+from copy import deepcopy
+import importlib
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+import requests
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import reduce_versions, update_versions_data
+
+scraper = importlib.import_module("scrapers.dapr")
+FIXTURES = Path(__file__).parent / "fixtures/dapr"
+INDEX = (FIXTURES / "index.yaml").read_bytes()
+OLD_WORKFLOW = (FIXTURES / "kind-1.16.0.yaml").read_bytes()
+NEW_WORKFLOW = (FIXTURES / "kind-1.18.3.yaml").read_bytes()
+
+
+def index(entries):
+    return yaml.safe_dump({"entries": {"dapr": entries}})
+
+
+def entry(app, chart=None, **extra):
+    return dict(name="dapr", appVersion=app, version=chart or app, **extra)
+
+
+def workflow(url):
+    version = url.split("/v", 1)[1].split("/", 1)[0]
+    return OLD_WORKFLOW if version in {"1.16.0", "1.16.1", "1.16.2", "1.16.3"} else NEW_WORKFLOW
+
+
+def stored(version, chart=None):
+    row = {"version": version, "kube": ["1.34", "1.33", "1.32"], "requirements": [],
+           "incompatibilities": [], "summary": None, "images": []}
+    if chart:
+        row["chart_version"] = chart
+    return row
+
+
+class ChartTests(unittest.TestCase):
+    def test_exact_live_index_fixture_contains_current_three_minor_series(self):
+        charts = scraper.parse_charts(INDEX)
+        self.assertEqual(set(charts), {"1.16.0", "1.16.3", "1.16.4", "1.16.19", "1.17.0",
+                                       "1.17.13", "1.18.0", "1.18.2", "1.18.3"})
+        self.assertTrue(all(app == chart for app, chart in charts.items()))
+
+    def test_window_uses_released_app_minors_and_exact_stable_chart_versions(self):
+        charts = scraper.parse_charts(index([
+            entry("1.15.0"), entry("1.16.0"), entry("1.17.0"), entry("1.18.0", "3.0.0"),
+            entry("1.18.0", "3.0.1"), entry("1.18.0", "3.1.0-rc.1"),
+            entry("1.19.0-rc.1", "4.0.0"), entry("1.19.0", deprecated=True),
+        ]))
+        self.assertEqual(charts, {"1.16.0": "1.16.0", "1.17.0": "1.17.0", "1.18.0": "3.0.1"})
+
+    def test_malformed_empty_or_conflicting_chart_index_is_rejected(self):
+        for content in ["null", "[]", "entries: []", index([]), index([None]),
+                        index([entry("1.18.0-rc.1")]),
+                        index([entry("1.17.0", "2.0.0"), entry("1.18.0", "2.0.0")])]:
+            with self.subTest(content=content), self.assertRaises(ValueError):
+                scraper.parse_charts(content)
+
+    def test_duplicate_yaml_keys_are_rejected_instead_of_overwritten(self):
+        with self.assertRaises(ValueError):
+            scraper.parse_charts("entries: {}\nentries: {dapr: []}\n")
+
+
+class MatrixTests(unittest.TestCase):
+    def test_release_tagged_fixtures_preserve_the_changed_finite_target_set(self):
+        self.assertEqual(scraper.parse_kubernetes_targets(OLD_WORKFLOW), ["1.31", "1.30", "1.29"])
+        self.assertEqual(scraper.parse_kubernetes_targets((FIXTURES / "kind-1.16.4.yaml").read_bytes()),
+                         ["1.34", "1.33", "1.32"])
+        self.assertEqual(scraper.parse_kubernetes_targets(NEW_WORKFLOW), ["1.34", "1.33", "1.32"])
+
+    def changed(self, mutate):
+        data = yaml.safe_load(NEW_WORKFLOW)
+        mutate(data["jobs"]["e2e"])
+        return yaml.safe_dump(data)
+
+    def test_dynamic_prerelease_partial_and_duplicate_targets_fail_closed(self):
+        for values in ["${{ fromJSON(needs.setup.outputs.versions) }}", [], ["1.34"],
+                       ["v1.35.0-rc.1"], ["v1.34.0", "v1.34.0"]]:
+            with self.subTest(values=values), self.assertRaises(ValueError):
+                scraper.parse_kubernetes_targets(self.changed(lambda job: job["strategy"]["matrix"].update({"k8s-version": values})))
+
+    def test_unsupported_exclusions_or_axes_are_not_silently_ignored(self):
+        for change in [{"exclude": [{"k8s-version": "v1.34.0"}]}, {"os": ["linux", "windows"]}]:
+            with self.subTest(change=change), self.assertRaises(ValueError):
+                scraper.parse_kubernetes_targets(self.changed(lambda job: job["strategy"]["matrix"].update(change)))
+
+    def test_conflicting_or_unpinned_matrix_includes_are_rejected(self):
+        for action in [
+            lambda matrix: matrix["include"].pop(),
+            lambda matrix: matrix["include"].append(dict(matrix["include"][0], **{"kind-image-sha": "sha256:" + "0" * 64})),
+            lambda matrix: matrix["include"][0].update({"k8s-version": "v1.35.0"}),
+            lambda matrix: matrix["include"][0].update({"kind-image-sha": "latest"}),
+        ]:
+            with self.subTest(action=action), self.assertRaises(ValueError):
+                scraper.parse_kubernetes_targets(self.changed(lambda job: action(job["strategy"]["matrix"])))
+
+    def test_unused_matrix_or_disabled_tests_cannot_establish_coverage(self):
+        for content in [
+            NEW_WORKFLOW.replace(b"matrix.k8s-version", b"matrix.other-version"),
+            NEW_WORKFLOW.replace(b"make test-e2e-all", b"echo tests skipped"),
+            self.changed(lambda job: job.update({"if": False})),
+        ]:
+            with self.subTest(content=content[:80]), self.assertRaises(ValueError):
+                scraper.parse_kubernetes_targets(content)
+
+    def test_unlisted_minor_is_not_interpolated(self):
+        data = yaml.safe_load(NEW_WORKFLOW)
+        matrix = data["jobs"]["e2e"]["strategy"]["matrix"]
+        matrix["k8s-version"].remove("v1.33.4")
+        matrix["include"] = [row for row in matrix["include"] if row["k8s-version"] != "v1.33.4"]
+        self.assertEqual(scraper.parse_kubernetes_targets(yaml.safe_dump(data)), ["1.34", "1.32"])
+
+    def test_commented_build_deploy_or_test_commands_cannot_establish_targets(self):
+        for target in [b"build-linux", b"docker-build", b"docker-deploy-k8s", b"test-e2e-all"]:
+            with self.subTest(target=target), self.assertRaises(ValueError):
+                scraper.parse_kubernetes_targets(NEW_WORKFLOW.replace(b"make " + target, b"# make " + target))
+
+    def test_other_checked_out_revision_or_runner_is_rejected(self):
+        def change_checkout(job):
+            next(step for step in job["steps"] if step.get("uses", "").startswith("actions/checkout@"))["with"] = {"ref": "master"}
+        for action in [change_checkout, lambda job: job.update({"runs-on": "windows-latest"})]:
+            with self.subTest(action=action), self.assertRaises(ValueError):
+                scraper.parse_kubernetes_targets(self.changed(action))
+
+
+class UpdateTests(unittest.TestCase):
+    def test_boundaries_change_point_and_latest_patch_follow_real_tagged_targets(self):
+        rows = scraper.build_updates(scraper.parse_charts(INDEX), [], workflow)
+        self.assertEqual([row["version"] for row in rows], ["1.18.3", "1.18.0", "1.17.0", "1.16.4", "1.16.0"])
+        self.assertEqual(rows[-1]["kube"], ["1.31", "1.30", "1.29"])
+        self.assertEqual(rows[-2]["kube"], ["1.34", "1.33", "1.32"])
+
+    def test_saved_rows_are_not_rewritten_and_repeat_is_noop(self):
+        charts = scraper.parse_charts(INDEX)
+        existing = reduce_versions(scraper.build_updates(charts, [], workflow))
+        existing[0]["summary"] = {"features": ["keep"]}
+        existing[0]["eolAt"] = "2027-01-01"
+        original = deepcopy(existing)
+        self.assertEqual(scraper.build_updates(charts, existing, workflow), [])
+        self.assertEqual(existing, original)
+
+    def test_older_stored_series_is_preserved_when_support_window_moves(self):
+        existing = [stored("1.15.0", "1.15.0")]
+        rows = scraper.build_updates(scraper.parse_charts(INDEX), existing, workflow)
+        self.assertEqual(next(r for r in reduce_versions(existing + rows) if r["version"] == "1.15.0"), existing[0])
+
+    def test_delayed_chart_adds_a_real_earlier_boundary(self):
+        previous = [stored("1.17.1", "1.17.1")]
+        rows = scraper.build_updates({"1.17.0": "1.17.0", "1.17.1": "1.17.1"}, previous, workflow)
+        self.assertEqual([r["version"] for r in rows], ["1.17.0"])
+
+    def test_existing_chartless_row_gets_exact_chart_without_losing_metadata(self):
+        old = stored("1.17.0")
+        old.update(summary={"features": ["keep"]}, eolAt="2027-01-01", kube=["1.33"])
+        original = deepcopy(old)
+        rows = scraper.build_updates({"1.17.0": "2.0.0"}, [old], lambda _: self.fail("No source refresh for stored coverage"))
+        self.assertEqual(rows, [dict(old, chart_version="2.0.0")])
+        self.assertEqual(old, original)
+        data = {"versions": [old]}
+        update_versions_data(data, deepcopy(rows))
+        self.assertEqual(scraper.build_updates({"1.17.0": "2.0.0"}, data["versions"], workflow), [])
+
+    def test_chart_matching_precedes_version_reduction(self):
+        rows = scraper.build_updates({"1.18.2": "1.18.2", "1.18.3": "1.18.3"}, [], workflow)
+        self.assertEqual([row["version"] for row in rows], ["1.18.3", "1.18.2"])
+        self.assertNotIn("1.18.0", [row["version"] for row in rows])
+
+
+class ScrapeTests(unittest.TestCase):
+    def test_source_http_timeout_or_bad_workflow_never_writes_partial_data(self):
+        for failure in [requests.Timeout("timeout"), requests.HTTPError("404"), [INDEX, b"jobs: {}"]]:
+            with self.subTest(failure=failure), patch.object(scraper, "read_yaml", return_value={"versions": []}), \
+                    patch.object(scraper, "_fetch", side_effect=failure), patch.object(scraper, "print_error"), \
+                    patch.object(scraper, "update_compatibility_info") as update:
+                scraper.scrape()
+                update.assert_not_called()
+
+    def test_invalid_local_metadata_does_not_fetch(self):
+        with patch.object(scraper, "read_yaml", return_value=None), patch.object(scraper, "_fetch") as fetch, \
+                patch.object(scraper, "print_error"), patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+            fetch.assert_not_called()
+            update.assert_not_called()
+
+    def test_fresh_scrape_uses_finite_chart_backed_rows(self):
+        def fetch(url):
+            return INDEX if url == scraper.INDEX_URL else workflow(url)
+        with patch.object(scraper, "read_yaml", return_value={"versions": []}), \
+                patch.object(scraper, "_fetch", side_effect=fetch), patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+            self.assertEqual([r["version"] for r in update.call_args.args[1]], ["1.18.3", "1.18.0", "1.17.0", "1.16.4", "1.16.0"])
+
+    def test_http_requests_use_timeout_and_status_validation(self):
+        with patch.object(scraper.requests, "get") as get:
+            get.return_value.content = b"source"
+            self.assertEqual(scraper._fetch(scraper.INDEX_URL), b"source")
+            get.assert_called_once_with(scraper.INDEX_URL, timeout=30)
+            get.return_value.raise_for_status.assert_called_once_with()
+
+
+class GeneratedDataTests(unittest.TestCase):
+    def test_registered_app_and_aggregate_match_the_source_backed_rows(self):
+        root = Path(__file__).resolve().parents[3]
+        app = yaml.safe_load((root / "static/compatibilities/dapr.yaml").read_text())
+        manifest = yaml.safe_load((root / "static/compatibilities/manifest.yaml").read_text())
+        aggregate = yaml.safe_load((root / "static/compatibilities.yaml").read_text())
+        self.assertEqual(manifest["names"].count("dapr"), 1)
+        self.assertEqual([a for a in aggregate["addons"] if a["name"] == "dapr"], [dict(app, name="dapr")])
+        self.assertEqual([r["version"] for r in app["versions"]], ["1.18.3", "1.18.0", "1.17.0", "1.16.4", "1.16.0"])
+        for row in app["versions"]:
+            version = row["version"]
+            self.assertEqual(row["chart_version"], version)
+            self.assertEqual(row["kube"], ["1.31", "1.30", "1.29"] if version == "1.16.0" else ["1.34", "1.33", "1.32"])
+            self.assertEqual(row["images"], [f"ghcr.io/dapr/{name}:{version}" for name in
+                                             ["injector", "operator", "placement", "scheduler", "sentry"]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Dapr is missing from the compatibility catalog. This adds its scraper, manifest entry and generated data for the current three stable minor series, with exact application/chart mappings from the official Helm index.

The Kubernetes values are the finite targets configured in each release tag's Linux KinD E2E workflow. That workflow pins the node images, builds the checked-out runtime, deploys it and invokes `make test-e2e-all`. These records do not assert successful historical CI runs or a universal Kubernetes support window. Dapr's rolling three-minor policy controls release discovery; the SDK and upgrade tables are not used as Kubernetes evidence.

| Dapr / chart | Configured Kubernetes targets |
| --- | --- |
| 1.18.3 | 1.34, 1.33, 1.32 |
| 1.18.0 | 1.34, 1.33, 1.32 |
| 1.17.0 | 1.34, 1.33, 1.32 |
| 1.16.4 | 1.34, 1.33, 1.32 |
| 1.16.0 | 1.31, 1.30, 1.29 |

Every candidate patch is checked against its own tagged workflow. The existing reducer retains minor boundaries, the target change at 1.16.4 and the overall latest patch. Stable chart resolution happens before reduction, so chartless records can be backfilled without losing stored metadata. Malformed, conflicting, dynamic or inactive source declarations fail before writing. All 51 existing add-ons remain unchanged; no shared utility is modified.

Sources:

- [Dapr support policy](https://docs.dapr.io/operations/support/support-release-policy/)
- [Official Helm index](https://dapr.github.io/helm-charts/index.yaml) and [latest stable 1.18.3 release](https://github.com/dapr/dapr/releases/tag/v1.18.3)
- Tagged E2E workflows: [1.16.0](https://github.com/dapr/dapr/blob/v1.16.0/.github/workflows/kind-e2e.yaml), [1.16.4](https://github.com/dapr/dapr/blob/v1.16.4/.github/workflows/kind-e2e.yaml), [1.17.0](https://github.com/dapr/dapr/blob/v1.17.0/.github/workflows/kind-e2e.yaml), [1.18.0](https://github.com/dapr/dapr/blob/v1.18.0/.github/workflows/kind-e2e.yaml), [1.18.3](https://github.com/dapr/dapr/blob/v1.18.3/.github/workflows/kind-e2e.yaml)

## Test Plan

- 23 offline tests pass for the original PR head, covering exact stable chart mapping, finite target matrices, commented/disabled commands, source failures, patch target changes, history preservation, delayed chart availability and no-op repeats.
- Live source selection checks all 38 stable chart-backed releases in 1.16–1.18 and reproduces the five saved rows.
- All five chart archive SHA-256 digests match the official index; their internal `Chart.yaml` application/chart versions match the selected records.
- All five default Helm charts rendered successfully; their operator, injector, placement, scheduler and sentry images are stored in the data. No sidecar image was inferred from the release name.
- Per-app, manifest and aggregate schemas pass. The aggregate matches the Dapr file exactly and preserves every other add-on.
- A normal live repeat calls no writer and leaves the per-app YAML byte-identical. No Kubernetes deployment or historical CI-run validation was performed.

Runnable test setup, source semantics and refresh instructions are documented in `utils/compatibility/tests/DAPR.md`.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly. Scraper validation documentation is included.
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code). Not applicable: no agent code changed.

Prepared with AI assistance and independently reviewed. Paid summarization APIs were disabled for scraping and rendering.

## Follow-up revision after closure

The review's chart-refresh finding is corrected in [fork commit 881dd3b](https://github.com/uyivzola/console/commit/881dd3b8d41c88aaca3cbb1d8e19c64a4e4c552b). Existing application records adopt strictly newer exact chart mappings, retain runtime metadata and refresh rendered images; missing or older mappings cannot cause rollback. The follow-up passes 26 focused tests, including a normal-writer regression and repeat no-op, and leaves the live data byte-identical. This closed PR still references its original head `188b349`; the follow-up commit is available on the existing fork branch for review. The PR has not been reopened.

Plural Flow: console
