### PR TITLE
Update RabbitMQ Cluster Operator 2.22.5 compatibility from upstream requirements

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -29188,7 +29188,25 @@ addons:
   release_url: https://github.com/rabbitmq/cluster-operator/releases/tag/v{vsn}
   helm_repository_url: https://charts.bitnami.com/bitnami
   chart_name: rabbitmq-cluster-operator
+  readme_url: https://www.rabbitmq.com/kubernetes/operator/install-operator#compatibility
   versions:
+  - version: 2.22.5
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31']
+    requirements: []
+    incompatibilities: []
+    summary:
+      helm_changes: Install this upstream release using its cluster-operator.yml manifest.
+      chart_updates: []
+      features: []
+      breaking_changes: [Requires Kubernetes 1.31 or later., Cluster Operator 2.20 and
+          later requires cert-manager to be installed; upstream does not specify a minimum
+          cert-manager version., The RabbitMQ image must provide RabbitMQ 3.13.7 or
+          later from a supported release series., 'Operator 2.22+ uses an HTTP startup
+          probe available in RabbitMQ 4.2.4+ and 4.3.0+. Older RabbitMQ versions require
+          the annotation rabbitmq.com/legacy-startup-probe: "true"; upstream notes that
+          such versions are unsupported community releases.', Upgrading the operator
+          can roll the managed RabbitMQ StatefulSets. Pause reconciliation before upgrading
+          and resume when safe to control timing.]
   - version: 2.16.1
     kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
       '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']

--- a/static/compatibilities/rabbitmq-cluster-operator.yaml
+++ b/static/compatibilities/rabbitmq-cluster-operator.yaml
@@ -3,7 +3,25 @@ git_url: https://github.com/rabbitmq/cluster-operator
 release_url: https://github.com/rabbitmq/cluster-operator/releases/tag/v{vsn}
 helm_repository_url: https://charts.bitnami.com/bitnami
 chart_name: rabbitmq-cluster-operator
+readme_url: https://www.rabbitmq.com/kubernetes/operator/install-operator#compatibility
 versions:
+- version: 2.22.5
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary:
+    helm_changes: Install this upstream release using its cluster-operator.yml manifest.
+    chart_updates: []
+    features: []
+    breaking_changes: [Requires Kubernetes 1.31 or later., Cluster Operator 2.20 and
+        later requires cert-manager to be installed; upstream does not specify a minimum
+        cert-manager version., The RabbitMQ image must provide RabbitMQ 3.13.7 or
+        later from a supported release series., 'Operator 2.22+ uses an HTTP startup
+        probe available in RabbitMQ 4.2.4+ and 4.3.0+. Older RabbitMQ versions require
+        the annotation rabbitmq.com/legacy-startup-probe: "true"; upstream notes that
+        such versions are unsupported community releases.', Upgrading the operator
+        can roll the managed RabbitMQ StatefulSets. Pause reconciliation before upgrading
+        and resume when safe to control timing.]
 - version: 2.16.1
   kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
     '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']

--- a/utils/compatibility/scrapers/rabbitmq-cluster-operator.py
+++ b/utils/compatibility/scrapers/rabbitmq-cluster-operator.py
@@ -1,125 +1,68 @@
-import re
-import yaml
 from collections import OrderedDict
 
 from utils import (
     current_kube_version,
-    expand_kube_versions,
-    fetch_page,
-    print_error,
+    get_latest_github_release,
     update_compatibility_info,
     validate_semver,
 )
 
 APP_NAME = "rabbitmq-cluster-operator"
 TARGET_FILE = f"../../static/compatibilities/{APP_NAME}.yaml"
-INDEX_URL = "https://charts.bitnami.com/bitnami/index.yaml"
+
+# This upstream change explicitly documents the requirements for Operator 2.20+:
+# https://github.com/rabbitmq/rabbitmq-website/commit/8f27a606dab0b2f9f39afca59319d841a0166fe6
+# These are installation requirements, not the separate list of tested versions.
+MIN_OPERATOR = "2.20.0"
+MIN_KUBE = "1.31"
 
 
-def parse_kube_range(spec, latest_kube):
-    if not spec:
-        return None
+def build_latest_version(release, latest_kube):
+    version = validate_semver(str(release).lstrip("v"))
+    kube = validate_semver(str(latest_kube))
+    minimum_kube = validate_semver(MIN_KUBE)
+    if not version or version < validate_semver(MIN_OPERATOR) or version.major != 2:
+        raise ValueError("Review upstream requirements before adding this operator release.")
+    if not kube or kube.major != minimum_kube.major or kube < minimum_kube:
+        raise ValueError("KUBE_VERSION must include the upstream Kubernetes 1.31 minimum.")
 
-    spec = spec.replace(",", " ")
-    pattern = r"(>=|<=|<|>|=)?\s*v?(\d+)\.(\d+)"
-    matches = re.findall(pattern, spec)
-    if not matches:
-        return None
+    breaking_changes = [
+        f"Requires Kubernetes {MIN_KUBE} or later.",
+        "Cluster Operator 2.20 and later requires cert-manager to be installed; "
+        "upstream does not specify a minimum cert-manager version.",
+        "The RabbitMQ image must provide RabbitMQ 3.13.7 or later from a supported release series.",
+    ]
+    if version >= validate_semver("2.22.0"):
+        # https://github.com/rabbitmq/cluster-operator/releases/tag/v2.22.0
+        breaking_changes.extend([
+            "Operator 2.22+ uses an HTTP startup probe available in RabbitMQ 4.2.4+ "
+            "and 4.3.0+. Older RabbitMQ versions require the annotation "
+            'rabbitmq.com/legacy-startup-probe: "true"; upstream notes that such '
+            "versions are unsupported community releases.",
+            "Upgrading the operator can roll the managed RabbitMQ StatefulSets. "
+            "Pause reconciliation before upgrading and resume when safe to control timing.",
+        ])
 
-    min_major = None
-    min_minor = None
-    max_major = None
-    max_minor = None
-
-    for op, maj_str, min_str in matches:
-        major = int(maj_str)
-        minor = int(min_str)
-
-        if not op or op in (">", ">="):
-            if min_major is None or (major, minor) > (min_major, min_minor):
-                min_major, min_minor = major, minor
-        elif op in ("<", "<="):
-            if op == "<":
-                minor -= 1
-                if minor < 0:
-                    continue
-            if max_major is None or (major, minor) < (max_major, max_minor):
-                max_major, max_minor = major, minor
-
-    if min_major is None:
-        return None
-
-    if max_major is None:
-        latest_major, latest_minor = latest_kube.split(".")
-        max_major = int(latest_major)
-        max_minor = int(latest_minor)
-
-    return f"{min_major}.{min_minor}", f"{max_major}.{max_minor}"
+    return OrderedDict(
+        [
+            ("version", str(version)),
+            ("kube", [f"{kube.major}.{minor}" for minor in range(kube.minor, minimum_kube.minor - 1, -1)]),
+            ("requirements", []),
+            ("incompatibilities", []),
+            ("summary", {
+                "helm_changes": "Install this upstream release using its cluster-operator.yml manifest.",
+                "chart_updates": [],
+                "features": [],
+                "breaking_changes": breaking_changes,
+            }),
+        ]
+    )
 
 
 def scrape():
-    latest_kube = current_kube_version()
-    if not latest_kube:
-        print_error("Could not determine current Kubernetes version from KUBE_VERSION.")
-        return
-
-    content = fetch_page(INDEX_URL)
-    if not content:
-        print_error("Failed to fetch Bitnami index.yaml.")
-        return
-
-    try:
-        index_yaml = yaml.safe_load(content)
-    except Exception as e:
-        print_error(f"Failed to parse Bitnami index.yaml: {e}")
-        return
-
-    entries = index_yaml.get("entries", {}).get(APP_NAME, [])
-    if not entries:
-        print_error("No chart entries found for rabbitmq-cluster-operator.")
-        return
-
-    versions: list[OrderedDict] = []
-    seen = set()
-    for entry in entries:
-        app_version_raw = entry.get("appVersion", "").lstrip("v")
-        app_version = validate_semver(app_version_raw)
-        if not app_version:
-            continue
-
-        version = str(app_version)
-        if version in seen:
-            continue
-
-        kube_spec = entry.get("kubeVersion")
-        bounds = parse_kube_range(kube_spec, latest_kube)
-        if not bounds:
-            continue
-
-        kube_min, kube_max = bounds
-        kube_versions = expand_kube_versions(kube_min, kube_max)
-        if not kube_versions:
-            continue
-
-        chart_version = entry.get("version", "").lstrip("v")
-        if not chart_version:
-            continue
-
-        seen.add(version)
-        versions.append(
-            OrderedDict(
-                [
-                    ("version", version),
-                    ("kube", kube_versions),
-                    ("requirements", []),
-                    ("incompatibilities", []),
-                    ("chart_version", chart_version),
-                ]
-            )
-        )
-
-    if not versions:
-        print_error("No compatibility data extracted from chart index.")
-        return
-
-    update_compatibility_info(TARGET_FILE, versions)
+    # The chart-based table omits newer upstream releases. Add only
+    # the current upstream release, without inventing a chart-version mapping.
+    # update_compatibility_info retains the existing historical version rows.
+    release = get_latest_github_release("rabbitmq", "cluster-operator")
+    row = build_latest_version(release, current_kube_version())
+    update_compatibility_info(TARGET_FILE, [row])

--- a/utils/compatibility/tests/test_rabbitmq_cluster_operator.py
+++ b/utils/compatibility/tests/test_rabbitmq_cluster_operator.py
@@ -1,0 +1,99 @@
+import copy
+import importlib
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import requests
+import yaml
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+scraper = importlib.import_module("scrapers.rabbitmq-cluster-operator")
+import utils
+
+
+class RabbitMQClusterOperatorTests(unittest.TestCase):
+    def test_latest_upstream_release_is_not_limited_by_bitnami_app_version(self):
+        with patch.object(scraper, "get_latest_github_release", return_value="v2.22.5") as release, \
+                patch.object(scraper, "current_kube_version", return_value="1.36"), \
+                patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+
+        release.assert_called_once_with("rabbitmq", "cluster-operator")
+        path, rows = update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/rabbitmq-cluster-operator.yaml")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["version"], "2.22.5")
+        self.assertEqual(rows[0]["kube"], ["1.36", "1.35", "1.34", "1.33", "1.32", "1.31"])
+        self.assertNotIn("chart_version", rows[0])
+        self.assertNotIn("images", rows[0])
+        self.assertTrue(any("cert-manager" in note for note in rows[0]["summary"]["breaking_changes"]))
+
+    def test_minimum_supported_versions_do_not_expand_past_current_kubernetes(self):
+        row = scraper.build_latest_version("v2.20.0", "1.31")
+        self.assertEqual(row["kube"], ["1.31"])
+
+    def test_http_probe_requirement_is_limited_to_operator_2_22_and_later(self):
+        older = scraper.build_latest_version("v2.21.0", "1.36")
+        current = scraper.build_latest_version("v2.22.5", "1.36")
+        self.assertFalse(any("HTTP startup probe" in note for note in older["summary"]["breaking_changes"]))
+        notes = " ".join(current["summary"]["breaking_changes"])
+        self.assertIn("RabbitMQ 4.2.4+ and 4.3.0+", notes)
+        self.assertIn('rabbitmq.com/legacy-startup-probe: "true"', notes)
+        self.assertIn("Pause reconciliation", notes)
+
+    def test_versions_outside_documented_policy_fail_before_writing(self):
+        for release in [None, "not-a-version", "v2.19.0", "v2.23.0-rc.1", "v3.0.0"]:
+            with self.subTest(release=release), \
+                    patch.object(scraper, "get_latest_github_release", return_value=release), \
+                    patch.object(scraper, "current_kube_version", return_value="1.36"), \
+                    patch.object(scraper, "update_compatibility_info") as update:
+                with self.assertRaises(ValueError):
+                    scraper.scrape()
+                update.assert_not_called()
+
+    def test_missing_or_unsupported_kubernetes_version_is_rejected(self):
+        for kube in [None, "", "invalid", "1.30", "1.36.0-rc.1", "2.0"]:
+            with self.subTest(kube=kube), self.assertRaises(ValueError):
+                scraper.build_latest_version("v2.22.5", kube)
+
+    def test_release_fetch_failure_does_not_write(self):
+        with patch.object(scraper, "get_latest_github_release", side_effect=requests.HTTPError("503")), \
+                patch.object(scraper, "update_compatibility_info") as update:
+            with self.assertRaises(requests.HTTPError):
+                scraper.scrape()
+            update.assert_not_called()
+
+    def test_updater_keeps_historical_chart_metadata_and_is_idempotent(self):
+        historical = {
+            "version": "2.16.1",
+            "kube": ["1.36", "1.19"],
+            "requirements": [],
+            "incompatibilities": [],
+            "chart_version": "4.4.34",
+            "images": ["docker.io/bitnami/rabbitmq-cluster-operator:2.16.1-debian-12-r0"],
+            "summary": {"features": ["Existing release note."]},
+        }
+        original = {"helm_repository_url": "https://charts.bitnami.com/bitnami", "versions": [historical]}
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "rabbitmq-cluster-operator.yaml"
+            path.write_text(yaml.safe_dump(original), encoding="utf-8")
+            # Use existing image metadata; this test never invokes Helm or an API.
+            with patch.object(utils, "get_chart_images", return_value=None), \
+                    patch.object(utils, "summarization_enabled", return_value=False):
+                row = scraper.build_latest_version("v2.22.5", "1.36")
+                utils.update_compatibility_info(path.as_posix(), [copy.deepcopy(row)])
+                first = yaml.safe_load(path.read_text(encoding="utf-8"))
+                utils.update_compatibility_info(path.as_posix(), [copy.deepcopy(row)])
+                second = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(first, second)
+        self.assertEqual(first["versions"], [row, historical])
+        self.assertEqual(first["helm_repository_url"], original["helm_repository_url"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The checked-in RabbitMQ Cluster Operator table stops at 2.16.1, while upstream's latest release is 2.22.5. This adds 2.22.5 and changes the scraper to obtain the latest upstream 2.x release instead of deriving operator versions solely from the Bitnami chart index.

The new row uses the documented Kubernetes minimum of 1.31, expanded through this repository's `KUBE_VERSION` (1.36). It records the cert-manager prerequisite and RabbitMQ image requirements, including the 2.22 HTTP startup-probe change and rolling-update warning. No minimum cert-manager version or Bitnami chart mapping is invented. The existing 20 historical rows and their chart metadata remain intact, and the aggregate catalog includes the same new row.

Sources:

- [Upstream v2.22.5 release](https://github.com/rabbitmq/cluster-operator/releases/tag/v2.22.5), marked Latest on September 8, 2026; published August 24, 2026.
- [Upstream requirements change for Operator 2.20+](https://github.com/rabbitmq/rabbitmq-website/commit/8f27a606dab0b2f9f39afca59319d841a0166fe6), July 2, 2026: Kubernetes 1.31 minimum, RabbitMQ 3.13.7 minimum, and cert-manager required for Operator 2.20 and later.
- [Pinned installation guide](https://github.com/rabbitmq/rabbitmq-website/blob/8f27a606dab0b2f9f39afca59319d841a0166fe6/kubernetes/operator/install-operator.md).
- [Operator v2.22.0 breaking change](https://github.com/rabbitmq/cluster-operator/releases/tag/v2.22.0): the HTTP startup probe requires RabbitMQ 4.2.4+ or 4.3.0+; older versions require `rabbitmq.com/legacy-startup-probe: "true"` and are identified by upstream as unsupported community releases.

The Kubernetes list represents the published installation requirement, not a claim that upstream tested every listed minor. The guide separately lists tests on 1.29–1.32, and the release's OpenShift OLM template declares a lower installation floor of 1.26. The stricter website requirement is used here. Existing historical versions are not retroactively assigned the 2.20+ policy. Only the latest upstream release is added; this does not backfill intervening releases. A new operator major version requires a policy review.

Validation:

- `cd utils/compatibility && python -m unittest discover -s tests -p test_rabbitmq_cluster_operator.py -v`: 7 tests passed, covering the stale-chart regression, version-policy bounds, the 2.22 HTTP-probe requirement, release lookup failure, preservation of historical metadata, and idempotent updating.
- Both changed YAML documents pass the repository's draft-07 compatibility schema. Verified all 20 historical RabbitMQ rows and the other 52 catalog entries remain semantically unchanged.
- `git diff --check` passed.
- Public sources were verified in Chrome. The live Python GitHub lookup could not connect through the local configured proxy, so the table was generated offline from the explicitly observed `v2.22.5` tag using the same production row builder. The complete network/Helm updater and Kubernetes deployments were not run. No dependencies were installed and no paid summarization service was called.

This contribution was prepared by an AI coding assistant on behalf of GitHub account `1080ssf`; it is not presented as personally implemented or deployed by the account holder. The README lists a $50 reward for a specific-version compatibility contribution. Please confirm whether this submission is eligible under that program and whether PayPal payout is available to the account holder. No reward has been awarded or received, and this request does not assume acceptance or payment.