### PR TITLE
feat: add Kured compatibility scraper and version matrix

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,170 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://raw.githubusercontent.com/kubereboot/website/main/static/img/kured.png
+  git_url: https://github.com/kubereboot/kured
+  release_url: https://github.com/kubereboot/kured/releases/tag/v{vsn}
+  readme_url: https://kured.dev/docs/installation/
+  helm_repository_url: https://kubereboot.github.io/charts
+  versions:
+  - version: 1.23.0
+    kube:
+    - '1.37'
+    - '1.36'
+    - '1.35'
+    requirements: []
+    incompatibilities: []
+    chart_version: 6.1.0
+  - version: 1.22.1
+    kube:
+    - '1.36'
+    - '1.35'
+    - '1.34'
+    requirements: []
+    incompatibilities: []
+    chart_version: 6.0.0
+  - version: 1.22.0
+    kube:
+    - '1.36'
+    - '1.35'
+    - '1.34'
+    requirements: []
+    incompatibilities: []
+    chart_version: 5.12.0
+  - version: 1.21.0
+    kube:
+    - '1.35'
+    - '1.34'
+    - '1.33'
+    requirements: []
+    incompatibilities: []
+    chart_version: 5.11.0
+  - version: 1.20.0
+    kube:
+    - '1.34'
+    - '1.33'
+    - '1.32'
+    requirements: []
+    incompatibilities: []
+    chart_version: 5.10.0
+  - version: 1.19.0
+    kube:
+    - '1.33'
+    - '1.32'
+    - '1.31'
+    requirements: []
+    incompatibilities: []
+    chart_version: 5.8.0
+  - version: 1.17.1
+    kube:
+    - '1.31'
+    - '1.30'
+    - '1.29'
+    requirements: []
+    incompatibilities: []
+    chart_version: 5.6.2
+  - version: 1.16.2
+    kube:
+    - '1.30'
+    - '1.29'
+    - '1.28'
+    requirements: []
+    incompatibilities: []
+    chart_version: 5.5.2
+  - version: 1.15.1
+    kube:
+    - '1.29'
+    - '1.28'
+    - '1.27'
+    requirements: []
+    incompatibilities: []
+    chart_version: 5.4.5
+  - version: 1.14.2
+    kube:
+    - '1.28'
+    - '1.27'
+    - '1.26'
+    requirements: []
+    incompatibilities: []
+    chart_version: 5.3.2
+  - version: 1.13.2
+    kube:
+    - '1.27'
+    - '1.26'
+    - '1.25'
+    requirements: []
+    incompatibilities: []
+    chart_version: 5.1.0
+  - version: 1.12.2
+    kube:
+    - '1.26'
+    - '1.25'
+    - '1.24'
+    requirements: []
+    incompatibilities: []
+    chart_version: 4.4.2
+  - version: 1.11.0
+    kube:
+    - '1.25'
+    - '1.24'
+    - '1.23'
+    requirements: []
+    incompatibilities: []
+    chart_version: 4.1.0
+  - version: 1.10.2
+    kube:
+    - '1.24'
+    - '1.23'
+    - '1.22'
+    requirements: []
+    incompatibilities: []
+    chart_version: 4.0.4
+  - version: 1.9.2
+    kube:
+    - '1.23'
+    - '1.22'
+    - '1.21'
+    requirements: []
+    incompatibilities: []
+    chart_version: 2.14.2
+  - version: 1.8.1
+    kube:
+    - '1.22'
+    - '1.21'
+    - '1.20'
+    requirements: []
+    incompatibilities: []
+    chart_version: 2.10.1
+  - version: 1.7.0
+    kube:
+    - '1.21'
+    - '1.20'
+    - '1.19'
+    requirements: []
+    incompatibilities: []
+    chart_version: 2.9.1
+  - version: 1.6.1
+    kube:
+    - '1.20'
+    - '1.19'
+    - '1.18'
+    requirements: []
+    incompatibilities: []
+    chart_version: 2.4.3
+  - version: 1.5.1
+    kube:
+    - '1.19'
+    - '1.18'
+    - '1.17'
+    requirements: []
+    incompatibilities: []
+    chart_version: 2.2.4
+  - version: 1.4.4
+    kube:
+    - '1.18'
+    - '1.17'
+    - '1.16'
+    requirements: []
+    incompatibilities: []
+    chart_version: 2.0.3
+  name: kured

--- a/static/compatibilities/kured.yaml
+++ b/static/compatibilities/kured.yaml
@@ -1,0 +1,166 @@
+icon: https://raw.githubusercontent.com/kubereboot/website/main/static/img/kured.png
+git_url: https://github.com/kubereboot/kured
+release_url: https://github.com/kubereboot/kured/releases/tag/v{vsn}
+readme_url: https://kured.dev/docs/installation/
+helm_repository_url: https://kubereboot.github.io/charts
+versions:
+- version: 1.23.0
+  kube:
+  - '1.37'
+  - '1.36'
+  - '1.35'
+  requirements: []
+  incompatibilities: []
+  chart_version: 6.1.0
+- version: 1.22.1
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+  chart_version: 6.0.0
+- version: 1.22.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  requirements: []
+  incompatibilities: []
+  chart_version: 5.12.0
+- version: 1.21.0
+  kube:
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  requirements: []
+  incompatibilities: []
+  chart_version: 5.11.0
+- version: 1.20.0
+  kube:
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  requirements: []
+  incompatibilities: []
+  chart_version: 5.10.0
+- version: 1.19.0
+  kube:
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  requirements: []
+  incompatibilities: []
+  chart_version: 5.8.0
+- version: 1.17.1
+  kube:
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  requirements: []
+  incompatibilities: []
+  chart_version: 5.6.2
+- version: 1.16.2
+  kube:
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  requirements: []
+  incompatibilities: []
+  chart_version: 5.5.2
+- version: 1.15.1
+  kube:
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  requirements: []
+  incompatibilities: []
+  chart_version: 5.4.5
+- version: 1.14.2
+  kube:
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  requirements: []
+  incompatibilities: []
+  chart_version: 5.3.2
+- version: 1.13.2
+  kube:
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  requirements: []
+  incompatibilities: []
+  chart_version: 5.1.0
+- version: 1.12.2
+  kube:
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  requirements: []
+  incompatibilities: []
+  chart_version: 4.4.2
+- version: 1.11.0
+  kube:
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  requirements: []
+  incompatibilities: []
+  chart_version: 4.1.0
+- version: 1.10.2
+  kube:
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  requirements: []
+  incompatibilities: []
+  chart_version: 4.0.4
+- version: 1.9.2
+  kube:
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.14.2
+- version: 1.8.1
+  kube:
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.10.1
+- version: 1.7.0
+  kube:
+  - '1.21'
+  - '1.20'
+  - '1.19'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.9.1
+- version: 1.6.1
+  kube:
+  - '1.20'
+  - '1.19'
+  - '1.18'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.4.3
+- version: 1.5.1
+  kube:
+  - '1.19'
+  - '1.18'
+  - '1.17'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.2.4
+- version: 1.4.4
+  kube:
+  - '1.18'
+  - '1.17'
+  - '1.16'
+  requirements: []
+  incompatibilities: []
+  chart_version: 2.0.3

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- kured

--- a/utils/compatibility/scrapers/kured.py
+++ b/utils/compatibility/scrapers/kured.py
@@ -1,0 +1,97 @@
+"""Read Kured's documented expected (not certified/tested) compatibility.
+
+Only explicit matrix releases with a published stable Helm chart are emitted.
+The upstream matrix includes expected future Kubernetes minors; retain those
+explicit values, without extending its ranges or inferring unlisted releases.
+"""
+
+import re
+from urllib.request import urlopen
+
+APP_NAME = "kured"
+SOURCE_URL = "https://raw.githubusercontent.com/kubereboot/website/main/content/en/docs/installation.md"
+INDEX_URL = "https://kubereboot.github.io/charts/index.yaml"
+TARGET_FILE = "../../static/compatibilities/kured.yaml"
+SEMVER = re.compile(r"v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)")
+
+
+def version_key(value):
+    match = SEMVER.fullmatch(str(value))
+    return tuple(map(int, match.groups())) if match else None
+
+
+def parse_matrix(content):
+    rows = {}
+    in_table = False
+    for line in content.splitlines():
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if cells[0].lower() == "kured" and cells[-1].lower() == "expected kubernetes compatibility":
+            if in_table or rows:
+                raise ValueError("Multiple Kured compatibility tables")
+            if len(cells) != 5:
+                raise ValueError("Changed Kured table columns")
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not line.strip().startswith("|"):
+            in_table = False
+            continue
+        if all(re.fullmatch(r":?-+:?", cell) for cell in cells):
+            continue
+        if len(cells) != 5 or version_key(cells[0]) is None:
+            raise ValueError("Malformed Kured compatibility row")
+        version = cells[0].removeprefix("v")
+        if version in rows:
+            raise ValueError(f"Duplicate Kured version: {version}")
+        kube = []
+        for token in cells[-1].split(","):
+            match = re.fullmatch(r"(\d+)\.(\d+)\.x", token.strip())
+            if not match:
+                raise ValueError(f"Unexpected Kubernetes compatibility: {token}")
+            kube.append(".".join(match.groups()))
+        rows[version] = sorted(set(kube), key=lambda v: tuple(map(int, v.split("."))), reverse=True)
+    if not rows:
+        raise ValueError("No Kured compatibility matrix found")
+    return rows
+
+
+def build_versions(matrix, entries):
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Missing Kured Helm chart entries")
+    charts = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Malformed Kured chart entry")
+        app, chart = entry.get("appVersion"), entry.get("version")
+        if version_key(app) is None or version_key(chart) is None:
+            continue
+        app, chart = str(app).removeprefix("v"), str(chart).removeprefix("v")
+        if app not in charts or version_key(chart) > version_key(charts[app]):
+            charts[app] = chart
+    versions = [
+        {"version": app, "kube": matrix[app], "requirements": [],
+         "incompatibilities": [], "chart_version": charts[app]}
+        for app in sorted(matrix, key=version_key, reverse=True) if app in charts
+    ]
+    if not versions:
+        raise ValueError("No documented Kured releases have stable Helm charts")
+    return versions
+
+
+def fetch_text(url):
+    with urlopen(url, timeout=30) as response:
+        return response.read().decode("utf-8")
+
+
+def scrape():
+    import yaml
+    from utils import update_compatibility_info
+
+    matrix = parse_matrix(fetch_text(SOURCE_URL))
+    index = yaml.safe_load(fetch_text(INDEX_URL))
+    if not isinstance(index, dict) or not isinstance(index.get("entries"), dict):
+        raise ValueError("Malformed Helm index")
+    versions = build_versions(matrix, index["entries"].get(APP_NAME))
+    # All fetching and validation finish before the existing writer is called.
+    update_compatibility_info(TARGET_FILE, versions)

--- a/utils/compatibility/tests/KURED.md
+++ b/utils/compatibility/tests/KURED.md
@@ -1,0 +1,47 @@
+# Kured compatibility scraper
+
+Run the focused tests from the repository root (Python 3.9+ with PyYAML):
+
+```sh
+python -m unittest discover -s utils/compatibility/tests -p test_kured.py -v
+```
+
+Run the scraper with the repository's compatibility dependencies and Helm installed:
+
+```sh
+cd utils/compatibility
+python -c "import importlib; importlib.import_module('scrapers.kured').scrape()"
+```
+
+## Sources and semantics
+
+- Official documentation: https://kured.dev/docs/installation/
+- Fixture source: https://github.com/kubereboot/website/blob/main/content/en/docs/installation.md
+- Fixture has trailing blank lines trimmed.
+- Source Git blob SHA: `1d734d308b0c9f8bfe09048b37a2f916efe923d0`
+- Official Helm index: https://kubereboot.github.io/charts/index.yaml
+- Retrieved on 2026-09-08.
+
+`fixtures/kured-index.yaml` projects only the 20 selected published chart entries
+from that index, preserving their application/chart versions, digests and URLs.
+It is a source fixture, not a full copy of the chart repository.
+
+The matrix describes **expected compatibility**, not a certified or exhaustive
+test matrix. The scraper preserves its explicit values, including the future
+Kubernetes 1.37 minor listed for Kured 1.23.0. It does not infer additional minors,
+copy current compatibility onto historical releases, or fill absent Kured rows
+(for example, 1.18.0 is not in this source).
+
+The source has 24 release rows. Twenty have exact stable application-version
+matches in the Helm index. Kured 1.0.0, 1.1.0, 1.2.0 and 1.3.0 have no matching
+chart in that index and are omitted. Multiple charts for an application version
+are resolved to the numerically highest stable chart version. Prereleases are
+excluded.
+
+The tests cover matrix parsing, source drift, malformed/duplicate rows, exact
+chart matching, prereleases, numeric version ordering, source failures before
+writing, and agreement between the generated per-app and aggregate data.
+Writer-boundary tests mock the existing shared writer. They do not establish
+that Helm templating or Kubernetes deployment works. The initial checked-in
+table contains no inferred image list; the existing shared writer enriches
+images when it runs with Helm.

--- a/utils/compatibility/tests/fixtures/kured-index.yaml
+++ b/utils/compatibility/tests/fixtures/kured-index.yaml
@@ -1,0 +1,104 @@
+# Projection of published entries from https://kubereboot.github.io/charts/index.yaml
+# Retrieved 2026-09-08; only the 20 selected app/chart pairs, with original digests and URLs.
+entries:
+  kured:
+  - appVersion: 1.23.0
+    version: 6.1.0
+    digest: 9451342cd13283a626fa63671eb593e88f734a848bdc02f49d42fd1b4ac224db
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-6.1.0/kured-6.1.0.tgz
+  - appVersion: 1.22.1
+    version: 6.0.0
+    digest: 8eac892fed1dbe2014f65bc1a29d2be93fd87cfc6a5b5aff8d3ff305ad6e33a0
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-6.0.0/kured-6.0.0.tgz
+  - appVersion: 1.22.0
+    version: 5.12.0
+    digest: 52805cbbe06d4da4cb360629f7df61a326ec37c8df6ebb38f72cd6ad2ba0a1db
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-5.12.0/kured-5.12.0.tgz
+  - appVersion: 1.21.0
+    version: 5.11.0
+    digest: 220e6469599308f852575b5358f222142b08b3936c59b6e6918919c84f8223ae
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-5.11.0/kured-5.11.0.tgz
+  - appVersion: 1.20.0
+    version: 5.10.0
+    digest: 63f35fb31551dd0e69558a9d10d93b78ab352e4f11cc0f1e92816104d9d63302
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-5.10.0/kured-5.10.0.tgz
+  - appVersion: 1.19.0
+    version: 5.8.0
+    digest: d6f0ef46caa95b6e164d3afa3272f6e09cffac907f5e4725e9665d55cf7e6171
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-5.8.0/kured-5.8.0.tgz
+  - appVersion: 1.17.1
+    version: 5.6.2
+    digest: ab81103dcd52d5d84ce9b959a0e9677d703a2d52edec838e529e2b65b41f9784
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-5.6.2/kured-5.6.2.tgz
+  - appVersion: 1.16.2
+    version: 5.5.2
+    digest: f8acdcf1f3b21dcd85bbe3d04f91f80e5e7d3207c0503e6b473830aa88c6d730
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-5.5.2/kured-5.5.2.tgz
+  - appVersion: 1.15.1
+    version: 5.4.5
+    digest: 58e3f838ec6c285fad3cbb97dc8470f37b24d6ad8d30bb8499cea531fd6e9439
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-5.4.5/kured-5.4.5.tgz
+  - appVersion: 1.14.2
+    version: 5.3.2
+    digest: c480cb381bf1b8eb64cda8e0c24a77ef697e24b438ec0e4944b0d6e3e2b7fa1a
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-5.3.2/kured-5.3.2.tgz
+  - appVersion: 1.13.2
+    version: 5.1.0
+    digest: 696b8230f95e5e087e93826c7475f438881d7c73376fe27d34193ecc6b16d0d2
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-5.1.0/kured-5.1.0.tgz
+  - appVersion: 1.12.2
+    version: 4.4.2
+    digest: 7162957d74693eb7d9325222b57a682daaa893ea7cfee73508309e20b1264d2f
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-4.4.2/kured-4.4.2.tgz
+  - appVersion: 1.11.0
+    version: 4.1.0
+    digest: f935c204fb285906eb92d11a3318a436cb958ad8ab5435555b633ac7d1b657fb
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-4.1.0/kured-4.1.0.tgz
+  - appVersion: 1.10.2
+    version: 4.0.4
+    digest: c9b2eee611800ee92b37b8973f328ef03211e9d2ed0124632e061cb8bed60e44
+    urls:
+    - https://github.com/kubereboot/charts/releases/download/kured-4.0.4/kured-4.0.4.tgz
+  - appVersion: 1.9.2
+    version: 2.14.2
+    digest: 48b267700a0d48ab73e4b6ace31c1c84c393959ed09c31a3ec03e170b6b4aacf
+    urls:
+    - https://kubereboot.github.io/charts/kured-2.14.2.tgz
+  - appVersion: 1.8.1
+    version: 2.10.1
+    digest: 905576b23f8263dcf26da50da6c004cb266a143cca0567f0e5d5586569b8e367
+    urls:
+    - https://kubereboot.github.io/charts/kured-2.10.1.tgz
+  - appVersion: 1.7.0
+    version: 2.9.1
+    digest: 02fd3ce98b427b411bf425cbdd60567072596f3c1ca44ff3ecb17f4852cd0099
+    urls:
+    - https://kubereboot.github.io/charts/kured-2.9.1.tgz
+  - appVersion: 1.6.1
+    version: 2.4.3
+    digest: 1961e0937676e0bcb8ceb7a4973c61450d059e2d4beea78481a9323cf0b964a6
+    urls:
+    - https://kubereboot.github.io/charts/kured-2.4.3.tgz
+  - appVersion: 1.5.1
+    version: 2.2.4
+    digest: b3a8b13a79efa56a0a94fa91976faa4916fbdab826d9f50ddf63f4d9179a36e4
+    urls:
+    - https://kubereboot.github.io/charts/kured-2.2.4.tgz
+  - appVersion: 1.4.4
+    version: 2.0.3
+    digest: 8ae0a2884d185ac6311d9333ba7b29c8815a2b433892bc073922c9ad5c0771bc
+    urls:
+    - https://kubereboot.github.io/charts/kured-2.0.3.tgz

--- a/utils/compatibility/tests/fixtures/kured-installation.md
+++ b/utils/compatibility/tests/fixtures/kured-installation.md
@@ -1,0 +1,63 @@
+---
+title: Installation
+weight: 1
+---
+
+## Default installation with manifests
+
+To obtain a default installation without Prometheus alerting interlock
+or Slack notifications:
+
+```console
+latest=$(curl -s https://api.github.com/repos/kubereboot/kured/releases | jq -r '.[0].tag_name')
+kubectl apply -f "https://github.com/kubereboot/kured/releases/download/$latest/kured-$latest-combined.yaml"
+```
+
+If you want to customise the installation, download the manifest and
+edit it in accordance with the following section before application.
+
+## Using the Helm-Chart
+
+Kured also provides its own helm-chart. Detailed instructions and documentation can be found [here](https://github.com/kubereboot/charts/tree/main/charts/kured).
+
+## Kubernetes & OS Compatibility
+
+The daemon image contains versions of `k8s.io/client-go` and
+`k8s.io/kubectl` (the binary of `kubectl` in older releases) for the purposes of
+maintaining the lock and draining worker nodes. Kubernetes aims to provide
+forwards and backwards compatibility of one minor version between client and
+server:
+
+| kured  | {k8s.io/,}kubectl | k8s.io/client-go | k8s.io/apimachinery | expected kubernetes compatibility |
+| ------ | ----------------- | ---------------- | ------------------- | --------------------------------- |
+| 1.23.0 | 0.36.2            | v0.36.2          | v0.36.2             | 1.35.x, 1.36.x, 1.37.x            |
+| 1.22.1 | 0.35.4            | v0.35.4          | v0.35.4             | 1.34.x, 1.35.x, 1.36.x            |
+| 1.22.0 | 0.35.4            | v0.35.4          | v0.35.4             | 1.34.x, 1.35.x, 1.36.x            |
+| 1.21.0 | 0.34.3            | v0.34.3          | v0.34.3             | 1.33.x, 1.34.x, 1.35.x            |
+| 1.20.0 | 0.33.4            | v0.33.4          | v0.33.4             | 1.32.x, 1.33.x, 1.34.x            |
+| 1.19.0 | 0.32.8            | v0.32.8          | v0.32.8             | 1.31.x, 1.32.x, 1.33.x            |
+| 1.17.1 | 0.30.10           | v0.30.10         | v0.30.10            | 1.29.x, 1.30.x, 1.31.x            |
+| 1.16.2 | 0.29.9            | v0.29.9          | v0.29.9             | 1.28.x, 1.29.x, 1.30.x            |
+| 1.15.1 | 0.28.8            | v0.28.8          | v0.28.8             | 1.27.x, 1.28.x, 1.29.x            |
+| 1.14.2 | 0.27.6            | v0.27.6          | v0.27.6             | 1.26.x, 1.27.x, 1.28.x            |
+| 1.13.2 | 0.26.7            | v0.26.7          | v0.26.7             | 1.25.x, 1.26.x, 1.27.x            |
+| 1.12.2 | 0.25.5            | v0.25.5          | v0.25.5             | 1.24.x, 1.25.x, 1.26.x            |
+| 1.11.0 | 0.24.7            | v0.24.7          | v0.24.7             | 1.23.x, 1.24.x, 1.25.x            |
+| 1.10.2 | 0.23.6            | v0.23.6          | v0.23.6             | 1.22.x, 1.23.x, 1.24.x            |
+| 1.9.2  | 0.22.4            | v0.22.4          | v0.22.4             | 1.21.x, 1.22.x, 1.23.x            |
+| 1.8.1  | 0.21.4            | v0.21.4          | v0.21.4             | 1.20.x, 1.21.x, 1.22.x            |
+| 1.7.0  | 0.20.5            | v0.20.5          | v0.20.5             | 1.19.x, 1.20.x, 1.21.x            |
+| 1.6.1  | 0.19.4            | v0.19.4          | v0.19.4             | 1.18.x, 1.19.x, 1.20.x            |
+| 1.5.1  | 0.18.8            | v0.18.8          | v0.18.8             | 1.17.x, 1.18.x, 1.19.x            |
+| 1.4.4  | 1.17.7            | v0.17.0          | v0.17.0             | 1.16.x, 1.17.x, 1.18.x            |
+| 1.3.0  | 1.15.10           | v12.0.0          | release-1.15        | 1.15.x, 1.16.x, 1.17.x            |
+| 1.2.0  | 1.13.6            | v10.0.0          | release-1.13        | 1.12.x, 1.13.x, 1.14.x            |
+| 1.1.0  | 1.12.1            | v9.0.0           | release-1.12        | 1.11.x, 1.12.x, 1.13.x            |
+| 1.0.0  | 1.7.6             | v4.0.0           | release-1.7         | 1.6.x, 1.7.x, 1.8.x               |
+
+See the [release notes](https://github.com/kubereboot/kured/releases)
+for specific version compatibility information, including which
+combination have been formally tested.
+
+Versions >=1.1.0 enter the host mount namespace to invoke
+`systemctl reboot`, so should work on any systemd distribution.

--- a/utils/compatibility/tests/test_kured.py
+++ b/utils/compatibility/tests/test_kured.py
@@ -1,0 +1,102 @@
+import importlib.util
+import unittest
+import sys
+from types import ModuleType
+from unittest.mock import Mock, patch
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("kured", ROOT / "scrapers/kured.py")
+kured = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(kured)
+FIXTURE = Path(__file__).parent / "fixtures/kured-installation.md"
+
+
+class KuredTests(unittest.TestCase):
+    def setUp(self):
+        self.content = FIXTURE.read_text()
+
+    def test_official_matrix(self):
+        matrix = kured.parse_matrix(self.content)
+        self.assertEqual(len(matrix), 24)
+        self.assertEqual(matrix["1.23.0"], ["1.37", "1.36", "1.35"])
+        self.assertEqual(matrix["1.0.0"], ["1.8", "1.7", "1.6"])
+        self.assertNotIn("1.18.0", matrix)
+
+    def test_missing_or_changed_table_rejected(self):
+        for body in ["", "# Error", self.content.replace("expected kubernetes compatibility", "tested versions")]:
+            with self.subTest(body=body[:30]), self.assertRaises(ValueError):
+                kured.parse_matrix(body)
+
+    def test_unsupported_cells_rejected(self):
+        for token in ["", "1.35.x - 1.37.x", "1.35.x, unknown", "latest"]:
+            with self.subTest(token=token), self.assertRaises(ValueError):
+                kured.parse_matrix(self.content.replace("1.35.x, 1.36.x, 1.37.x", token))
+
+    def test_duplicate_release_rejected(self):
+        with self.assertRaises(ValueError):
+            kured.parse_matrix(self.content.replace("| 1.22.1 |", "| 1.23.0 |"))
+
+    def test_missing_column_rejected(self):
+        with self.assertRaises(ValueError):
+            kured.parse_matrix(self.content.replace("| v0.36.2             |", ""))
+
+    def test_exact_stable_chart_mapping_and_numeric_order(self):
+        entries = [
+            {"appVersion": "v1.23.0", "version": "6.9.0"},
+            {"appVersion": "1.23.0", "version": "6.10.0"},
+            {"appVersion": "1.23.0", "version": "7.0.0-rc1"},
+            {"appVersion": "1.22.1-rc1", "version": "6.0.0"},
+            {"appVersion": "1.18.0", "version": "5.0.0"},
+            {"appVersion": "1.9.2", "version": "2.0.0"},
+        ]
+        rows = kured.build_versions(kured.parse_matrix(self.content), entries)
+        self.assertEqual([row["version"] for row in rows], ["1.23.0", "1.9.2"])
+        self.assertEqual(rows[0]["chart_version"], "6.10.0")
+        self.assertEqual(rows[1]["kube"], ["1.23", "1.22", "1.21"])
+
+    def test_empty_invalid_or_unmatched_charts_rejected(self):
+        for entries in [None, {}, [], [None], [{"appVersion": "9.0.0", "version": "9.0.0"}]]:
+            with self.subTest(entries=entries), self.assertRaises(ValueError):
+                kured.build_versions(kured.parse_matrix(self.content), entries)
+
+    def test_source_failure_does_not_call_writer(self):
+        utils = ModuleType("utils")
+        utils.update_compatibility_info = Mock()
+        for responses in [OSError("offline"), [self.content, OSError("offline")]]:
+            with self.subTest(responses=responses), patch.dict(sys.modules, {"utils": utils}):
+                with patch.object(kured, "fetch_text", side_effect=responses), self.assertRaises(OSError):
+                    kured.scrape()
+            utils.update_compatibility_info.assert_not_called()
+
+    def test_scrape_validates_both_sources_before_writer(self):
+        utils = ModuleType("utils")
+        utils.update_compatibility_info = Mock()
+        index = 'entries:\n  kured:\n  - appVersion: 1.23.0\n    version: 6.1.0\n'
+        with patch.dict(sys.modules, {"utils": utils}), patch.object(kured, "fetch_text", side_effect=[self.content, index]):
+            kured.scrape()
+        utils.update_compatibility_info.assert_called_once()
+        path, rows = utils.update_compatibility_info.call_args.args
+        self.assertEqual(path, kured.TARGET_FILE)
+        self.assertEqual(rows[0]["chart_version"], "6.1.0")
+
+    def test_generated_table_and_aggregate_match_sources(self):
+        import yaml
+        repo = ROOT.parents[1]
+        addon = yaml.safe_load((repo / "static/compatibilities/kured.yaml").read_text())
+        matrix = kured.parse_matrix(self.content)
+        index = yaml.safe_load((FIXTURE.parent / "kured-index.yaml").read_text())
+        self.assertEqual(addon["versions"], kured.build_versions(matrix, index["entries"]["kured"]))
+        self.assertEqual(len(addon["versions"]), 20)
+        for row in addon["versions"]:
+            self.assertEqual(row["kube"], matrix[row["version"]])
+            self.assertIsNotNone(kured.version_key(row["chart_version"]))
+        manifest = yaml.safe_load((repo / "static/compatibilities/manifest.yaml").read_text())
+        self.assertEqual(manifest["names"].count("kured"), 1)
+        aggregate = yaml.safe_load((repo / "static/compatibilities.yaml").read_text())
+        matches = [a for a in aggregate["addons"] if a["name"] == "kured"]
+        self.assertEqual(matches, [{**addon, "name": "kured"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Kured compatibility scraper and 20 stable Helm-chart-backed version rows.

Sources: https://kured.dev/docs/installation/ and https://kubereboot.github.io/charts/index.yaml

10 targeted tests pass. Full shared-writer/Helm execution is not verified. The matrix describes expected compatibility, not certified testing. See utils/compatibility/tests/KURED.md.