### PR TITLE
feat: add Volcano Kubernetes compatibility scraper

### DIFF
--- a/.github/workflows/volcano-compatibility.yaml
+++ b/.github/workflows/volcano-compatibility.yaml
@@ -1,0 +1,31 @@
+name: Test Volcano compatibility scraper
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/volcano-compatibility.yaml'
+      - 'utils/compatibility/scrapers/volcano.py'
+      - 'utils/compatibility/tests/test_volcano.py'
+      - 'utils/compatibility/tests/fixtures/volcano-compatibility.md'
+      - 'utils/compatibility/utils.py'
+      - 'utils/compatibility/summarizer.py'
+      - 'utils/compatibility/requirements.txt'
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/volcano-compatibility.yaml'
+      - 'utils/compatibility/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: python -m pip install -r utils/compatibility/requirements.txt pytest
+      - run: python -m pytest utils/compatibility/tests/test_volcano.py -q

--- a/.github/workflows/volcano-compatibility.yaml
+++ b/.github/workflows/volcano-compatibility.yaml
@@ -4,12 +4,10 @@ on:
   pull_request:
     paths:
       - '.github/workflows/volcano-compatibility.yaml'
-      - 'utils/compatibility/scrapers/volcano.py'
-      - 'utils/compatibility/tests/test_volcano.py'
-      - 'utils/compatibility/tests/fixtures/volcano-compatibility.md'
-      - 'utils/compatibility/utils.py'
-      - 'utils/compatibility/summarizer.py'
-      - 'utils/compatibility/requirements.txt'
+      - 'utils/compatibility/**'
+      - 'static/compatibilities/**'
+      - 'static/compatibilities.yaml'
+      - 'KUBE_VERSION'
   push:
     branches: [master]
     paths:
@@ -23,9 +21,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.12'
       - run: python -m pip install -r utils/compatibility/requirements.txt pytest
-      - run: python -m pytest utils/compatibility/tests/test_volcano.py -q
+      - run: python -m pytest utils/compatibility/tests -q

--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,159 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://raw.githubusercontent.com/volcano-sh/volcano/master/docs/images/volcano-horizontal-color.png
+  git_url: https://github.com/volcano-sh/volcano
+  release_url: https://github.com/volcano-sh/volcano/releases/tag/v{vsn}
+  helm_repository_url: https://volcano-sh.github.io/helm-charts
+  versions:
+  - version: 1.15.2
+    kube:
+    - '1.35'
+    - '1.34'
+    - '1.33'
+    - '1.32'
+    - '1.31'
+    - '1.30'
+    - '1.29'
+    - '1.28'
+    - '1.27'
+    - '1.26'
+    - '1.25'
+    - '1.24'
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.15.2
+    images:
+    - docker.io/volcanosh/vc-controller-manager:v1.15.2
+    - docker.io/volcanosh/vc-scheduler:v1.15.2
+    - docker.io/volcanosh/vc-webhook-manager:v1.15.2
+  - version: 1.15.0
+    kube:
+    - '1.35'
+    - '1.34'
+    - '1.33'
+    - '1.32'
+    - '1.31'
+    - '1.30'
+    - '1.29'
+    - '1.28'
+    - '1.27'
+    - '1.26'
+    - '1.25'
+    - '1.24'
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.15.0
+    images:
+    - docker.io/volcanosh/vc-controller-manager:v1.15.0
+    - docker.io/volcanosh/vc-scheduler:v1.15.0
+    - docker.io/volcanosh/vc-webhook-manager:v1.15.0
+  - version: 1.14.0
+    kube:
+    - '1.34'
+    - '1.33'
+    - '1.32'
+    - '1.31'
+    - '1.30'
+    - '1.29'
+    - '1.28'
+    - '1.27'
+    - '1.26'
+    - '1.25'
+    - '1.24'
+    - '1.23'
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.14.0
+    images:
+    - docker.io/volcanosh/vc-controller-manager:v1.14.0
+    - docker.io/volcanosh/vc-scheduler:v1.14.0
+    - docker.io/volcanosh/vc-webhook-manager:v1.14.0
+  - version: 1.13.0
+    kube:
+    - '1.33'
+    - '1.32'
+    - '1.31'
+    - '1.30'
+    - '1.29'
+    - '1.28'
+    - '1.27'
+    - '1.26'
+    - '1.25'
+    - '1.24'
+    - '1.23'
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.13.0
+    images:
+    - docker.io/volcanosh/vc-controller-manager:v1.13.0
+    - docker.io/volcanosh/vc-scheduler:v1.13.0
+    - docker.io/volcanosh/vc-webhook-manager:v1.13.0
+  - version: 1.12.0
+    kube:
+    - '1.32'
+    - '1.31'
+    - '1.30'
+    - '1.29'
+    - '1.28'
+    - '1.27'
+    - '1.26'
+    - '1.25'
+    - '1.24'
+    - '1.23'
+    - '1.22'
+    - '1.21'
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.12.0
+    images:
+    - docker.io/volcanosh/vc-controller-manager:v1.12.0
+    - docker.io/volcanosh/vc-scheduler:v1.12.0
+    - docker.io/volcanosh/vc-webhook-manager:v1.12.0
+  - version: 1.11.0
+    kube:
+    - '1.31'
+    - '1.30'
+    - '1.29'
+    - '1.28'
+    - '1.27'
+    - '1.26'
+    - '1.25'
+    - '1.24'
+    - '1.23'
+    - '1.22'
+    - '1.21'
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.11.0
+    images:
+    - docker.io/volcanosh/vc-controller-manager:v1.11.0
+    - docker.io/volcanosh/vc-scheduler:v1.11.0
+    - docker.io/volcanosh/vc-webhook-manager:v1.11.0
+  - version: 1.10.0
+    kube:
+    - '1.30'
+    - '1.29'
+    - '1.28'
+    - '1.27'
+    - '1.26'
+    - '1.25'
+    - '1.24'
+    - '1.23'
+    - '1.22'
+    - '1.21'
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.10.0
+    images:
+    - docker.io/volcanosh/vc-controller-manager:v1.10.0
+    - docker.io/volcanosh/vc-scheduler:v1.10.0
+    - docker.io/volcanosh/vc-webhook-manager:v1.10.0
+  name: volcano

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- volcano

--- a/static/compatibilities/volcano.yaml
+++ b/static/compatibilities/volcano.yaml
@@ -1,0 +1,67 @@
+icon: https://raw.githubusercontent.com/volcano-sh/volcano/master/docs/images/volcano-horizontal-color.png
+git_url: https://github.com/volcano-sh/volcano
+release_url: https://github.com/volcano-sh/volcano/releases/tag/v{vsn}
+helm_repository_url: https://volcano-sh.github.io/helm-charts
+versions:
+- version: 1.15.2
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.15.2
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.15.2', 'docker.io/volcanosh/vc-scheduler:v1.15.2',
+    'docker.io/volcanosh/vc-webhook-manager:v1.15.2']
+- version: 1.15.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.15.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.15.0', 'docker.io/volcanosh/vc-scheduler:v1.15.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.15.0']
+- version: 1.14.0
+  kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25',
+    '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.14.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.14.0', 'docker.io/volcanosh/vc-scheduler:v1.14.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.14.0']
+- version: 1.13.0
+  kube: ['1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24',
+    '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.13.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.13.0', 'docker.io/volcanosh/vc-scheduler:v1.13.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.13.0']
+- version: 1.12.0
+  kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23',
+    '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.12.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.12.0', 'docker.io/volcanosh/vc-scheduler:v1.12.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.12.0']
+- version: 1.11.0
+  kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22',
+    '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.11.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.11.0', 'docker.io/volcanosh/vc-scheduler:v1.11.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.11.0']
+- version: 1.10.0
+  kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.10.0
+  images: ['docker.io/volcanosh/vc-controller-manager:v1.10.0', 'docker.io/volcanosh/vc-scheduler:v1.10.0',
+    'docker.io/volcanosh/vc-webhook-manager:v1.10.0']

--- a/utils/compatibility/scrapers/volcano.py
+++ b/utils/compatibility/scrapers/volcano.py
@@ -1,0 +1,82 @@
+"""Join Volcano's published release-family matrix to stable Helm releases."""
+
+import re
+from collections import OrderedDict
+
+import requests
+
+from utils import get_chart_versions, update_compatibility_info
+
+APP_NAME = "volcano"
+TARGET_FILE = "../../static/compatibilities/volcano.yaml"
+README_URL = "https://raw.githubusercontent.com/volcano-sh/volcano/master/README.md"
+STABLE_VERSION = re.compile(r"\d+\.\d+\.\d+")
+
+
+def parse_kube_versions(content, version):
+    """Only a check mark denotes exact compatibility; neither +/- nor HEAD does."""
+    if not STABLE_VERSION.fullmatch(version):
+        raise ValueError(f"Invalid stable Volcano version: {version!r}")
+    family = ".".join(version.split(".")[:2])
+    target = f"Volcano v{family}"
+    headers = None
+    matches = []
+    for line in content.splitlines():
+        if not line.strip().startswith("|"):
+            headers = None
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) > 1 and any(cell.startswith("Kubernetes ") for cell in cells[1:]):
+            headers = []
+            for cell in cells[1:]:
+                match = re.fullmatch(r"Kubernetes (\d+\.\d+)", cell)
+                if not match:
+                    raise ValueError(f"Invalid Kubernetes column: {cell!r}")
+                headers.append(match.group(1))
+            if len(headers) != len(set(headers)):
+                raise ValueError("Duplicate Kubernetes columns")
+        elif cells[0] == target and headers is not None:
+            if len(cells) != len(headers) + 1:
+                raise ValueError(f"Incomplete Volcano compatibility row for {version}")
+            if any(cell not in {"✓", "+", "-"} for cell in cells[1:]):
+                raise ValueError(f"Unknown compatibility marker for {version}")
+            matches.append([kube for kube, marker in zip(headers, cells[1:]) if marker == "✓"])
+    if len(matches) != 1 or not matches[0]:
+        raise ValueError(f"Expected one nonempty exact-compatibility row for {version}")
+    return sorted(matches[0], key=lambda value: tuple(map(int, value.split("."))), reverse=True)
+
+
+def collect_versions(content, chart_versions):
+    families = set(re.findall(r"^\|\s*Volcano v(\d+\.\d+)\s*\|", content, re.MULTILINE))
+    if not families:
+        raise ValueError("No published Volcano release-family rows found")
+    # Validate every family before joining; malformed docs must not silently
+    # replace a previously complete table with a subset.
+    compatibility = {family: parse_kube_versions(content, f"{family}.0") for family in families}
+    rows = []
+    for version, chart in chart_versions.items():
+        # Some historical charts advertise appVersion 0.1. Do not infer an
+        # application release from a chart version or from development metadata.
+        if not STABLE_VERSION.fullmatch(version) or not STABLE_VERSION.fullmatch(chart):
+            continue
+        family = ".".join(version.split(".")[:2])
+        if family not in compatibility:
+            continue
+        rows.append(OrderedDict([
+            ("version", version),
+            ("kube", compatibility[family]),
+            ("chart_version", chart),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ]))
+    if not rows:
+        raise ValueError("No released Volcano charts match the published compatibility matrix")
+    return sorted(rows, key=lambda row: tuple(map(int, row["version"].split("."))), reverse=True)
+
+
+def scrape():
+    # Collect and validate every source before touching the existing table.
+    response = requests.get(README_URL, timeout=30)
+    response.raise_for_status()
+    rows = collect_versions(response.text, get_chart_versions(APP_NAME))
+    update_compatibility_info(TARGET_FILE, rows)

--- a/utils/compatibility/tests/fixtures/volcano-compatibility.md
+++ b/utils/compatibility/tests/fixtures/volcano-compatibility.md
@@ -1,0 +1,18 @@
+Source: https://github.com/volcano-sh/volcano/blob/606c628d364db8de18c045e947d5255ef058aa26/README.md
+Retrieved: 2026-09-08. Upstream Apache-2.0 documentation excerpt.
+
+## Kubernetes compatibility
+|                       | Kubernetes 1.36 | Kubernetes 1.35 | Kubernetes 1.34 | Kubernetes 1.33 | Kubernetes 1.32 | Kubernetes 1.31 | Kubernetes 1.30 | Kubernetes 1.29 | Kubernetes 1.28 | Kubernetes 1.27 | Kubernetes 1.26 | Kubernetes 1.25 | Kubernetes 1.24 | Kubernetes 1.23 | Kubernetes 1.22 | Kubernetes 1.21 |
+|-----------------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|-----------------|
+| Volcano HEAD (master) | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | -               | -               | -               |
+| Volcano v1.15         | -               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | -               | -               | -               |
+| Volcano v1.14         | -               | -               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | -               | -               |
+| Volcano v1.13         | -               | -               | -               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | -               | -               |
+| Volcano v1.12         | -               | -               | -               | -               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
+| Volcano v1.11         | -               | -               | -               | -               | -               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
+| Volcano v1.10         | -               | -               | -               | -               | -               | -               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               | ✓               |
+
+Key:
+* `✓` Volcano and the Kubernetes version are exactly compatible.
+* `+` Volcano has features or API objects that may not be present in the Kubernetes version.
+* `-` The Kubernetes version has features or API objects that Volcano can't use.

--- a/utils/compatibility/tests/test_volcano.py
+++ b/utils/compatibility/tests/test_volcano.py
@@ -1,0 +1,114 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+scraper = importlib.import_module("scrapers.volcano")
+FIXTURE = Path(__file__).parent / "fixtures" / "volcano-compatibility.md"
+
+
+def matrix(row="| Volcano v1.15 | ✓ | - | + |", headers="Kubernetes 1.35 | Kubernetes 1.34 | Kubernetes 1.33"):
+    return f"| | {headers} |\n|---|---|---|---|\n{row}\n"
+
+
+def test_published_matrix_joins_only_released_documented_families():
+    rows = scraper.collect_versions(FIXTURE.read_text(encoding="utf8"), {
+        "1.15.2": "1.15.2", "1.14.4": "1.14.4", "1.10.0": "1.10.0",
+        "1.16.0-alpha.1": "1.16.0-alpha.1", "1.16.0": "1.16.0",
+        "0.1": "1.9.1", "1.15.3": "1.15.3-rc.1",
+    })
+    assert [r["version"] for r in rows] == ["1.15.2", "1.14.4", "1.10.0"]
+    assert rows[0]["kube"] == [f"1.{minor}" for minor in range(35, 23, -1)]
+    assert rows[1]["kube"] == [f"1.{minor}" for minor in range(34, 22, -1)]
+    assert rows[2]["kube"] == [f"1.{minor}" for minor in range(30, 20, -1)]
+
+
+def test_plus_minus_and_head_are_not_exact_release_compatibility():
+    content = matrix() + "| Volcano HEAD (master) | ✓ | ✓ | ✓ |\n"
+    assert scraper.parse_kube_versions(content, "1.15.2") == ["1.35"]
+
+
+def test_numeric_sort_and_chart_version_are_preserved():
+    content = matrix(headers="Kubernetes 1.9 | Kubernetes 1.10 | Kubernetes 1.11",
+                     row="| Volcano v1.15 | ✓ | ✓ | ✓ |")
+    rows = scraper.collect_versions(content, {"1.15.2": "2.0.0", "1.15.10": "2.1.0"})
+    assert [r["version"] for r in rows] == ["1.15.10", "1.15.2"]
+    assert rows[0]["chart_version"] == "2.1.0"
+    assert rows[0]["kube"] == ["1.11", "1.10", "1.9"]
+
+
+@pytest.mark.parametrize("content", [
+    "", "<html>Upstream unavailable</html>",
+    matrix(row="| Volcano v1.15 | ✓ | - |"),
+    matrix(row="| Volcano v1.15 | ? | - | + |"),
+    matrix(row="| Volcano v1.15 | - | - | + |"),
+    matrix(headers="Kubernetes 1.35 | Kubernetes 1.35 | Kubernetes 1.33"),
+    matrix(headers="Kubernetes 1.35 | Kubernetes latest | Kubernetes 1.33"),
+    matrix() + "| Volcano v1.15 | ✓ | - | + |\n",
+])
+def test_rejects_malformed_or_ambiguous_matrix(content):
+    with pytest.raises(ValueError):
+        scraper.collect_versions(content, {"1.15.2": "1.15.2"})
+
+
+@pytest.mark.parametrize("charts", [{}, {"0.1": "1.9.1"}, {"1.16.0": "1.16.0"}])
+def test_empty_join_is_an_error(charts):
+    with pytest.raises(ValueError):
+        scraper.collect_versions(matrix(), charts)
+
+
+def test_scrape_passes_validated_rows_to_shared_updater(monkeypatch):
+    response = Mock(text=matrix())
+    get = Mock(return_value=response)
+    update = Mock()
+    monkeypatch.setattr(scraper.requests, "get", get)
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: {"1.15.2": "1.15.2"})
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+    scraper.scrape()
+    get.assert_called_once_with(scraper.README_URL, timeout=30)
+    response.raise_for_status.assert_called_once()
+    path, rows = update.call_args.args
+    assert path == scraper.TARGET_FILE
+    assert rows[0]["version"] == "1.15.2"
+    assert rows[0]["kube"] == ["1.35"]
+
+
+@pytest.mark.parametrize("failure", ["http", "network", "matrix", "charts"])
+def test_failure_does_not_write(monkeypatch, failure):
+    response = Mock(text="bad matrix" if failure == "matrix" else matrix())
+    if failure == "http":
+        response.raise_for_status.side_effect = requests.HTTPError("503")
+    get = Mock(return_value=response)
+    if failure == "network":
+        get.side_effect = requests.Timeout()
+    monkeypatch.setattr(scraper.requests, "get", get)
+    monkeypatch.setattr(scraper, "get_chart_versions", lambda _: {} if failure == "charts" else {"1.15.2": "1.15.2"})
+    update = Mock()
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+    with pytest.raises((ValueError, requests.RequestException)):
+        scraper.scrape()
+    update.assert_not_called()
+
+
+def test_shared_updater_preserves_metadata_and_unlisted_historical_rows(monkeypatch, tmp_path):
+    import utils
+    import yaml
+
+    target = tmp_path / "volcano.yaml"
+    target.write_text(yaml.safe_dump({
+        "icon": "https://example.test/logo.png",
+        "helm_repository_url": "https://example.test/charts",
+        "versions": [{"version": "1.9.0", "kube": ["1.29"], "chart_version": "1.9.0"}],
+    }))
+    monkeypatch.setattr(utils, "get_chart_images", lambda *args: [])
+    monkeypatch.setattr(utils, "summarization_enabled", lambda: False)
+    rows = scraper.collect_versions(matrix(), {"1.15.2": "1.15.2"})
+    utils.update_compatibility_info(str(target).replace("\\", "/"), rows)
+    stored = yaml.safe_load(target.read_text())
+    assert stored["icon"] == "https://example.test/logo.png"
+    assert [r["version"] for r in stored["versions"]] == ["1.15.2", "1.9.0"]
+    assert stored["versions"][0]["kube"] == ["1.35"]


### PR DESCRIPTION
Volcano is missing from the add-on compatibility catalogue. This adds its upstream Kubernetes compatibility matrix, a repeatable scraper, catalogue metadata, Helm-rendered image references, and the aggregate catalogue entry.

The scraper joins explicitly named release-family rows in Volcano's maintained README to stable application/chart versions in its official Helm index. Only check marks count as exact compatibility. It excludes HEAD, prereleases, families absent from the matrix, and historical chart entries with ambiguous appVersion 0.1. Source failures or malformed matrices stop processing before the shared updater is called; previously stored historical rows are preserved by the updater.

On 2026-09-08, 24 stable releases matched the matrix. Plural's existing reduction logic stores seven entries across the 1.10–1.15 families, including latest 1.15.2. This is upstream-declared family compatibility, not independent Kubernetes integration testing. Some release-tag READMEs omit their own family, which is why this uses the maintained matrix instead of guessing from a tagged HEAD row.

## Sources

- [Maintained compatibility matrix](https://github.com/volcano-sh/volcano#kubernetes-compatibility)
- [Exact documentation snapshot used for the fixture and generation](https://github.com/volcano-sh/volcano/blob/606c628d364db8de18c045e947d5255ef058aa26/README.md#kubernetes-compatibility)
- [Official Helm index](https://volcano-sh.github.io/helm-charts/index.yaml)
- [Volcano installation documentation](https://volcano.sh/docs/gettingstarted/installation/)

## Test Plan

- Python 3.12 with the repository's compatibility requirements: `python -m pytest utils/compatibility/tests -q` — 147 passed, 81 subtests passed.
- 20 new offline tests cover source fixtures, non-compatible markers, prereleases, malformed/ambiguous matrices, empty joins, failures before writing, version ordering, and shared-updater persistence.
- A scoped GitHub Actions workflow runs the new offline tests. No GitHub CI run is claimed yet.
- Live `scrapers.volcano.scrape()` completed with Helm 3.19.0, rendering images for all seven stored entries. Paid summarization was disabled.
- Both generated YAML files validate against `static/compatibilities/schema.json`. Existing aggregate entries are semantically unchanged.
- Official icon URL verified; patch whitespace checks pass.

Test environment: local Python 3.12 on Windows; no running Plural deployment required for this catalogue-only change.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added tests to cover my changes.
- Documentation updates: not required; source links and fixture provenance are included.
- Agent deployment: not applicable; no agent code changes.

Plural Flow: console

## Contributor programme

Prepared with OpenAI Codex for @honanevan; implementation and validation were agent-led, with no separate human review claimed. Please consider this contribution under the README's published $300 new-compatibility-scraper reward, subject to your review and one-award-per-month rule. Could you confirm eligibility and whether an accepted award can be paid via PayPal? Payment information will be exchanged privately through the appropriate payout channel when ready. No award or payment is assumed.