### PR TITLE
feat(compatibilities): add EMQX Operator scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31041,3 +31041,73 @@ addons:
     chart_version: 0.4.0
     images: ['kuberay/operator:v0.4.0']
   name: kuberay-operator
+- icon: https://avatars.githubusercontent.com/u/25221711?v=4
+  git_url: https://github.com/emqx/emqx-operator
+  release_url: https://github.com/emqx/emqx-operator/releases/tag/{vsn}
+  helm_repository_url: https://repos.emqx.io/charts
+  versions:
+  - version: 2.3.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.3.2
+    images: ['alpine/k8s:1.31.4', 'ghcr.io/emqx/emqx-operator:2.3.2']
+  - version: 2.3.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.3.0
+    images: ['alpine/k8s:1.31.4', 'ghcr.io/emqx/emqx-operator:2.3.0']
+  - version: 2.2.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.2.0
+    images: ['emqx/emqx-operator-controller:2.2.0']
+  - version: 2.1.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.1.1
+    images: ['emqx/emqx-operator-controller:2.1.1']
+  - version: 2.1.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.1.0
+    images: ['emqx/emqx-operator-controller:2.1.0']
+  - version: 2.0.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.0.0
+    images: ['emqx/emqx-operator-controller:2.0.0']
+  - version: 1.2.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.6
+    images: ['emqx/emqx-operator-controller:1.2.0']
+  - version: 1.1.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.1
+    images: ['emqx/emqx-operator-controller:1.1.2']
+  name: emqx-operator

--- a/static/compatibilities/emqx-operator.yaml
+++ b/static/compatibilities/emqx-operator.yaml
@@ -1,0 +1,69 @@
+icon: https://avatars.githubusercontent.com/u/25221711?v=4
+git_url: https://github.com/emqx/emqx-operator
+release_url: https://github.com/emqx/emqx-operator/releases/tag/{vsn}
+helm_repository_url: https://repos.emqx.io/charts
+versions:
+- version: 2.3.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.3.2
+  images: ['alpine/k8s:1.31.4', 'ghcr.io/emqx/emqx-operator:2.3.2']
+- version: 2.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.3.0
+  images: ['alpine/k8s:1.31.4', 'ghcr.io/emqx/emqx-operator:2.3.0']
+- version: 2.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.2.0
+  images: ['emqx/emqx-operator-controller:2.2.0']
+- version: 2.1.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.1.1
+  images: ['emqx/emqx-operator-controller:2.1.1']
+- version: 2.1.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.1.0
+  images: ['emqx/emqx-operator-controller:2.1.0']
+- version: 2.0.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.0.0
+  images: ['emqx/emqx-operator-controller:2.0.0']
+- version: 1.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.6
+  images: ['emqx/emqx-operator-controller:1.2.0']
+- version: 1.1.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.1
+  images: ['emqx/emqx-operator-controller:1.1.2']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -50,3 +50,4 @@ names:
 - wiz-admission-controller
 - wiz-network-analyzer
 - kuberay-operator
+- emqx-operator

--- a/utils/compatibility/scrapers/emqx-operator.py
+++ b/utils/compatibility/scrapers/emqx-operator.py
@@ -1,0 +1,135 @@
+"""Join published EMQX charts to the Kubernetes requirements at each release tag."""
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import requests
+import yaml
+from packaging.version import Version
+
+app_name = "emqx-operator"
+helm_index_url = "https://repos.emqx.io/charts/index.yaml"
+readme_url = "https://raw.githubusercontent.com/emqx/emqx-operator/{version}/README.md"
+
+_RELEASE = re.compile(r"\d+\.\d+\.\d+")
+_REQUIREMENT = re.compile(
+    r"^The EMQX Operator requires a Kubernetes cluster of version `>=(1\.\d+(?:\.0)?)`\.$",
+    re.MULTILINE,
+)
+_PREREQUISITE = re.compile(
+    r"^- Access to a Kubernetes v(1\.\d+)\+ cluster\.$", re.MULTILINE
+)
+
+
+def chart_releases(content: bytes | str) -> list[tuple[str, str]]:
+    """Keep every stable app release, choosing its newest published stable chart."""
+    index = yaml.safe_load(content)
+    catalog = index.get("entries") if isinstance(index, dict) else None
+    entries = catalog.get(app_name) if isinstance(catalog, dict) else None
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("EMQX Operator chart entries not found")
+
+    releases: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Malformed EMQX Operator chart entry")
+        chart = str(entry.get("version", ""))
+        version = str(entry.get("appVersion", ""))
+        # Neither chart prereleases nor app prereleases establish stable compatibility.
+        if not _RELEASE.fullmatch(chart) or not _RELEASE.fullmatch(version):
+            continue
+        if version not in releases or Version(chart) > Version(releases[version]):
+            releases[version] = chart
+    if not releases:
+        raise ValueError("No stable EMQX Operator application/chart pairs found")
+    return sorted(releases.items(), key=lambda pair: Version(pair[0]), reverse=True)
+
+
+def supported_kubernetes(content: bytes | str, current: str) -> list[str]:
+    """Expand only explicit >=, + or 'latest' requirements through KUBE_VERSION.
+
+    Quoted conditional requirements (for deployments without particular features)
+    are intentionally excluded. Unknown or changed support declarations fail closed.
+    """
+    markdown = content.decode("utf-8") if isinstance(content, bytes) else content
+    declarations = _REQUIREMENT.findall(markdown) + _PREREQUISITE.findall(markdown)
+    minimums = {".".join(value.split(".")[:2]) for value in declarations}
+    if len(minimums) != 1:
+        raise ValueError("Missing or conflicting EMQX Kubernetes requirement")
+    minimum = minimums.pop()
+
+    # When upstream publishes a detailed table, accept its full-feature row only.
+    # A newly introduced upper bound or changed qualification must be reviewed.
+    columns = None
+    table_found = False
+    full_support = []
+    for line in markdown.splitlines():
+        if not line.strip().startswith("|"):
+            columns = None
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if "EMQX Operator Compatibility" in cells:
+            if "Kubernetes Versions" not in cells:
+                raise ValueError("Unexpected EMQX Kubernetes table columns")
+            table_found = True
+            columns = (cells.index("Kubernetes Versions"), cells.index("EMQX Operator Compatibility"))
+        elif columns and len(cells) > max(columns):
+            if cells[columns[1]] == "All functions supported":
+                full_support.append(cells[columns[0]])
+    if table_found:
+        if len(full_support) != 1:
+            raise ValueError("Missing or ambiguous EMQX full-feature Kubernetes range")
+        match = re.fullmatch(
+            r"(1\.\d+)(?: or higher| \(included\) [~～] latest)", full_support[0]
+        )
+        if not match or match.group(1) != minimum:
+            raise ValueError("Unexpected EMQX full-feature Kubernetes range")
+
+    if not re.fullmatch(r"1\.\d+", current):
+        raise ValueError("Invalid current Kubernetes minor version")
+    first = int(minimum.split(".")[1])
+    last = int(current.split(".")[1])
+    if first > last:
+        raise ValueError("EMQX Kubernetes requirement is newer than KUBE_VERSION")
+    return [f"1.{minor}" for minor in range(last, first - 1, -1)]
+
+
+def build_rows(index: bytes | str, current: str, fetcher) -> list[OrderedDict]:
+    rows = []
+    for version, chart in chart_releases(index):
+        source = readme_url.format(version=version)
+        content = fetcher(source)
+        if not content:
+            raise ValueError(f"Missing EMQX {version} release README: {source}")
+        try:
+            kube = supported_kubernetes(content, current)
+        except (ValueError, UnicodeError) as exc:
+            raise ValueError(f"Invalid EMQX {version} release requirements: {exc}") from exc
+        rows.append(OrderedDict([
+            ("version", version),
+            ("kube", kube),
+            ("chart_version", chart),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ]))
+    return rows
+
+
+def scrape() -> None:
+    from utils import current_kube_version, update_compatibility_info
+
+    current = current_kube_version()
+    if not current:
+        raise ValueError("KUBE_VERSION is unavailable")
+    # Resolve every release before writing so a source outage cannot publish a partial table.
+    with requests.Session() as session:
+        def fetch_document(url: str) -> bytes:
+            response = session.get(url, timeout=(10, 30))
+            response.raise_for_status()
+            return response.content
+
+        index = fetch_document(helm_index_url)
+        rows = build_rows(index, current, fetch_document)
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", rows)

--- a/utils/compatibility/tests/EMQX_OPERATOR.md
+++ b/utils/compatibility/tests/EMQX_OPERATOR.md
@@ -1,0 +1,65 @@
+# EMQX Operator compatibility sources
+
+The scraper joins stable application/chart pairs from the official
+[EMQX Helm index](https://repos.emqx.io/charts/index.yaml) to the README at each
+exact [EMQX Operator release tag](https://github.com/emqx/emqx-operator/tags).
+It reads every published stable application release; it does not substitute the
+moving `latest` documentation for historical release requirements. Prerelease
+charts and prerelease application versions are excluded. When multiple stable
+charts package the same application, the newest chart is selected.
+
+The release documents contain three explicit forms of Kubernetes requirements:
+
+- [1.2.8](https://github.com/emqx/emqx-operator/blob/1.2.8/README.md) declares
+  `>=1.20.0`. This format continues through operator 2.1.0.
+- [2.1.1](https://github.com/emqx/emqx-operator/blob/2.1.1/README.md) declares
+  `>=1.24`. Its quoted exception for clusters without `MixedProtocolLBService`
+  is excluded. Later [2.1.2](https://github.com/emqx/emqx-operator/blob/2.1.2/README.md)
+  and [2.2.29](https://github.com/emqx/emqx-operator/blob/2.2.29/README.md) tables
+  agree on full-feature support from 1.24 upwards; restricted rows are excluded.
+- [2.3.2](https://github.com/emqx/emqx-operator/blob/2.3.2/README.md) declares
+  access to a Kubernetes `v1.24+` cluster under **Development / Prerequisites**.
+  The 2.3.x README no longer contains the earlier general compatibility table.
+  This is a declared prerequisite, not a published tested-version matrix.
+
+Only these explicit open-ended requirements are expanded, ending at this
+repository's `KUBE_VERSION`; an omitted maximum alone does not establish a range.
+Missing, conflicting, restricted, or newly bounded recognized requirements abort
+the run before any compatibility data is written. A missing release document
+also aborts the whole join instead of silently dropping that release.
+
+The official index on 2026-09-08 contained 53 distinct stable application
+releases. The existing shared reducer keeps eight minor/support boundaries and
+the latest release. Older chart versions differ from their application versions:
+for example, chart 1.0.6 packages operator 1.2.0. All eight retained chart archives
+were downloaded from the official repository and their SHA-256 digests and
+`Chart.yaml` application/chart versions were checked against the index.
+The live scraper rendered all eight charts successfully and recorded their
+actual container images. The add-on, manifest, and aggregate were validated
+against `static/compatibilities/schema.json`.
+
+Fixtures are actual upstream excerpts with source URLs and retrieval dates.
+Tests cover both historical table formats, conditional requirements, reordered
+columns, removed full-support rows, newly introduced bounds, malformed input,
+exact chart mappings, duplicate chart selection, prereleases, and unavailable
+release documents. The chart-image fixture retains relevant subtrees from an
+actual Helm render: CRD schema properties named `image` must not be mistaken for
+pod container image references.
+
+Run from `utils/compatibility` with Python 3.10+ and the dependencies in
+`requirements.txt` installed:
+
+```sh
+env -u OPENAI_API_KEY -u EXA_API_KEY python -m unittest discover -s tests -p 'test_emqx_operator.py' -v
+env -u OPENAI_API_KEY -u EXA_API_KEY python -m unittest discover -s tests -p 'test_chart_images.py' -v
+```
+
+Run the live scraper from the same directory, with `helm` on `PATH` and separate
+Helm configuration/cache/data directories when other scrapers run concurrently:
+
+```sh
+env -u OPENAI_API_KEY -u EXA_API_KEY python -c 'import importlib; importlib.import_module("scrapers.emqx-operator").scrape()'
+```
+
+The declared compatibility data and chart rendering checks do not establish that
+every listed Kubernetes version has been tested with a deployed EMQX cluster.

--- a/utils/compatibility/tests/fixtures/chart-images/emqx-operator-2.3.2.yaml
+++ b/utils/compatibility/tests/fixtures/chart-images/emqx-operator-2.3.2.yaml
@@ -1,0 +1,39 @@
+# Relevant subtrees from the actual Helm-rendered EMQX Operator 2.3.2 chart.
+# Source: https://repos.emqx.io/charts/emqx-operator-2.3.2.tgz
+# Rendered 2026-09-08 with --kube-version 1.36; unrelated fields omitted.
+kind: CustomResourceDefinition
+metadata:
+  name: emqxes.apps.emqx.io
+spec:
+  versions:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              image:
+                description: 'EMQX container image.
+
+                  More info: https://kubernetes.io/docs/concepts/containers/images'
+                type: string
+---
+kind: Deployment
+metadata:
+  name: release-name-emqx-operator-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: ghcr.io/emqx/emqx-operator:2.3.2
+---
+kind: Job
+metadata:
+  name: release-name-emqx-operator-pre-upgrade
+spec:
+  template:
+    spec:
+      containers:
+      - name: cleanup
+        image: alpine/k8s:1.31.4

--- a/utils/compatibility/tests/fixtures/emqx-operator/README-1.2.0.md
+++ b/utils/compatibility/tests/fixtures/emqx-operator/README-1.2.0.md
@@ -1,0 +1,5 @@
+<!-- Excerpt: https://raw.githubusercontent.com/emqx/emqx-operator/1.2.0/README.md ; fetched 2026-09-08 -->
+
+## Prerequisites
+
+The EMQX Operator requires a Kubernetes cluster of version `>=1.20.0`.

--- a/utils/compatibility/tests/fixtures/emqx-operator/README-1.2.8.md
+++ b/utils/compatibility/tests/fixtures/emqx-operator/README-1.2.8.md
@@ -1,0 +1,5 @@
+<!-- Excerpt: https://raw.githubusercontent.com/emqx/emqx-operator/1.2.8/README.md ; fetched 2026-09-08 -->
+
+## Prerequisites
+
+The EMQX Operator requires a Kubernetes cluster of version `>=1.20.0`.

--- a/utils/compatibility/tests/fixtures/emqx-operator/README-2.1.1.md
+++ b/utils/compatibility/tests/fixtures/emqx-operator/README-2.1.1.md
@@ -1,0 +1,11 @@
+<!-- Excerpt: https://raw.githubusercontent.com/emqx/emqx-operator/2.1.1/README.md ; fetched 2026-09-08 -->
+
+## Prerequisites
+
+The EMQX Operator requires a Kubernetes cluster of version `>=1.24`.
+
+> ### Why we need kubernetes 1.24:
+>
+> The `MixedProtocolLBService` feature is enabled by default in Kubernetes 1.24 and above. For its documentation, please refer to: [MixedProtocolLBService](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/). The `MixedProtocolLBService` attribute allows different protocols to be used within the same Service instance of type `LoadBalancer`. Therefore, if the user deploys the EMQX cluster on Kubernetes and uses the `LoadBalancer` type of Service, there are both TCP and UDP protocols in the Service, please pay attention to upgrading the Kubernetes version to 1.24 or above, otherwise the Service creation will fail.
+> 
+> **If user doesn't need `MixedProtocolLBService` feature, the EMQX Operator requires a Kubernetes cluster of version `>=1.21`.**

--- a/utils/compatibility/tests/fixtures/emqx-operator/README-2.1.2.md
+++ b/utils/compatibility/tests/fixtures/emqx-operator/README-2.1.2.md
@@ -1,0 +1,13 @@
+<!-- Excerpt: https://raw.githubusercontent.com/emqx/emqx-operator/2.1.2/README.md ; fetched 2026-09-08 -->
+
+## How to selector Kubernetes version
+
+The EMQX Operator requires a Kubernetes cluster of version `>=1.24`.
+
+| Kubernetes Versions     | EMQX Operator Compatibility                                  | Notes                                                        |
+| ----------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| 1.24 or higher          | All functions supported                                      |                                                              |
+| 1.21 (included) ～ 1.23 | Supported, except [MixedProtocolLBService](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) | EMQX cluster can only use one protocol in `LoadBalancer` type of Service, for example TCP or UDP. |
+| 1.20 (included) ～ 1.21 | Supported, manual `.spec.ports[].nodePort` assignment required if using `NodePort` type of Service | For more details, please refer to [Kubernetes changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#bug-or-regression-4). |
+| 1.16 (included) ～ 1.20 | Supported, not recommended due to lack of testing            |                                                              |
+| Lower than 1.16         | Not supported                                                | `apiextensions/v1` APIVersion is not supported.               |

--- a/utils/compatibility/tests/fixtures/emqx-operator/README-2.2.29.md
+++ b/utils/compatibility/tests/fixtures/emqx-operator/README-2.2.29.md
@@ -1,0 +1,11 @@
+<!-- Excerpt: https://raw.githubusercontent.com/emqx/emqx-operator/2.2.29/README.md ; fetched 2026-09-08 -->
+
+## How to selector Kubernetes version
+
+The EMQX Operator requires a Kubernetes cluster of version `>=1.24`.
+
+| Kubernetes Versions     | EMQX Operator Compatibility                                  | Notes                                                        |
+| ----------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| 1.24 (included) ~ latest | All functions supported                                      |  |
+| 1.22 (included) ～ 1.23 | Supported, except [MixedProtocolLBService](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) | EMQX cluster can only use one protocol in `LoadBalancer` type of Service, for example TCP or UDP. |
+| Lower than 1.22       | Not supported                                                | `unknown field "x-kubernetes-validations" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps]` |

--- a/utils/compatibility/tests/fixtures/emqx-operator/README-2.3.2.md
+++ b/utils/compatibility/tests/fixtures/emqx-operator/README-2.3.2.md
@@ -1,0 +1,7 @@
+<!-- Excerpt: https://raw.githubusercontent.com/emqx/emqx-operator/2.3.2/README.md ; fetched 2026-09-08 -->
+
+### Prerequisites
+- go version v1.22.0+
+- docker version 17.03+.
+- kubectl version v1.24+.
+- Access to a Kubernetes v1.24+ cluster.

--- a/utils/compatibility/tests/fixtures/emqx-operator/index.yaml
+++ b/utils/compatibility/tests/fixtures/emqx-operator/index.yaml
@@ -1,0 +1,94 @@
+# Exact selected entries from https://repos.emqx.io/charts/index.yaml
+# Fetched 2026-09-08; other apps/releases omitted to keep the fixture focused.
+apiVersion: v1
+entries:
+  emqx-operator:
+  - apiVersion: v2
+    appVersion: 2.3.3-rc.1
+    created: '2026-09-03T16:20:19.279343439Z'
+    description: A Helm chart for EMQX Operator Controller
+    digest: 46e4bc7ddcdb9ac6f361ab8ea2b68a23f30be1ab691e35537775da513021f21b
+    name: emqx-operator
+    sources:
+    - https://github.com/emqx/emqx-operator/tree/main-2.3/deploy/charts/emqx-operator
+    - https://github.com/emqx/emqx
+    type: application
+    urls:
+    - emqx-operator-2.3.3-rc.1.tgz
+    version: 2.3.3-rc.1
+  - apiVersion: v2
+    appVersion: 2.3.2
+    created: '2026-09-03T16:20:19.275113851Z'
+    description: A Helm chart for EMQX Operator Controller
+    digest: e2bb4e484a2d628306a714c3a2360d7f620f6c629bb435caf456805e432ee393
+    name: emqx-operator
+    sources:
+    - https://github.com/emqx/emqx-operator/tree/main-2.3/deploy/charts/emqx-operator
+    - https://github.com/emqx/emqx
+    type: application
+    urls:
+    - emqx-operator-2.3.2.tgz
+    version: 2.3.2
+  - apiVersion: v2
+    appVersion: 2.2.29
+    created: '2026-09-03T16:20:19.229408473Z'
+    description: A Helm chart for EMQX Operator Controller
+    digest: 8a89f97a72b5e8c4db61a47798749da075c02c1eb62352e419ceffc3eec75341
+    name: emqx-operator
+    sources:
+    - https://github.com/emqx/emqx-operator/tree/main/deploy/charts/emqx-operator
+    - https://github.com/emqx/emqx
+    type: application
+    urls:
+    - emqx-operator-2.2.29.tgz
+    version: 2.2.29
+  - apiVersion: v2
+    appVersion: 2.1.2
+    created: '2026-09-03T16:20:19.083147439Z'
+    description: A Helm chart for EMQX Operator Controller
+    digest: 685f930a96ac9e50f3de980c5bc747311620fd82a51ed8e550fda57c2e6d3ae7
+    name: emqx-operator
+    type: application
+    urls:
+    - emqx-operator-2.1.2.tgz
+    version: 2.1.2
+  - apiVersion: v2
+    appVersion: 2.1.1
+    created: '2026-09-03T16:20:19.079010586Z'
+    description: A Helm chart for EMQX Operator Controller
+    digest: 1d9e39a4fc875c87cae0c2493294c567265ce347930b5bc4585235f745200c9f
+    name: emqx-operator
+    type: application
+    urls:
+    - emqx-operator-2.1.1.tgz
+    version: 2.1.1
+  - apiVersion: v2
+    appVersion: 1.2.8
+    created: '2026-09-03T16:20:19.038432736Z'
+    description: A Helm chart for EMQX Operator Controller
+    digest: e809c84c18465076d448192f4c1dab10e83b5db8c3200d81217979d044acc27e
+    name: emqx-operator
+    type: application
+    urls:
+    - emqx-operator-1.0.12.tgz
+    version: 1.0.12
+  - apiVersion: v2
+    appVersion: 1.2.0
+    created: '2026-09-03T16:20:19.05300526Z'
+    description: A Helm chart for EMQX Operator Controller
+    digest: 748fba6e7733d815bd42310ad94ada28718ccea47ba000fbdb476fc56ae0fea7
+    name: emqx-operator
+    type: application
+    urls:
+    - emqx-operator-1.0.6.tgz
+    version: 1.0.6
+  - apiVersion: v2
+    appVersion: 1.2.0
+    created: '2026-09-03T16:20:19.049615137Z'
+    description: A Helm chart for EMQX Operator Controller
+    digest: 66bfd695db29e35fffd3da9420ead2be11f2e98bdda8ca14c2de20f432f9a7ed
+    name: emqx-operator
+    type: application
+    urls:
+    - emqx-operator-1.0.5.tgz
+    version: 1.0.5

--- a/utils/compatibility/tests/test_chart_images.py
+++ b/utils/compatibility/tests/test_chart_images.py
@@ -1,0 +1,44 @@
+"""Image discovery must distinguish rendered CRD schemas from pod images."""
+
+from pathlib import Path
+import sys
+import unittest
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils import find_nested_images
+
+
+class ChartImageTests(unittest.TestCase):
+    def test_rendered_emqx_schema_and_container_images(self):
+        fixture = Path(__file__).parent / "fixtures/chart-images/emqx-operator-2.3.2.yaml"
+        objects = list(yaml.safe_load_all(fixture.read_text()))
+        self.assertEqual(find_nested_images(objects), [
+            "alpine/k8s:1.31.4",
+            "ghcr.io/emqx/emqx-operator:2.3.2",
+        ])
+
+    def test_non_string_image_fields_are_traversed_without_becoming_images(self):
+        objects = {"image": [
+            {"image": {"type": "string", "properties": {"image": {"type": "object"}}}},
+            {"image": "ghcr.io/emqx/emqx-operator:2.3.2"},
+            {"image": None},
+            {"image": 42},
+        ]}
+        self.assertEqual(find_nested_images(objects), ["ghcr.io/emqx/emqx-operator:2.3.2"])
+
+    def test_invalid_image_strings_and_unrelated_values_are_not_included(self):
+        objects = [
+            {"image": "https://example.com/logo.svg"},
+            {"image": "not an image reference"},
+            {"image": ""},
+            {"description": "ghcr.io/emqx/emqx-operator:2.3.2"},
+            {"image": "alpine/k8s:1.31.4"},
+            {"image": "alpine/k8s:1.31.4"},
+        ]
+        self.assertEqual(find_nested_images(objects), ["alpine/k8s:1.31.4"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_emqx_operator.py
+++ b/utils/compatibility/tests/test_emqx_operator.py
@@ -1,0 +1,155 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+import yaml
+
+SCRAPER = Path(__file__).parents[1] / "scrapers" / "emqx-operator.py"
+FIXTURES = Path(__file__).parent / "fixtures" / "emqx-operator"
+spec = importlib.util.spec_from_file_location("emqx_operator", SCRAPER)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+def readme(version):
+    return (FIXTURES / f"README-{version}.md").read_bytes()
+
+
+def release_document(url):
+    return readme(url.split("/")[-2])
+
+
+class EMQXOperatorTests(unittest.TestCase):
+    def test_real_index_maps_operator_versions_to_distinct_chart_versions(self):
+        releases = scraper.chart_releases((FIXTURES / "index.yaml").read_bytes())
+        self.assertEqual(releases, [
+            ("2.3.2", "2.3.2"),
+            ("2.2.29", "2.2.29"),
+            ("2.1.2", "2.1.2"),
+            ("2.1.1", "2.1.1"),
+            ("1.2.8", "1.0.12"),
+            ("1.2.0", "1.0.6"),
+        ])
+
+    def test_chart_order_does_not_change_the_selected_mapping(self):
+        index = yaml.safe_load((FIXTURES / "index.yaml").read_text())
+        expected = scraper.chart_releases(yaml.safe_dump(index))
+        index["entries"]["emqx-operator"].reverse()
+        self.assertEqual(scraper.chart_releases(yaml.safe_dump(index)), expected)
+
+    def test_stable_chart_does_not_make_an_app_prerelease_stable(self):
+        index = yaml.safe_load((FIXTURES / "index.yaml").read_text())
+        index["entries"]["emqx-operator"].append({
+            "version": "3.0.0", "appVersion": "3.0.0-rc.1",
+        })
+        releases = scraper.chart_releases(yaml.safe_dump(index))
+        self.assertNotIn("3.0.0-rc.1", dict(releases))
+
+    def test_malformed_or_empty_catalog_fails_closed(self):
+        for payload in ["entries: []", "entries: {}", "[]", "entries: {emqx-operator: [null]}"]:
+            with self.subTest(payload=payload), self.assertRaises(ValueError):
+                scraper.chart_releases(payload)
+
+    def test_legacy_release_requires_kubernetes_120(self):
+        self.assertEqual(
+            scraper.supported_kubernetes(readme("1.2.8"), "1.24"),
+            ["1.24", "1.23", "1.22", "1.21", "1.20"],
+        )
+
+    def test_conditional_lower_requirement_is_not_full_feature_support(self):
+        # Actual 2.1.1 README permits 1.21 only without MixedProtocolLBService.
+        self.assertEqual(
+            scraper.supported_kubernetes(readme("2.1.1"), "1.26"),
+            ["1.26", "1.25", "1.24"],
+        )
+
+    def test_both_published_table_formats_exclude_limited_versions(self):
+        for version in ["2.1.2", "2.2.29"]:
+            with self.subTest(version=version):
+                self.assertEqual(
+                    scraper.supported_kubernetes(readme(version), "1.26"),
+                    ["1.26", "1.25", "1.24"],
+                )
+
+    def test_current_release_explicit_plus_requirement_is_bounded_by_catalog(self):
+        self.assertEqual(
+            scraper.supported_kubernetes(readme("2.3.2"), "1.25"),
+            ["1.25", "1.24"],
+        )
+
+    def test_reordered_compatibility_columns_preserve_support(self):
+        lines = []
+        for line in readme("2.2.29").decode().splitlines():
+            if line.startswith("|"):
+                cells = line.strip("|").split("|")
+                cells[0], cells[1] = cells[1], cells[0]
+                line = "|" + "|".join(cells) + "|"
+            lines.append(line)
+        self.assertEqual(
+            scraper.supported_kubernetes("\n".join(lines), "1.26"),
+            ["1.26", "1.25", "1.24"],
+        )
+
+    def test_missing_or_qualified_full_support_row_is_not_headline_fallback(self):
+        source = readme("2.2.29").decode()
+        for changed in [
+            source.replace("All functions supported", "Supported, with exceptions"),
+            source.replace("Kubernetes Versions", "Kubernetes Releases"),
+            "\n".join(line for line in source.splitlines() if "All functions supported" not in line),
+        ]:
+            with self.subTest(source=changed), self.assertRaises(ValueError):
+                scraper.supported_kubernetes(changed, "1.26")
+
+    def test_missing_or_changed_requirement_is_not_guessed(self):
+        source = readme("1.2.8").decode()
+        for changed in [
+            "Kubernetes is required.",
+            source.replace(">=1.20.0", ">=1.20.0, <1.25.0"),
+            source.replace(">=1.20.0", ">=1.20.1"),
+        ]:
+            with self.subTest(source=changed), self.assertRaises(ValueError):
+                scraper.supported_kubernetes(changed, "1.26")
+
+    def test_new_table_bounds_and_conflicting_requirements_require_review(self):
+        source = readme("2.2.29").decode()
+        for changed in [
+            source.replace("1.24 (included) ~ latest", "1.24 (included) ~ 1.25"),
+            source.replace("1.24 (included) ~ latest", "1.25 (included) ~ latest"),
+            source + "\n- Access to a Kubernetes v1.25+ cluster.\n",
+        ]:
+            with self.subTest(source=changed), self.assertRaises(ValueError):
+                scraper.supported_kubernetes(changed, "1.26")
+
+    def test_invalid_current_version_and_future_requirement_fail_closed(self):
+        for current in ["1.23", "2.0", "1.25.0", "not-a-version"]:
+            with self.subTest(current=current), self.assertRaises(ValueError):
+                scraper.supported_kubernetes(readme("2.3.2"), current)
+
+    def test_rows_join_real_chart_and_tagged_readme_fixtures(self):
+        rows = scraper.build_rows(
+            (FIXTURES / "index.yaml").read_bytes(), "1.26", release_document
+        )
+        versions = {row["version"]: row for row in rows}
+        self.assertEqual(len(versions), 6)
+        self.assertEqual(versions["1.2.8"]["chart_version"], "1.0.12")
+        self.assertEqual(versions["1.2.8"]["kube"][-1], "1.20")
+        self.assertEqual(versions["2.1.1"]["kube"][-1], "1.24")
+        self.assertEqual(versions["2.3.2"]["kube"], ["1.26", "1.25", "1.24"])
+
+    def test_one_unavailable_release_aborts_instead_of_returning_partial_rows(self):
+        def missing_oldest(url):
+            return None if url.endswith("/1.2.0/README.md") else release_document(url)
+
+        with self.assertRaisesRegex(ValueError, "Missing EMQX 1.2.0 release README"):
+            scraper.build_rows((FIXTURES / "index.yaml").read_bytes(), "1.26", missing_oldest)
+
+    def test_invalid_release_document_identifies_the_affected_version(self):
+        def corrupt_current(url):
+            return b"\xff" if url.endswith("/2.3.2/README.md") else release_document(url)
+
+        with self.assertRaisesRegex(ValueError, "Invalid EMQX 2.3.2 release requirements"):
+            scraper.build_rows((FIXTURES / "index.yaml").read_bytes(), "1.26", corrupt_current)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -235,8 +235,9 @@ def find_nested_images(objs: Any) -> List[str]:
 
         if isinstance(x, dict):
             for k, v in x.items():
-                if k == "image":
-                    images.add(v)
+                if k == "image" and isinstance(v, str):
+                    if _looks_like_image(v):
+                        images.add(v.strip())
                     continue
                 walk(v)
 


### PR DESCRIPTION
Add EMQX Operator compatibility data using the official Helm index and the README at each exact operator release tag. This preserves historical Kubernetes requirements and the distinction between chart versions and application versions.

- Add the scraper, catalog metadata/icon, manifest registration, generated addon and aggregate data, source notes, and regression fixtures.
- Read all 53 stable application releases; the existing reducer retains eight version/support boundaries. Select the latest stable chart when multiple charts package the same application.
- Fix shared image extraction so a CRD schema property named `image` cannot be mistaken for a container image and cause a `TypeError`. The regression fixture comes from a real EMQX chart render, and the helper change is isolated in commit `5f8ecb4f`.
- Abort on missing/conflicting requirements or unavailable release documents, with bounded requests, before writing compatibility data.

Sources: [official Helm index](https://repos.emqx.io/charts/index.yaml), tagged requirements for [1.2.8](https://github.com/emqx/emqx-operator/blob/1.2.8/README.md), [2.1.1](https://github.com/emqx/emqx-operator/blob/2.1.1/README.md), [2.2.29](https://github.com/emqx/emqx-operator/blob/2.2.29/README.md), and [2.3.2](https://github.com/emqx/emqx-operator/blob/2.3.2/README.md).

Validation:
- **65 Python tests passed**, including 16 scraper and three image-extraction regressions.
- Live scraper execution read all 53 release documents, rendered all eight retained Helm charts, and recorded their actual images.
- All eight chart archives matched the official index's SHA-256 digests and application/chart metadata.
- Addon, manifest, and aggregate pass JSON Schema validation. Other aggregate entries are unchanged.
- `git diff --check` passes.

Compatibility limitation: the 2.3.x README specifies Kubernetes `v1.24+` under Development / Prerequisites, rather than a tested-version matrix. Earlier releases have explicit requirements/support tables. The scraper uses these declared requirements; this PR does not claim deployed-cluster validation across the listed Kubernetes versions. No unrelated Elixir/frontend test pass is claimed.

Reproduction and source notes: `utils/compatibility/tests/EMQX_OPERATOR.md`.

AI assistance: Codex GPT-6 and companion agents prepared and reviewed the scraper, helper fix, fixtures, tests, documentation and generated data. The local test, source, schema and Helm checks above were actually run. This contribution is submitted with the user's authorization; no human-written or manual-review claim is made.
