### PR TITLE
Add NVIDIA Network Operator compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- network-operator

--- a/static/compatibilities/network-operator.yaml
+++ b/static/compatibilities/network-operator.yaml
@@ -1,0 +1,63 @@
+icon: https://raw.githubusercontent.com/pluralsh/plural-artifacts/main/nvidia-operator/plural/icons/nvidia.png?raw=true
+git_url: https://github.com/Mellanox/network-operator
+release_url: https://github.com/Mellanox/network-operator/releases/tag/v{vsn}
+helm_repository_url: https://helm.ngc.nvidia.com/nvidia
+chart_name: network-operator
+readme_url: https://github.com/Mellanox/network-operator/blob/master/README.md
+versions:
+- version: 26.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 26.7.0
+  images: ['nvcr.io/nvidia/cloud-native/network-operator:v26.7.0', 'nvcr.io/nvidia/mellanox/node-feature-discovery:network-operator-v26.7.0']
+- version: 26.4.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 26.4.1
+  images: ['nvcr.io/nvidia/cloud-native/network-operator:v26.4.1', 'nvcr.io/nvidia/mellanox/node-feature-discovery:network-operator-v26.4.1']
+- version: 26.4.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 26.4.0
+  images: ['nvcr.io/nvidia/cloud-native/network-operator:v26.4.0', 'nvcr.io/nvidia/mellanox/node-feature-discovery:network-operator-v26.4.0']
+- version: 26.1.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 26.1.0
+  images: ['nvcr.io/nvidia/cloud-native/network-operator:v26.1.0', 'nvcr.io/nvidia/mellanox/node-feature-discovery:network-operator-v26.1.0']
+- version: 25.10.0
+  kube: ['1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 25.10.0
+  images: ['nvcr.io/nvidia/cloud-native/network-operator:v25.10.0', 'nvcr.io/nvidia/mellanox/node-feature-discovery:network-operator-v25.10.0']
+- version: 25.7.0
+  kube: ['1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 25.7.0
+  images: ['nvcr.io/nvidia/cloud-native/network-operator:v25.7.0', 'nvcr.io/nvidia/mellanox/node-feature-discovery:network-operator-v25.7.0']
+- version: 25.4.0
+  kube: ['1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 25.4.0
+  images: ['nvcr.io/nvidia/cloud-native/network-operator:v25.4.0', 'registry.k8s.io/nfd/node-feature-discovery:v0.17.0']
+- version: 24.4.0
+  kube: ['1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 24.4.0
+  images: ['nvcr.io/nvidia/cloud-native/network-operator:v24.4.0', 'registry.k8s.io/nfd/node-feature-discovery:v0.13.2']

--- a/utils/compatibility/scrapers/network-operator.py
+++ b/utils/compatibility/scrapers/network-operator.py
@@ -1,0 +1,100 @@
+import re
+
+import yaml
+from bs4 import BeautifulSoup
+from packaging.version import InvalidVersion, Version
+
+APP_NAME = "network-operator"
+INDEX_URL = "https://helm.ngc.nvidia.com/nvidia/index.yaml"
+DOC_URL = (
+    "https://docs.nvidia.com/networking/display/"
+    "kubernetes{slug}/platform-support.html"
+)
+
+
+def stable_charts(content):
+    entries = yaml.safe_load(content).get("entries", {}).get(APP_NAME)
+    if not entries:
+        raise ValueError("Network Operator chart entries not found")
+    charts = {}
+    for entry in entries:
+        try:
+            app = str(entry["appVersion"]).lstrip("v")
+            chart = str(entry["version"])
+            av, cv = Version(app), Version(chart)
+        except (KeyError, InvalidVersion):
+            continue
+        if not re.fullmatch(r"\d+\.\d+\.\d+", app):
+            continue
+        if av.is_prerelease or cv.is_prerelease or cv.is_devrelease or cv.local:
+            continue
+        if app not in charts or cv > Version(charts[app]):
+            charts[app] = chart
+    if not charts:
+        raise ValueError("No stable Network Operator charts found")
+    return dict(sorted(charts.items(), key=lambda item: Version(item[0]), reverse=True))
+
+
+def parse_support(content, version):
+    soup = BeautifulSoup(content, "html.parser")
+    identities = set(re.findall(
+        r"NVIDIA Network Operator v(\d+\.\d+\.\d+)",
+        soup.get_text(" ", strip=True),
+    ))
+    if identities != {version}:
+        raise ValueError(f"Documentation identity mismatch for {version}: {identities}")
+    constraints = set()
+    for table in soup.find_all("table"):
+        headers = [cell.get_text(" ", strip=True) for cell in table.find_all("th")]
+        if headers[:2] != ["Component", "Version"]:
+            continue
+        for row in table.find_all("tr"):
+            cells = row.find_all("td", recursive=False)
+            if len(cells) >= 2 and cells[0].get_text(" ", strip=True) == "Kubernetes":
+                constraints.add(cells[1].get_text(" ", strip=True))
+    if len(constraints) != 1:
+        raise ValueError(f"Expected one Kubernetes prerequisite for {version}")
+    constraint = constraints.pop()
+    match = re.fullmatch(r">=1\.(\d+)\s+and\s+<=1\.(\d+)", constraint)
+    if not match:
+        # A minor-only matrix cannot express a ceiling such as 1.30.4.
+        raise ValueError(f"Cannot represent Kubernetes prerequisite: {constraint}")
+    start, end = map(int, match.groups())
+    if start > end:
+        raise ValueError("Reversed Kubernetes prerequisite range")
+    return [f"1.{minor}" for minor in range(end, start - 1, -1)]
+
+
+def build_rows(index, fetch, warn=print):
+    rows = []
+    for version, chart in stable_charts(index).items():
+        url = DOC_URL.format(slug=version.replace(".", ""))
+        content = fetch(url)
+        if not content:
+            warn(f"Skipping {version}: no version-specific support page")
+            continue
+        try:
+            kube = parse_support(content, version)
+        except ValueError as error:
+            warn(f"Skipping {version}: {error}")
+            continue
+        rows.append({
+            "version": version,
+            "kube": kube,
+            "chart_version": chart,
+            "requirements": [],
+            "incompatibilities": [],
+        })
+    if not rows:
+        raise ValueError("No representable Network Operator compatibility rows")
+    return rows
+
+
+def scrape():
+    from utils import fetch_page, print_warning, update_compatibility_info
+
+    index = fetch_page(INDEX_URL)
+    if not index:
+        raise ValueError("Could not fetch official NVIDIA Helm index")
+    rows = build_rows(index, fetch_page, print_warning)
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", rows)

--- a/utils/compatibility/tests/NETWORK_OPERATOR.md
+++ b/utils/compatibility/tests/NETWORK_OPERATOR.md
@@ -1,0 +1,41 @@
+# NVIDIA Network Operator compatibility
+
+The scraper joins stable application/chart versions from
+https://helm.ngc.nvidia.com/nvidia/index.yaml with the **Kubernetes** row in
+each release's **Component / Version** prerequisites table. It expands only
+explicit inclusive minor bounds; it does not infer compatibility from release
+dates, the GPU Operator, or the OpenShift platform column.
+
+Sources include:
+
+- https://docs.nvidia.com/networking/display/kubernetes2670/platform-support.html
+- https://docs.nvidia.com/networking/display/kubernetes2641/platform-support.html
+- https://docs.nvidia.com/networking/display/kubernetes2470/platform-support.html
+
+The fixtures are prerequisite-table excerpts retrieved on 2026-09-08, with
+the release identity added as a minimal page wrapper. They cover two real
+minor ranges and the older patch ceiling. Other fixtures in the test module
+are deliberately hand-written malformed/selection cases.
+
+Coverage limits are intentional:
+
+- Missing version-specific pages are skipped, with a warning.
+- Page identity must match the chart's application version. In particular,
+  `kubernetes2410` serves **24.10.0**, not **24.1.0**.
+- `<=1.30.4` cannot be represented faithfully as a minor-only support list.
+  Releases with that ceiling are skipped rather than asserting all of 1.30
+  is supported. The original bound is printed in the warning and retained in
+  the 24.7.0 fixture.
+- These are upstream software prerequisites, not proof that every OS, NIC,
+  firmware, or deployment topology is supported. Consult the release's full
+  platform table for those constraints.
+
+Run the offline checks from the repository root:
+
+```sh
+python3 -m unittest discover -s utils/compatibility/tests -p test_network_operator.py -v
+```
+
+The normal compatibility runner can select this scraper with
+`SCRAPER=network-operator` from `utils/compatibility`. A total source/parsing
+failure raises before the compatibility file is updated.

--- a/utils/compatibility/tests/NETWORK_OPERATOR.md
+++ b/utils/compatibility/tests/NETWORK_OPERATOR.md
@@ -13,7 +13,7 @@ Sources include:
 - https://docs.nvidia.com/networking/display/kubernetes2470/platform-support.html
 
 The fixtures are prerequisite-table excerpts retrieved on 2026-09-08, with
-the release identity added as a minimal page wrapper. They cover two real
+the actual upstream release-heading and navigation-link markup preserved. They cover two real
 minor ranges and the older patch ceiling. Other fixtures in the test module
 are deliberately hand-written malformed/selection cases.
 

--- a/utils/compatibility/tests/fixtures/network-operator/24.7.0.html
+++ b/utils/compatibility/tests/fixtures/network-operator/24.7.0.html
@@ -1,5 +1,7 @@
-<!-- Extracted from https://docs.nvidia.com/networking/display/kubernetes2470/platform-support.html on 2026-09-08 -->
-<p>NVIDIA Network Operator v24.7.0</p>
+<!-- Upstream identity elements and prerequisite table from https://docs.nvidia.com/networking/display/kubernetes2470/platform-support.html; retrieved 2026-09-08 -->
+<div class="PageHeading-title">NVIDIA Network Operator v24.7.0</div>
+<a class="Link" href="https://docs.nvidia.com/networking/display/kubernetes2470/index.html">NVIDIA Network Operator v24.7.0</a>
+<a class="Link" href="https://docs.nvidia.com/networking/display/kubernetes2470/index.html">NVIDIA Network Operator v24.7.0</a>
 <table>
 <colgroup>
 <col style="width: 33%"/>

--- a/utils/compatibility/tests/fixtures/network-operator/24.7.0.html
+++ b/utils/compatibility/tests/fixtures/network-operator/24.7.0.html
@@ -1,0 +1,28 @@
+<!-- Extracted from https://docs.nvidia.com/networking/display/kubernetes2470/platform-support.html on 2026-09-08 -->
+<p>NVIDIA Network Operator v24.7.0</p>
+<table>
+<colgroup>
+<col style="width: 33%"/>
+<col style="width: 33%"/>
+<col style="width: 33%"/>
+</colgroup>
+<tbody>
+<tr>
+<th class="head"><p>Component</p></th>
+<th class="head"><p>Version</p></th>
+<th class="head"><p>Notes</p></th>
+</tr>
+<tr class="row-even"><td>Kubernetes</td>
+<td>&gt;=1.27 and &lt;=1.30.4</td>
+<td></td>
+</tr>
+<tr class="row-odd"><td>Helm</td>
+<td>v3.5+</td>
+<td>For information and methods of Helm installation, please refer to the official Helm Website.</td>
+</tr>
+<tr class="row-even"><td>Node Feature Discovery</td>
+<td>&gt;=0.15.6 and &lt;=0.16.3</td>
+<td>When deploying the Network Operator and GPU Operator on the same cluster, ensure only one instance of Node Feature Discovery (NFD) is installed. We recommend using the version included with the GPU Operator.</td>
+</tr>
+</tbody>
+</table>

--- a/utils/compatibility/tests/fixtures/network-operator/26.4.1.html
+++ b/utils/compatibility/tests/fixtures/network-operator/26.4.1.html
@@ -1,0 +1,16 @@
+<!-- Extracted from https://docs.nvidia.com/networking/display/kubernetes2641/platform-support.html on 2026-09-08 -->
+<p>NVIDIA Network Operator v26.4.1</p>
+<table><style>td:nth-child(1) {width: 33%;}td:nth-child(2) {width: 33%;}td:nth-child(3) {width: 33%;}; width: fit-content;</style><tbody><tr><th class="head"><p>Component</p></th><th class="head"><p>Version</p></th><th class="head"><p>Notes</p></th></tr>
+<tr class="row-even"><td>Kubernetes</td>
+<td>&gt;=1.31 and &lt;=1.36</td>
+<td></td>
+</tr>
+<tr class="row-odd"><td>Helm</td>
+<td>v3.5+</td>
+<td>For installation methods, refer to the official <a class="external" href="https://helm.sh/">Helm website</a>.</td>
+</tr>
+<tr class="row-even"><td>Node Feature Discovery</td>
+<td>&gt;=0.15.6 and &lt;=0.17.0</td>
+<td>When deploying the Network Operator and GPU Operator on the same cluster, ensure only one instance of Node Feature Discovery (NFD) is installed. We recommend using the version included with the GPU Operator.</td>
+</tr>
+</tbody></table>

--- a/utils/compatibility/tests/fixtures/network-operator/26.4.1.html
+++ b/utils/compatibility/tests/fixtures/network-operator/26.4.1.html
@@ -1,5 +1,7 @@
-<!-- Extracted from https://docs.nvidia.com/networking/display/kubernetes2641/platform-support.html on 2026-09-08 -->
-<p>NVIDIA Network Operator v26.4.1</p>
+<!-- Upstream identity elements and prerequisite table from https://docs.nvidia.com/networking/display/kubernetes2641/platform-support.html; retrieved 2026-09-08 -->
+<div class="PageHeading-title">NVIDIA Network Operator v26.4.1</div>
+<a class="Link" href="https://docs.nvidia.com/networking/display/kubernetes2641/index.html">NVIDIA Network Operator v26.4.1</a>
+<a class="Link" href="https://docs.nvidia.com/networking/display/kubernetes2641/index.html">NVIDIA Network Operator v26.4.1</a>
 <table><style>td:nth-child(1) {width: 33%;}td:nth-child(2) {width: 33%;}td:nth-child(3) {width: 33%;}; width: fit-content;</style><tbody><tr><th class="head"><p>Component</p></th><th class="head"><p>Version</p></th><th class="head"><p>Notes</p></th></tr>
 <tr class="row-even"><td>Kubernetes</td>
 <td>&gt;=1.31 and &lt;=1.36</td>

--- a/utils/compatibility/tests/fixtures/network-operator/26.7.0.html
+++ b/utils/compatibility/tests/fixtures/network-operator/26.7.0.html
@@ -1,0 +1,16 @@
+<!-- Extracted from https://docs.nvidia.com/networking/display/kubernetes2670/platform-support.html on 2026-09-08 -->
+<p>NVIDIA Network Operator v26.7.0</p>
+<table><style>td:nth-child(1) {width: 33%;}td:nth-child(2) {width: 33%;}td:nth-child(3) {width: 33%;}; width: fit-content;</style><tbody><tr><th class="head"><p>Component</p></th><th class="head"><p>Version</p></th><th class="head"><p>Notes</p></th></tr>
+<tr class="row-even"><td>Kubernetes</td>
+<td>&gt;=1.32 and &lt;=1.36</td>
+<td></td>
+</tr>
+<tr class="row-odd"><td>Helm</td>
+<td>v3.5+</td>
+<td>For installation methods, refer to the official <a class="external" href="https://helm.sh/">Helm website</a>.</td>
+</tr>
+<tr class="row-even"><td>Node Feature Discovery</td>
+<td>&gt;=0.15.6 and &lt;=0.17.0</td>
+<td>When deploying the Network Operator and GPU Operator on the same cluster, ensure only one instance of Node Feature Discovery (NFD) is installed. We recommend using the version included with the GPU Operator.</td>
+</tr>
+</tbody></table>

--- a/utils/compatibility/tests/fixtures/network-operator/26.7.0.html
+++ b/utils/compatibility/tests/fixtures/network-operator/26.7.0.html
@@ -1,5 +1,7 @@
-<!-- Extracted from https://docs.nvidia.com/networking/display/kubernetes2670/platform-support.html on 2026-09-08 -->
-<p>NVIDIA Network Operator v26.7.0</p>
+<!-- Upstream identity elements and prerequisite table from https://docs.nvidia.com/networking/display/kubernetes2670/platform-support.html; retrieved 2026-09-08 -->
+<div class="PageHeading-title">NVIDIA Network Operator v26.7.0</div>
+<a class="Link" href="https://docs.nvidia.com/networking/display/kubernetes2670/index.html">NVIDIA Network Operator v26.7.0</a>
+<a class="Link" href="https://docs.nvidia.com/networking/display/kubernetes2670/index.html">NVIDIA Network Operator v26.7.0</a>
 <table><style>td:nth-child(1) {width: 33%;}td:nth-child(2) {width: 33%;}td:nth-child(3) {width: 33%;}; width: fit-content;</style><tbody><tr><th class="head"><p>Component</p></th><th class="head"><p>Version</p></th><th class="head"><p>Notes</p></th></tr>
 <tr class="row-even"><td>Kubernetes</td>
 <td>&gt;=1.32 and &lt;=1.36</td>

--- a/utils/compatibility/tests/test_network_operator.py
+++ b/utils/compatibility/tests/test_network_operator.py
@@ -1,0 +1,76 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+path = Path(__file__).parents[1] / "scrapers/network-operator.py"
+spec = importlib.util.spec_from_file_location("network_operator", path)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+def page(version="26.7.0", constraint="&gt;=1.32 and &lt;=1.36"):
+    return f"""<p>NVIDIA Network Operator v{version}</p>
+    <table><tr><th>Component</th><th>Version</th><th>Notes</th></tr>
+    <tr><td>Kubernetes</td><td>{constraint}</td><td></td></tr></table>"""
+
+
+INDEX = """entries:
+  network-operator:
+  - {version: 26.7.0, appVersion: v26.7.0}
+  - {version: 26.7.1, appVersion: v26.7.0}
+  - {version: 26.7.2-rc.1, appVersion: v26.7.0}
+  - {version: 26.8.0, appVersion: v26.8.0-rc.1}
+  - {version: 26.4.0, appVersion: v26.4.0}
+  - {version: junk, appVersion: junk}
+"""
+
+
+class NetworkOperatorTests(unittest.TestCase):
+    def test_official_prerequisite_table_fixtures(self):
+        fixtures = Path(__file__).parent / "fixtures/network-operator"
+        for version, low, high in [("26.7.0", 32, 36), ("26.4.1", 31, 36)]:
+            with self.subTest(version=version):
+                content = (fixtures / f"{version}.html").read_text()
+                self.assertEqual(scraper.parse_support(content, version),
+                                 [f"1.{minor}" for minor in range(high, low - 1, -1)])
+        with self.assertRaisesRegex(ValueError, "Cannot represent"):
+            scraper.parse_support((fixtures / "24.7.0.html").read_text(), "24.7.0")
+
+    def test_explicit_inclusive_range(self):
+        self.assertEqual(scraper.parse_support(page(), "26.7.0"),
+                         ["1.36", "1.35", "1.34", "1.33", "1.32"])
+
+    def test_identity_prevents_2410_slug_collision(self):
+        with self.assertRaisesRegex(ValueError, "identity mismatch"):
+            scraper.parse_support(page("24.10.0"), "24.1.0")
+
+    def test_patch_ceiling_is_not_widened(self):
+        with self.assertRaisesRegex(ValueError, "Cannot represent"):
+            scraper.parse_support(page(constraint="&gt;=1.27 and &lt;=1.30.4"), "26.7.0")
+
+    def test_missing_and_reversed_ranges(self):
+        for content in [page().replace("Kubernetes", "OpenShift"),
+                        page(constraint="&gt;=1.36 and &lt;=1.32")]:
+            with self.assertRaises(ValueError):
+                scraper.parse_support(content, "26.7.0")
+
+    def test_chart_selection_excludes_prereleases(self):
+        self.assertEqual(scraper.stable_charts(INDEX),
+                         {"26.7.0": "26.7.1", "26.4.0": "26.4.0"})
+
+    def test_missing_page_does_not_inherit_other_release(self):
+        warnings = []
+        rows = scraper.build_rows(INDEX, lambda url: page() if "2670/" in url else None,
+                                  warnings.append)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["chart_version"], "26.7.1")
+        self.assertEqual(rows[0]["version"], "26.7.0")
+        self.assertEqual(len(warnings), 1)
+
+    def test_total_source_failure_raises_before_write(self):
+        with self.assertRaisesRegex(ValueError, "No representable"):
+            scraper.build_rows(INDEX, lambda url: None, lambda message: None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds NVIDIA Network Operator to the compatibility catalog using explicit Kubernetes prerequisites from NVIDIA's versioned platform-support pages and chart mappings from the official NGC Helm index. The scraper yields 11 documented releases; the existing updater reduces these to eight distinct compatibility records and populates their chart images.

The parser verifies the page's release identity before using its table: the `kubernetes2410` URL actually serves 24.10.0, not 24.1.0. Missing pages, identity mismatches, and patch-bounded ranges such as `<=1.30.4` are skipped with warnings rather than broadened into unsupported minor ranges. The included notes explain coverage and hardware/OS limitations.

Sources:
- [Official NVIDIA Helm index](https://helm.ngc.nvidia.com/nvidia/index.yaml)
- [26.7.0 prerequisites](https://docs.nvidia.com/networking/display/kubernetes2670/platform-support.html)
- [26.4.1 prerequisites](https://docs.nvidia.com/networking/display/kubernetes2641/platform-support.html)
- [24.7.0 patch-bounded prerequisites](https://docs.nvidia.com/networking/display/kubernetes2470/platform-support.html)

## Test Plan

Test environment: local macOS arm64, Python 3.13, Helm 4.2.4. No cluster deployment or physical NVIDIA hardware test is claimed; this changes compatibility metadata and its scraper.

- `python3 -m unittest discover -s utils/compatibility/tests -p test_network_operator.py -v`: eight tests pass. Includes actual upstream table excerpts plus synthetic malformed inputs, prerelease selection, missing pages, and total-source failure.
- Executed `scrapers.network-operator.scrape()` from `utils/compatibility` against live sources using the real updater and Helm; eight output records have chart images. AI summarization disabled.
- Validated the generated add-on YAML against `static/compatibilities/schema.json` (`#/definitions/addOn`).
- `git diff --check` passes.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (not applicable: no agent code changed).

This contribution was researched, implemented, and tested with OpenAI Codex. I would like it considered under the README's new-scraper contributor reward tier. Please confirm eligibility and whether an accepted contribution can be paid through PayPal; no award is assumed. Payment details will be shared privately at claim time.

Plural Flow: console
