### PR TITLE
feat(compatibilities): add StackGres release-specific scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31041,3 +31041,145 @@ addons:
     chart_version: 0.4.0
     images: ['kuberay/operator:v0.4.0']
   name: kuberay-operator
+- icon: https://gitlab.com/uploads/-/system/project/avatar/12584701/logo-stackgres.png?width=64
+  git_url: https://gitlab.com/ongresinc/stackgres
+  release_url: https://gitlab.com/ongresinc/stackgres/-/releases/{vsn}
+  helm_repository_url: https://stackgres.io/downloads/stackgres-k8s/stackgres/helm
+  chart_name: stackgres-operator
+  versions:
+  - version: 1.19.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.19.0
+    images: ['quay.io/ongres/kubectl:v1.36.2-build-6.53', 'quay.io/stackgres/operator:1.19.0']
+  - version: 1.18.3
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+      '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.18.3
+    images: []
+  - version: 1.18.0
+    kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25',
+      '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.18.0
+    images: []
+  - version: 1.17.4
+    kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25',
+      '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.17.4
+    images: []
+  - version: 1.17.0
+    kube: ['1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24',
+      '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.17.0
+    images: []
+  - version: 1.16.0
+    kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23',
+      '1.22', '1.21', '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.16.0
+    images: []
+  - version: 1.15.0
+    kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23',
+      '1.22', '1.21', '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.15.0
+    images: []
+  - version: 1.14.0
+    kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22',
+      '1.21', '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.14.0
+    images: []
+  - version: 1.13.0
+    kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22',
+      '1.21', '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.13.0
+    images: []
+  - version: 1.12.0
+    kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21',
+      '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.12.0
+    images: []
+  - version: 1.11.0
+    kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21',
+      '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.11.0
+    images: []
+  - version: 1.10.0
+    kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
+      '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.10.0
+    images: []
+  - version: 1.9.0
+    kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
+      '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.9.0
+    images: []
+  - version: 1.8.0
+    kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
+      '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.8.0
+    images: []
+  - version: 1.7.0
+    kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
+      '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.7.0
+    images: []
+  - version: 1.6.0
+    kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19',
+      '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.6.0
+    images: []
+  - version: 1.5.0
+    kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.5.0
+    images: []
+  name: stackgres

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -30,6 +30,7 @@ names:
 - opentelemetry-operator
 - rook
 - strimzi-kafka
+- stackgres
 - traefik
 - velero
 - vitess

--- a/static/compatibilities/stackgres.yaml
+++ b/static/compatibilities/stackgres.yaml
@@ -1,0 +1,141 @@
+icon: https://gitlab.com/uploads/-/system/project/avatar/12584701/logo-stackgres.png?width=64
+git_url: https://gitlab.com/ongresinc/stackgres
+release_url: https://gitlab.com/ongresinc/stackgres/-/releases/{vsn}
+helm_repository_url: https://stackgres.io/downloads/stackgres-k8s/stackgres/helm
+chart_name: stackgres-operator
+versions:
+- version: 1.19.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.19.0
+  images: ['quay.io/ongres/kubectl:v1.36.2-build-6.53', 'quay.io/stackgres/operator:1.19.0']
+- version: 1.18.3
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.18.3
+  images: []
+- version: 1.18.0
+  kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25',
+    '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.18.0
+  images: []
+- version: 1.17.4
+  kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25',
+    '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.17.4
+  images: []
+- version: 1.17.0
+  kube: ['1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24',
+    '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.17.0
+  images: []
+- version: 1.16.0
+  kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23',
+    '1.22', '1.21', '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.16.0
+  images: []
+- version: 1.15.0
+  kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23',
+    '1.22', '1.21', '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.15.0
+  images: []
+- version: 1.14.0
+  kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22',
+    '1.21', '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.14.0
+  images: []
+- version: 1.13.0
+  kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22',
+    '1.21', '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.13.0
+  images: []
+- version: 1.12.0
+  kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21',
+    '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.12.0
+  images: []
+- version: 1.11.0
+  kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21',
+    '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.11.0
+  images: []
+- version: 1.10.0
+  kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
+    '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.10.0
+  images: []
+- version: 1.9.0
+  kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
+    '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.9.0
+  images: []
+- version: 1.8.0
+  kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
+    '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.8.0
+  images: []
+- version: 1.7.0
+  kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20',
+    '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.7.0
+  images: []
+- version: 1.6.0
+  kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19',
+    '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.6.0
+  images: []
+- version: 1.5.0
+  kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.0
+  images: []

--- a/utils/compatibility/scrapers/stackgres.py
+++ b/utils/compatibility/scrapers/stackgres.py
@@ -57,7 +57,9 @@ def build_rows(index_payload):
         if constraint is None:
             # The official pre-1.5 charts omit this field. Missing metadata does
             # not prove that a historical release supports current Kubernetes.
-            continue
+            if app_version < (1, 5, 0):
+                continue
+            raise ValueError(f"Missing Kubernetes bounds for StackGres {chart['appVersion']}")
         kube = parse_kube_range(constraint)
         previous = releases.get(app_version)
         if previous is not None:

--- a/utils/compatibility/scrapers/stackgres.py
+++ b/utils/compatibility/scrapers/stackgres.py
@@ -1,0 +1,95 @@
+"""Read release-specific Kubernetes bounds from the official StackGres charts."""
+
+import re
+from collections import OrderedDict
+
+import yaml
+
+APP_NAME = "stackgres"
+CHART_NAME = "stackgres-operator"
+HELM_REPOSITORY_URL = "https://stackgres.io/downloads/stackgres-k8s/stackgres/helm"
+INDEX_URL = f"{HELM_REPOSITORY_URL}/index.yaml"
+TARGET_FILE = f"../../static/compatibilities/{APP_NAME}.yaml"
+
+STABLE_VERSION = re.compile(r"v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)")
+KUBE_RANGE = re.compile(r"1\.(\d+)\.0(?:-0)?\s+-\s+1\.(\d+)\.[xX*](?:-0)?")
+
+
+def stable_version(value):
+    """Ignore prereleases and non-semver entries in the public Helm index."""
+    match = STABLE_VERSION.fullmatch(str(value).strip())
+    return tuple(map(int, match.groups())) if match else None
+
+
+def parse_kube_range(spec):
+    """Expand StackGres's inclusive, bounded Helm range into Kubernetes minors.
+
+    Refuse unbounded or unfamiliar constraints instead of inferring support from
+    Plural's current Kubernetes version or StackGres's moving /latest docs.
+    """
+    if not isinstance(spec, str):
+        raise ValueError("StackGres Kubernetes constraint must be a string")
+    match = KUBE_RANGE.fullmatch(spec.strip())
+    if not match:
+        raise ValueError(f"Unsupported StackGres Kubernetes constraint: {spec!r}")
+    start, end = map(int, match.groups())
+    if start > end:
+        raise ValueError(f"Reversed StackGres Kubernetes constraint: {spec!r}")
+    return [f"1.{minor}" for minor in range(end, start - 1, -1)]
+
+
+def build_rows(index_payload):
+    index = yaml.safe_load(index_payload)
+    entries = index.get("entries") if isinstance(index, dict) else None
+    charts = entries.get(CHART_NAME) if isinstance(entries, dict) else None
+    if not isinstance(charts, list) or not charts:
+        raise ValueError("Official StackGres operator chart entries not found")
+
+    releases = {}
+    for chart in charts:
+        if not isinstance(chart, dict):
+            raise ValueError("Malformed StackGres operator chart entry")
+        app_version = stable_version(chart.get("appVersion"))
+        chart_version = stable_version(chart.get("version"))
+        if app_version is None or chart_version is None:
+            continue
+        constraint = chart.get("kubeVersion")
+        if constraint is None:
+            # The official pre-1.5 charts omit this field. Missing metadata does
+            # not prove that a historical release supports current Kubernetes.
+            continue
+        kube = parse_kube_range(constraint)
+        previous = releases.get(app_version)
+        if previous is not None:
+            previous_chart, previous_kube = previous
+            if previous_chart == chart_version and previous_kube != kube:
+                raise ValueError(f"Conflicting StackGres chart metadata: {chart['version']}")
+            if previous_chart >= chart_version:
+                continue
+        releases[app_version] = (chart_version, kube)
+
+    if not releases:
+        raise ValueError("No stable StackGres releases with Kubernetes bounds found")
+
+    # Keep all published patch versions here. The shared catalog reducer keeps
+    # compatibility transitions, including bounds that change within a minor.
+    return [
+        OrderedDict([
+            ("version", ".".join(map(str, app_version))),
+            ("kube", kube),
+            ("requirements", []),
+            ("incompatibilities", []),
+            ("chart_version", ".".join(map(str, chart_version))),
+        ])
+        for app_version, (chart_version, kube) in sorted(releases.items(), reverse=True)
+    ]
+
+
+def scrape():
+    from utils import fetch_page, update_compatibility_info
+
+    index = fetch_page(INDEX_URL)
+    if not index:
+        raise ValueError("Could not fetch the official StackGres Helm index")
+    rows = build_rows(index)
+    update_compatibility_info(TARGET_FILE, rows)

--- a/utils/compatibility/tests/STACKGRES.md
+++ b/utils/compatibility/tests/STACKGRES.md
@@ -1,0 +1,20 @@
+# StackGres compatibility scraper
+
+The source is the [official StackGres Helm index](https://stackgres.io/downloads/stackgres-k8s/stackgres/helm/index.yaml), specifically `stackgres-operator` entries' `appVersion`, `version`, and `kubeVersion` fields. The [installation guide](https://stackgres.io/doc/latest/install/helm/) confirms this Helm repository.
+
+Each stable chart provides its own inclusive Kubernetes range. The scraper preserves patch-level changes and passes them to the existing catalog reducer. For example, 1.18.2 ends at Kubernetes 1.34, while 1.18.3 ends at 1.35. This is more precise than using a moving `/latest` page or applying a minor's newest documentation to every patch. The [1.18 documentation](https://stackgres.io/doc/1.18/install/prerequisites/k8s/) corroborates the later 1.18 bounds; [1.17](https://stackgres.io/doc/1.17/install/prerequisites/k8s/), [1.16](https://stackgres.io/doc/1.16/install/prerequisites/k8s/), and [1.14](https://stackgres.io/doc/1.14/install/prerequisites/k8s/) corroborate their respective release lines.
+
+Charts older than 1.5 have no `kubeVersion` and are omitted. Prereleases are excluded. Unknown, unbounded, conflicting, or reversed declared constraints raise an error before updating the catalog. Bounds are never extended to Plural's latest Kubernetes version.
+
+Run from `utils/compatibility` after installing its requirements:
+
+```sh
+python -m unittest discover -s tests -p 'test_stackgres.py'
+python -c 'from scrapers.stackgres import scrape; scrape()'
+```
+
+The standard dispatcher also supports `SCRAPER=stackgres python main.py`. It refreshes the aggregate catalog and Kubernetes changelog in addition to running this scraper.
+
+The fixture is a projection of nine actual entries retrieved on 2026-09-08, retaining only the three consumed fields. Tests verify distinct historic bounds, release filtering, determinism, duplicate handling, and malformed upstream metadata.
+
+The shared image enrichment helper renders charts against the repository's current `KUBE_VERSION`. Historical charts with a lower explicit maximum may refuse that optional rendering; this does not change their compatibility bounds. Helm chart installation is not performed by the scraper.

--- a/utils/compatibility/tests/fixtures/stackgres/index.yaml
+++ b/utils/compatibility/tests/fixtures/stackgres/index.yaml
@@ -1,0 +1,31 @@
+# Projection of real entries from the official Helm index, retrieved 2026-09-08.
+# https://stackgres.io/downloads/stackgres-k8s/stackgres/helm/index.yaml
+# Only version, appVersion and kubeVersion (the scraper's inputs) are retained.
+entries:
+  stackgres-operator:
+  - version: 1.19.0
+    appVersion: 1.19.0
+    kubeVersion: 1.25.0-0 - 1.36.x-0
+  - version: 1.19.0-rc3
+    appVersion: 1.19.0-rc3
+    kubeVersion: 1.18.0-0 - 1.36.x-0
+  - version: 1.18.8
+    appVersion: 1.18.8
+    kubeVersion: 1.18.0-0 - 1.35.x-0
+  - version: 1.18.3
+    appVersion: 1.18.3
+    kubeVersion: 1.18.0-0 - 1.35.x-0
+  - version: 1.18.2
+    appVersion: 1.18.2
+    kubeVersion: 1.18.0-0 - 1.34.x-0
+  - version: 1.17.4
+    appVersion: 1.17.4
+    kubeVersion: 1.18.0-0 - 1.34.x-0
+  - version: 1.17.3
+    appVersion: 1.17.3
+    kubeVersion: 1.18.0-0 - 1.33.x-0
+  - version: 1.5.0
+    appVersion: 1.5.0
+    kubeVersion: 1.18.0-0 - 1.27.x-0
+  - version: 1.4.3
+    appVersion: 1.4.3

--- a/utils/compatibility/tests/test_stackgres.py
+++ b/utils/compatibility/tests/test_stackgres.py
@@ -1,0 +1,91 @@
+"""Regressions using release metadata captured from StackGres's real index."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+spec = importlib.util.spec_from_file_location("stackgres_scraper", ROOT / "scrapers/stackgres.py")
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+FIXTURE = Path(__file__).parent / "fixtures/stackgres/index.yaml"
+
+from utils import ensure_keys, reduce_versions
+
+
+class StackGresTests(unittest.TestCase):
+    def setUp(self):
+        self.index = yaml.safe_load(FIXTURE.read_bytes())
+
+    def rows(self):
+        return scraper.build_rows(yaml.safe_dump(self.index))
+
+    def test_real_release_bounds_include_both_endpoints(self):
+        rows = self.rows()
+        self.assertEqual(rows[0]["version"], "1.19.0")
+        self.assertEqual(rows[0]["chart_version"], "1.19.0")
+        self.assertEqual(rows[0]["kube"], [f"1.{v}" for v in range(36, 24, -1)])
+        self.assertEqual(rows[-1]["version"], "1.5.0")
+        self.assertEqual(rows[-1]["kube"], [f"1.{v}" for v in range(27, 17, -1)])
+
+    def test_patch_level_support_changes_are_not_overwritten_by_latest_docs(self):
+        rows = {row["version"]: row for row in self.rows()}
+        self.assertEqual(rows["1.18.2"]["kube"][0], "1.34")
+        self.assertEqual(rows["1.18.3"]["kube"][0], "1.35")
+        self.assertEqual(rows["1.17.3"]["kube"][0], "1.33")
+        self.assertEqual(rows["1.17.4"]["kube"][0], "1.34")
+        self.assertNotIn("1.36", rows["1.18.8"]["kube"])
+
+    def test_prereleases_and_undocumented_historical_charts_are_excluded(self):
+        versions = [row["version"] for row in self.rows()]
+        self.assertNotIn("1.19.0-rc3", versions)
+        self.assertNotIn("1.4.3", versions)
+        self.assertEqual(len(versions), 7)
+
+    def test_catalog_reducer_preserves_patch_support_transitions(self):
+        rows = reduce_versions([ensure_keys(row) for row in self.rows()])
+        versions = [row["version"] for row in rows]
+        self.assertIn("1.18.2", versions)
+        self.assertIn("1.18.3", versions)
+        self.assertIn("1.17.3", versions)
+        self.assertIn("1.17.4", versions)
+        self.assertNotIn("1.18.8", versions)
+        self.assertEqual(versions[0], "1.19.0")
+
+    def test_index_order_and_identical_duplicates_do_not_change_output(self):
+        expected = self.rows()
+        charts = self.index["entries"][scraper.CHART_NAME]
+        charts.append(dict(charts[0]))
+        charts.reverse()
+        self.assertEqual(self.rows(), expected)
+
+    def test_unknown_and_unbounded_ranges_fail_before_catalog_update(self):
+        for constraint in [">=1.18.0", "1.18.0 - 1.35.0", "1.36.0-0 - 1.25.x-0", "1.18.0-0 - 2.0.x-0", "garbage", 135, ""]:
+            with self.subTest(constraint=constraint), self.assertRaises(ValueError):
+                self.index["entries"][scraper.CHART_NAME][0]["kubeVersion"] = constraint
+                self.rows()
+
+    def test_conflicting_duplicate_metadata_is_rejected(self):
+        charts = self.index["entries"][scraper.CHART_NAME]
+        conflicting = dict(charts[0], kubeVersion="1.18.0-0 - 1.36.x-0")
+        charts.append(conflicting)
+        with self.assertRaisesRegex(ValueError, "Conflicting"):
+            self.rows()
+
+    def test_malformed_or_empty_indices_do_not_generate_rows(self):
+        for index in [None, [], {}, {"entries": []}, {"entries": {scraper.CHART_NAME: []}}, {"entries": {scraper.CHART_NAME: [None]}}]:
+            with self.subTest(index=index), self.assertRaises(ValueError):
+                scraper.build_rows(yaml.safe_dump(index))
+
+    def test_all_missing_bounds_is_an_error(self):
+        self.index["entries"][scraper.CHART_NAME] = [self.index["entries"][scraper.CHART_NAME][-1]]
+        with self.assertRaisesRegex(ValueError, "No stable StackGres"):
+            self.rows()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_stackgres.py
+++ b/utils/compatibility/tests/test_stackgres.py
@@ -76,6 +76,11 @@ class StackGresTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Conflicting"):
             self.rows()
 
+    def test_missing_modern_release_bounds_does_not_silently_keep_stale_data(self):
+        del self.index["entries"][scraper.CHART_NAME][0]["kubeVersion"]
+        with self.assertRaisesRegex(ValueError, "Missing Kubernetes bounds"):
+            self.rows()
+
     def test_malformed_or_empty_indices_do_not_generate_rows(self):
         for index in [None, [], {}, {"entries": []}, {"entries": {scraper.CHART_NAME: []}}, {"entries": {scraper.CHART_NAME: [None]}}]:
             with self.subTest(index=index), self.assertRaises(ValueError):


### PR DESCRIPTION
Add StackGres operator compatibility data from each published Helm chart's exact `kubeVersion` constraint. The scraper preserves patch-level support changes instead of applying today's documentation to historical releases.

Includes a scraper, official metadata/icon, manifest registration, generated per-addon and aggregate catalogs, and regression tests. The current official index yields 37 stable releases with explicit bounds, reduced by the existing framework to 17 compatibility transitions. Pre-1.5 charts without bounds and prereleases are excluded; missing modern bounds or unfamiliar/conflicting constraints fail before updating the catalog.

Sources:
- [Official Helm index](https://stackgres.io/downloads/stackgres-k8s/stackgres/helm/index.yaml)
- [Official Helm installation guide](https://stackgres.io/doc/latest/install/helm/)
- [Version 1.18 Kubernetes requirements](https://stackgres.io/doc/1.18/install/prerequisites/k8s/)
- [Version 1.17 Kubernetes requirements](https://stackgres.io/doc/1.17/install/prerequisites/k8s/)

Validation:
- 10 focused regression tests pass, including real index fixtures, patch-level bounds, duplicate/order handling and fail-closed behavior.
- Real `scrape()` execution and official-index comparison verify the saved version/chart/range data.
- Addon, manifest and aggregate pass JSON Schema validation; previous aggregate entries remain unchanged.
- Latest 1.19.0 chart renders with real operator/kubectl images. Historical charts reject the framework's current Kubernetes 1.36 during optional image enrichment, so their image lists remain empty and their supported ranges are not widened.
- `git diff --check` passes. No cluster deployment or unrelated Elixir/frontend test pass is claimed.

Reproduction and source notes: `utils/compatibility/tests/STACKGRES.md`.

AI assistance: Codex GPT-6 and companion agents prepared the scraper, fixtures, tests and documentation, checked source mappings, and reviewed the change. Actual local parser/schema checks and network/Helm validation were run; no human-written or manual-review claim is made.
