### PR TITLE
Add Volcano compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -39,6 +39,7 @@ names:
 - tigera-operator
 - argo-cd
 - argo-workflows
+- volcano
 - vector
 - victoria-metrics-operator
 - gpu-operator
@@ -52,4 +53,4 @@ names:
 - wiz-admission-controller
 - wiz-network-analyzer
 - kuberay-operator
-- volcano
+- mongodb-kubernetes

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -52,3 +52,4 @@ names:
 - wiz-admission-controller
 - wiz-network-analyzer
 - kuberay-operator
+- volcano

--- a/static/compatibilities/volcano.yaml
+++ b/static/compatibilities/volcano.yaml
@@ -1,0 +1,68 @@
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/volcano/icon/color/volcano-icon-color.svg
+git_url: https://github.com/volcano-sh/volcano
+release_url: https://github.com/volcano-sh/volcano/releases/tag/v{vsn}
+readme_url: https://github.com/volcano-sh/volcano/blob/master/README.md#kubernetes-compatibility
+helm_repository_url: https://volcano-sh.github.io/helm-charts
+versions:
+- version: 1.15.2
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.15.2
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.15.2', 'docker.io/volcanosh/vc-scheduler:v1.15.2',
+    'docker.io/volcanosh/vc-webhook-manager:v1.15.2']
+- version: 1.15.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.15.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.15.0', 'docker.io/volcanosh/vc-scheduler:v1.15.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.15.0']
+- version: 1.14.0
+  kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25',
+    '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.14.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.14.0', 'docker.io/volcanosh/vc-scheduler:v1.14.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.14.0']
+- version: 1.13.0
+  kube: ['1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24',
+    '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.13.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.13.0', 'docker.io/volcanosh/vc-scheduler:v1.13.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.13.0']
+- version: 1.12.0
+  kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23',
+    '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.12.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.12.0', 'docker.io/volcanosh/vc-scheduler:v1.12.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.12.0']
+- version: 1.11.0
+  kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22',
+    '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.11.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.11.0', 'docker.io/volcanosh/vc-scheduler:v1.11.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.11.0']
+- version: 1.10.0
+  kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.10.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.10.0', 'docker.io/volcanosh/vc-scheduler:v1.10.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.10.0']

--- a/utils/compatibility/scrapers/volcano.py
+++ b/utils/compatibility/scrapers/volcano.py
@@ -1,0 +1,105 @@
+import re
+
+import requests
+import yaml
+from packaging.version import Version
+
+from utils import update_compatibility_info
+
+
+app_name = "volcano"
+MATRIX_URL = "https://raw.githubusercontent.com/volcano-sh/volcano/master/README.md"
+CHART_INDEX_URL = "https://volcano-sh.github.io/helm-charts/index.yaml"
+
+
+def fetch(url):
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
+def parse_matrix(markdown):
+    sections = re.split(r"^## Kubernetes compatibility\s*$", markdown, flags=re.MULTILINE)
+    if len(sections) != 2:
+        raise ValueError("Expected exactly one Volcano Kubernetes compatibility section")
+    section = re.split(r"^## ", sections[1], maxsplit=1, flags=re.MULTILINE)[0]
+    rows = [line.strip().strip("|").split("|") for line in section.splitlines()
+            if line.strip().startswith("|")]
+    rows = [[cell.strip() for cell in row] for row in rows]
+    if len(rows) < 3:
+        raise ValueError("Missing Volcano compatibility table")
+
+    headers = rows[0][1:]
+    if not headers or any(not re.fullmatch(r"Kubernetes \d+\.\d+", cell) for cell in headers):
+        raise ValueError("Unexpected Kubernetes version headers")
+    kube_versions = [cell.split()[1] for cell in headers]
+    if len(kube_versions) != len(set(kube_versions)):
+        raise ValueError("Duplicate Kubernetes version headers")
+    if len(rows[1]) != len(rows[0]) or any(not re.fullmatch(r":?-+:?", cell) for cell in rows[1]):
+        raise ValueError("Invalid compatibility table separator")
+
+    matrix = {}
+    for row in rows[2:]:
+        if len(row) != len(rows[0]) or any(cell not in {"✓", "+", "-"} for cell in row[1:]):
+            raise ValueError("Unexpected compatibility table cells")
+        if row[0] == "Volcano HEAD (master)":
+            continue
+        match = re.fullmatch(r"Volcano v(\d+\.\d+)", row[0])
+        if not match or match[1] in matrix:
+            raise ValueError("Unexpected or duplicate Volcano release row")
+        # '+' and '-' both describe API/feature differences, not exact compatibility.
+        supported = [version for version, cell in zip(kube_versions, row[1:]) if cell == "✓"]
+        if not supported:
+            raise ValueError(f"No exact Kubernetes compatibility for Volcano {match[1]}")
+        matrix[match[1]] = sorted(supported, key=Version, reverse=True)
+    if not matrix:
+        raise ValueError("No released Volcano versions in compatibility table")
+    return matrix
+
+
+def parse_chart_versions(index):
+    document = yaml.safe_load(index)
+    if not isinstance(document, dict) or not isinstance(document.get("entries"), dict):
+        raise ValueError("Invalid Volcano Helm index")
+    entries = document["entries"].get(app_name)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("No Volcano Helm charts")
+    versions = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Invalid Volcano chart entry")
+        app = str(entry.get("appVersion", "")).removeprefix("v")
+        chart = str(entry.get("version", ""))
+        # Older charts used appVersion 0.1; previews and missing versions are not releases.
+        if not re.fullmatch(r"\d+\.\d+\.\d+", app) or not re.fullmatch(r"v?\d+\.\d+\.\d+", chart):
+            continue
+        if app not in versions or Version(chart) > Version(versions[app]):
+            versions[app] = chart
+    if not versions:
+        raise ValueError("No stable Volcano Helm app versions")
+    return versions
+
+
+def build_versions(matrix, chart_versions):
+    versions = []
+    for app in sorted(chart_versions, key=Version, reverse=True):
+        minor = ".".join(app.split(".")[:2])
+        if minor not in matrix:
+            continue
+        versions.append({
+            "version": app,
+            "kube": matrix[minor],
+            "chart_version": chart_versions[app],
+            "requirements": [],
+            "incompatibilities": [],
+        })
+    if not versions:
+        raise ValueError("No published Volcano releases match the compatibility matrix")
+    return versions
+
+
+def scrape():
+    matrix = parse_matrix(fetch(MATRIX_URL).decode("utf-8"))
+    chart_versions = parse_chart_versions(fetch(CHART_INDEX_URL))
+    versions = build_versions(matrix, chart_versions)
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", versions)

--- a/utils/compatibility/tests/test_nested_images.py
+++ b/utils/compatibility/tests/test_nested_images.py
@@ -1,0 +1,52 @@
+"""Regression coverage for image fields in Helm-rendered resources and CRDs."""
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import find_nested_images
+
+
+class NestedImagesTests(unittest.TestCase):
+    def test_crd_image_schema_does_not_hide_container_images(self):
+        documents = [
+            {
+                "kind": "CustomResourceDefinition",
+                "spec": {"versions": [{"schema": {"openAPIV3Schema": {
+                    "properties": {"spec": {"properties": {
+                        "image": {"description": "Container image", "type": "string"}
+                    }}}
+                }}}]},
+            },
+            {
+                "kind": "Deployment",
+                "spec": {"template": {"spec": {
+                    "initContainers": [{"image": "registry.example/init:v1"}],
+                    "containers": [
+                        {"image": "registry.example/controller:v1"},
+                        {"image": "registry.example/controller:v1"},
+                    ],
+                }}},
+            },
+        ]
+        self.assertEqual(find_nested_images(documents), [
+            "registry.example/controller:v1", "registry.example/init:v1"
+        ])
+
+    def test_structured_image_values_are_walked_for_nested_image_fields(self):
+        documents = [
+            {"image": {"container": {"image": "registry.example/dict:v1"}}},
+            {"image": [{"image": "registry.example/list:v1"}, "not-an-image-field"]},
+        ]
+        self.assertEqual(find_nested_images(documents), [
+            "registry.example/dict:v1", "registry.example/list:v1"
+        ])
+
+    def test_non_string_image_scalars_are_ignored(self):
+        documents = [{"image": value} for value in [None, False, 42, 1.5]]
+        self.assertEqual(find_nested_images(documents), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_volcano.py
+++ b/utils/compatibility/tests/test_volcano.py
@@ -1,0 +1,116 @@
+import importlib
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+import requests
+import yaml
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+scraper = importlib.import_module("scrapers.volcano")
+
+MATRIX = """## Kubernetes compatibility
+| | Kubernetes 1.36 | Kubernetes 1.35 | Kubernetes 1.34 |
+|---|---|---|---|
+| Volcano HEAD (master) | ✓ | ✓ | ✓ |
+| Volcano v1.15 | - | ✓ | ✓ |
+| Volcano v1.14 | - | + | ✓ |
+
+Key: ✓ is exact compatibility; + and - indicate feature/API differences.
+## Other table
+| unrelated | ignored |
+"""
+
+
+def index(entries):
+    return yaml.safe_dump({"entries": {"volcano": entries}})
+
+
+class VolcanoScraperTests(unittest.TestCase):
+    def test_only_exact_compatibility_for_released_minors(self):
+        self.assertEqual(scraper.parse_matrix(MATRIX), {
+            "1.15": ["1.35", "1.34"], "1.14": ["1.34"],
+        })
+
+    def test_matrix_format_changes_fail(self):
+        cases = [
+            "", MATRIX + MATRIX,
+            MATRIX.replace("Kubernetes 1.35", "Kubernetes 1.36"),
+            MATRIX.replace("| - | + | ✓ |", "| - | + |"),
+            MATRIX.replace("| - | + | ✓ |", "| - | + | maybe |"),
+            MATRIX.replace("| - | + | ✓ |", "| - | + | - |"),
+            MATRIX.replace("Volcano v1.14", "Volcano v1.15"),
+            MATRIX.replace("Volcano v1.14", "Volcano v1.14.0-rc.1"),
+            MATRIX.replace("Kubernetes 1.35", "Kubernetes 1.35+"),
+            MATRIX.replace("|---|---|---|---|", "|---|---|"),
+        ]
+        for markdown in cases:
+            with self.subTest(markdown=markdown), self.assertRaises(ValueError):
+                scraper.parse_matrix(markdown)
+
+    def test_chart_mapping_uses_app_version_and_semantic_chart_order(self):
+        entries = [
+            {"appVersion": "v1.15.2", "version": "2.9.0"},
+            {"appVersion": "1.15.2", "version": "v2.10.0"},
+            {"appVersion": "1.15.2", "version": "2.11.0-alpha.1"},
+            {"appVersion": "1.16.0-alpha.1", "version": "1.16.0"},
+            {"appVersion": "0.1", "version": "1.9.0"},
+            {"version": "1.15.0"},
+            {"appVersion": "1.14.4", "version": "1.14.4"},
+        ]
+        self.assertEqual(scraper.parse_chart_versions(index(entries)), {
+            "1.15.2": "v2.10.0", "1.14.4": "1.14.4",
+        })
+
+    def test_empty_or_invalid_chart_index_fails(self):
+        for source in ["null", "[]", "entries: []", index([]), index([None]),
+                       index([{"appVersion": "0.1", "version": "1.9.0"}])]:
+            with self.subTest(source=source), self.assertRaises(ValueError):
+                scraper.parse_chart_versions(source)
+
+    def test_does_not_infer_undocumented_or_unpublished_releases(self):
+        versions = scraper.build_versions(scraper.parse_matrix(MATRIX), {
+            "1.16.0": "1.16.0", "1.15.2": "1.15.2", "1.15.0": "1.15.0", "1.9.0": "1.9.0",
+        })
+        self.assertEqual([row["version"] for row in versions], ["1.15.2", "1.15.0"])
+        self.assertTrue(all(row["kube"] == ["1.35", "1.34"] for row in versions))
+        with self.assertRaises(ValueError):
+            scraper.build_versions(scraper.parse_matrix(MATRIX), {"1.9.0": "1.9.0"})
+
+    def test_scrape_updates_only_after_both_sources_validate(self):
+        charts = index([{"appVersion": "1.15.2", "version": "1.15.2"}]).encode()
+        with patch.object(scraper, "fetch", side_effect=[MATRIX.encode(), charts]) as fetch, \
+                patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+        self.assertEqual([call.args[0] for call in fetch.call_args_list],
+                         [scraper.MATRIX_URL, scraper.CHART_INDEX_URL])
+        path, versions = update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/volcano.yaml")
+        self.assertEqual(versions, [{
+            "version": "1.15.2", "kube": ["1.35", "1.34"], "chart_version": "1.15.2",
+            "requirements": [], "incompatibilities": [],
+        }])
+
+    def test_failed_sources_never_write_partial_data(self):
+        cases = [[requests.HTTPError("503")], [MATRIX.encode(), requests.Timeout()],
+                 [MATRIX.encode(), b"entries: {}"], [b"bad source"]]
+        for responses in cases:
+            with self.subTest(responses=responses), \
+                    patch.object(scraper, "fetch", side_effect=responses), \
+                    patch.object(scraper, "update_compatibility_info") as update:
+                with self.assertRaises((ValueError, requests.RequestException)):
+                    scraper.scrape()
+                update.assert_not_called()
+
+    def test_http_errors_and_timeout_are_not_hidden(self):
+        with patch.object(scraper.requests, "get") as get:
+            get.return_value.raise_for_status.side_effect = requests.HTTPError("503")
+            with self.assertRaises(requests.HTTPError):
+                scraper.fetch(scraper.MATRIX_URL)
+            get.assert_called_once_with(scraper.MATRIX_URL, timeout=30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -225,7 +225,7 @@ def find_nested_images(objs: Any) -> List[str]:
 
     Important behavior:
     - Traverses dict VALUES only (not keys), to avoid collecting component names.
-    - Only returns strings that look like real image references (repo/name:tag or @sha256 digest).
+    - Only returns string values under image keys; structured values are traversed.
     """
     images: Set[str] = set()
 
@@ -235,7 +235,7 @@ def find_nested_images(objs: Any) -> List[str]:
 
         if isinstance(x, dict):
             for k, v in x.items():
-                if k == "image":
+                if k == "image" and isinstance(v, str):
                     images.add(v)
                     continue
                 walk(v)

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -225,7 +225,7 @@ def find_nested_images(objs: Any) -> List[str]:
 
     Important behavior:
     - Traverses dict VALUES only (not keys), to avoid collecting component names.
-    - Only returns string values under image keys; structured values are traversed.
+    - Only returns strings that look like real image references (repo/name:tag or @sha256 digest).
     """
     images: Set[str] = set()
 
@@ -235,7 +235,8 @@ def find_nested_images(objs: Any) -> List[str]:
 
         if isinstance(x, dict):
             for k, v in x.items():
-                if k == "image" and isinstance(v, str):
+                # CRD schemas also use "image" keys whose values are mappings.
+                if k == "image" and isinstance(v, str) and _looks_like_image(v):
                     images.add(v)
                     continue
                 walk(v)


### PR DESCRIPTION
Volcano has no compatibility entry in the console. This adds its official Kubernetes compatibility matrix, a scraper to keep it updated, Helm/release/icon metadata, and manifest registration. Only exact-compatible (`✓`) combinations for published stable releases are recorded; HEAD, previews, undocumented minors and the legacy chart `appVersion: 0.1` are excluded.

Additional regressions cover structured CRD fields named `image`, nested container image fields and non-string values. The existing upstream image-extraction fix is preserved.

Sources:

- [Official Volcano compatibility matrix](https://github.com/volcano-sh/volcano/blob/master/README.md#kubernetes-compatibility)
- [Published Helm index](https://volcano-sh.github.io/helm-charts/index.yaml)
- [Official Helm installation instructions](https://volcano-sh.github.io/helm-charts/)

The minor-level matrix is joined to published stable chart app versions. The existing reduction helper keeps compatibility boundaries and the latest release, currently 1.15.2. API/feature-difference cells (`+` and `-`) are not treated as exact compatibility. Source errors abort before the update helper is called.

## Test Plan

- `python -m unittest discover -s utils/compatibility/tests -p 'test_*.py'`: 112 tests passed with the proposed changes applied to upstream `4590056`, including 8 new Volcano tests and 3 shared image-extraction regressions.
- All `static/compatibilities/*.yaml` files validate against the repository JSON schema.
- Ran `scrapers.volcano.scrape()` against the live official sources with Helm 3.19.0. It generated 7 boundary/latest rows and rendered 3 container images for every row.
- Generated version/Kubernetes/chart mappings match independently saved official source snapshots.
- Python compilation and `git diff --check` passed.

Test environment: local Python 3.14.7 and Helm 3.19.0; Helm template rendering, no live Kubernetes cluster.

AI disclosure: Codex prepared, reviewed and executed the code and tests for this account. No human cluster testing is claimed.

## Checklist

- [x] Meaningful title and summary.
- [x] Source documentation linked.
- [x] Tests cover the changes.
- [ ] Agent deployment test: not applicable; this changes compatibility data tooling.

Plural Flow: console

Contributor program: please consider this contribution for the documented new-scraper reward, subject to maintainer approval and the one-award-per-calendar-month limit.
