### PR TITLE
fix: preserve compatibility data and validate fork pull requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,13 @@ name: CI / Console
 
 env:
   DOCKER_METADATA_PR_HEAD_SHA: 'true'
+  # Fork and Dependabot PRs still build and test, but cannot publish images.
+  CAN_PUBLISH_IMAGES: >-
+    ${{ github.repository == 'pluralsh/console' && github.actor != 'dependabot[bot]' &&
+        (github.event_name == 'push' ||
+         (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.user.login != 'dependabot[bot]')) }}
 
 on:
   push:
@@ -47,12 +54,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
+        if: env.CAN_PUBLISH_IMAGES == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker
+        if: env.CAN_PUBLISH_IMAGES == 'true'
         uses: docker/login-action@v3
         with:
           username: mjgpluralsh
@@ -67,12 +76,12 @@ jobs:
         with:
           context: "."
           file: "./Dockerfile"
-          push: true
+          push: ${{ env.CAN_PUBLISH_IMAGES == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=registry,ref=ghcr.io/pluralsh/console:buildcache
-          cache-to: type=registry,ref=ghcr.io/pluralsh/console-cache:buildcache,mode=max
+          cache-to: ${{ env.CAN_PUBLISH_IMAGES == 'true' && 'type=registry,ref=ghcr.io/pluralsh/console-cache:buildcache,mode=max' || '' }}
           build-args: |
             GIT_COMMIT=${{ github.sha }}
             VITE_PROD_SECRET_KEY=${{ secrets.VITE_PROD_SECRET_KEY }}
@@ -101,6 +110,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      HAS_SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK != '' }}
     steps:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
@@ -112,6 +123,7 @@ jobs:
         with:
           version: latest
       - name: Login to Docker
+        if: env.CAN_PUBLISH_IMAGES == 'true'
         uses: docker/login-action@v3
         with:
           username: mjgpluralsh
@@ -155,7 +167,7 @@ jobs:
           fields: workflow,job,repo,message,commit,author
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }} # required
-        if: always()
+        if: ${{ always() && env.HAS_SLACK_WEBHOOK == 'true' }}
   updateSchema:
     name: Check that Schema is up to date
     runs-on: ubuntu-latest

--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -18515,7 +18515,7 @@ addons:
     images: ['docker.io/istio/pilot:1.23.0']
     eolAt: '2025-04-16'
   - version: 1.22.0
-    kube: ['1.30', '1.29', 1.28', '1.27']
+    kube: ['1.30', '1.29', '1.28', '1.27']
     requirements: []
     incompatibilities: []
     summary:
@@ -18535,7 +18535,7 @@ addons:
     images: ['docker.io/istio/pilot:1.22.0']
     eolAt: '2025-01-22'
   - version: 1.21.0
-    kube: ['1.29', 1.28', '1.27', '1.26']
+    kube: ['1.29', '1.28', '1.27', '1.26']
     requirements: []
     incompatibilities: []
     summary:

--- a/static/compatibilities/istio.yaml
+++ b/static/compatibilities/istio.yaml
@@ -147,7 +147,7 @@ versions:
   images: ['docker.io/istio/pilot:1.23.0']
   eolAt: '2025-04-16'
 - version: 1.22.0
-  kube: ['1.30', '1.29', 1.28', '1.27']
+  kube: ['1.30', '1.29', '1.28', '1.27']
   requirements: []
   incompatibilities: []
   summary:
@@ -166,7 +166,7 @@ versions:
   images: ['docker.io/istio/pilot:1.22.0']
   eolAt: '2025-01-22'
 - version: 1.21.0
-  kube: ['1.29', 1.28', '1.27', '1.26']
+  kube: ['1.29', '1.28', '1.27', '1.26']
   requirements: []
   incompatibilities: []
   summary:

--- a/utils/compatibility/scrapers/argo-rollouts.py
+++ b/utils/compatibility/scrapers/argo-rollouts.py
@@ -2,13 +2,22 @@
 
 import re
 from collections import OrderedDict
+from copy import deepcopy
 
 import requests
 import yaml
 
-from utils import get_chart_versions, print_success, update_compatibility_info
+from utils import (
+    get_chart_images,
+    get_chart_versions,
+    print_success,
+    read_yaml,
+    reduce_versions,
+    update_compatibility_info,
+)
 
 app_name = "argo-rollouts"
+TARGET_FILE = f"../../static/compatibilities/{app_name}.yaml"
 github_api_tags_url = "https://api.github.com/repos/argoproj/argo-rollouts/tags"
 workflow_url = (
     "https://raw.githubusercontent.com/argoproj/argo-rollouts/"
@@ -62,6 +71,11 @@ def parse_kube_versions(content):
 
 
 def scrape():
+    existing = read_yaml(TARGET_FILE)
+    if not existing or not isinstance(existing.get("versions"), list):
+        raise ValueError("Could not read existing Argo Rollouts compatibility versions")
+    existing_versions = {row["version"]: row for row in existing["versions"]}
+
     release_tags = fetch_github_tags()
     if not release_tags:
         raise ValueError("No Argo Rollouts release tags found")
@@ -85,19 +99,38 @@ def scrape():
         response = requests.get(workflow_url.format(tag=tag), timeout=30)
         response.raise_for_status()
         kube_versions = parse_kube_versions(response.text)
-        rows.append(OrderedDict(
+        # Keep recorded metadata when a transient Helm render cannot refresh images.
+        previous = existing_versions.get(tag_version)
+        row = deepcopy(previous) or OrderedDict(
             [
                 ("version", tag_version),
-                ("kube", kube_versions),
-                ("chart_version", chart_version),
                 ("images", []),
                 ("requirements", []),
                 ("incompatibilities", []),
             ]
-        ))
+        )
+        if previous and previous.get("chart_version") != chart_version:
+            # Never save a new chart number with images from the previous chart.
+            images = get_chart_images(
+                existing["helm_repository_url"], existing.get("chart_name", app_name),
+                chart_version, existing.get("helm_values"),
+            )
+            if not images:
+                rows.append(row)
+                continue
+            row["images"] = images
+        row["kube"] = kube_versions
+        row["chart_version"] = chart_version
+        rows.append(row)
         print_success(f"Fetched compatibility info for tag: {tag}")
 
     # Fetch and validate every candidate before changing the existing table.
     if not rows:
         raise ValueError("No chart-backed Argo Rollouts compatibility rows found")
-    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", rows)
+    merged = {**existing_versions, **{row["version"]: row for row in rows}}
+    retained = reduce_versions(list(merged.values()))
+    if retained == existing["versions"] and all(
+        row.get("images") for row in retained if row.get("chart_version")
+    ):
+        return
+    update_compatibility_info(TARGET_FILE, rows)

--- a/utils/compatibility/scrapers/argo-rollouts.py
+++ b/utils/compatibility/scrapers/argo-rollouts.py
@@ -14,6 +14,7 @@ from utils import (
     read_yaml,
     reduce_versions,
     update_compatibility_info,
+    validate_semver,
 )
 
 app_name = "argo-rollouts"
@@ -101,6 +102,13 @@ def scrape():
         kube_versions = parse_kube_versions(response.text)
         # Keep recorded metadata when a transient Helm render cannot refresh images.
         previous = existing_versions.get(tag_version)
+        if previous and previous.get("chart_version"):
+            saved_chart = validate_semver(str(previous["chart_version"]))
+            if saved_chart is None:
+                raise ValueError(f"Invalid saved Helm chart version: {previous['chart_version']!r}")
+            # An incomplete index must not roll back a previously verified chart.
+            if saved_chart > validate_semver(chart_version):
+                chart_version = str(saved_chart)
         row = deepcopy(previous) or OrderedDict(
             [
                 ("version", tag_version),

--- a/utils/compatibility/scrapers/cloudnative-pg.py
+++ b/utils/compatibility/scrapers/cloudnative-pg.py
@@ -1,10 +1,12 @@
 import re
 from collections import OrderedDict
+from copy import deepcopy
 
 from bs4 import BeautifulSoup
 
 from utils import (
     fetch_page,
+    get_chart_images,
     get_chart_versions,
     print_error,
     read_yaml,
@@ -157,7 +159,7 @@ def scrape():
     if not existing or not isinstance(existing.get("versions"), list):
         print_error("Could not read existing CloudNativePG compatibility versions.")
         return
-    existing_versions = {entry["version"] for entry in existing["versions"]}
+    existing_versions = {entry["version"]: entry for entry in existing["versions"]}
 
     parsed_versions: OrderedDict[str, OrderedDict] = OrderedDict()
     try:
@@ -186,17 +188,35 @@ def scrape():
     # Preserve recorded concrete releases: the moving .x table can gain support
     # in a later patch (for example 1.28.4), which must not be assigned to .0.
     versions = [entry for version, entry in parsed_versions.items() if version not in existing_versions]
-    if not versions:
-        return
-    chart_versions = get_chart_versions(APP_NAME, chart_name="cloudnative-pg")
+    chart_versions = {
+        version: validate_semver(chart)
+        for version, chart in get_chart_versions(APP_NAME, chart_name="cloudnative-pg").items()
+        if isinstance(chart, str) and re.fullmatch(r"\d+\.\d+\.\d+", chart)
+    }
     if not chart_versions:
         print_error("No CloudNativePG chart versions found.")
         return
     released_versions = []
+    # Exact chart packaging can advance without a new application release.
+    # Keep saved support and metadata rather than re-reading the moving matrix.
+    for version, original in existing_versions.items():
+        chart = chart_versions.get(version)
+        saved_chart = original.get("chart_version")
+        current = validate_semver(saved_chart) if isinstance(saved_chart, str) else None
+        if chart and (not saved_chart or (current and chart > current)):
+            try:
+                images = get_chart_images(existing["helm_repository_url"],
+                                          existing.get("chart_name", APP_NAME), str(chart),
+                                          existing.get("helm_values"))
+            except Exception as error:
+                print_error(f"Could not render CloudNativePG chart {chart}: {error}")
+                continue
+            if images:
+                released_versions.append(dict(deepcopy(original), chart_version=str(chart), images=images))
     try:
         for entry in versions:
             chart_version = chart_versions.get(entry["version"])
-            if not chart_version or not validate_semver(chart_version):
+            if not chart_version:
                 continue
             version = entry["version"]
             url = f"{RELEASE_DOCS}/v{version}/docs/src/supported_releases.md"
@@ -204,7 +224,7 @@ def scrape():
             if not content:
                 raise ValueError(f"Could not fetch the release-tag matrix: {url}")
             entry["kube"] = release_kube_versions(content, version)
-            entry["chart_version"] = chart_version
+            entry["chart_version"] = str(chart_version)
             released_versions.append(entry)
     except ValueError as error:
         print_error(str(error))

--- a/utils/compatibility/scrapers/dynatrace-operator.py
+++ b/utils/compatibility/scrapers/dynatrace-operator.py
@@ -6,13 +6,14 @@ still apply. Keep recorded releases when the moving recommendation changes.
 """
 
 from collections import OrderedDict
+from copy import deepcopy
 import re
 
 from bs4 import BeautifulSoup
 import requests
 import yaml
 
-from utils import print_error, read_yaml, reduce_versions, update_compatibility_info
+from utils import get_chart_images, print_error, read_yaml, reduce_versions, update_compatibility_info
 
 
 APP_NAME = "dynatrace-operator"
@@ -105,11 +106,16 @@ def parse_helm_versions(content):
 
 
 def build_rows(recommendations, charts, existing):
-    recorded = {row["version"] for row in existing}
+    recorded = {row["version"]: row for row in existing}
     rows = []
     for app, chart in charts.items():
         version = ".".join(map(str, app))
         if version in recorded:
+            original = recorded[version]
+            saved_chart = original.get("chart_version")
+            current = _stable_version(saved_chart)
+            if not saved_chart or (current and chart > current):
+                rows.append(dict(deepcopy(original), chart_version=".".join(map(str, chart))))
             continue
         kube = sorted(
             (kube for kube, rule in recommendations.items() if _matches(app, rule)),
@@ -122,7 +128,9 @@ def build_rows(recommendations, charts, existing):
             ]))
     # Resolve real charts first, then apply the repository's boundary/latest rule.
     # Including history here avoids rewriting on every run for redundant patches.
-    retained = {row["version"] for row in reduce_versions(existing + rows)}
+    combined = deepcopy(recorded)
+    combined.update({row["version"]: row for row in rows})
+    retained = {row["version"] for row in reduce_versions(list(combined.values()))}
     return [row for row in rows if row["version"] in retained]
 
 
@@ -144,5 +152,20 @@ def scrape():
     except (requests.RequestException, ValueError, yaml.YAMLError) as exc:
         print_error(f"Cannot update Dynatrace compatibility: {exc}")
         return
-    if rows:
-        update_compatibility_info(TARGET_FILE, rows)
+    recorded = {row["version"] for row in existing["versions"]}
+    verified = []
+    for row in rows:
+        if row["version"] in recorded:
+            try:
+                images = get_chart_images(existing["helm_repository_url"],
+                                          existing.get("chart_name", APP_NAME), row["chart_version"],
+                                          existing.get("helm_values"))
+            except Exception as error:
+                print_error(f"Could not render Dynatrace chart {row['chart_version']}: {error}")
+                continue
+            if not images:
+                continue
+            row["images"] = images
+        verified.append(row)
+    if verified:
+        update_compatibility_info(TARGET_FILE, verified)

--- a/utils/compatibility/tests/test_argo_rollouts.py
+++ b/utils/compatibility/tests/test_argo_rollouts.py
@@ -295,3 +295,42 @@ def test_empty_saved_images_are_retried_on_an_otherwise_unchanged_run(monkeypatc
     scraper.scrape()
     assert yaml.safe_load(path.read_text())["versions"][0]["images"] == images
     render.assert_called_once()
+
+
+def test_older_index_chart_preserves_saved_chart_but_still_refreshes_kubernetes(monkeypatch, tmp_path):
+    root = COMPATIBILITY.parents[1]
+    data = yaml.safe_load((root / "static/compatibilities/argo-rollouts.yaml").read_text())
+    saved = deepcopy(data["versions"][0])
+    saved.update(chart_version="2.43.1", kube=["1.34"], eolAt="2027-01-01")
+    data["versions"] = [saved]
+    path = tmp_path / "argo-rollouts.yaml"
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    monkeypatch.setattr(scraper, "TARGET_FILE", str(path))
+    monkeypatch.setattr(scraper, "read_yaml", utils.read_yaml)
+    monkeypatch.setattr(scraper, "fetch_github_tags", lambda: ["v1.10.0"])
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: {"1.10.0": "2.43.0"})
+    monkeypatch.setattr(scraper.requests, "get", Mock(return_value=response(text=fixture("1.10.0"))))
+    preflight = Mock()
+    monkeypatch.setattr(scraper, "get_chart_images", preflight)
+    render = Mock(return_value=None)
+    monkeypatch.setattr(utils, "get_chart_images", render)
+    monkeypatch.setattr(utils, "summarization_enabled", lambda: False)
+    write = Mock(wraps=utils.write_yaml)
+    monkeypatch.setattr(utils, "write_yaml", write)
+
+    scraper.scrape()
+    assert yaml.safe_load(path.read_text())["versions"] == [{
+        **saved, "kube": ["1.35", "1.34", "1.33", "1.32"],
+    }]
+    preflight.assert_not_called()
+    render.assert_called_once_with(data["helm_repository_url"], "argo-rollouts", "2.43.1", None)
+    write.assert_called_once()
+
+    before = path.read_bytes()
+    render.reset_mock()
+    write.reset_mock()
+    scraper.scrape()
+    assert path.read_bytes() == before
+    preflight.assert_not_called()
+    render.assert_not_called()
+    write.assert_not_called()

--- a/utils/compatibility/tests/test_argo_rollouts.py
+++ b/utils/compatibility/tests/test_argo_rollouts.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+from copy import deepcopy
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -14,7 +15,14 @@ spec = importlib.util.spec_from_file_location(
 )
 scraper = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(scraper)
+import utils
+
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(autouse=True)
+def existing_versions(monkeypatch):
+    monkeypatch.setattr(scraper, "read_yaml", lambda _: {"versions": []})
 
 
 def fixture(version):
@@ -138,3 +146,152 @@ def test_static_rows_match_release_matrices_and_real_chart_versions():
         assert versions[version]["images"] == [f"quay.io/argoproj/argo-rollouts:v{version}"]
     aggregate = yaml.safe_load((root / "static/compatibilities.yaml").read_text())
     assert next(row for row in aggregate["addons"] if row["name"] == "argo-rollouts") == {**addon, "name": "argo-rollouts"}
+
+
+@pytest.mark.parametrize("rendered_images", [
+    None,
+    ["quay.io/argoproj/argo-rollouts:v1.10.0@sha256:" + "a" * 64],
+])
+def test_refresh_preserves_metadata_and_only_replaces_images_on_success(
+    monkeypatch, tmp_path, rendered_images
+):
+    saved = {
+        "version": "1.10.0", "kube": ["1.34"], "chart_version": "2.43.0",
+        "images": ["quay.io/argoproj/argo-rollouts:v1.10.0"],
+        "requirements": [{"name": "existing requirement", "version": "1.0.0"}],
+        "incompatibilities": [{"name": "existing incompatibility", "version": "2.0.0"}],
+        "summary": {"features": ["Retained release note"]}, "eolAt": "2027-01-01",
+    }
+    path = tmp_path / "argo-rollouts.yaml"
+    path.write_text(yaml.safe_dump({
+        "helm_repository_url": "https://argoproj.github.io/argo-helm",
+        "versions": [saved],
+    }, sort_keys=False))
+    monkeypatch.setattr(scraper, "TARGET_FILE", str(path))
+    monkeypatch.setattr(scraper, "read_yaml", utils.read_yaml)
+    monkeypatch.setattr(scraper, "fetch_github_tags", lambda: ["v1.10.0"])
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: {"1.10.0": "2.43.0"})
+    monkeypatch.setattr(scraper.requests, "get", Mock(return_value=response(text=fixture("1.10.0"))))
+    render = Mock(return_value=rendered_images)
+    monkeypatch.setattr(utils, "get_chart_images", render)
+    monkeypatch.setattr(utils, "summarization_enabled", lambda: False)
+    write = Mock(wraps=utils.write_yaml)
+    monkeypatch.setattr(utils, "write_yaml", write)
+
+    scraper.scrape()
+    expected = deepcopy(saved)
+    expected["kube"] = ["1.35", "1.34", "1.33", "1.32"]
+    if rendered_images:
+        expected["images"] = rendered_images
+    assert yaml.safe_load(path.read_text())["versions"] == [expected]
+    render.assert_called_once_with(
+        "https://argoproj.github.io/argo-helm", "argo-rollouts", "2.43.0", None
+    )
+    write.assert_called_once()
+
+    before = path.read_bytes()
+    render.reset_mock()
+    write.reset_mock()
+    scraper.scrape()
+    assert path.read_bytes() == before
+    render.assert_not_called()
+    write.assert_not_called()
+
+
+def test_reduced_intermediate_patch_does_not_prevent_unchanged_noop(monkeypatch):
+    root = COMPATIBILITY.parents[1]
+    saved = yaml.safe_load((root / "static/compatibilities/argo-rollouts.yaml").read_text())
+    original = deepcopy(saved)
+    monkeypatch.setattr(scraper, "read_yaml", lambda _: saved)
+    monkeypatch.setattr(scraper, "fetch_github_tags", lambda: ["v1.8.3"])
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: {"1.8.3": "2.40.5"})
+    monkeypatch.setattr(scraper.requests, "get", Mock(return_value=response(text=fixture("1.8.3"))))
+    update = Mock()
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+    scraper.scrape()
+    update.assert_not_called()
+    assert saved == original
+
+
+def test_unreadable_existing_data_never_fetches_or_writes(monkeypatch):
+    monkeypatch.setattr(scraper, "read_yaml", lambda _: None)
+    fetch = Mock()
+    update = Mock()
+    monkeypatch.setattr(scraper, "fetch_github_tags", fetch)
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+    with pytest.raises(ValueError, match="existing Argo Rollouts"):
+        scraper.scrape()
+    fetch.assert_not_called()
+    update.assert_not_called()
+
+
+def test_changed_chart_retries_failed_render_and_saves_verified_images_then_noops(
+    monkeypatch, tmp_path
+):
+    root = COMPATIBILITY.parents[1]
+    data = yaml.safe_load((root / "static/compatibilities/argo-rollouts.yaml").read_text())
+    data["versions"] = [data["versions"][0]]
+    saved = deepcopy(data["versions"][0])
+    path = tmp_path / "argo-rollouts.yaml"
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    monkeypatch.setattr(scraper, "TARGET_FILE", str(path))
+    monkeypatch.setattr(scraper, "read_yaml", utils.read_yaml)
+    monkeypatch.setattr(scraper, "fetch_github_tags", lambda: ["v1.10.0"])
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: {"1.10.0": "2.43.1"})
+    monkeypatch.setattr(scraper.requests, "get", Mock(return_value=response(text=fixture("1.10.0"))))
+    preflight = Mock(return_value=None)
+    monkeypatch.setattr(scraper, "get_chart_images", preflight)
+    render = Mock(return_value=None)
+    monkeypatch.setattr(utils, "get_chart_images", render)
+    monkeypatch.setattr(utils, "summarization_enabled", lambda: False)
+    write = Mock(wraps=utils.write_yaml)
+    monkeypatch.setattr(utils, "write_yaml", write)
+
+    before = path.read_bytes()
+    scraper.scrape()
+    assert path.read_bytes() == before
+    preflight.assert_called_once_with(data["helm_repository_url"], "argo-rollouts", "2.43.1", None)
+    render.assert_not_called()
+    write.assert_not_called()
+
+    images = ["quay.io/argoproj/argo-rollouts:v1.10.0@sha256:" + "b" * 64]
+    preflight.return_value = images
+    scraper.scrape()
+    assert preflight.call_count == 2
+    assert yaml.safe_load(path.read_text())["versions"] == [{
+        **saved, "chart_version": "2.43.1", "images": images,
+    }]
+    # A failed second render in the shared writer retains the preflight's exact-chart images.
+    render.assert_called_once()
+    write.assert_called_once()
+
+    before = path.read_bytes()
+    preflight.reset_mock()
+    render.reset_mock()
+    write.reset_mock()
+    scraper.scrape()
+    assert path.read_bytes() == before
+    preflight.assert_not_called()
+    render.assert_not_called()
+    write.assert_not_called()
+
+
+def test_empty_saved_images_are_retried_on_an_otherwise_unchanged_run(monkeypatch, tmp_path):
+    root = COMPATIBILITY.parents[1]
+    data = yaml.safe_load((root / "static/compatibilities/argo-rollouts.yaml").read_text())
+    data["versions"] = [data["versions"][0]]
+    images = data["versions"][0]["images"]
+    data["versions"][0]["images"] = []
+    path = tmp_path / "argo-rollouts.yaml"
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    monkeypatch.setattr(scraper, "TARGET_FILE", str(path))
+    monkeypatch.setattr(scraper, "read_yaml", utils.read_yaml)
+    monkeypatch.setattr(scraper, "fetch_github_tags", lambda: ["v1.10.0"])
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: {"1.10.0": "2.43.0"})
+    monkeypatch.setattr(scraper.requests, "get", Mock(return_value=response(text=fixture("1.10.0"))))
+    render = Mock(return_value=images)
+    monkeypatch.setattr(utils, "get_chart_images", render)
+    monkeypatch.setattr(utils, "summarization_enabled", lambda: False)
+    scraper.scrape()
+    assert yaml.safe_load(path.read_text())["versions"][0]["images"] == images
+    render.assert_called_once()

--- a/utils/compatibility/tests/test_cloudnative_pg.py
+++ b/utils/compatibility/tests/test_cloudnative_pg.py
@@ -1,5 +1,6 @@
 """Offline regressions: python -m unittest discover -s tests -p 'test_cloudnative_pg.py'."""
 
+from copy import deepcopy
 import importlib.util
 from pathlib import Path
 import sys
@@ -30,13 +31,17 @@ class CloudNativePGTests(unittest.TestCase):
                 for version in ("1.29.0", "1.30.0")
             },
         }
-        self.existing = {"versions": [{"version": "1.28.0", "kube": ["1.34", "1.33", "1.32"]}]}
+        self.existing = {"helm_repository_url": "https://charts.example.test", "chart_name": "cloudnative-pg",
+                         "helm_values": "monitoring.enabled=true", "versions": [
+                             {"version": "1.28.0", "kube": ["1.34", "1.33", "1.32"], "chart_version": "0.27.0"}]}
         self.charts = {"1.30.0": "0.29.0", "1.29.0": "0.28.0", "1.28.0": "0.27.0"}
 
-    def run_scrape(self):
+    def run_scrape(self, images=("registry.example.test/operator:new",), error=None):
         with patch.object(scraper, "fetch_page", side_effect=self.sources.get) as fetch, \
                 patch.object(scraper, "read_yaml", return_value=self.existing), \
                 patch.object(scraper, "get_chart_versions", return_value=self.charts), \
+                patch.object(scraper, "get_chart_images", return_value=list(images) if images else images,
+                             side_effect=error), \
                 patch.object(scraper, "print_error"), \
                 patch.object(scraper, "update_compatibility_info") as update:
             scraper.scrape()
@@ -130,9 +135,75 @@ class CloudNativePGTests(unittest.TestCase):
                 update.assert_not_called()
 
     def test_existing_versions_make_rerun_a_noop(self):
-        self.existing["versions"].extend([{"version": "1.29.0"}, {"version": "1.30.0"}])
+        update, _ = self.run_scrape()
+        self.existing["versions"].extend(update.call_args.args[1])
         update, _ = self.run_scrape()
         update.assert_not_called()
+
+    def recorded_release(self):
+        update, _ = self.run_scrape()
+        self.existing["versions"].extend(update.call_args.args[1])
+        saved = next(row for row in self.existing["versions"] if row["version"] == "1.30.0")
+        saved.update(summary={"updates": "Keep custom notes"}, eolAt="2027-01-01",
+                     requirements=[{"name": "existing", "version": ">=1.0.0"}],
+                     incompatibilities=[{"name": "other", "version": "<2.0.0"}],
+                     images=["registry.example.test/operator:old"])
+        return saved
+
+    def test_newer_exact_chart_preserves_full_metadata_then_becomes_noop(self):
+        saved = self.recorded_release()
+        before = deepcopy(self.existing)
+        self.charts["1.30.0"] = "0.29.1"
+        update, fetch = self.run_scrape()
+        refreshed, = update.call_args.args[1]
+        self.assertEqual(refreshed, dict(saved, chart_version="0.29.1",
+                                         images=["registry.example.test/operator:new"]))
+        self.assertEqual(self.existing, before)
+        self.assertFalse(any("raw.githubusercontent.com" in call.args[0] for call in fetch.call_args_list))
+        saved.update(refreshed)
+        update, _ = self.run_scrape()
+        update.assert_not_called()
+
+    def test_missing_chart_is_backfilled_without_duplicate_version(self):
+        saved = self.recorded_release()
+        saved.pop("chart_version")
+        update, _ = self.run_scrape()
+        refreshed, = update.call_args.args[1]
+        self.assertEqual(refreshed["chart_version"], "0.29.0")
+        self.assertEqual(refreshed["kube"], saved["kube"])
+        self.assertEqual(refreshed["summary"], saved["summary"])
+
+    def test_recorded_chart_cannot_downgrade_or_use_prerelease_or_other_app(self):
+        self.recorded_release()
+        for chart in ("0.28.9", "0.29.0", "0.29.1-rc.1", "0.29.1+build", "0.30"):
+            with self.subTest(chart=chart):
+                self.charts = {"1.30.0": chart, "1.30.1": "0.29.2"}
+                update, _ = self.run_scrape()
+                update.assert_not_called()
+        self.charts = {"1.30.1": "0.29.2"}
+        update, _ = self.run_scrape()
+        update.assert_not_called()
+
+    def test_failed_new_chart_render_keeps_entire_saved_record(self):
+        self.recorded_release()
+        before = deepcopy(self.existing)
+        self.charts["1.30.0"] = "0.29.1"
+        for images, error in ((None, None), ([], None), (None, OSError("helm unavailable"))):
+            with self.subTest(images=images, error=error):
+                update, _ = self.run_scrape(images=images, error=error)
+                update.assert_not_called()
+                self.assertEqual(self.existing, before)
+
+    def test_failed_refresh_does_not_block_another_successful_chart(self):
+        self.recorded_release()
+        self.charts.update({"1.30.0": "0.29.1", "1.29.0": "0.28.1"})
+        before = deepcopy(self.existing)
+        update, _ = self.run_scrape(error=[None, ["registry.example.test/operator:other"]])
+        refreshed, = update.call_args.args[1]
+        original = next(row for row in self.existing["versions"] if row["version"] == "1.29.0")
+        self.assertEqual(refreshed, dict(original, chart_version="0.28.1",
+                                         images=["registry.example.test/operator:other"]))
+        self.assertEqual(self.existing, before)
 
     def test_unreadable_existing_file_never_writes(self):
         self.existing = None

--- a/utils/compatibility/tests/test_dynatrace_operator.py
+++ b/utils/compatibility/tests/test_dynatrace_operator.py
@@ -11,6 +11,7 @@ import requests
 import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import utils as compatibility_utils
 from utils import reduce_versions
 
 scraper = importlib.import_module("scrapers.dynatrace-operator")
@@ -158,6 +159,92 @@ class ScrapeSafetyTests(unittest.TestCase):
             self.assertEqual(scraper._fetch(scraper.SUPPORT_URL), b"fixture")
             get.assert_called_once_with(scraper.SUPPORT_URL, timeout=30)
             get.return_value.raise_for_status.assert_called_once_with()
+
+
+class RecordedChartRefreshTests(unittest.TestCase):
+    def setUp(self):
+        self.saved = row("1.10.2")
+        self.saved.update(eolAt="2027-01-01", images=["registry.example.test/operator:old"],
+                          incompatibilities=[{"name": "other", "version": "<2.0.0"}])
+        # Historical charts may require credentials and intentionally have no images.
+        self.existing = {"helm_repository_url": "https://charts.example.test", "chart_name": "operator",
+                         "helm_values": "apiToken=fixture", "versions": [self.saved, row("0.6.0")]}
+        self.entries = [{"appVersion": "1.10.2", "version": "1.10.3"}]
+
+    def run_scrape(self, images=("registry.example.test/operator:new",), error=None):
+        with patch.object(scraper, "read_yaml", return_value=self.existing), \
+                patch.object(scraper, "_fetch", side_effect=[table([["1.36", "v1.10.2"]]), index(self.entries)]), \
+                patch.object(scraper, "get_chart_images", return_value=list(images) if images else images,
+                             side_effect=error) as render, \
+                patch.object(scraper, "print_error"), \
+                patch.object(scraper, "update_compatibility_info") as write:
+            scraper.scrape()
+        return write, render
+
+    def test_newer_exact_chart_preserves_metadata_and_only_renders_changed_chart_then_noop(self):
+        before = deepcopy(self.existing)
+        write, render = self.run_scrape()
+        refreshed, = write.call_args.args[1]
+        self.assertEqual(refreshed, dict(self.saved, chart_version="1.10.3",
+                                         images=["registry.example.test/operator:new"]))
+        self.assertEqual(self.existing, before)
+        render.assert_called_once_with("https://charts.example.test", "operator", "1.10.3", "apiToken=fixture")
+        self.saved.update(refreshed)
+        write, render = self.run_scrape()
+        write.assert_not_called()
+        render.assert_not_called()
+
+    def test_missing_chart_backfill_preserves_record_without_duplicate_sorting(self):
+        self.saved.pop("chart_version")
+        write, _ = self.run_scrape()
+        refreshed, = write.call_args.args[1]
+        self.assertEqual(refreshed, dict(self.saved, chart_version="1.10.3",
+                                         images=["registry.example.test/operator:new"]))
+
+    def test_older_equal_prerelease_and_mismatched_chart_cannot_refresh(self):
+        for chart in ("1.10.1", "1.10.2", "1.10.3-rc.1", "1.10.3+build", "1.11"):
+            with self.subTest(chart=chart):
+                self.entries = [{"appVersion": "1.10.2", "version": chart},
+                                {"appVersion": "1.10.3", "version": "1.11.0"}]
+                write, render = self.run_scrape()
+                write.assert_not_called()
+                render.assert_not_called()
+        self.entries = [{"appVersion": "1.10.3", "version": "1.11.0"}]
+        write, render = self.run_scrape()
+        write.assert_not_called()
+        render.assert_not_called()
+
+    def test_failed_new_chart_render_keeps_entire_saved_record(self):
+        before = deepcopy(self.existing)
+        for images, error in ((None, None), ([], None), (None, OSError("helm unavailable"))):
+            with self.subTest(images=images, error=error):
+                write, _ = self.run_scrape(images=images, error=error)
+                write.assert_not_called()
+                self.assertEqual(self.existing, before)
+
+    def test_failed_refresh_does_not_block_another_successful_chart(self):
+        other = row("1.9.0")
+        self.existing["versions"].append(other)
+        self.entries.append({"appVersion": "1.9.0", "version": "1.9.1"})
+        before = deepcopy(self.existing)
+        write, _ = self.run_scrape(error=[None, ["registry.example.test/operator:other"]])
+        refreshed, = write.call_args.args[1]
+        self.assertEqual(refreshed, dict(other, chart_version="1.9.1",
+                                         images=["registry.example.test/operator:other"]))
+        self.assertEqual(self.existing, before)
+
+    def test_normal_writer_keeps_verified_new_images_if_its_second_render_fails(self):
+        write, _ = self.run_scrape()
+        rows = write.call_args.args[1]
+        with patch.object(compatibility_utils, "read_yaml", return_value=deepcopy(self.existing)), \
+                patch.object(compatibility_utils, "get_chart_images", return_value=None), \
+                patch.object(compatibility_utils, "summarization_enabled", return_value=False), \
+                patch.object(compatibility_utils, "write_yaml", return_value=True) as persist:
+            compatibility_utils.update_compatibility_info(scraper.TARGET_FILE, rows)
+        persisted = {row["version"]: row for row in persist.call_args.args[1]["versions"]}
+        self.assertEqual(persisted["1.10.2"], dict(self.saved, chart_version="1.10.3",
+                                                 images=["registry.example.test/operator:new"]))
+        self.assertEqual(persisted["0.6.0"], self.existing["versions"][1])
 
 
 class GeneratedDataTests(unittest.TestCase):


### PR DESCRIPTION
Compatibility refreshes can lose stored metadata or miss chart-only releases. This follow-up preserves existing records and fixes fork PR validation, which stopped before testing at an unconditional Docker login:

- Argo Rollouts keeps saved images, requirements, incompatibilities, summaries and EOL dates when Helm rendering fails. A changed chart is adopted only after it renders successfully; an older index cannot downgrade a saved chart. Unchanged output avoids another write, while missing images and failed chart changes remain retryable.
- CloudNativePG and Dynatrace can backfill missing charts or adopt strictly newer stable charts for an already recorded app version. They retain the saved Kubernetes support and metadata, and keep the previous chart and images if the new render fails.
- Correct the pre-existing `1.28'` typo to `1.28` for Istio 1.21.0 and 1.22.0 in both compatibility files, matching the [official support table](https://istio.io/latest/docs/releases/supported-releases/).
- Fork and Dependabot runs keep all test and Docker build steps while skipping registry logins, image publishing and registry cache exports. Trusted upstream publication is preserved. Slack notifications run only when the webhook exists. Workflow events and permissions are unchanged.

Validation: **145 compatibility tests pass** (`python -m pytest -q tests` from `utils/compatibility`), including real-writer regressions for failed rendering, successful refresh, retry, rollback and subsequent no-op. All 57 compatibility YAML documents pass the schema; the five recently merged apps match their aggregate entries. Live upstream reads for Argo, CloudNativePG and Dynatrace produce no pending data changes or render requests. Shared helpers are unchanged; the only static-data changes are the four Istio value occurrences. The workflow passes actionlint 1.7.12 and nine event scenarios plus two Slack-presence cases evaluated with GitHub's `@actions/expressions` engine; structural checks confirm all jobs, test commands and failure checks remain intact. Anonymous manifest checks confirm the build/test dependencies and imported cache are publicly readable.

Follow-up to #4157, #4158, #4171 and #4173.

CI at `2661136`: all eight code/test/build/schema jobs passed. The [Console run](https://github.com/pluralsh/console/actions/runs/34256104775) completed successfully, including the Docker image build, schema freshness check and backend suite (3,078 tests, 0 failures, 62 skipped). Both CodeQL jobs, both Helm template jobs and compatibility schema validation also passed. The only failed workflow is the required-label check: a maintainer needs to apply `bug-fix`, which automatically triggers a new label check. GitHub does not permit this contributor account to set repository labels.
