### PR TITLE
feat: add Kubewarden Admission Controller compatibility scraper

### DIFF
--- a/.github/workflows/compatibility-schema-validation.yaml
+++ b/.github/workflows/compatibility-schema-validation.yaml
@@ -7,6 +7,7 @@ on:
       - 'static/addons/**'
       - 'static/compatibilities/**'
       - 'static/compatibilities.yaml'
+      - 'utils/compatibility/**'
   push:
     branches:
       - master
@@ -15,11 +16,28 @@ on:
       - 'static/addons/**'
       - 'static/compatibilities/**'
       - 'static/compatibilities.yaml'
+      - 'utils/compatibility/**'
 
 permissions:
   contents: read
 
 jobs:
+  test-compatibility-scrapers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install scraper dependencies
+        run: python -m pip install -r utils/compatibility/requirements.txt
+
+      - name: Run offline scraper tests
+        run: python -m unittest discover -s utils/compatibility/tests -v
+
   validate-compatibility-schemas:
     runs-on: ubuntu-latest
     steps:

--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -30780,6 +30780,32 @@ addons:
     chart_version: 0.29.6
     images: []
   name: kubescape-operator
+- icon: https://www.kubewarden.io/images/icon-kubewarden.svg
+  git_url: https://github.com/kubewarden/adm-controller
+  release_url: https://github.com/kubewarden/adm-controller/releases/tag/v{vsn}
+  readme_url: https://docs.kubewarden.io/admission-controller/latest/en/quick-start.html
+  helm_repository_url: https://charts.kubewarden.io
+  chart_name: admission-controller
+  versions:
+  - version: 1.37.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 6.0.2
+    images: ['ghcr.io/kubewarden/adm-controller/audit-scanner:v1.37.2', 'ghcr.io/kubewarden/adm-controller/controller:v1.37.2',
+      'ghcr.io/kubewarden/adm-controller/policy-server:v1.37.2']
+  - version: 1.37.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 6.0.0
+    images: ['ghcr.io/kubewarden/adm-controller/audit-scanner:v1.37.0', 'ghcr.io/kubewarden/adm-controller/controller:v1.37.0',
+      'ghcr.io/kubewarden/adm-controller/policy-server:v1.37.0']
+  name: kubewarden
 - icon: https://assets.dynatrace.com/global/resources/Signet_Logo_RGB_CP_512x512px.png
   git_url: https://github.com/Dynatrace/dynatrace-operator
   release_url: https://github.com/Dynatrace/dynatrace-operator/releases/tag/v{vsn}

--- a/static/compatibilities/kubewarden.yaml
+++ b/static/compatibilities/kubewarden.yaml
@@ -1,0 +1,25 @@
+icon: https://www.kubewarden.io/images/icon-kubewarden.svg
+git_url: https://github.com/kubewarden/adm-controller
+release_url: https://github.com/kubewarden/adm-controller/releases/tag/v{vsn}
+readme_url: https://docs.kubewarden.io/admission-controller/latest/en/quick-start.html
+helm_repository_url: https://charts.kubewarden.io
+chart_name: admission-controller
+versions:
+- version: 1.37.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 6.0.2
+  images: ['ghcr.io/kubewarden/adm-controller/audit-scanner:v1.37.2', 'ghcr.io/kubewarden/adm-controller/controller:v1.37.2',
+    'ghcr.io/kubewarden/adm-controller/policy-server:v1.37.2']
+- version: 1.37.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 6.0.0
+  images: ['ghcr.io/kubewarden/adm-controller/audit-scanner:v1.37.0', 'ghcr.io/kubewarden/adm-controller/controller:v1.37.0',
+    'ghcr.io/kubewarden/adm-controller/policy-server:v1.37.0']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -47,6 +47,7 @@ names:
 - rabbitmq-cluster-operator
 - kserve
 - kubescape-operator
+- kubewarden
 - dynatrace-operator
 - wiz-sensor
 - wiz-admission-controller

--- a/utils/compatibility/scrapers/kubewarden.py
+++ b/utils/compatibility/scrapers/kubewarden.py
@@ -1,0 +1,157 @@
+"""Compatibility for Kubewarden's current admission-controller Helm chart.
+
+Use each release's Helm constraint and the versioned quick-start's additional
+minimum for namespaced AdmissionPolicy. Neither source is a Kubernetes test
+matrix. The deprecated kubewarden-controller chart is deliberately excluded.
+"""
+
+import re
+from collections import OrderedDict
+
+import requests
+import semantic_version
+import yaml
+from bs4 import BeautifulSoup
+
+from utils import current_kube_version, print_error, update_compatibility_info
+
+APP_NAME = "kubewarden"
+CHART_NAME = "admission-controller"
+INDEX_URL = "https://charts.kubewarden.io/index.yaml"
+DOCS_URL = "https://docs.kubewarden.io/admission-controller/{series}/en/quick-start.html"
+TARGET_FILE = f"../../static/compatibilities/{APP_NAME}.yaml"
+
+
+def _stable_version(value):
+    if not isinstance(value, str):
+        return None
+    try:
+        version = semantic_version.Version(value.strip().removeprefix("v"))
+    except ValueError:
+        return None
+    return None if version.prerelease or version.build else version
+
+
+def parse_kube_versions(spec, latest_kube):
+    """Expand only the whole-minor minimum constraints published by this chart.
+
+    Unknown syntax, patch-specific floors and future minima yield no rows. This
+    intentionally does not guess the meaning of an arbitrary Helm expression.
+    """
+    if not isinstance(spec, str) or not isinstance(latest_kube, str):
+        return []
+    floor = re.fullmatch(r">=\s*1\.(0|[1-9]\d*)\.0(?:-0)?", spec.strip())
+    ceiling = re.fullmatch(r"1\.(0|[1-9]\d*)", latest_kube.strip())
+    if not floor or not ceiling:
+        return []
+    first, last = int(floor[1]), int(ceiling[1])
+    return [f"1.{minor}" for minor in range(last, first - 1, -1)]
+
+
+def extract_versions(index, latest_kube):
+    """Select the newest eligible stable chart for each stable application."""
+    if not isinstance(index, dict) or not isinstance(index.get("entries"), dict):
+        return []
+    entries = index["entries"].get(CHART_NAME)
+    if not isinstance(entries, list):
+        return []
+    selected = {}
+    for chart in entries:
+        if not isinstance(chart, dict) or chart.get("deprecated", False):
+            continue
+        if chart.get("name", CHART_NAME) != CHART_NAME:
+            continue
+        app_version = _stable_version(chart.get("appVersion"))
+        chart_version = _stable_version(chart.get("version"))
+        kube = parse_kube_versions(chart.get("kubeVersion"), latest_kube)
+        if app_version is None or chart_version is None or not kube:
+            continue
+        previous = selected.get(app_version)
+        if previous and chart_version <= previous[0]:
+            continue
+        selected[app_version] = (chart_version, kube)
+
+    return [
+        OrderedDict([
+            ("version", str(app_version)),
+            ("kube", selected[app_version][1]),
+            ("requirements", []),
+            ("incompatibilities", []),
+            ("chart_version", str(selected[app_version][0])),
+        ])
+        for app_version in sorted(selected, reverse=True)
+    ]
+
+
+def parse_policy_minimum(content):
+    """Read the explicit AdmissionPolicy requirement, not another page version."""
+    if not isinstance(content, (str, bytes)):
+        return None
+    text = BeautifulSoup(content, "html.parser").get_text(" ", strip=True)
+    text = " ".join(text.split())
+    requirements = re.finditer(r"\bAdmissionPolicy requires Kubernetes ", text)
+    minima = set()
+    for requirement in requirements:
+        match = re.match(r"(1\.(?:0|[1-9]\d*))\.0 or greater\b", text[requirement.end():])
+        if match is None:
+            return None
+        minima.add(match[1])
+    return next(iter(minima)) if len(minima) == 1 else None
+
+
+def apply_policy_minimum(rows, minimum):
+    if not isinstance(minimum, str) or not re.fullmatch(r"1\.(0|[1-9]\d*)", minimum):
+        return []
+    floor = int(minimum.split(".")[1])
+    result = []
+    for row in rows:
+        kube = [version for version in row["kube"] if int(version.split(".")[1]) >= floor]
+        if kube:
+            entry = OrderedDict(row)
+            entry["kube"] = kube
+            result.append(entry)
+    return result
+
+
+def _fetch(url):
+    try:
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        return response.content
+    except requests.RequestException as exc:
+        print_error(f"Failed to fetch Kubewarden source {url}: {exc}")
+        return None
+
+
+def scrape():
+    content = _fetch(INDEX_URL)
+    if content is None:
+        return
+    try:
+        index = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        print_error(f"Invalid Kubewarden Helm index: {exc}")
+        return
+    rows = extract_versions(index, current_kube_version())
+    if not rows:
+        print_error("No stable Kubewarden admission-controller compatibility rows found.")
+        return
+
+    by_series = {}
+    for row in rows:
+        series = ".".join(row["version"].split(".")[:2])
+        by_series.setdefault(series, []).append(row)
+
+    versions = []
+    for series, series_rows in by_series.items():
+        page = _fetch(DOCS_URL.format(series=series))
+        minimum = parse_policy_minimum(page)
+        if minimum is None:
+            print_error(f"No unambiguous AdmissionPolicy Kubernetes minimum for {series}; skipping.")
+            continue
+        versions.extend(apply_policy_minimum(series_rows, minimum))
+
+    if not versions:
+        print_error("No Kubewarden versions with both Helm and feature requirements verified.")
+        return
+    update_compatibility_info(TARGET_FILE, versions)

--- a/utils/compatibility/tests/fixtures/kubewarden_admission_controller_index.yaml
+++ b/utils/compatibility/tests/fixtures/kubewarden_admission_controller_index.yaml
@@ -1,0 +1,26 @@
+# Reduced from https://charts.kubewarden.io/index.yaml on 2026-09-08.
+# Retains the version, application, and Kubernetes fields of the five published
+# admission-controller entries; unrelated chart metadata is omitted.
+apiVersion: v1
+entries:
+  admission-controller:
+    - name: admission-controller
+      version: 6.0.2
+      appVersion: v1.37.2
+      kubeVersion: '>= 1.19.0-0'
+    - name: admission-controller
+      version: 6.0.1
+      appVersion: v1.37.1
+      kubeVersion: '>= 1.19.0-0'
+    - name: admission-controller
+      version: 6.0.0
+      appVersion: v1.37.0
+      kubeVersion: '>= 1.19.0-0'
+    - name: admission-controller
+      version: 6.0.0-rc.2
+      appVersion: v1.37.0-rc.2
+      kubeVersion: '>= 1.19.0-0'
+    - name: admission-controller
+      version: 6.0.0-alpha
+      appVersion: v1.37.0-alpha
+      kubeVersion: '>= 1.19.0-0'

--- a/utils/compatibility/tests/fixtures/kubewarden_admission_policy_minimum.html
+++ b/utils/compatibility/tests/fixtures/kubewarden_admission_policy_minimum.html
@@ -1,0 +1,8 @@
+<!-- Minimal text excerpt from the versioned 1.37 quick start, checked 2026-09-08:
+https://docs.kubewarden.io/admission-controller/1.37/en/quick-start.html
+Inline markup exercises the same visible-text parsing needed for linked CRDs. -->
+<html><body>
+  <h3>AdmissionPolicy</h3>
+  <p><a href="reference/CRDs.html">AdmissionPolicy</a> requires Kubernetes
+    <code>1.21.0</code> or greater.</p>
+</body></html>

--- a/utils/compatibility/tests/fixtures/kubewarden_deployment_labels.yaml
+++ b/utils/compatibility/tests/fixtures/kubewarden_deployment_labels.yaml
@@ -1,0 +1,35 @@
+# Reduced Deployment metadata from Helm-rendered admission-controller charts,
+# checked 2026-09-08 in venv/helm-state/rendered-{chart_version}.yaml.
+# These are controller Deployments; the audit scanner is a CronJob.
+# Sources:
+# https://github.com/kubewarden/helm-charts/releases/download/admission-controller-6.0.0/admission-controller-6.0.0.tgz
+# https://github.com/kubewarden/helm-charts/releases/download/admission-controller-6.0.2/admission-controller-6.0.2.tgz
+charts:
+  - chart_version: 6.0.0
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: release-name-admission-controller
+      namespace: default
+      labels:
+        helm.sh/chart: admission-controller-6.0.0
+        app.kubernetes.io/name: admission-controller
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/version: v1.37.0
+        app.kubernetes.io/part-of: kubewarden
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/managed-by: Helm
+  - chart_version: 6.0.2
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: release-name-admission-controller
+      namespace: default
+      labels:
+        helm.sh/chart: admission-controller-6.0.2
+        app.kubernetes.io/name: admission-controller
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/version: v1.37.2
+        app.kubernetes.io/part-of: kubewarden
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/managed-by: Helm

--- a/utils/compatibility/tests/test_chart_images.py
+++ b/utils/compatibility/tests/test_chart_images.py
@@ -31,6 +31,122 @@ class ChartImageTests(unittest.TestCase):
             {"image": "registry.example/operator@sha256:" + "a" * 64},
         ]), ["registry.example/operator@sha256:" + "a" * 64, "registry.example:5000/operator:v1"])
 
+    def test_crd_image_schema_is_not_a_container_image(self):
+        # Reduced shape that caused Kubewarden chart rendering to crash: the
+        # CRD declares a field named image whose value is a schema dictionary.
+        crd = {
+            "kind": "CustomResourceDefinition",
+            "spec": {"versions": [{"schema": {"openAPIV3Schema": {
+                "properties": {"spec": {"properties": {"image": {
+                    "description": "Container image used by the policy server",
+                    "type": "string",
+                }}}},
+            }}}]},
+        }
+        server = {"kind": "PolicyServer", "spec": {"image": "ghcr.io/kubewarden/policy-server:v1.37.0"}}
+        self.assertEqual(find_nested_images([crd, server]), ["ghcr.io/kubewarden/policy-server:v1.37.0"])
+
+    def test_non_string_image_values_do_not_crash_or_hide_valid_neighbors(self):
+        for invalid in ({"type": "string"}, ["not-an-image-value"], None, False, True, 7, 1.5):
+            with self.subTest(image=invalid):
+                resource = {"image": invalid, "child": {"image": "registry.example.com/app:1.2.3"}}
+                self.assertEqual(find_nested_images(resource), ["registry.example.com/app:1.2.3"])
+
+    def test_discovers_pod_init_container_and_policy_server_images(self):
+        resources = [
+            {"kind": "Pod", "spec": {
+                "initContainers": [{"name": "prepare", "image": "busybox:1.37"}],
+                "containers": [{"name": "controller", "image": "ghcr.io/kubewarden/controller:v1.37.2"}],
+            }},
+            {"kind": "PolicyServer", "spec": {"image": "ghcr.io/kubewarden/policy-server:v1.37.0"}},
+        ]
+        self.assertEqual(find_nested_images(resources), [
+            "busybox:1.37",
+            "ghcr.io/kubewarden/controller:v1.37.2",
+            "ghcr.io/kubewarden/policy-server:v1.37.0",
+        ])
+
+    def test_deduplicates_tag_and_digest_images_without_collecting_unrelated_strings(self):
+        digest = "registry.example.com:5000/team/app@sha256:" + "a" * 64
+        resources = [
+            {"image": digest}, {"image": digest},
+            {"image": "nginx:1.27"}, {"nested": [{"image": "nginx:1.27"}]},
+            {"ghcr.io/not-a-runtime-image:v1": "ghcr.io/not-an-image-field:v2"},
+            {"description": "redis:7.4"},
+        ]
+        self.assertEqual(find_nested_images(resources), ["nginx:1.27", digest])
+
+    def test_invalid_image_strings_are_rejected(self):
+        invalid = [
+            "", " ", "not an image", "https://example.com/image.png",
+            "${IMAGE}", "<image>", "-placeholder", "_placeholder",
+            "image@sha256:abc", "repo:tag extra",
+        ]
+        resources = [{"image": value} for value in invalid] + [{"image": "docker.io/library/nginx:1.27"}]
+        self.assertEqual(find_nested_images(resources), ["docker.io/library/nginx:1.27"])
+
+    def test_embedded_default_policy_server_manifest_retains_its_image(self):
+        # Reduced from admission-controller 6.0.2's rendered kubewarden-defaults
+        # ConfigMap, including its actual image reference and data key.
+        configmap = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "kubewarden-defaults"},
+            "data": {"policyserver-default.yaml": (
+                "apiVersion: policies.kubewarden.io/v1\n"
+                "kind: PolicyServer\n"
+                "metadata:\n  name: default\n"
+                "spec:\n  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.37.2\n"
+                "  replicas: 1\n"
+            )},
+        }
+        self.assertEqual(find_nested_images(configmap), ["ghcr.io/kubewarden/adm-controller/policy-server:v1.37.2"])
+
+    def test_embedded_multiple_documents_and_regular_images_are_deduplicated(self):
+        configmap = {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "data": {"resources.yml": (
+                "---\n"
+                "apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - image: nginx:1.27\n"
+                "---\n"
+                "apiVersion: policies.kubewarden.io/v1\nkind: PolicyServer\n"
+                "spec:\n  image: ghcr.io/kubewarden/adm-controller/policy-server:v1.37.2\n"
+                "---\n"
+            )},
+        }
+        self.assertEqual(find_nested_images([configmap, {"image": "nginx:1.27"}]), [
+            "ghcr.io/kubewarden/adm-controller/policy-server:v1.37.2", "nginx:1.27",
+        ])
+
+    def test_malformed_or_nonmanifest_config_is_ignored(self):
+        invalid = [
+            None, False, "[", "null", "plain configuration text",
+            "image: redis:7.4\n",
+            "apiVersion: v1\nimage: redis:7.4\n",
+            "kind: Pod\nimage: redis:7.4\n",
+            "apiVersion: null\nkind: Pod\nimage: redis:7.4\n",
+            "apiVersion: v1\nkind: []\nimage: redis:7.4\n",
+            "- apiVersion: v1\n  kind: Pod\n  image: redis:7.4\n",
+            "apiVersion: v1\nkind: Pod\nimage: redis:7.4\n---\n[",
+        ]
+        for content in invalid:
+            with self.subTest(content=content):
+                configmap = {"kind": "ConfigMap", "data": {"config.yaml": content}}
+                self.assertEqual(find_nested_images([configmap, {"image": "nginx:1.27"}]), ["nginx:1.27"])
+
+    def test_manifest_text_is_only_parsed_in_configmap_yaml_entries(self):
+        content = "apiVersion: v1\nkind: Pod\nspec:\n  containers:\n    - image: redis:7.4\n"
+        resources = [
+            {"kind": "Secret", "data": {"resource.yaml": content}},
+            {"kind": "ConfigMap", "data": {"resource.txt": content}},
+            {"kind": "ConfigMap", "metadata": {"resource.yaml": content}},
+            {"kind": "ConfigMap", "data": content},
+            {"data": {"resource.yaml": content}},
+            {"image": "nginx:1.27"},
+        ]
+        self.assertEqual(find_nested_images(resources), ["nginx:1.27"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/utils/compatibility/tests/test_chart_images_recursive.py
+++ b/utils/compatibility/tests/test_chart_images_recursive.py
@@ -1,0 +1,68 @@
+"""Image discovery must tolerate YAML aliases without losing neighboring images."""
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import find_nested_images
+
+
+class RecursiveChartImageTests(unittest.TestCase):
+    def test_recursive_embedded_mapping_keeps_its_image_and_valid_neighbor(self):
+        configmap = {"kind": "ConfigMap", "data": {"server.yaml": (
+            "apiVersion: policies.kubewarden.io/v1\n"
+            "kind: PolicyServer\n"
+            "spec: &server\n"
+            "  image: registry.example/policy-server:v1\n"
+            "  recursive: *server\n"
+        )}}
+        neighbor = {"spec": {"containers": [{"image": "nginx:1.27"}]}}
+        self.assertEqual(find_nested_images([configmap, neighbor]), [
+            "nginx:1.27", "registry.example/policy-server:v1",
+        ])
+
+    def test_recursive_embedded_sequence_keeps_its_image_and_valid_neighbor(self):
+        configmap = {"kind": "ConfigMap", "data": {"pod.yaml": (
+            "apiVersion: v1\nkind: Pod\n"
+            "spec:\n"
+            "  containers: &containers\n"
+            "    - image: registry.example/worker:v1\n"
+            "    - *containers\n"
+        )}}
+        neighbor = {"spec": {"initContainers": [{"image": "busybox:1.37"}]}}
+        self.assertEqual(find_nested_images([configmap, neighbor]), [
+            "busybox:1.37", "registry.example/worker:v1",
+        ])
+
+    def test_shared_aliases_preserve_unique_images_across_documents(self):
+        configmap = {"kind": "ConfigMap", "data": {"pods.yml": (
+            "apiVersion: v1\nkind: Pod\n"
+            "spec:\n"
+            "  initContainers: &shared\n"
+            "    - image: busybox:1.37\n"
+            "  containers: *shared\n"
+            "---\n"
+            "apiVersion: v1\nkind: Pod\n"
+            "spec:\n"
+            "  containers: &shared\n"
+            "    - image: nginx:1.27\n"
+            "  repeated: *shared\n"
+        )}}
+        self.assertEqual(find_nested_images(configmap), ["busybox:1.37", "nginx:1.27"])
+
+    def test_separately_parsed_embedded_manifests_do_not_lose_images(self):
+        resources = []
+        expected = []
+        for index in range(64):
+            reference = f"registry.example/worker:v{index}"
+            expected.append(reference)
+            resources.append({"kind": "ConfigMap", "data": {"pod.yaml": (
+                "apiVersion: v1\nkind: Pod\n"
+                f"spec:\n  containers:\n    - image: {reference}\n"
+            )}})
+        self.assertEqual(find_nested_images(resources), sorted(expected))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_kubewarden_admission_controller.py
+++ b/utils/compatibility/tests/test_kubewarden_admission_controller.py
@@ -1,0 +1,360 @@
+"""Offline tests for Kubewarden's current admission-controller chart scraper."""
+
+import copy
+import importlib.util
+from pathlib import Path
+import random
+import sys
+import unittest
+from collections import OrderedDict
+from unittest.mock import patch
+
+import yaml
+
+
+COMPATIBILITY_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY_DIR))
+SPEC = importlib.util.spec_from_file_location(
+    "kubewarden_scraper",
+    COMPATIBILITY_DIR / "scrapers" / "kubewarden.py",
+)
+scraper = importlib.util.module_from_spec(SPEC)
+with patch("requests.sessions.Session.request", side_effect=AssertionError("Unexpected network request")):
+    SPEC.loader.exec_module(scraper)
+
+
+def chart(version="6.0.2", app_version="v1.37.2", kube_version=">= 1.19.0-0", **extra):
+    """Construct input records, not a model of the scraper's implementation."""
+    return {
+        "name": "admission-controller",
+        "version": version,
+        "appVersion": app_version,
+        "kubeVersion": kube_version,
+        **extra,
+    }
+
+
+def index_with(*entries):
+    return {"apiVersion": "v1", "entries": {"admission-controller": list(entries)}}
+
+
+class OfflineScraperTest(unittest.TestCase):
+    def setUp(self):
+        network = patch("requests.sessions.Session.request", side_effect=AssertionError("Unexpected network request"))
+        network.start()
+        self.addCleanup(network.stop)
+
+
+class KubernetesConstraintTests(OfflineScraperTest):
+    def test_observed_floor_expands_only_through_current_minor(self):
+        self.assertEqual(
+            scraper.parse_kube_versions(">= 1.19.0-0", "1.22"),
+            ["1.22", "1.21", "1.20", "1.19"],
+        )
+
+    def test_whole_minor_floor_without_helm_prerelease_sentinel(self):
+        self.assertEqual(scraper.parse_kube_versions(">=1.20.0", "1.22"), ["1.22", "1.21", "1.20"])
+
+    def test_equal_floor_and_cap_keeps_that_minor(self):
+        self.assertEqual(scraper.parse_kube_versions(">= 1.19.0-0", "1.19"), ["1.19"])
+
+    def test_future_floor_does_not_claim_current_compatibility(self):
+        self.assertEqual(scraper.parse_kube_versions(">= 1.37.0-0", "1.36"), [])
+
+    def test_unknown_or_partial_minor_constraints_are_not_guessed(self):
+        constraints = [
+            None, "", 119, {}, [],
+            ">= 1.19.1", ">= 1.19.1-0", "> 1.19.0", ">= 1.19",
+            "1.19.0", "~1.19.0", "^1.19.0", "1.19.x", "*",
+            ">= 1.19.0 < 1.30.0", ">= 1.19.0 || >= 1.25.0",
+            ">= 1.19.0, < 1.30.0", ">= 1.19.0-rc.1", ">= 1.19.0+build",
+            ">= 2.0.0", "prefix >= 1.19.0", ">= 1.19.0 trailing",
+        ]
+        for constraint in constraints:
+            with self.subTest(constraint=constraint):
+                self.assertEqual(scraper.parse_kube_versions(constraint, "1.36"), [])
+
+    def test_invalid_current_kubernetes_version_yields_no_claim(self):
+        for latest in (None, "", "latest", "1", "1.-1", "2.0", "1.36-rc.1", {}, []):
+            with self.subTest(latest=latest):
+                self.assertEqual(scraper.parse_kube_versions(">= 1.19.0-0", latest), [])
+
+
+class ChartIndexTests(OfflineScraperTest):
+    def test_current_published_chart_fixture_uses_app_not_chart_version(self):
+        fixture = Path(__file__).parent / "fixtures" / "kubewarden_admission_controller_index.yaml"
+        data = yaml.safe_load(fixture.read_text(encoding="utf-8"))
+        rows = scraper.extract_versions(data, "1.21")
+        self.assertEqual(
+            rows,
+            [
+                OrderedDict([
+                    ("version", "1.37.2"),
+                    ("kube", ["1.21", "1.20", "1.19"]),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                    ("chart_version", "6.0.2"),
+                ]),
+                OrderedDict([
+                    ("version", "1.37.1"),
+                    ("kube", ["1.21", "1.20", "1.19"]),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                    ("chart_version", "6.0.1"),
+                ]),
+                OrderedDict([
+                    ("version", "1.37.0"),
+                    ("kube", ["1.21", "1.20", "1.19"]),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                    ("chart_version", "6.0.0"),
+                ]),
+            ],
+        )
+        self.assertTrue(all(isinstance(row, OrderedDict) for row in rows))
+
+    def test_other_chart_keys_cannot_supply_or_override_versions(self):
+        data = index_with(chart())
+        data["entries"]["kubewarden-controller"] = [chart("99.0.0", "v99.0.0")]
+        data["entries"]["kubewarden-crds"] = [chart("100.0.0", "v100.0.0")]
+        self.assertEqual([row["version"] for row in scraper.extract_versions(data, "1.20")], ["1.37.2"])
+        self.assertEqual(scraper.extract_versions({"entries": {"kubewarden-controller": [chart()]}}, "1.20"), [])
+
+    def test_newest_eligible_chart_is_numeric_and_independent_of_index_order(self):
+        entries = [
+            chart("6.9.0", "v1.37.2", ">= 1.19.0-0"),
+            chart("6.10.0", "1.37.2", ">= 1.20.0-0"),
+            chart("7.0.0-rc.1", "v1.37.2"),
+            chart("7.0.0+build.1", "v1.37.2"),
+            chart("8.0.0", "v1.37.2", deprecated=True),
+            chart("9.0.0", "v1.37.2", ">= 1.50.0"),
+            chart("10.0.0", "v1.37.2", ">= 1.19.1"),
+        ]
+        for seed in range(8):
+            shuffled = copy.deepcopy(entries)
+            random.Random(seed).shuffle(shuffled)
+            with self.subTest(seed=seed):
+                rows = scraper.extract_versions(index_with(*shuffled), "1.22")
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(rows[0]["chart_version"], "6.10.0")
+                self.assertEqual(rows[0]["version"], "1.37.2")
+                self.assertEqual(rows[0]["kube"], ["1.22", "1.21", "1.20"])
+
+    def test_application_versions_sort_numerically_descending(self):
+        rows = scraper.extract_versions(index_with(
+            chart("6.0.0", "v1.9.0"),
+            chart("7.0.0", "v1.37.2"),
+            chart("8.0.0", "v1.37.10"),
+            chart("9.0.0", "v2.0.0"),
+        ), "1.20")
+        self.assertEqual([row["version"] for row in rows], ["2.0.0", "1.37.10", "1.37.2", "1.9.0"])
+
+    def test_prerelease_build_and_malformed_versions_are_excluded_on_both_axes(self):
+        invalid = (None, "", "1.37", "01.37.2", "1.37.2-rc.1", "1.37.2+build.1", "next", {}, [], 1372)
+        for value in invalid:
+            for field in ("version", "appVersion"):
+                with self.subTest(field=field, value=value):
+                    bad = chart()
+                    bad[field] = value
+                    rows = scraper.extract_versions(index_with(bad, chart("5.0.0", "v1.36.0")), "1.20")
+                    self.assertEqual([row["version"] for row in rows], ["1.36.0"])
+
+    def test_deprecated_only_release_is_omitted(self):
+        self.assertEqual(scraper.extract_versions(index_with(chart(deprecated=True)), "1.20"), [])
+
+    def test_malformed_records_do_not_hide_valid_neighbors(self):
+        entries = [None, [], "bad", 7, {}, {"version": "6.0.0"}, chart(kube_version=None), chart()]
+        rows = scraper.extract_versions(index_with(*entries), "1.20")
+        self.assertEqual([row["version"] for row in rows], ["1.37.2"])
+
+    def test_malformed_index_shapes_are_empty(self):
+        invalid = [
+            None, [], "bad", {}, {"entries": None}, {"entries": []},
+            {"entries": {"admission-controller": None}},
+            {"entries": {"admission-controller": {"version": "6.0.2"}}},
+            {"entries": {"admission-controller": "bad"}},
+        ]
+        for data in invalid:
+            with self.subTest(data=data):
+                self.assertEqual(scraper.extract_versions(data, "1.20"), [])
+
+    def test_invalid_current_version_yields_no_rows(self):
+        self.assertEqual(scraper.extract_versions(index_with(chart()), "unknown"), [])
+
+    def test_index_and_nested_entries_are_not_mutated(self):
+        data = index_with(chart("6.9.0"), chart("6.10.0"))
+        original = copy.deepcopy(data)
+        scraper.extract_versions(data, "1.22")
+        self.assertEqual(data, original)
+
+
+class RuntimeCatalogTests(OfflineScraperTest):
+    def setUp(self):
+        super().setUp()
+        fixture = Path(__file__).parent / "fixtures" / "kubewarden_deployment_labels.yaml"
+        self.deployments = yaml.safe_load(fixture.read_text(encoding="utf-8"))["charts"]
+        self.catalog_dir = COMPATIBILITY_DIR.parents[1] / "static" / "compatibilities"
+
+    def test_catalog_key_is_published_as_a_supported_runtime_label(self):
+        # AddRuntimeServiceInfo explicitly checks app.kubernetes.io/part-of;
+        # validLabel directly accepts a value present in supportedAddons.
+        # See go/deployment-operator/pkg/ping/runtime_service.go. This checks
+        # the chart/catalog boundary without reimplementing the Go detector.
+        manifest = yaml.safe_load((self.catalog_dir / "manifest.yaml").read_text(encoding="utf-8"))
+        catalog_key = Path(scraper.TARGET_FILE).stem
+        for deployment in self.deployments:
+            with self.subTest(chart=deployment["chart_version"]):
+                labels = deployment["metadata"]["labels"]
+                self.assertEqual(deployment["kind"], "Deployment")
+                self.assertEqual(catalog_key, labels["app.kubernetes.io/part-of"])
+                self.assertEqual(scraper.APP_NAME, catalog_key)
+                self.assertIn(catalog_key, manifest["names"])
+        catalog = yaml.safe_load((self.catalog_dir / f"{catalog_key}.yaml").read_text(encoding="utf-8"))
+        self.assertEqual(catalog["chart_name"], scraper.CHART_NAME)
+
+    def test_rendered_version_labels_resolve_to_extracted_application_rows(self):
+        # Use the frozen source index: scheduled catalog reduction may replace
+        # a historical patch row once a later application minor is released.
+        fixture = Path(__file__).parent / "fixtures" / "kubewarden_admission_controller_index.yaml"
+        index = yaml.safe_load(fixture.read_text(encoding="utf-8"))
+        rows = {row["version"]: row for row in scraper.extract_versions(index, "1.21")}
+        for deployment in self.deployments:
+            with self.subTest(chart=deployment["chart_version"]):
+                label_version = deployment["metadata"]["labels"]["app.kubernetes.io/version"]
+                app_version = label_version.removeprefix("v")
+                self.assertIn(app_version, rows)
+                self.assertEqual(rows[app_version]["chart_version"], deployment["chart_version"])
+
+
+class ScrapeWorkflowTests(OfflineScraperTest):
+    def setUp(self):
+        super().setUp()
+        fixtures = Path(__file__).parent / "fixtures"
+        self.index = (fixtures / "kubewarden_admission_controller_index.yaml").read_text(encoding="utf-8")
+        self.docs = (fixtures / "kubewarden_admission_policy_minimum.html").read_text(encoding="utf-8")
+
+    def test_fetches_docs_once_per_series_and_publishes_only_intersection(self):
+        with patch.object(scraper, "_fetch", side_effect=[self.index, self.docs]) as fetch, \
+                patch.object(scraper, "current_kube_version", return_value="1.23"), \
+                patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+        self.assertEqual(fetch.call_count, 2)
+        self.assertEqual(fetch.call_args_list[0].args, (scraper.INDEX_URL,))
+        self.assertEqual(fetch.call_args_list[1].args, (scraper.DOCS_URL.format(series="1.37"),))
+        update.assert_called_once()
+        target, rows = update.call_args.args
+        self.assertEqual(target, scraper.TARGET_FILE)
+        self.assertEqual([row["version"] for row in rows], ["1.37.2", "1.37.1", "1.37.0"])
+        self.assertTrue(all(row["kube"] == ["1.23", "1.22", "1.21"] for row in rows))
+
+    def test_missing_docs_do_not_borrow_another_series_minimum(self):
+        data = yaml.safe_load(self.index)
+        data["entries"]["admission-controller"].append(chart("5.0.0", "v1.36.9"))
+        responses = {
+            scraper.INDEX_URL: yaml.safe_dump(data),
+            scraper.DOCS_URL.format(series="1.37"): self.docs,
+            scraper.DOCS_URL.format(series="1.36"): None,
+        }
+        with patch.object(scraper, "_fetch", side_effect=responses.__getitem__) as fetch, \
+                patch.object(scraper, "current_kube_version", return_value="1.23"), \
+                patch.object(scraper, "print_error"), \
+                patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+        self.assertEqual(fetch.call_count, 3)
+        update.assert_called_once()
+        self.assertEqual([row["version"] for row in update.call_args.args[1]], ["1.37.2", "1.37.1", "1.37.0"])
+
+    def test_no_verified_documentation_prevents_output_write(self):
+        for docs in (None, "<html>Documentation moved</html>"):
+            with self.subTest(docs=docs), \
+                    patch.object(scraper, "_fetch", side_effect=[self.index, docs]), \
+                    patch.object(scraper, "current_kube_version", return_value="1.23"), \
+                    patch.object(scraper, "print_error"), \
+                    patch.object(scraper, "update_compatibility_info") as update:
+                scraper.scrape()
+                update.assert_not_called()
+
+    def test_missing_or_malformed_index_prevents_docs_fetch_and_output_write(self):
+        for content in (None, "entries: [", "entries: {}"):
+            with self.subTest(content=content), \
+                    patch.object(scraper, "_fetch", return_value=content) as fetch, \
+                    patch.object(scraper, "current_kube_version", return_value="1.23"), \
+                    patch.object(scraper, "print_error"), \
+                    patch.object(scraper, "update_compatibility_info") as update:
+                scraper.scrape()
+                fetch.assert_called_once_with(scraper.INDEX_URL)
+                update.assert_not_called()
+
+
+class PolicyMinimumTests(OfflineScraperTest):
+    def test_versioned_quick_start_explicit_minimum_across_html_nodes(self):
+        fixture = Path(__file__).parent / "fixtures" / "kubewarden_admission_policy_minimum.html"
+        self.assertEqual(scraper.parse_policy_minimum(fixture.read_text(encoding="utf-8")), "1.21")
+
+    def test_no_inference_from_unrelated_versions_or_policy_names(self):
+        for html in (
+            "", "<p>Kubernetes 1.21.0 is supported.</p>",
+            "<p>ClusterAdmissionPolicy requires Kubernetes 1.21.0 or greater.</p>",
+            "<p>AdmissionPolicy is enabled.</p><p>Another component requires Kubernetes 1.21.0 or greater.</p>",
+        ):
+            with self.subTest(html=html):
+                self.assertIsNone(scraper.parse_policy_minimum(html))
+
+    def test_conflicting_explicit_minima_are_ambiguous(self):
+        html = (
+            "<p>AdmissionPolicy requires Kubernetes 1.21.0 or greater.</p>"
+            "<p>AdmissionPolicy requires Kubernetes 1.25.0 or greater.</p>"
+        )
+        self.assertIsNone(scraper.parse_policy_minimum(html))
+
+    def test_patch_minimum_cannot_be_reported_as_a_whole_supported_minor(self):
+        self.assertIsNone(scraper.parse_policy_minimum("<p>AdmissionPolicy requires Kubernetes 1.21.1 or greater.</p>"))
+
+    def test_supported_floor_does_not_hide_an_unsupported_conflicting_requirement(self):
+        html = (
+            "<p>AdmissionPolicy requires Kubernetes 1.21.0 or greater.</p>"
+            "<p>AdmissionPolicy requires Kubernetes 1.25.1 or greater.</p>"
+        )
+        self.assertIsNone(scraper.parse_policy_minimum(html))
+
+    def test_same_explicit_minimum_repeated_is_consistent(self):
+        note = "<p>AdmissionPolicy requires Kubernetes 1.21.0 or greater.</p>"
+        self.assertEqual(scraper.parse_policy_minimum(note + note), "1.21")
+
+    def test_policy_floor_intersects_helm_support_and_preserves_row_metadata(self):
+        rows = scraper.extract_versions(index_with(chart()), "1.23")
+        original = copy.deepcopy(rows)
+        clamped = scraper.apply_policy_minimum(rows, "1.21")
+        self.assertEqual(clamped, [OrderedDict([
+            ("version", "1.37.2"),
+            ("kube", ["1.23", "1.22", "1.21"]),
+            ("requirements", []),
+            ("incompatibilities", []),
+            ("chart_version", "6.0.2"),
+        ])])
+        self.assertEqual(rows, original)
+        self.assertIsNot(clamped, rows)
+        self.assertIsNot(clamped[0], rows[0])
+
+    def test_policy_floor_does_not_expand_a_stricter_chart_range(self):
+        rows = scraper.extract_versions(index_with(chart(kube_version=">= 1.23.0")), "1.24")
+        self.assertEqual(scraper.apply_policy_minimum(rows, "1.21")[0]["kube"], ["1.24", "1.23"])
+
+    def test_policy_floor_comparison_is_numeric_and_inclusive(self):
+        rows = scraper.extract_versions(index_with(chart(kube_version=">= 1.8.0")), "1.10")
+        self.assertEqual(scraper.apply_policy_minimum(rows, "1.9")[0]["kube"], ["1.10", "1.9"])
+
+    def test_empty_intersection_omits_only_unsupported_rows(self):
+        rows = scraper.extract_versions(index_with(chart()), "1.20")
+        self.assertEqual(scraper.apply_policy_minimum(rows, "1.21"), [])
+        self.assertEqual(scraper.apply_policy_minimum([], "1.21"), [])
+
+    def test_unknown_policy_minimum_does_not_publish_helm_only_support(self):
+        rows = scraper.extract_versions(index_with(chart()), "1.23")
+        for minimum in (None, "", "unknown"):
+            with self.subTest(minimum=minimum):
+                self.assertEqual(scraper.apply_policy_minimum(rows, minimum), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -12,7 +12,7 @@ from colorama import Fore, Style
 from packaging.version import Version
 from datetime import datetime
 from summarizer import helm_summary, summarization_enabled
-from typing import Any, List, Set
+from typing import Any, Dict, List, Set
 
 KUBE_VERSION_FILE = "../../KUBE_VERSION"
 
@@ -229,10 +229,18 @@ def find_nested_images(objs: Any) -> List[str]:
     - Reads Kubernetes manifests embedded in ConfigMap .yaml/.yml data entries.
     """
     images: Set[str] = set()
+    # Retain each object so separately parsed YAML cannot reuse a visited id.
+    visited: Dict[int, Any] = {}
 
     def walk(x: Any) -> None:
         if x is None:
             return
+
+        if isinstance(x, (dict, list, tuple, set)):
+            identity = id(x)
+            if identity in visited:
+                return
+            visited[identity] = x
 
         if isinstance(x, dict):
             if x.get("kind") == "ConfigMap" and isinstance(x.get("data"), dict):

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -226,6 +226,7 @@ def find_nested_images(objs: Any) -> List[str]:
     Important behavior:
     - Traverses dict VALUES only (not keys), to avoid collecting component names.
     - Only returns strings that look like real image references (repo/name:tag or @sha256 digest).
+    - Reads Kubernetes manifests embedded in ConfigMap .yaml/.yml data entries.
     """
     images: Set[str] = set()
 
@@ -234,6 +235,21 @@ def find_nested_images(objs: Any) -> List[str]:
             return
 
         if isinstance(x, dict):
+            if x.get("kind") == "ConfigMap" and isinstance(x.get("data"), dict):
+                for filename, content in x["data"].items():
+                    if not isinstance(filename, str) or not filename.endswith((".yaml", ".yml")) or not isinstance(content, str):
+                        continue
+                    try:
+                        manifests = list(yaml.safe_load_all(content))
+                    except yaml.YAMLError:
+                        continue
+                    for manifest in manifests:
+                        if (
+                            isinstance(manifest, dict)
+                            and isinstance(manifest.get("apiVersion"), str)
+                            and isinstance(manifest.get("kind"), str)
+                        ):
+                            walk(manifest)
             for k, v in x.items():
                 # CRD schemas also use "image" keys whose values are mappings.
                 if k == "image" and isinstance(v, str) and _looks_like_image(v):


### PR DESCRIPTION
Kubewarden Admission Controller is missing from the compatibility catalog. This adds a scraper for its current `admission-controller` Helm chart, metadata, manifest registration, and generated per-app and aggregate tables.

The catalog key is `kubewarden`, matching the controller Deployment's `app.kubernetes.io/part-of` label. Plural's existing runtime-service detector can therefore associate this workload with the table using its application version label. The Helm `chart_name` remains `admission-controller`.

The scraper reads stable chart/application pairs from the [official Helm index](https://charts.kubewarden.io/index.yaml), then intersects each chart's Kubernetes constraint with the namespaced `AdmissionPolicy` minimum from that application's versioned quick start. The current [1.37 documentation](https://docs.kubewarden.io/admission-controller/1.37/en/quick-start.html#_admissionpolicy) requires Kubernetes 1.21.0 or newer; the [chart](https://github.com/kubewarden/helm-charts/blob/admission-controller-6.0.2/charts/admission-controller/Chart.yaml) declares `>= 1.19.0-0`. The intersection is capped at this repository's `KUBE_VERSION`, currently 1.36.

This represents documented minimum requirements, not an upstream tested Kubernetes support matrix. Prereleases, deprecated charts, unsupported constraints, and releases without an unambiguous version-specific documentation minimum are skipped. The deprecated `kubewarden-controller` chart is intentionally excluded: the [current chart README](https://github.com/kubewarden/helm-charts/blob/main/charts/admission-controller/README.md) describes the successor chart.

The index provides app/chart pairs 1.37.0/6.0.0, 1.37.1/6.0.1, and 1.37.2/6.0.2. The existing shared reduction retains 1.37.0 and 1.37.2 because the compatibility range is unchanged within this minor. Both generated rows include images extracted by rendering the corresponding Helm chart.

The shared image extractor now reads Kubernetes manifests embedded in ConfigMap `.yaml`/`.yml` data entries, which this chart uses for its default PolicyServer. Without this traversal, the generated row omits that runtime image. Malformed YAML and ordinary configuration are ignored. Traversal tracks container identities and retains their references so recursive YAML aliases terminate safely and separate parsed manifests cannot reuse a visited identity. The existing upstream guard for CRD schema dictionaries is preserved. Regression coverage includes embedded manifests, regular Pod/init-container/PolicyServer images, invalid values, deduplication, recursive aliases, and separate documents.

## Test Plan

- The current 132-test offline suite passes on Windows Python 3.12 and Linux Python 3.13.15, including the 46 tests added here and the newly merged upstream tests. Tests cover upstream fixtures, semantic version ordering, invalid and ambiguous constraints, per-minor documentation isolation, and image extraction regressions. Two recursive-alias cases reproduce `RecursionError` before the traversal fix and pass afterward; additional cases preserve shared aliases and images from separate parsed manifests.
- The live scraper completed with Helm 4.2.4; a second run produced identical table bytes. The scraper and Kubewarden table are unchanged after rebasing onto the latest upstream.
- Both retained chart versions render successfully at the repository's configured Kubernetes version. The latest chart renders 31 YAML resources; image extraction matches the generated row.
- All 58 YAML files (per-app tables, manifest, and aggregate) validate against the repository's JSON schema. The aggregate's existing 53 entries are unchanged.
- The proposed CI command and dependency installation pass in an isolated Linux Python 3.13 container. Hosted GitHub Actions has not run yet.
- Installed chart 6.0.0 and upgraded to 6.0.2 in a disposable kind cluster running Kubernetes 1.36.4. Both controller and PolicyServer images match the corresponding catalog rows. The namespaced policy became healthy, allowed a real safe pod to complete, and rejected a privileged pod by server dry-run with the exact policy reason. The final upgrade check waited for all policy conditions and the current rollout, with only the expected latest PolicyServer endpoint serving traffic.
- The same privileged pod passed server dry-run in an empty control namespace, confirming namespace scope. The actual 6.0.2 audit-scanner CronJob template completed as a Job and generated an OpenReport with one pass and zero errors or failures.
- Compiled unchanged upstream Go discovery and image-heuristic functions in a bounded harness using real Kubernetes API types. Both controller and PolicyServer Deployments independently resolved to the correct catalog/application versions from live exports. Executed actual upstream Elixir selection functions (27 tests) and the real static YAML loader/decoder (9 additional tests); all 55 manifest applications loaded with repository-locked decoder dependencies after the final rebase.

The Kubernetes runtime check covers 1.36.4 only, not every listed minor or optional feature. The Go harness is not the full operator build or authenticated Console registration. Elixir used 1.19.4 with OTP 28.3.1 rather than the repository's requested OTP 28.5; full Console/DB/UI, ETS and remote-refresh integration were not run. The local cgroup-v1 Docker host required a task-only kubelet `failCgroupV1: false` setting.

## Checklist

- [x] Meaningful title and summary describing the user impact.
- [x] Upstream documentation links explain the compatibility logic.
- [x] Tests cover the change and integration regression.
- Deployment operator code is unchanged.

Discord handle for the contributor program: **simonella4914**; GitHub: **ervinpelonio8**.

Plural Flow: console
