### PR TITLE
fix: refresh ExternalDNS 0.22 compatibility independently of chart packaging

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -16400,6 +16400,24 @@ addons:
   release_url: https://github.com/kubernetes-sigs/external-dns/releases/tag/v{vsn}
   helm_repository_url: https://kubernetes-sigs.github.io/external-dns
   versions:
+  - version: 0.22.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary:
+      helm_changes: Application support is verified independently of Helm chart availability.
+      chart_updates: []
+      features: []
+      breaking_changes: [The default annotation prefix is now external-dns.kubernetes.io/
+          with no fallback. Migrate annotations or explicitly retain --annotation-prefix=external-dns.alpha.kubernetes.io/;
+          incorrect migration can delete DNS records., --policy is required and has
+          no default. Choose it explicitly before upgrading., 'In-tree Plural, Akamai
+          and Transip providers were removed. Use a supported webhook provider or retain
+          a compatible prior ExternalDNS version.', 'Upstream warns that --dry-run does
+          not prevent changes with ns1, hetzner and alibaba cloud providers; do not
+          rely on it as a universal safety guarantee.']
+    images: ['registry.k8s.io/external-dns/external-dns:v0.22.0@sha256:5fdcaf7deb5c158f93a1fc6fe169cdff4cfb9ae0172bee1a90ab0ef74fb9c9cf']
   - version: 0.21.0
     kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
       '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']

--- a/static/compatibilities/external-dns.yaml
+++ b/static/compatibilities/external-dns.yaml
@@ -3,6 +3,24 @@ git_url: https://github.com/kubernetes-sigs/external-dns
 release_url: https://github.com/kubernetes-sigs/external-dns/releases/tag/v{vsn}
 helm_repository_url: https://kubernetes-sigs.github.io/external-dns
 versions:
+- version: 0.22.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary:
+    helm_changes: Application support is verified independently of Helm chart availability.
+    chart_updates: []
+    features: []
+    breaking_changes: [The default annotation prefix is now external-dns.kubernetes.io/
+        with no fallback. Migrate annotations or explicitly retain --annotation-prefix=external-dns.alpha.kubernetes.io/;
+        incorrect migration can delete DNS records., --policy is required and has
+        no default. Choose it explicitly before upgrading., 'In-tree Plural, Akamai
+        and Transip providers were removed. Use a supported webhook provider or retain
+        a compatible prior ExternalDNS version.', 'Upstream warns that --dry-run does
+        not prevent changes with ns1, hetzner and alibaba cloud providers; do not
+        rely on it as a universal safety guarantee.']
+  images: ['registry.k8s.io/external-dns/external-dns:v0.22.0@sha256:5fdcaf7deb5c158f93a1fc6fe169cdff4cfb9ae0172bee1a90ab0ef74fb9c9cf']
 - version: 0.21.0
   kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
     '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']

--- a/utils/compatibility/scrapers/external-dns.py
+++ b/utils/compatibility/scrapers/external-dns.py
@@ -206,7 +206,12 @@ def scrape():
         backfills = []
         for version, original in recorded.items():
             chart = charts.get(version)
-            if not original.get("chart_version") and stable_version(chart):
+            current_chart = original.get("chart_version")
+            candidate = stable_version(chart)
+            current = stable_version(current_chart)
+            # Packaging can advance without an application release. Never roll
+            # back a recorded chart or guess how an invalid saved version sorts.
+            if candidate and (not current_chart or (current and candidate > current)):
                 backfills.append(dict(deepcopy(original), chart_version=chart))
         rows, refreshed = [], []
         for version in sorted(versions, key=stable_version, reverse=True):

--- a/utils/compatibility/scrapers/external-dns.py
+++ b/utils/compatibility/scrapers/external-dns.py
@@ -1,90 +1,228 @@
-# scrapers/external_dns.py
+"""Join released ExternalDNS versions with their immutable Kubernetes matrix."""
+
+from copy import deepcopy
+import hashlib
+import json
+import re
 
 import requests
-from collections import OrderedDict
-from packaging.version import Version
-from utils import (
-    print_error,
-    update_compatibility_info,
-    get_chart_versions,
-    current_kube_version,
-)
+import yaml
 
-GITHUB_REPO_URL = "https://github.com/kubernetes-sigs/external-dns"
-GITHUB_API_TAGS_URL = (
-    "https://api.github.com/repos/kubernetes-sigs/external-dns/tags"
-)
+from utils import (current_kube_version, get_chart_versions, print_error,
+                   print_warning, read_yaml, reduce_versions, update_compatibility_info)
 
+app_name = "external-dns"
+target_file = "../../static/compatibilities/external-dns.yaml"
+releases_url = "https://api.github.com/repos/kubernetes-sigs/external-dns/releases?per_page=100"
+matrix_url = "https://raw.githubusercontent.com/kubernetes-sigs/external-dns/v{version}/README.md"
+registry_url = "https://registry.k8s.io/v2/external-dns/external-dns"
+image_name = "registry.k8s.io/external-dns/external-dns"
+legacy_cutoff = (0, 21, 0)
+manifest_accept = ", ".join([
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+])
 
-def fetch_github_tags():
-    response = requests.get(GITHUB_API_TAGS_URL)
-    if response.status_code != 200:
-        print_error(
-            f"Failed to fetch GitHub tags. Status code: {response.status_code}"
-        )
-        return []
-    return [tag["name"] for tag in response.json()]
-
-
-def expand_kube_versions(start_version, end_version):
-    start_major, start_minor = map(int, start_version.split("."))
-    end_major, end_minor = map(int, end_version.split("."))
-    expanded_versions = []
-
-    major, minor = start_major, start_minor
-    while (major < end_major) or (major == end_major and minor <= end_minor):
-        expanded_versions.append(f"{major}.{minor}")
-        if minor == 9:
-            major += 1
-            minor = 0
-        else:
-            minor += 1
-
-    return expanded_versions
-
-
-compat_map = {
-    "0.9.0": expand_kube_versions("1.10", "1.21"),
-    "0.10.0": expand_kube_versions("1.19", current_kube_version()),
+# Documented migration constraints, not generated release summaries.
+migration_022 = {
+    "helm_changes": "Application support is verified independently of Helm chart availability.",
+    "chart_updates": [], "features": [],
+    "breaking_changes": [
+        "The default annotation prefix is now external-dns.kubernetes.io/ with no fallback. Migrate annotations or explicitly retain --annotation-prefix=external-dns.alpha.kubernetes.io/; incorrect migration can delete DNS records.",
+        "--policy is required and has no default. Choose it explicitly before upgrading.",
+        "In-tree Plural, Akamai and Transip providers were removed. Use a supported webhook provider or retain a compatible prior ExternalDNS version.",
+        "Upstream warns that --dry-run does not prevent changes with ns1, hetzner and alibaba cloud providers; do not rely on it as a universal safety guarantee.",
+    ],
 }
 
 
-def extract_version_info(release_tags, chart_versions):
-    rows = []
-    for tag in release_tags:
-        tag_version = tag.lstrip("v")
-        parsed_tag_version = Version(tag_version)
-        chart_version = chart_versions.get(tag_version)
-        if not chart_version:
+def stable_version(value):
+    if not isinstance(value, str) or not re.fullmatch(r"\d+\.\d+\.\d+", value):
+        return None
+    return tuple(map(int, value.split(".")))
+
+
+def _get(url, headers=None):
+    response = requests.get(url, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response
+
+
+def released_versions(content):
+    releases = json.loads(content)
+    if not isinstance(releases, list):
+        raise ValueError("Expected a GitHub release list")
+    versions = set()
+    for release in releases:
+        if not isinstance(release, dict):
+            raise ValueError("Malformed release entry")
+        if release.get("draft") is not False or release.get("prerelease") is not False:
             continue
+        tag = release.get("tag_name", "")
+        version = stable_version(tag[1:]) if isinstance(tag, str) and tag.startswith("v") else None
+        if version and version > legacy_cutoff:
+            versions.add(version)
+    return [".".join(map(str, version)) for version in sorted(versions, reverse=True)]
 
-        if parsed_tag_version <= Version("0.9.0"):
-            kube_versions = compat_map["0.9.0"]
-        else:
-            kube_versions = compat_map["0.10.0"]
 
-        version_info = OrderedDict(
-            [
-                ("version", tag_version),
-                ("kube", kube_versions.copy()),
-                ("chart_version", chart_version),
-                ("images", []),
-                ("requirements", []),
-                ("incompatibilities", []),
-            ]
-        )
-        rows.append(version_info)
-    return rows
+def _constraint(text, allow_x=False):
+    """Parse only the table's explicit exact, union, and bounded range notation."""
+    parts = text.replace("≥", ">=").replace("≤", "<=").split(" and ")
+    atoms = []
+    suffix = r"(?:\.x)?" if allow_x else ""
+    for part in parts:
+        match = re.fullmatch(r"\s*(>=|<=)?\s*(\d+)\.(\d+)" + suffix + r"\s*", part)
+        if not match:
+            raise ValueError(f"Unrecognized compatibility constraint: {text!r}")
+        atoms.append((match[1], (int(match[2]), int(match[3]))))
+    if all(operator is None for operator, _ in atoms):
+        values = {value for _, value in atoms}
+        return lambda version: version in values
+    if any(operator is None for operator, _ in atoms):
+        raise ValueError(f"Mixed range and exact values: {text!r}")
+    lower = max((value for operator, value in atoms if operator == ">="), default=(0, 0))
+    upper = min((value for operator, value in atoms if operator == "<="), default=(999, 999))
+    if lower > upper:
+        raise ValueError(f"Reversed compatibility range: {text!r}")
+    return lambda version: lower <= version <= upper
+
+
+def supported_kubernetes(content, version, ceiling):
+    app_version = stable_version(version)
+    cap = re.fullmatch(r"1\.(\d+)", ceiling or "")
+    if not app_version or not cap:
+        raise ValueError("Invalid application version or cached Kubernetes 1.x ceiling")
+    text = content.decode("utf-8") if isinstance(content, bytes) else content
+    section = re.split(r"(?m)^## Kubernetes version compatibility\s*$", text)
+    if len(section) != 2:
+        raise ValueError("Missing or ambiguous Kubernetes compatibility section")
+    section = re.split(r"(?m)^## ", section[1], maxsplit=1)[0]
+    table = [[cell.strip() for cell in line.strip().strip("|").split("|")]
+             for line in section.splitlines() if line.strip().startswith("|")]
+    if len(table) < 3 or table[0][0] != "ExternalDNS":
+        raise ValueError("Missing ExternalDNS compatibility matrix")
+    if any(not re.fullmatch(r":?-+:?", cell) for cell in table[1]):
+        raise ValueError("Malformed compatibility table separator")
+    selected = [i for i, header in enumerate(table[0][1:], 1)
+                if _constraint(header, allow_x=True)(app_version[:2])]
+    if len(selected) != 1:
+        raise ValueError("Application does not match exactly one compatibility column")
+    support = {}
+    for row in table[2:]:
+        if len(row) != len(table[0]) or not row[0].startswith("Kubernetes "):
+            raise ValueError("Malformed Kubernetes compatibility row")
+        if any(cell not in {":white_check_mark:", ":x:"} for cell in row[1:]):
+            raise ValueError("Unknown compatibility marker")
+        matches = _constraint(row[0].removeprefix("Kubernetes "))
+        compatible = row[selected[0]] == ":white_check_mark:"
+        for minor in range(int(cap[1]) + 1):
+            if matches((1, minor)):
+                if minor in support and support[minor] != compatible:
+                    raise ValueError("Conflicting Kubernetes compatibility rows")
+                support[minor] = compatible
+    versions = [f"1.{minor}" for minor, compatible in sorted(support.items(), reverse=True) if compatible]
+    if not versions:
+        raise ValueError("No compatible Kubernetes versions within cached ceiling")
+    return versions
+
+
+def _verified_json(response, digest=None):
+    digest = digest or response.headers.get("Docker-Content-Digest", "")
+    if not re.fullmatch(r"sha256:[a-f0-9]{64}", digest):
+        raise ValueError("Registry artifact lacks a SHA256 digest")
+    if "sha256:" + hashlib.sha256(response.content).hexdigest() != digest:
+        raise ValueError("Registry artifact digest mismatch")
+    document = json.loads(response.content)
+    if not isinstance(document, dict):
+        raise ValueError("Malformed registry artifact")
+    return document, digest
+
+
+def verified_image(version):
+    """Read public registry metadata only; never pull or execute image layers."""
+    response = _get(f"{registry_url}/manifests/v{version}", {"Accept": manifest_accept})
+    document, index_digest = _verified_json(response)
+    if document.get("schemaVersion") != 2:
+        raise ValueError("Unsupported registry manifest schema")
+    if "manifests" in document:
+        manifests = document["manifests"]
+        if not isinstance(manifests, list):
+            raise ValueError("Malformed image index")
+        linux = [manifest for manifest in manifests if isinstance(manifest, dict)
+                 and isinstance(manifest.get("platform"), dict)
+                 and manifest["platform"].get("os") == "linux"
+                 and manifest["platform"].get("architecture") == "amd64"]
+        if len(linux) != 1:
+            raise ValueError("No unique Linux amd64 release manifest")
+        digest = linux[0].get("digest")
+        if not isinstance(digest, str) or not re.fullmatch(r"sha256:[a-f0-9]{64}", digest):
+            raise ValueError("Malformed platform manifest digest")
+        document, _ = _verified_json(_get(f"{registry_url}/manifests/{digest}", {"Accept": manifest_accept}), digest)
+    config = document.get("config", {})
+    digest = config.get("digest") if isinstance(config, dict) else None
+    if not isinstance(digest, str) or not re.fullmatch(r"sha256:[a-f0-9]{64}", digest):
+        raise ValueError("Missing image configuration digest")
+    configuration, _ = _verified_json(_get(f"{registry_url}/blobs/{digest}"), digest)
+    config = configuration.get("config")
+    labels = config.get("Labels", {}) if isinstance(config, dict) else {}
+    labels = labels or {}
+    if not isinstance(labels, dict):
+        raise ValueError("Malformed image configuration labels")
+    version_label = labels.get("org.opencontainers.image.version", f"v{version}")
+    if not isinstance(version_label, str) or version_label.lstrip("v") != version:
+        raise ValueError("Image configuration version does not match release")
+    source = labels.get("org.opencontainers.image.source", "https://github.com/kubernetes-sigs/external-dns")
+    if not isinstance(source, str) or source.rstrip("/") != "https://github.com/kubernetes-sigs/external-dns":
+        raise ValueError("Image configuration points to another project")
+    return f"{image_name}:v{version}@{index_digest}"
 
 
 def scrape():
-    release_tags = fetch_github_tags()
-    if not release_tags:
-        print_error("No release tags found.")
+    existing = read_yaml(target_file)
+    if not isinstance(existing, dict) or not isinstance(existing.get("versions"), list):
+        print_error("Existing ExternalDNS compatibility data is missing or invalid")
         return
-    chart_versions = get_chart_versions("external-dns")
-    rows = extract_version_info(release_tags, chart_versions)
-    update_compatibility_info(
-        "../../static/compatibilities/external-dns.yaml", rows
-    )
-
+    try:
+        recorded = {row["version"]: row for row in existing["versions"]}
+        if len(recorded) != len(existing["versions"]):
+            raise ValueError("Duplicate existing ExternalDNS versions")
+        versions = released_versions(_get(releases_url).content)
+        charts = get_chart_versions(app_name)
+        backfills = []
+        for version, original in recorded.items():
+            chart = charts.get(version)
+            if not original.get("chart_version") and stable_version(chart):
+                backfills.append(dict(deepcopy(original), chart_version=chart))
+        rows = []
+        for version in versions:
+            if version in recorded:
+                continue
+            kube = supported_kubernetes(_get(matrix_url.format(version=version)).content,
+                                        version, current_kube_version())
+            row = {"version": version, "kube": kube, "requirements": [], "incompatibilities": []}
+            chart = charts.get(version)
+            if stable_version(chart):
+                row["chart_version"] = chart
+            if version == "0.22.0":
+                row["summary"] = deepcopy(migration_022)
+                if row.get("chart_version"):
+                    row["summary"]["helm_changes"] = "Official chart packaging is available; review the application migration constraints below."
+            rows.append(row)
+        combined = deepcopy(recorded)
+        combined.update({row["version"]: row for row in backfills + rows})
+        retained = {row["version"] for row in reduce_versions(list(combined.values()))}
+        rows = [row for row in rows if row["version"] in retained]
+        backfills = [row for row in backfills if row["version"] in retained]
+        for row in rows:
+            try:
+                row["images"] = [verified_image(row["version"])]
+            except (requests.RequestException, ValueError, KeyError, TypeError) as error:
+                print_warning(f"Could not verify released image for {row['version']}: {error}")
+                row["images"] = []
+    except (requests.RequestException, ValueError, KeyError, TypeError, yaml.YAMLError) as error:
+        print_error(f"Cannot update ExternalDNS compatibility: {error}")
+        return
+    if backfills or rows:
+        update_compatibility_info(target_file, backfills + rows)

--- a/utils/compatibility/scrapers/external-dns.py
+++ b/utils/compatibility/scrapers/external-dns.py
@@ -44,6 +44,13 @@ def stable_version(value):
     return tuple(map(int, value.split(".")))
 
 
+def recorded_ceiling(row):
+    kube = row.get("kube", [])
+    if not isinstance(kube, list) or any(not isinstance(value, str) or not re.fullmatch(r"1\.\d+", value) for value in kube):
+        raise ValueError("Invalid recorded Kubernetes versions")
+    return max(kube, key=lambda value: int(value.split(".")[1]), default=None)
+
+
 def _get(url, headers=None):
     response = requests.get(url, headers=headers, timeout=30)
     response.raise_for_status()
@@ -188,19 +195,37 @@ def scrape():
         recorded = {row["version"]: row for row in existing["versions"]}
         if len(recorded) != len(existing["versions"]):
             raise ValueError("Duplicate existing ExternalDNS versions")
-        versions = released_versions(_get(releases_url).content)
+        versions = set(released_versions(_get(releases_url).content))
+        # Stored nonlegacy releases may have fallen off the bounded release list.
+        # Their immutable matrices still determine whether a new ceiling extends
+        # an explicitly open-ended range. Legacy history remains untouched.
+        versions.update(version for version in recorded
+                        if stable_version(version) and stable_version(version)[:2] >= (0, 22))
+        ceiling = current_kube_version()
         charts = get_chart_versions(app_name)
         backfills = []
         for version, original in recorded.items():
             chart = charts.get(version)
             if not original.get("chart_version") and stable_version(chart):
                 backfills.append(dict(deepcopy(original), chart_version=chart))
-        rows = []
-        for version in versions:
-            if version in recorded:
+        rows, refreshed = [], []
+        for version in sorted(versions, key=stable_version, reverse=True):
+            original = recorded.get(version)
+            if original and stable_version(version)[:2] < (0, 22):
+                continue
+            if original and recorded_ceiling(original) == ceiling:
                 continue
             kube = supported_kubernetes(_get(matrix_url.format(version=version)).content,
-                                        version, current_kube_version())
+                                        version, ceiling)
+            if original:
+                if kube != original["kube"]:
+                    # Retain a simultaneous exact chart backfill on this version
+                    # as well as all saved image, summary and EOL metadata.
+                    row = deepcopy(next((row for row in backfills if row["version"] == version), original))
+                    row["kube"] = kube
+                    refreshed.append(row)
+                    backfills = [row for row in backfills if row["version"] != version]
+                continue
             row = {"version": version, "kube": kube, "requirements": [], "incompatibilities": []}
             chart = charts.get(version)
             if stable_version(chart):
@@ -211,10 +236,11 @@ def scrape():
                     row["summary"]["helm_changes"] = "Official chart packaging is available; review the application migration constraints below."
             rows.append(row)
         combined = deepcopy(recorded)
-        combined.update({row["version"]: row for row in backfills + rows})
+        combined.update({row["version"]: row for row in backfills + refreshed + rows})
         retained = {row["version"] for row in reduce_versions(list(combined.values()))}
         rows = [row for row in rows if row["version"] in retained]
         backfills = [row for row in backfills if row["version"] in retained]
+        refreshed = [row for row in refreshed if row["version"] in retained]
         for row in rows:
             try:
                 row["images"] = [verified_image(row["version"])]
@@ -224,5 +250,5 @@ def scrape():
     except (requests.RequestException, ValueError, KeyError, TypeError, yaml.YAMLError) as error:
         print_error(f"Cannot update ExternalDNS compatibility: {error}")
         return
-    if backfills or rows:
-        update_compatibility_info(target_file, backfills + rows)
+    if backfills or refreshed or rows:
+        update_compatibility_info(target_file, backfills + refreshed + rows)

--- a/utils/compatibility/scrapers/external-dns.py
+++ b/utils/compatibility/scrapers/external-dns.py
@@ -172,6 +172,10 @@ def verified_image(version):
     if not isinstance(digest, str) or not re.fullmatch(r"sha256:[a-f0-9]{64}", digest):
         raise ValueError("Missing image configuration digest")
     configuration, _ = _verified_json(_get(f"{registry_url}/blobs/{digest}"), digest)
+    # Direct manifests have no index descriptor to establish their platform.
+    # Check the actual configuration in both paths, including descriptor claims.
+    if configuration.get("os") != "linux" or configuration.get("architecture") != "amd64":
+        raise ValueError("Image configuration is not Linux amd64")
     config = configuration.get("config")
     labels = config.get("Labels", {}) if isinstance(config, dict) else {}
     labels = labels or {}

--- a/utils/compatibility/tests/EXTERNAL_DNS.md
+++ b/utils/compatibility/tests/EXTERNAL_DNS.md
@@ -1,0 +1,43 @@
+# ExternalDNS compatibility validation
+
+Run from the repository root with the existing compatibility dependencies:
+
+```sh
+python -m unittest discover -s utils/compatibility/tests -v
+```
+
+The ExternalDNS tests use a reduced copy of the immutable v0.22.0 README matrix
+and synthetic registry metadata with computed byte digests. They require no
+network, Helm, Docker credentials, DNS credentials, or paid summarization.
+
+The scraper discovers stable application releases in the latest 100 GitHub
+release records, excluding draft/prerelease/chart-only tags. New releases read
+their own tagged README matrix. The explicitly compatible open Kubernetes range
+is capped at the repository's configured `KUBE_VERSION`, currently 1.36; this is
+not a claim that 1.36 is the newest upstream Kubernetes version. Recorded history
+is preserved. Missing exact charts can be filled later, even for legacy versions
+outside the current release list, without replacing stored compatibility.
+
+Sources verified on 2026-09-08:
+
+- [Stable release and migration notes](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.22.0).
+- [Tagged compatibility matrix](https://github.com/kubernetes-sigs/external-dns/blob/v0.22.0/README.md#kubernetes-version-compatibility): ExternalDNS >=0.18.x supports Kubernetes 1.21, 1.22–1.32 and >=1.33; 1.19 and 1.20 are explicitly incompatible.
+- [Official Helm index](https://kubernetes-sigs.github.io/external-dns/index.yaml): latest chart 1.21.1 packages app 0.21.0; no 0.22.0 mapping was invented.
+- [Public release image index](https://registry.k8s.io/v2/external-dns/external-dns/manifests/v0.22.0): index SHA256 `5fdcaf7deb5c158f93a1fc6fe169cdff4cfb9ae0172bee1a90ab0ef74fb9c9cf`. The scraper verifies index, selected Linux amd64 manifest and configuration byte digests without fetching image layers. The release explicitly names this image tag. Configuration revision is empty, so it does not independently prove a Git commit.
+
+The tagged [Kustomization](https://github.com/kubernetes-sigs/external-dns/blob/v0.22.0/kustomize/kustomization.yaml)
+and [AWS tutorial](https://github.com/kubernetes-sigs/external-dns/blob/v0.22.0/docs/tutorials/aws.md)
+still reference 0.21.0. They were excluded as evidence for the 0.22.0 image.
+If a future registry artifact cannot be verified, compatibility can be recorded
+with an explicitly empty images list; no image is inferred from a tag string.
+
+The 0.22.0 generated summary records the required explicit policy, annotation
+prefix migration, removed Plural/Akamai/Transip providers, and upstream's warning
+that dry-run does not prevent changes for ns1/hetzner/alibaba providers.
+
+Live validation read official sources and rendered all 13 retained historical
+Helm charts with isolated Helm/Docker paths and both optional paid API keys unset.
+There was no Kubernetes installation, image execution, image-layer download, or
+DNS operation. Existing 13 records remain exactly unchanged; only the 0.22.0 row
+is added. Both generated YAML schemas pass, unrelated add-ons are unchanged, and
+a repeated live scrape calls no writer or image verifier.

--- a/utils/compatibility/tests/EXTERNAL_DNS.md
+++ b/utils/compatibility/tests/EXTERNAL_DNS.md
@@ -14,9 +14,13 @@ The scraper discovers stable application releases in the latest 100 GitHub
 release records, excluding draft/prerelease/chart-only tags. New releases read
 their own tagged README matrix. The explicitly compatible open Kubernetes range
 is capped at the repository's configured `KUBE_VERSION`, currently 1.36; this is
-not a claim that 1.36 is the newest upstream Kubernetes version. Recorded history
-is preserved. Missing exact charts can be filled later, even for legacy versions
-outside the current release list, without replacing stored compatibility.
+not a claim that 1.36 is the newest upstream Kubernetes version. Recorded legacy
+history is preserved. If the configured ceiling differs from the highest saved supported
+minor, recorded releases from 0.22 onward recheck their own immutable matrices.
+An explicit finite range is never extended beyond its source. Only changed
+Kubernetes lists are updated; summary/images/EOL and any simultaneous exact chart
+backfill are preserved. Unchanged ceilings produce no writes. Missing exact charts
+can be filled later, even for legacy versions outside the current release list, without replacing stored compatibility.
 
 Sources verified on 2026-09-08:
 

--- a/utils/compatibility/tests/EXTERNAL_DNS.md
+++ b/utils/compatibility/tests/EXTERNAL_DNS.md
@@ -21,6 +21,11 @@ An explicit finite range is never extended beyond its source. Only changed
 Kubernetes lists are updated; summary/images/EOL and any simultaneous exact chart
 backfill are preserved. Unchanged ceilings produce no writes. Missing exact charts
 can be filled later, even for legacy versions outside the current release list, without replacing stored compatibility.
+Strictly newer stable charts for the same recorded application also update;
+equal, older, and prerelease mappings do not. The normal writer refreshes chart
+images while preserving compatibility, custom summaries, requirements and EOL.
+Regression tests exercise chart advancement, image refresh, the subsequent no-op,
+rollback rejection, and a simultaneous support-ceiling refresh.
 
 Sources verified on 2026-09-08:
 
@@ -38,6 +43,8 @@ with an explicitly empty images list; no image is inferred from a tag string.
 The 0.22.0 generated summary records the required explicit policy, annotation
 prefix migration, removed Plural/Akamai/Transip providers, and upstream's warning
 that dry-run does not prevent changes for ns1/hetzner/alibaba providers.
+Its chart-independent support statement remains accurate after chart packaging
+arrives, so backfills need not overwrite any generated or custom summary text.
 
 Live validation read official sources and rendered all 13 retained historical
 Helm charts with isolated Helm/Docker paths and both optional paid API keys unset.

--- a/utils/compatibility/tests/EXTERNAL_DNS.md
+++ b/utils/compatibility/tests/EXTERNAL_DNS.md
@@ -39,6 +39,11 @@ and [AWS tutorial](https://github.com/kubernetes-sigs/external-dns/blob/v0.22.0/
 still reference 0.21.0. They were excluded as evidence for the 0.22.0 image.
 If a future registry artifact cannot be verified, compatibility can be recorded
 with an explicitly empty images list; no image is inferred from a tag string.
+Direct OCI/Docker manifests and manifests selected through an image index must
+both have a digest-verified configuration declaring `os: linux` and
+`architecture: amd64`. An index descriptor alone is insufficient. Regression
+tests accept Linux/amd64 direct manifests and reject arm64, Windows, and missing
+platform configuration in both paths, including inconsistent index claims.
 
 The 0.22.0 generated summary records the required explicit policy, annotation
 prefix migration, removed Plural/Akamai/Transip providers, and upstream's warning

--- a/utils/compatibility/tests/fixtures/external-dns/matrix.md
+++ b/utils/compatibility/tests/fixtures/external-dns/matrix.md
@@ -1,0 +1,16 @@
+## Kubernetes version compatibility
+
+Breaking changes were introduced in external-dns in the following versions:
+
+- [`v0.10.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.10.0): use of `networking.k8s.io/ingresses` instead of `extensions/ingresses` (see [#2281](https://github.com/kubernetes-sigs/external-dns/pull/2281))
+- [`v0.18.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.18.0): use of `discovery.k8s.io/endpointslices` instead of `endpoints` (see [#5493](https://github.com/kubernetes-sigs/external-dns/pull/5493))
+- [`v0.19.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.19.0): don't expose internal ipv6 by default (see [#5575](https://github.com/kubernetes-sigs/external-dns/pull/5575)) and disable legacy listeners on `traefik.containo.us` API Group (see [#5565](https://github.com/kubernetes-sigs/external-dns/pull/5565))
+
+| ExternalDNS                  |      ≤ 0.9.x       | ≥ 0.10.x and ≤ 0.17.x |      ≥ 0.18.x      |
+| ---------------------------- | :----------------: | :-------------------: | :----------------: |
+| Kubernetes ≤ 1.18            | :white_check_mark: |          :x:          |        :x:         |
+| Kubernetes 1.19 and 1.20     | :white_check_mark: |  :white_check_mark:   |        :x:         |
+| Kubernetes 1.21              | :white_check_mark: |  :white_check_mark:   | :white_check_mark: |
+| Kubernetes ≥ 1.22 and ≤ 1.32 |        :x:         |  :white_check_mark:   | :white_check_mark: |
+| Kubernetes ≥ 1.33            |        :x:         |          :x:          | :white_check_mark: |
+

--- a/utils/compatibility/tests/test_chart_images.py
+++ b/utils/compatibility/tests/test_chart_images.py
@@ -1,0 +1,36 @@
+"""Image extraction regressions from charts that also template CRD schemas."""
+
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import find_nested_images
+
+
+class ChartImageTests(unittest.TestCase):
+    def test_crd_image_schema_does_not_crash_or_hide_container_images(self):
+        manifests = [
+            {"kind": "CustomResourceDefinition", "spec": {"properties": {
+                "image": {"description": "Container image", "type": "string"},
+            }}},
+            {"kind": "Deployment", "spec": {"template": {"spec": {
+                "containers": [{"image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0"}],
+                "initContainers": [{"image": "busybox:1.36"}],
+            }}}},
+        ]
+        self.assertEqual(find_nested_images(manifests), [
+            "busybox:1.36", "ghcr.io/cloudnative-pg/cloudnative-pg:1.30.0",
+        ])
+
+    def test_non_image_values_are_ignored_and_references_deduplicated(self):
+        self.assertEqual(find_nested_images([
+            {"image": None}, {"image": 123}, {"image": "not an image"},
+            {"image": "registry.example:5000/operator:v1"},
+            {"image": "registry.example:5000/operator:v1"},
+            {"image": "registry.example/operator@sha256:" + "a" * 64},
+        ]), ["registry.example/operator@sha256:" + "a" * 64, "registry.example:5000/operator:v1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_external_dns.py
+++ b/utils/compatibility/tests/test_external_dns.py
@@ -32,11 +32,11 @@ class ExternalDNSTests(unittest.TestCase):
         self.sources = {scraper.releases_url: response([release("0.22.0"), release("0.21.0")]),
             scraper.matrix_url.format(version="0.22.0"): SimpleNamespace(content=MATRIX)}
 
-    def run_scrape(self, failure=None):
+    def run_scrape(self, failure=None, ceiling="1.36"):
         with patch.object(scraper, "read_yaml", return_value=self.existing), \
                 patch.object(scraper, "_get", side_effect=lambda url, *args: self.sources[url]), \
                 patch.object(scraper, "get_chart_versions", return_value=self.charts), \
-                patch.object(scraper, "current_kube_version", return_value="1.36"), \
+                patch.object(scraper, "current_kube_version", return_value=ceiling), \
                 patch.object(scraper, "verified_image", side_effect=failure,
                              return_value=scraper.image_name + ":v0.22.0@sha256:" + "a"*64) as image, \
                 patch.object(scraper, "print_warning"), patch.object(scraper, "print_error"), \
@@ -113,6 +113,38 @@ class ExternalDNSTests(unittest.TestCase):
         write, image = self.run_scrape()
         write.assert_not_called()
         image.assert_not_called()
+
+    def test_recorded_open_range_refreshes_new_ceiling_preserving_metadata_then_noops(self):
+        self.save(self.run_scrape()[0].call_args.args[1])
+        saved = self.existing["versions"][0]
+        saved.update(eolAt="2027-01-01", requirements=[{"name": "keep", "version": "1.0"}])
+        before = deepcopy(self.existing)
+        # The release may already have fallen off the latest 100 release records.
+        self.sources[scraper.releases_url] = response([])
+        write, image = self.run_scrape(ceiling="1.37")
+        rows = write.call_args.args[1]
+        self.assertEqual(rows, [dict(saved, kube=["1.37"] + saved["kube"])])
+        self.assertEqual(self.existing, before)
+        image.assert_not_called()
+        self.save(rows)
+        self.assertEqual(self.existing["versions"][1], before["versions"][1])
+        self.sources = {scraper.releases_url: response([])}
+        self.run_scrape(ceiling="1.37")[0].assert_not_called()
+
+    def test_ceiling_refresh_merges_a_simultaneous_exact_chart_backfill(self):
+        self.save(self.run_scrape()[0].call_args.args[1])
+        saved = deepcopy(self.existing["versions"][0])
+        self.charts["0.22.0"] = "1.22.2"
+        rows = self.run_scrape(ceiling="1.37")[0].call_args.args[1]
+        self.assertEqual(rows, [dict(saved, kube=["1.37"] + saved["kube"], chart_version="1.22.2")])
+        self.save(rows)
+        self.run_scrape(ceiling="1.37")[0].assert_not_called()
+
+    def test_finite_matrix_range_does_not_extend_with_a_new_ceiling(self):
+        self.save(self.run_scrape()[0].call_args.args[1])
+        self.sources[scraper.matrix_url.format(version="0.22.0")] = SimpleNamespace(
+            content=MATRIX.replace("≥ 1.33".encode(), "≥ 1.33 and ≤ 1.36".encode()))
+        self.run_scrape(ceiling="1.37")[0].assert_not_called()
 
     def test_delayed_exact_chart_backfill_preserves_metadata_and_noops_next_run(self):
         self.save(self.run_scrape()[0].call_args.args[1])

--- a/utils/compatibility/tests/test_external_dns.py
+++ b/utils/compatibility/tests/test_external_dns.py
@@ -246,8 +246,9 @@ class ExternalDNSTests(unittest.TestCase):
         self.assertEqual(reduced[1]["eolAt"], "2027-01-01")
         self.assertEqual(max(Version(r["chart_version"]) for r in reduced if r.get("chart_version")), Version("1.21.1"))
 
-    def registry_artifacts(self, labels=None):
-        config = response({"config": {"Labels": labels or {"org.opencontainers.image.source": "https://github.com/kubernetes-sigs/external-dns"}}})
+    def registry_artifacts(self, labels=None, image_os="linux", architecture="amd64"):
+        config = response({"os": image_os, "architecture": architecture,
+                           "config": {"Labels": labels or {"org.opencontainers.image.source": "https://github.com/kubernetes-sigs/external-dns"}}})
         manifest = response({"schemaVersion": 2, "config": {"digest": config.headers["Docker-Content-Digest"]}})
         index = response({"schemaVersion": 2, "manifests": [{"platform": {"os": "linux", "architecture": "amd64"},
                                                           "digest": manifest.headers["Docker-Content-Digest"]}]})
@@ -261,6 +262,25 @@ class ExternalDNSTests(unittest.TestCase):
         self.assertEqual(get.call_count, 3)
         self.assertEqual(get.call_args_list[0].args[1], {"Accept": scraper.manifest_accept})
         self.assertIn("/blobs/sha256:", get.call_args_list[-1].args[0])
+
+    def test_direct_manifest_accepts_verified_linux_amd64_config(self):
+        _, manifest, config = self.registry_artifacts()
+        with patch.object(scraper, "_get", side_effect=[manifest, config]) as get:
+            image = scraper.verified_image("0.22.0")
+        self.assertEqual(image, scraper.image_name + ":v0.22.0@" + manifest.headers["Docker-Content-Digest"])
+        self.assertEqual(get.call_count, 2)
+        self.assertEqual(get.call_args_list[-1].args[0],
+                         scraper.registry_url + "/blobs/" + config.headers["Docker-Content-Digest"])
+
+    def test_direct_and_index_manifests_reject_non_linux_amd64_configuration(self):
+        for image_os, architecture in (("linux", "arm64"), ("windows", "amd64"),
+                                       (None, "amd64"), ("linux", None)):
+            artifacts = self.registry_artifacts(image_os=image_os, architecture=architecture)
+            for selected in (artifacts, artifacts[1:]):
+                with self.subTest(image_os=image_os, architecture=architecture, direct=len(selected) == 2), \
+                        patch.object(scraper, "_get", side_effect=selected), \
+                        self.assertRaisesRegex(ValueError, "configuration is not Linux amd64"):
+                    scraper.verified_image("0.22.0")
 
     def test_registry_rejects_wrong_digest_version_source_or_missing_platform(self):
         cases = [self.registry_artifacts({"org.opencontainers.image.version": "v0.21.0"}),

--- a/utils/compatibility/tests/test_external_dns.py
+++ b/utils/compatibility/tests/test_external_dns.py
@@ -1,0 +1,218 @@
+"""Offline tests for ExternalDNS compatibility and immutable image metadata."""
+from copy import deepcopy
+import hashlib
+import importlib
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+import requests
+from packaging.version import Version
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+scraper = importlib.import_module("scrapers.external-dns")
+from utils import reduce_versions, update_versions_data
+MATRIX = (Path(__file__).parent / "fixtures/external-dns/matrix.md").read_bytes()
+
+def response(value):
+    content = json.dumps(value, separators=(",", ":")).encode()
+    return SimpleNamespace(content=content, headers={"Docker-Content-Digest": "sha256:" + hashlib.sha256(content).hexdigest()})
+
+def release(version):
+    return {"tag_name": "v" + version, "draft": False, "prerelease": False}
+
+class ExternalDNSTests(unittest.TestCase):
+    def setUp(self):
+        self.existing = {"versions": [{"version": "0.21.0", "kube": ["1.36", "1.21", "1.19"],
+            "chart_version": "1.21.1", "images": ["existing:0.21.0"],
+            "requirements": [], "incompatibilities": [], "summary": {"features": ["Stored"]}}]}
+        self.charts = {"0.21.0": "1.21.1"}
+        self.sources = {scraper.releases_url: response([release("0.22.0"), release("0.21.0")]),
+            scraper.matrix_url.format(version="0.22.0"): SimpleNamespace(content=MATRIX)}
+
+    def run_scrape(self, failure=None):
+        with patch.object(scraper, "read_yaml", return_value=self.existing), \
+                patch.object(scraper, "_get", side_effect=lambda url, *args: self.sources[url]), \
+                patch.object(scraper, "get_chart_versions", return_value=self.charts), \
+                patch.object(scraper, "current_kube_version", return_value="1.36"), \
+                patch.object(scraper, "verified_image", side_effect=failure,
+                             return_value=scraper.image_name + ":v0.22.0@sha256:" + "a"*64) as image, \
+                patch.object(scraper, "print_warning"), patch.object(scraper, "print_error"), \
+                patch.object(scraper, "update_compatibility_info") as write:
+            scraper.scrape()
+        return write, image
+
+    def save(self, rows):
+        update_versions_data(self.existing, deepcopy(rows))
+        self.existing["versions"] = reduce_versions(self.existing["versions"])
+
+    def test_explicit_matrix_excludes_unsupported_kubernetes_and_caps_open_range(self):
+        self.assertEqual(scraper.supported_kubernetes(MATRIX, "0.22.0", "1.36"),
+                         [f"1.{i}" for i in range(36, 20, -1)])
+        self.assertEqual(scraper.supported_kubernetes(MATRIX, "0.22.0", "1.21"), ["1.21"])
+        self.assertEqual(scraper.supported_kubernetes(MATRIX, "0.17.0", "1.36"),
+                         [f"1.{i}" for i in range(32, 18, -1)])
+
+    def test_column_order_does_not_change_selected_support(self):
+        lines = MATRIX.decode().splitlines()
+        for i, line in enumerate(lines):
+            if line.startswith("|"):
+                cells = line.strip("|").split("|")
+                cells[1], cells[-1] = cells[-1], cells[1]
+                lines[i] = "|" + "|".join(cells) + "|"
+        self.assertEqual(scraper.supported_kubernetes("\n".join(lines), "0.22.0", "1.36"),
+                         scraper.supported_kubernetes(MATRIX, "0.22.0", "1.36"))
+
+    def test_malformed_or_ambiguous_matrix_never_partially_parses(self):
+        invalid = [b"Missing", MATRIX.replace(b"ExternalDNS", b"Ray"), MATRIX + MATRIX,
+            MATRIX.replace(b":white_check_mark:", b"maybe", 1),
+            MATRIX.replace("≥ 1.33".encode(), b"1.33+"),
+            MATRIX.replace("≥ 1.22 and ≤ 1.32".encode(), "≥ 1.32 and ≤ 1.22".encode()),
+            MATRIX.replace("≤ 0.9.x".encode(), "≥ 0.18.x".encode()),
+            MATRIX.replace(b"| Kubernetes 1.21", b"| extra | Kubernetes 1.21")]
+        for source in invalid:
+            with self.subTest(source=source[:30]), self.assertRaises(ValueError):
+                scraper.supported_kubernetes(source, "0.22.0", "1.36")
+
+    def test_bad_release_or_ceiling_is_rejected(self):
+        for version, cap in [("0.22.0-rc1", "1.36"), ("0.22", "1.36"), ("0.22.0", None),
+                             ("0.22.0", "1.36+"), ("0.22.0", "2.0"), ("0.22.0", "1.20")]:
+            with self.subTest(version=version, cap=cap), self.assertRaises(ValueError):
+                scraper.supported_kubernetes(MATRIX, version, cap)
+
+    def test_only_released_stable_apps_are_selected_and_deduplicated(self):
+        data = [release("0.22.0"), release("0.22.0"), release("0.21.0"), release("0.22.1-rc1"),
+                dict(release("0.23.0"), draft=True), dict(release("0.24.0"), prerelease=True),
+                {"tag_name": "external-dns-helm-chart-1.22.0", "draft": False, "prerelease": False}]
+        self.assertEqual(scraper.released_versions(json.dumps(data)), ["0.22.0"])
+        for source in ("null", "{}", "[null]"):
+            with self.assertRaises(ValueError):
+                scraper.released_versions(source)
+
+    def test_chartless_release_retains_verified_image_and_concrete_migration_notes(self):
+        original = deepcopy(self.existing)
+        row = self.run_scrape()[0].call_args.args[1][0]
+        self.assertEqual(row["version"], "0.22.0")
+        self.assertNotIn("chart_version", row)
+        self.assertIn("@sha256:", row["images"][0])
+        notes = " ".join(row["summary"]["breaking_changes"])
+        for detail in ("--policy", "external-dns.alpha.kubernetes.io/", "Plural", "ns1", "hetzner", "alibaba"):
+            self.assertIn(detail, notes)
+        self.assertEqual(self.existing, original)
+
+    def test_missing_registry_artifact_keeps_support_without_inventing_image(self):
+        row = self.run_scrape(requests.HTTPError("404"))[0].call_args.args[1][0]
+        self.assertEqual(row["images"], [])
+        self.assertEqual(row["kube"][-1], "1.21")
+
+    def test_completed_rerun_does_not_fetch_matrix_image_or_write(self):
+        self.save(self.run_scrape()[0].call_args.args[1])
+        self.sources = {scraper.releases_url: self.sources[scraper.releases_url]}
+        write, image = self.run_scrape()
+        write.assert_not_called()
+        image.assert_not_called()
+
+    def test_delayed_exact_chart_backfill_preserves_metadata_and_noops_next_run(self):
+        self.save(self.run_scrape()[0].call_args.args[1])
+        saved = self.existing["versions"][0]
+        saved.update(eolAt="2027-01-01", requirements=[{"name": "keep", "version": "1.0"}])
+        original = deepcopy(saved)
+        self.charts["0.22.0"] = "1.22.2"
+        self.sources = {scraper.releases_url: self.sources[scraper.releases_url]}
+        write, image = self.run_scrape()
+        self.assertEqual(write.call_args.args[1], [dict(original, chart_version="1.22.2")])
+        image.assert_not_called()
+        self.save(write.call_args.args[1])
+        self.assertEqual(len(self.existing["versions"]), len({r["version"] for r in self.existing["versions"]}))
+        self.run_scrape()[0].assert_not_called()
+
+    def test_legacy_backfill_does_not_require_a_current_matrix_or_release_entry(self):
+        self.save(self.run_scrape()[0].call_args.args[1])
+        legacy = {"version": "0.8.0", "kube": ["1.15"], "images": ["old:0.8.0"],
+                  "summary": {"features": ["Keep"]}, "eolAt": "2020-01-01"}
+        self.existing["versions"].append(legacy)
+        self.charts["0.8.0"] = "1.0.0"
+        self.sources = {scraper.releases_url: response([])}
+        for blank in (None, ""):
+            legacy["chart_version"] = blank
+            write, image = self.run_scrape()
+            self.assertEqual(write.call_args.args[1], [dict(legacy, chart_version="1.0.0")])
+            image.assert_not_called()
+
+    def test_existing_chart_and_prerelease_mapping_are_not_used_as_backfills(self):
+        self.save(self.run_scrape()[0].call_args.args[1])
+        self.charts.update({"0.21.0": "99.0.0", "0.22.0": "1.22.0-rc1"})
+        self.run_scrape()[0].assert_not_called()
+
+    def test_charted_intermediate_patch_is_retained_before_reduction(self):
+        self.sources[scraper.releases_url] = response([release(f"0.22.{i}") for i in range(3)])
+        for i in (1, 2):
+            self.sources[scraper.matrix_url.format(version=f"0.22.{i}")] = SimpleNamespace(content=MATRIX)
+        self.charts["0.22.1"] = "1.22.1"
+        rows = self.run_scrape()[0].call_args.args[1]
+        self.assertEqual({r["version"] for r in rows}, {"0.22.0", "0.22.1", "0.22.2"})
+        self.assertEqual(next(r for r in rows if r["version"] == "0.22.1")["chart_version"], "1.22.1")
+
+    def test_second_matrix_failure_aborts_entire_batch_before_image_reads(self):
+        self.sources[scraper.releases_url] = response([release("0.22.1"), release("0.22.0")])
+        self.sources[scraper.matrix_url.format(version="0.22.1")] = SimpleNamespace(content=MATRIX)
+        self.sources[scraper.matrix_url.format(version="0.22.0")] = SimpleNamespace(content=b"Missing")
+        write, image = self.run_scrape()
+        write.assert_not_called()
+        image.assert_not_called()
+
+    def test_duplicate_existing_versions_fail_before_lossy_merge(self):
+        self.existing["versions"].append(deepcopy(self.existing["versions"][0]))
+        self.run_scrape()[0].assert_not_called()
+
+    def test_mixed_chart_reducer_preserves_latest_available_chart_images_and_eol(self):
+        rows = [{"version": "0.21.0", "kube": ["1.33"], "chart_version": "1.21.0"},
+                {"version": "0.21.1", "kube": ["1.33"], "chart_version": "1.21.1", "eolAt": "2027-01-01"},
+                {"version": "0.22.0", "kube": ["1.33"], "images": ["verified:0.22.0"]}]
+        reduced = reduce_versions(rows)
+        self.assertEqual([r["version"] for r in reduced], ["0.22.0", "0.21.1", "0.21.0"])
+        self.assertEqual(reduced[0]["images"], ["verified:0.22.0"])
+        self.assertEqual(reduced[1]["eolAt"], "2027-01-01")
+        self.assertEqual(max(Version(r["chart_version"]) for r in reduced if r.get("chart_version")), Version("1.21.1"))
+
+    def registry_artifacts(self, labels=None):
+        config = response({"config": {"Labels": labels or {"org.opencontainers.image.source": "https://github.com/kubernetes-sigs/external-dns"}}})
+        manifest = response({"schemaVersion": 2, "config": {"digest": config.headers["Docker-Content-Digest"]}})
+        index = response({"schemaVersion": 2, "manifests": [{"platform": {"os": "linux", "architecture": "amd64"},
+                                                          "digest": manifest.headers["Docker-Content-Digest"]}]})
+        return index, manifest, config
+
+    def test_registry_checks_index_platform_and_config_digests_without_image_layers(self):
+        artifacts = self.registry_artifacts()
+        with patch.object(scraper, "_get", side_effect=artifacts) as get:
+            image = scraper.verified_image("0.22.0")
+        self.assertEqual(image, scraper.image_name + ":v0.22.0@" + artifacts[0].headers["Docker-Content-Digest"])
+        self.assertEqual(get.call_count, 3)
+        self.assertEqual(get.call_args_list[0].args[1], {"Accept": scraper.manifest_accept})
+        self.assertIn("/blobs/sha256:", get.call_args_list[-1].args[0])
+
+    def test_registry_rejects_wrong_digest_version_source_or_missing_platform(self):
+        cases = [self.registry_artifacts({"org.opencontainers.image.version": "v0.21.0"}),
+                 self.registry_artifacts({"org.opencontainers.image.source": "https://example.com/other"})]
+        broken = list(self.registry_artifacts())
+        broken[-1].content += b" "
+        cases.append(broken)
+        broken = list(self.registry_artifacts())
+        broken[0].headers["Docker-Content-Digest"] = "sha256:" + "0"*64
+        cases.append(broken)
+        cases.extend([[response(d)] for d in [
+            {"schemaVersion": 2, "manifests": []}, {"schemaVersion": 2, "config": {}}, {"schemaVersion": 1}]])
+        for artifacts in cases:
+            with self.subTest(artifacts=artifacts), patch.object(scraper, "_get", side_effect=artifacts), self.assertRaises(ValueError):
+                scraper.verified_image("0.22.0")
+
+    def test_http_reads_have_timeout_and_raise_for_status(self):
+        with patch.object(scraper.requests, "get") as get:
+            scraper._get("https://example.com")
+            get.assert_called_once_with("https://example.com", headers=None, timeout=30)
+            get.return_value.raise_for_status.assert_called_once_with()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_external_dns.py
+++ b/utils/compatibility/tests/test_external_dns.py
@@ -13,6 +13,7 @@ from packaging.version import Version
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 scraper = importlib.import_module("scrapers.external-dns")
+import utils
 from utils import reduce_versions, update_versions_data
 MATRIX = (Path(__file__).parent / "fixtures/external-dns/matrix.md").read_bytes()
 
@@ -135,8 +136,11 @@ class ExternalDNSTests(unittest.TestCase):
         self.save(self.run_scrape()[0].call_args.args[1])
         saved = deepcopy(self.existing["versions"][0])
         self.charts["0.22.0"] = "1.22.2"
-        rows = self.run_scrape(ceiling="1.37")[0].call_args.args[1]
-        self.assertEqual(rows, [dict(saved, kube=["1.37"] + saved["kube"], chart_version="1.22.2")])
+        for old_chart in (None, "1.22.1"):
+            with self.subTest(old_chart=old_chart):
+                self.existing["versions"][0]["chart_version"] = old_chart
+                rows = self.run_scrape(ceiling="1.37")[0].call_args.args[1]
+                self.assertEqual(rows, [dict(saved, kube=["1.37"] + saved["kube"], chart_version="1.22.2")])
         self.save(rows)
         self.run_scrape(ceiling="1.37")[0].assert_not_called()
 
@@ -157,6 +161,8 @@ class ExternalDNSTests(unittest.TestCase):
         self.assertEqual(write.call_args.args[1], [dict(original, chart_version="1.22.2")])
         image.assert_not_called()
         self.save(write.call_args.args[1])
+        self.assertEqual(self.existing["versions"][0]["summary"]["helm_changes"],
+                         "Application support is verified independently of Helm chart availability.")
         self.assertEqual(len(self.existing["versions"]), len({r["version"] for r in self.existing["versions"]}))
         self.run_scrape()[0].assert_not_called()
 
@@ -173,10 +179,41 @@ class ExternalDNSTests(unittest.TestCase):
             self.assertEqual(write.call_args.args[1], [dict(legacy, chart_version="1.0.0")])
             image.assert_not_called()
 
-    def test_existing_chart_and_prerelease_mapping_are_not_used_as_backfills(self):
+    def test_newer_exact_chart_preserves_metadata_refreshes_images_then_noops(self):
         self.save(self.run_scrape()[0].call_args.args[1])
-        self.charts.update({"0.21.0": "99.0.0", "0.22.0": "1.22.0-rc1"})
+        self.existing["helm_repository_url"] = "https://charts.example.test"
+        legacy = self.existing["versions"][1]
+        legacy.update(eolAt="2027-01-01", requirements=[{"name": "keep", "version": "1.0"}],
+                      summary={"helm_changes": "Custom packaging notes", "features": ["Keep"]})
+        before = deepcopy(self.existing)
+        self.charts["0.21.0"] = "1.21.2"
+        self.sources = {scraper.releases_url: response([])}
+        write, image = self.run_scrape()
+        changed = dict(legacy, chart_version="1.21.2")
+        self.assertEqual(write.call_args.args[1], [changed])
+        self.assertEqual(self.existing, before)
+        image.assert_not_called()
+        with patch.object(utils, "read_yaml", return_value=deepcopy(self.existing)), \
+                patch.object(utils, "get_chart_images", return_value=["from-new-chart:0.21.0"]) as render, \
+                patch.object(utils, "summarization_enabled", return_value=False), \
+                patch.object(utils, "print_warning"), patch.object(utils, "print_success"), \
+                patch.object(utils, "write_yaml", return_value=True) as persist:
+            utils.update_compatibility_info(scraper.target_file, write.call_args.args[1])
+        render.assert_called_once_with("https://charts.example.test", "external-dns", "1.21.2", None)
+        self.existing = persist.call_args.args[1]
+        self.assertEqual(self.existing["versions"][1], dict(changed, images=["from-new-chart:0.21.0"]))
+        self.assertEqual(self.existing["versions"][0], before["versions"][0])
         self.run_scrape()[0].assert_not_called()
+        self.charts["0.21.0"] = "1.21.1"
+        self.run_scrape()[0].assert_not_called()
+
+    def test_equal_older_and_nonstable_charts_are_not_used_as_updates(self):
+        self.save(self.run_scrape()[0].call_args.args[1])
+        self.charts["0.22.0"] = "1.22.0-rc1"
+        for chart in ("1.21.1", "1.21.0", "1.22.0-rc1", "1.22", "invalid", None):
+            with self.subTest(chart=chart):
+                self.charts["0.21.0"] = chart
+                self.run_scrape()[0].assert_not_called()
 
     def test_charted_intermediate_patch_is_retained_before_reduction(self):
         self.sources[scraper.releases_url] = response([release(f"0.22.{i}") for i in range(3)])

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -235,7 +235,8 @@ def find_nested_images(objs: Any) -> List[str]:
 
         if isinstance(x, dict):
             for k, v in x.items():
-                if k == "image":
+                # CRD schemas also use "image" keys whose values are mappings.
+                if k == "image" and isinstance(v, str) and _looks_like_image(v):
                     images.add(v)
                     continue
                 walk(v)
@@ -461,6 +462,9 @@ def reduce_versions(versions):
 
     # Sort versions to ensure the latest version is last
     versions = sort_versions(versions)
+    # Chart consumers cannot use newer manifest-only releases. Keep their latest
+    # available chart as well as the latest application release.
+    latest_chart_index = next((i for i, data in enumerate(versions) if data.get("chart_version")), None)
 
     for i, data in reversed(list(enumerate(versions))):
         version = validate_semver(data["version"])
@@ -471,6 +475,7 @@ def reduce_versions(versions):
             or cur_minor != version.minor   # or if it's a new minor version
             or cur_kube != set(kube)        # or if kube list changed
             or i == 0                       # or if it's the latest version
+            or i == latest_chart_index      # or if it's the latest chart-backed version
         ):
             cur_major = version.major
             cur_minor = version.minor
@@ -489,6 +494,8 @@ def reduce_versions(versions):
             # Include chart_version if it exists in the original data
             if "chart_version" in data:
                 version_info["chart_version"] = data["chart_version"]
+            # Official release manifests can provide images without a Helm chart.
+            if "images" in data or "chart_version" in data:
                 version_info["images"] = data.get("images", [])
             if "eolAt" in data:
                 version_info["eolAt"] = data["eolAt"]


### PR DESCRIPTION
ExternalDNS 0.22.0 is released, but the scraper skips it because the official Helm index still packages 0.21.0. Track stable application releases independently of chart availability and read each new version's immutable README compatibility matrix.

The new 0.22.0 record contains Kubernetes 1.21–1.36. Upstream explicitly supports 1.21, 1.22–1.32 and >=1.33 for ExternalDNS >=0.18.x; 1.36 is this repository's configured ceiling. The old constant 1.19 floor is not copied into the new record. All 13 historical records remain unchanged.

No chart version is invented. The release's official registry image tag was verified anonymously, including the image-index, Linux amd64 manifest and configuration byte digests, and is recorded with the immutable index digest. Both direct OCI/Docker manifests and index-selected manifests must have a digest-verified configuration declaring Linux/amd64; missing or inconsistent platform fields are rejected. The tagged Kustomization and AWS tutorial still point to 0.21.0 and were excluded as evidence for the new image. The generated summary includes the concrete 0.22 migration requirements: explicit --policy, changed annotation prefix with legacy override, removed in-tree Plural/Akamai/Transip providers, and the upstream warning that dry-run does not prevent changes with ns1/hetzner/alibaba providers.

Recorded releases from 0.22 onward recheck their immutable matrices when the configured ceiling differs from the saved upper supported minor, even after they leave the latest 100 release records. Refresh only changed Kubernetes lists while preserving summary, images, EOL and any simultaneous exact chart backfill. Finite source ranges remain finite.

Preserve the latest existing chart for Helm consumers and fill missing exact charts when packaging arrives later, including stored legacy rows no longer present in the release list. Strictly newer stable charts for the same application also update; equal, older and prerelease mappings are ignored. The normal writer refreshes chart images while preserving compatibility, custom summaries and EOL. The generated chart-independent support statement remains accurate after packaging arrives. Merge by application version before reducing rows. Shared utility changes preserve the latest available chart for chart consumers and ignore CRD image schema values; EOL preservation is already upstream from #4173.

Sources:

- [Released 0.22.0 and migration notes](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.22.0).
- [Immutable Kubernetes compatibility matrix](https://github.com/kubernetes-sigs/external-dns/blob/v0.22.0/README.md#kubernetes-version-compatibility).
- [Official chart index](https://kubernetes-sigs.github.io/external-dns/index.yaml), currently chart 1.21.1 / application 0.21.0.
- [Official image-index endpoint](https://registry.k8s.io/v2/external-dns/external-dns/manifests/v0.22.0), verified SHA256 `5fdcaf7deb5c158f93a1fc6fe169cdff4cfb9ae0172bee1a90ab0ef74fb9c9cf`.

## Test Plan

- 24 focused ExternalDNS tests and 2 shared image tests pass; full current compatibility suite is 54/54. From repo root: `python -m unittest discover -s utils/compatibility/tests -v`.
- Live source generation and 13 historical chart renders pass with Helm v4.2.4, isolated Helm/Docker configuration and optional paid summarization disabled. No Kubernetes installation, DNS operation, image execution or image-layer download was performed.
- All 13 old records are exactly preserved; per-app and aggregate both validate against the repository schema; unrelated add-ons are unchanged. Both YAML diffs add only 18 lines.
- A live repeat makes no write or image-verification call. A live read-only simulation of ceiling 1.36 to 1.37 yields exactly the expected Kubernetes-list extension; regression tests also cover simultaneous chart backfill and finite-range non-extension. Offline tests cover strict source parsing, configured support ceiling, malformed registry metadata, digest checks, Linux/amd64 configuration verification for direct and index manifests, missing-image fallback, legacy chart backfills, metadata preservation, latest-chart selection and duplicate-free merging.
- Reproduction and source limitations are documented in `utils/compatibility/tests/EXTERNAL_DNS.md`. New application discovery examines the latest 100 GitHub release records; stored legacy chart backfills do not depend on that window.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly. Source provenance, migration constraints and reproduction steps are included.
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code). Not applicable: no agent code changed.

AI-assisted implementation with independent code/source review. Submitted for contributor-program consideration; no reward is assumed.

Plural Flow: console
