### PR TITLE
Add OpenBao compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -30,6 +30,7 @@ names:
 - longhorn
 - metrics-server
 - opentelemetry-operator
+- openbao
 - rook
 - strimzi-kafka
 - traefik

--- a/static/compatibilities/openbao.yaml
+++ b/static/compatibilities/openbao.yaml
@@ -1,0 +1,62 @@
+icon: https://avatars.githubusercontent.com/u/152585220?v=4
+git_url: https://github.com/openbao/openbao
+release_url: https://github.com/openbao/openbao/releases/tag/v{vsn}
+helm_repository_url: https://openbao.github.io/openbao-helm
+chart_name: openbao
+versions:
+- version: 2.6.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.29.4
+  images: ['docker.io/hashicorp/vault-k8s:1.7.2', 'quay.io/openbao/openbao:2.6.2']
+- version: 2.5.5
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.28.4
+  images: ['docker.io/hashicorp/vault-k8s:1.7.2', 'quay.io/openbao/openbao:2.5.5']
+- version: 2.4.4
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.24.1
+  images: ['docker.io/hashicorp/vault-k8s:1.7.2', 'quay.io/openbao/openbao:2.4.4']
+- version: 2.3.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.4
+  images: ['docker.io/hashicorp/vault-k8s:1.4.2', 'quay.io/openbao/openbao:2.3.2']
+- version: 2.2.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.1
+  images: ['docker.io/hashicorp/vault-k8s:1.4.2', 'quay.io/openbao/openbao:2.2.2']
+- version: 2.1.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.1
+  images: ['docker.io/hashicorp/vault-k8s:1.4.2', 'quay.io/openbao/openbao:2.1.1']
+- version: 2.1.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.7.0
+  images: ['docker.io/hashicorp/vault-k8s:1.4.2', 'quay.io/openbao/openbao:2.1.0']
+- version: 2.0.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.6.0
+  images: ['docker.io/hashicorp/vault-k8s:1.4.2', 'quay.io/openbao/openbao:2.0.2']

--- a/utils/compatibility/scrapers/openbao.py
+++ b/utils/compatibility/scrapers/openbao.py
@@ -137,7 +137,12 @@ def _chart_url(entry):
     return urljoin("https://openbao.github.io/openbao-helm/", url)
 
 
+def _mapping(value):
+    return value if isinstance(value, dict) else {}
+
+
 def _format_image(image_config, app_version):
+    image_config = _mapping(image_config)
     registry = image_config.get("registry") or "docker.io"
     repository = image_config.get("repository")
     if not repository:
@@ -157,9 +162,12 @@ def extract_default_images(chart_content, app_version):
     except (tarfile.TarError, yaml.YAMLError, OSError):
         return []
 
+    values = _mapping(values)
+    server = _mapping(values.get("server"))
+    injector = _mapping(values.get("injector"))
     images = {
-        _format_image(values.get("server", {}).get("image", {}), app_version),
-        _format_image(values.get("injector", {}).get("image", {}), app_version),
+        _format_image(server.get("image"), app_version),
+        _format_image(injector.get("image"), app_version),
     }
     return sorted(image for image in images if image)
 
@@ -183,7 +191,12 @@ def extract_rows(index_yaml, latest_kube):
             continue
 
         chart_url = _chart_url(entry)
-        chart_content = fetch_page(chart_url) if chart_url else None
+        chart_content = None
+        if chart_url:
+            try:
+                chart_content = fetch_page(chart_url)
+            except Exception as exc:
+                print_error(f"Failed to fetch OpenBao chart {chart_version}: {exc}")
         images = extract_default_images(chart_content, app_version) if chart_content else []
 
         rows_by_version[app_version] = OrderedDict(

--- a/utils/compatibility/scrapers/openbao.py
+++ b/utils/compatibility/scrapers/openbao.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import re
+import tarfile
+from collections import OrderedDict
+from io import BytesIO
+from urllib.parse import urljoin
+
+import yaml
+
+from utils import (
+    current_kube_version,
+    fetch_page,
+    print_error,
+    update_compatibility_info,
+    validate_semver,
+)
+
+
+APP_NAME = "openbao"
+CHART_NAME = "openbao"
+HELM_INDEX_URL = "https://openbao.github.io/openbao-helm/index.yaml"
+OUTPUT_PATH = f"../../static/compatibilities/{APP_NAME}.yaml"
+
+
+def _clean_version(raw):
+    version = validate_semver(str(raw).strip().lstrip("v"))
+    return str(version) if version else None
+
+
+def _version_tuple(major, minor, patch=0):
+    return int(major), int(minor), int(patch or 0)
+
+
+def _next_minor(major, minor):
+    return major, minor + 1
+
+
+def _parse_constraints(spec):
+    constraints = []
+    normalized = spec.replace(",", " ")
+
+    for operator, major, minor, patch in re.findall(
+        r"(>=|<=|<|>|=)?\s*v?(\d+)\.(\d+)(?:\.(\d+))?",
+        normalized,
+    ):
+        constraints.append((operator or ">=", _version_tuple(major, minor, patch)))
+
+    return constraints
+
+
+def _minor_bounds(version):
+    parsed = validate_semver(version)
+    if not parsed:
+        return None
+    return parsed.major, parsed.minor
+
+
+def _minor(version):
+    parsed = validate_semver(version)
+    if not parsed:
+        return None
+    return f"{parsed.major}.{parsed.minor}"
+
+
+def _minor_satisfies_constraints(major, minor, constraints):
+    start = (major, minor, 0)
+    end = (*_next_minor(major, minor), 0)
+
+    for operator, bound in constraints:
+        if operator in (">=", ">"):
+            if end <= bound:
+                return False
+        elif operator == "<":
+            if start >= bound:
+                return False
+        elif operator == "<=":
+            if start > bound:
+                return False
+        elif operator == "=":
+            if not (start <= bound < end):
+                return False
+
+    return True
+
+
+def parse_kube_constraint(spec, latest_kube):
+    if not spec or not latest_kube:
+        return []
+
+    latest = _minor_bounds(latest_kube)
+    if not latest:
+        return []
+
+    constraints = _parse_constraints(spec)
+    lower_bounds = [
+        (bound[0], bound[1])
+        for operator, bound in constraints
+        if operator in (">=", ">", "=")
+    ]
+    if not constraints or not lower_bounds:
+        return []
+
+    major, minor = max(lower_bounds)
+    kube_versions = []
+
+    while (major, minor) <= latest:
+        if _minor_satisfies_constraints(major, minor, constraints):
+            kube_versions.append(f"{major}.{minor}")
+        major, minor = _next_minor(major, minor)
+
+    return kube_versions
+
+
+def load_index(content):
+    try:
+        index = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        print_error(f"Failed to parse OpenBao Helm index: {exc}")
+        return None
+
+    if not isinstance(index, dict):
+        print_error("Unexpected OpenBao Helm index format.")
+        return None
+
+    return index
+
+
+def _chart_url(entry):
+    urls = entry.get("urls") or []
+    if not urls:
+        return None
+
+    url = urls[0]
+    if url.startswith("http"):
+        return url
+    return urljoin("https://openbao.github.io/openbao-helm/", url)
+
+
+def _format_image(image_config, app_version):
+    registry = image_config.get("registry") or "docker.io"
+    repository = image_config.get("repository")
+    if not repository:
+        return None
+
+    tag = image_config.get("tag") or app_version
+    return f"{registry}/{repository}:{tag}"
+
+
+def extract_default_images(chart_content, app_version):
+    try:
+        with tarfile.open(fileobj=BytesIO(chart_content), mode="r:gz") as archive:
+            values_file = archive.extractfile("openbao/values.yaml")
+            if not values_file:
+                return []
+            values = yaml.safe_load(values_file.read())
+    except (tarfile.TarError, yaml.YAMLError, OSError):
+        return []
+
+    images = {
+        _format_image(values.get("server", {}).get("image", {}), app_version),
+        _format_image(values.get("injector", {}).get("image", {}), app_version),
+    }
+    return sorted(image for image in images if image)
+
+
+def extract_rows(index_yaml, latest_kube):
+    rows_by_version = {}
+    entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
+
+    for entry in entries:
+        app_version = _clean_version(entry.get("appVersion", ""))
+        chart_version = _clean_version(entry.get("version", ""))
+        if not app_version or not chart_version:
+            continue
+
+        kube_versions = parse_kube_constraint(entry.get("kubeVersion", ""), latest_kube)
+        if not kube_versions:
+            continue
+
+        current = rows_by_version.get(app_version)
+        if current and validate_semver(chart_version) <= validate_semver(current["chart_version"]):
+            continue
+
+        chart_url = _chart_url(entry)
+        chart_content = fetch_page(chart_url) if chart_url else None
+        images = extract_default_images(chart_content, app_version) if chart_content else []
+
+        rows_by_version[app_version] = OrderedDict(
+            [
+                ("version", app_version),
+                ("kube", kube_versions),
+                ("chart_version", chart_version),
+                ("images", images),
+                ("requirements", []),
+                ("incompatibilities", []),
+            ]
+        )
+
+    rows = sorted(
+        rows_by_version.values(),
+        key=lambda row: validate_semver(row["version"]),
+        reverse=True,
+    )
+    return _representative_rows(rows)
+
+
+def _representative_rows(rows):
+    selected = []
+    seen = {}
+
+    for row in rows:
+        minor = _minor(row["version"])
+        if not minor:
+            continue
+
+        kube = tuple(row["kube"])
+        if minor not in seen:
+            selected.append(row)
+            seen[minor] = kube
+            continue
+
+        if seen[minor] != kube:
+            selected.append(row)
+            seen[minor] = kube
+
+    return selected
+
+
+def scrape():
+    latest_kube = current_kube_version()
+    if not latest_kube:
+        print_error("Could not determine current Kubernetes version from KUBE_VERSION.")
+        return
+
+    content = fetch_page(HELM_INDEX_URL)
+    if not content:
+        return
+
+    index_yaml = load_index(content)
+    if not index_yaml:
+        return
+
+    rows = extract_rows(index_yaml, latest_kube)
+    if not rows:
+        print_error("No OpenBao versions extracted from Helm index.")
+        return
+
+    update_compatibility_info(OUTPUT_PATH, rows)

--- a/utils/compatibility/tests/test_openbao.py
+++ b/utils/compatibility/tests/test_openbao.py
@@ -167,6 +167,48 @@ injector:
     def test_extract_default_images_fails_closed_on_bad_archive(self):
         self.assertEqual(openbao.extract_default_images(b"not a chart", "2.6.2"), [])
 
+    def test_extract_default_images_ignores_unexpected_values_yaml(self):
+        for values in ("", "- just\n- a\n- list\n", "server:\n"):
+            with self.subTest(values=values):
+                chart = self._chart_with_values(values)
+
+                self.assertEqual(openbao.extract_default_images(chart, "2.6.2"), [])
+
+    def test_extract_default_images_ignores_null_image_sections(self):
+        chart = self._chart_with_values(
+            """
+server: null
+injector:
+  image: null
+"""
+        )
+
+        self.assertEqual(openbao.extract_default_images(chart, "2.6.2"), [])
+
+    def test_extract_rows_keeps_row_when_chart_download_fails(self):
+        index_yaml = {
+            "entries": {
+                "openbao": [
+                    {
+                        "version": "0.29.4",
+                        "appVersion": "v2.6.2",
+                        "kubeVersion": ">= 1.30.0-0",
+                        "urls": ["openbao-0.29.4.tgz"],
+                    }
+                ],
+            }
+        }
+
+        with (
+            patch.object(openbao, "fetch_page", side_effect=RuntimeError("timeout")),
+            patch.object(openbao, "print_error") as print_error,
+        ):
+            rows = openbao.extract_rows(index_yaml, "1.36")
+
+        self.assertEqual([row["version"] for row in rows], ["2.6.2"])
+        self.assertEqual(rows[0]["images"], [])
+        print_error.assert_called_once()
+
     def _chart_with_values(self, values):
         output = BytesIO()
         with tarfile.open(fileobj=output, mode="w:gz") as archive:

--- a/utils/compatibility/tests/test_openbao.py
+++ b/utils/compatibility/tests/test_openbao.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tarfile
+import unittest
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+
+COMPATIBILITY_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = COMPATIBILITY_DIR / "scrapers" / "openbao.py"
+sys.path.insert(0, str(COMPATIBILITY_DIR))
+
+utils_spec = importlib.util.spec_from_file_location("utils", COMPATIBILITY_DIR / "utils.py")
+compat_utils = importlib.util.module_from_spec(utils_spec)
+assert utils_spec.loader is not None
+utils_spec.loader.exec_module(compat_utils)
+
+utils_module = sys.modules.get("utils")
+if utils_module is None:
+    sys.modules["utils"] = compat_utils
+else:
+    for name in (
+        "current_kube_version",
+        "fetch_page",
+        "print_error",
+        "update_compatibility_info",
+        "validate_semver",
+    ):
+        setattr(utils_module, name, getattr(compat_utils, name))
+
+spec = importlib.util.spec_from_file_location("openbao", MODULE_PATH)
+openbao = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(openbao)
+
+
+class OpenBaoScraperTest(unittest.TestCase):
+    def test_parse_kube_constraint_expands_minimum_to_current_kubernetes(self):
+        self.assertEqual(
+            openbao.parse_kube_constraint(">= 1.30.0-0", "1.36"),
+            ["1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36"],
+        )
+
+    def test_parse_kube_constraint_honors_upper_boundaries(self):
+        self.assertEqual(
+            openbao.parse_kube_constraint(">=1.27.0-0 <1.31.0-0", "1.36"),
+            ["1.27", "1.28", "1.29", "1.30"],
+        )
+
+    def test_parse_kube_constraint_keeps_patch_overlap_within_minor(self):
+        self.assertEqual(
+            openbao.parse_kube_constraint(">1.29.0 <=1.31.0", "1.36"),
+            ["1.29", "1.30", "1.31"],
+        )
+
+    def test_extract_rows_uses_stable_versions_and_latest_chart_patch(self):
+        index_yaml = {
+            "entries": {
+                "openbao": [
+                    {
+                        "version": "0.29.4",
+                        "appVersion": "v2.6.2",
+                        "kubeVersion": ">= 1.30.0-0",
+                        "urls": ["openbao-0.29.4.tgz"],
+                    },
+                    {
+                        "version": "0.29.1",
+                        "appVersion": "v2.6.1",
+                        "kubeVersion": ">= 1.30.0-0",
+                        "urls": ["openbao-0.29.1.tgz"],
+                    },
+                    {
+                        "version": "0.29.0-beta",
+                        "appVersion": "v2.6.1-beta",
+                        "kubeVersion": ">= 1.30.0-0",
+                        "urls": ["openbao-0.29.0-beta.tgz"],
+                    },
+                    {
+                        "version": "0.28.1",
+                        "appVersion": "v2.5.0",
+                        "kubeVersion": ">= 1.29.0-0",
+                        "urls": ["openbao-0.28.1.tgz"],
+                    },
+                    {
+                        "version": "0.27.0",
+                        "appVersion": "v2.4.0",
+                        "kubeVersion": ">= 1.29.0-0",
+                        "urls": ["openbao-0.27.0.tgz"],
+                    },
+                    {
+                        "version": "0.26.0",
+                        "appVersion": "v2.3.2",
+                        "kubeVersion": "",
+                        "urls": ["openbao-0.26.0.tgz"],
+                    },
+                ],
+                "openbao-crds": [
+                    {
+                        "version": "0.29.4",
+                        "appVersion": "v2.6.2",
+                        "kubeVersion": ">= 1.30.0-0",
+                        "urls": ["openbao-crds-0.29.4.tgz"],
+                    }
+                ],
+            }
+        }
+        chart = self._chart_with_values(
+            """
+server:
+  image:
+    registry: quay.io
+    repository: openbao/openbao
+    tag: ""
+injector:
+  image:
+    registry: docker.io
+    repository: hashicorp/vault-k8s
+    tag: 1.7.2
+"""
+        )
+
+        with patch.object(openbao, "fetch_page", return_value=chart):
+            rows = openbao.extract_rows(index_yaml, "1.36")
+
+        self.assertEqual(
+            [row["version"] for row in rows],
+            ["2.6.2", "2.5.0", "2.4.0"],
+        )
+        self.assertEqual(
+            [row["chart_version"] for row in rows],
+            ["0.29.4", "0.28.1", "0.27.0"],
+        )
+        self.assertEqual(rows[0]["kube"], ["1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36"])
+        self.assertEqual(
+            rows[0]["images"],
+            ["docker.io/hashicorp/vault-k8s:1.7.2", "quay.io/openbao/openbao:2.6.2"],
+        )
+        self.assertEqual(rows[1]["kube"][0], "1.29")
+
+    def test_load_index_rejects_non_mapping_yaml(self):
+        with patch.object(openbao, "print_error"):
+            self.assertIsNone(openbao.load_index("- just\n- a\n- list\n"))
+
+    def test_extract_default_images_reads_server_and_injector_defaults(self):
+        chart = self._chart_with_values(
+            """
+server:
+  image:
+    registry: quay.io
+    repository: openbao/openbao
+    tag: ""
+injector:
+  image:
+    repository: hashicorp/vault-k8s
+    tag: 1.7.2
+"""
+        )
+
+        self.assertEqual(
+            openbao.extract_default_images(chart, "2.6.2"),
+            ["docker.io/hashicorp/vault-k8s:1.7.2", "quay.io/openbao/openbao:2.6.2"],
+        )
+
+    def test_extract_default_images_fails_closed_on_bad_archive(self):
+        self.assertEqual(openbao.extract_default_images(b"not a chart", "2.6.2"), [])
+
+    def _chart_with_values(self, values):
+        output = BytesIO()
+        with tarfile.open(fileobj=output, mode="w:gz") as archive:
+            encoded = values.encode("utf-8")
+            info = tarfile.TarInfo("openbao/values.yaml")
+            info.size = len(encoded)
+            archive.addfile(info, BytesIO(encoded))
+        return output.getvalue()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -179,8 +179,12 @@ def get_chart_images(url, chart, version, values=None):
     # Add repo with a temp name
     oci_repo = url.startswith("oci://")
     if (chart, url) not in IMPORTED_REPOS and not oci_repo:
-        subprocess.run(["helm", "repo", "add", chart, url, "--force-update"], check=True)
-        subprocess.run(["helm", "repo", "update"], check=True)
+        try:
+            subprocess.run(["helm", "repo", "add", chart, url, "--force-update"], check=True)
+            subprocess.run(["helm", "repo", "update"], check=True)
+        except FileNotFoundError:
+            print_warning("Helm is not installed; skipping chart image refresh.")
+            return None
         IMPORTED_REPOS.add((chart, url))
     cmd = ["helm", "template", f"{chart}/{chart}", "--version", version, "--kube-version", current_kube_version()]
     if oci_repo:
@@ -189,11 +193,15 @@ def get_chart_images(url, chart, version, values=None):
     if values:
         cmd.append("--set")
         cmd.append(values)
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True
+        )
+    except FileNotFoundError:
+        print_warning("Helm is not installed; skipping chart image refresh.")
+        return None
     if result.returncode != 0:
         print_error(f"Failed to template helm chart: {result.stderr}")
         return None


### PR DESCRIPTION
This adds OpenBao to the compatibility catalog and gives it a scraper backed by the official OpenBao Helm chart index. The scraper reads each stable chart entry, uses the chart's `kubeVersion` constraint for the Kubernetes minor range, and keeps the latest chart patch for each OpenBao app version.

The checked-in table currently covers OpenBao 2.0 through 2.6 and includes the default server and injector images from the chart archive. I added that direct chart-archive image extraction because my local Windows environment does not have Helm installed; the shared chart helper now skips image refresh cleanly in that case instead of stopping the scrape with a traceback.

Validation I ran locally from `utils/compatibility`:

- `python -m unittest tests.test_openbao tests.test_chart_images -v`
- `python -m unittest discover -s tests -p 'test_*.py' -v`
- `python -c "import importlib.util; spec=importlib.util.spec_from_file_location('openbao','scrapers/openbao.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); mod.scrape()"`
- `git diff --check`
