### PR TITLE
Add Secrets Store CSI Driver compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,127 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+  git_url: https://github.com/kubernetes-sigs/secrets-store-csi-driver
+  release_url: https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v{vsn}
+  helm_repository_url: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+  versions:
+  - version: 1.6.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.6.0
+    images: ['registry.k8s.io/csi-secrets-store/driver-crds:v1.6.0', 'registry.k8s.io/csi-secrets-store/driver:v1.6.0',
+      'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0', 'registry.k8s.io/sig-storage/livenessprobe:v2.18.0']
+  - version: 1.5.6
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.5.6
+    images: ['registry.k8s.io/csi-secrets-store/driver-crds:v1.5.6', 'registry.k8s.io/csi-secrets-store/driver:v1.5.6',
+      'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0', 'registry.k8s.io/sig-storage/livenessprobe:v2.15.0']
+  - version: 1.4.8
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.4.8
+    images: ['registry.k8s.io/csi-secrets-store/driver-crds:v1.4.8', 'registry.k8s.io/csi-secrets-store/driver:v1.4.8',
+      'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.11.1', 'registry.k8s.io/sig-storage/livenessprobe:v2.13.1']
+  - version: 1.3.4
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.3.4
+    images: ['registry.k8s.io/csi-secrets-store/driver-crds:v1.3.4', 'registry.k8s.io/csi-secrets-store/driver:v1.3.4',
+      'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0', 'registry.k8s.io/sig-storage/livenessprobe:v2.10.0']
+  - version: 1.2.4
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.2.4
+    images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v1.2.4', 'k8s.gcr.io/csi-secrets-store/driver:v1.2.4',
+      'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1', 'k8s.gcr.io/sig-storage/livenessprobe:v2.7.0']
+  - version: 1.1.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.1.2
+    images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v1.1.2', 'k8s.gcr.io/csi-secrets-store/driver:v1.1.2',
+      'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.6.0']
+  - version: 1.0.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.1
+    images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v1.0.1', 'k8s.gcr.io/csi-secrets-store/driver:v1.0.1',
+      'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.5.0']
+  - version: 0.3.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.3.0
+    images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v0.3.0', 'k8s.gcr.io/csi-secrets-store/driver:v0.3.0',
+      'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.4.0']
+  - version: 0.2.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.2.0
+    images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v0.2.0', 'k8s.gcr.io/csi-secrets-store/driver:v0.2.0',
+      'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.3.0']
+  - version: 0.1.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.1.0
+    images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v0.1.0', 'k8s.gcr.io/csi-secrets-store/driver:v0.1.0',
+      'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.3.0']
+  - version: 0.0.23
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.0.23
+    images: ['k8s.gcr.io/csi-secrets-store/driver:v0.0.23', 'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0',
+      'k8s.gcr.io/sig-storage/livenessprobe:v2.3.0']
+  - version: 0.0.13
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.0.13
+    images: ['quay.io/k8scsi/csi-node-driver-registrar:v1.2.0', 'quay.io/k8scsi/livenessprobe:v2.0.0',
+      'us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.13']
+  name: secrets-store-csi-driver

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- secrets-store-csi-driver

--- a/static/compatibilities/secrets-store-csi-driver.yaml
+++ b/static/compatibilities/secrets-store-csi-driver.yaml
@@ -1,0 +1,123 @@
+icon: https://github.com/kubernetes/kubernetes/blob/master/logo/logo.png
+git_url: https://github.com/kubernetes-sigs/secrets-store-csi-driver
+release_url: https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases/tag/v{vsn}
+helm_repository_url: https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+versions:
+- version: 1.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.6.0
+  images: ['registry.k8s.io/csi-secrets-store/driver-crds:v1.6.0', 'registry.k8s.io/csi-secrets-store/driver:v1.6.0',
+    'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0', 'registry.k8s.io/sig-storage/livenessprobe:v2.18.0']
+- version: 1.5.6
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.6
+  images: ['registry.k8s.io/csi-secrets-store/driver-crds:v1.5.6', 'registry.k8s.io/csi-secrets-store/driver:v1.5.6',
+    'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0', 'registry.k8s.io/sig-storage/livenessprobe:v2.15.0']
+- version: 1.4.8
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.4.8
+  images: ['registry.k8s.io/csi-secrets-store/driver-crds:v1.4.8', 'registry.k8s.io/csi-secrets-store/driver:v1.4.8',
+    'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.11.1', 'registry.k8s.io/sig-storage/livenessprobe:v2.13.1']
+- version: 1.3.4
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.4
+  images: ['registry.k8s.io/csi-secrets-store/driver-crds:v1.3.4', 'registry.k8s.io/csi-secrets-store/driver:v1.3.4',
+    'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0', 'registry.k8s.io/sig-storage/livenessprobe:v2.10.0']
+- version: 1.2.4
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.4
+  images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v1.2.4', 'k8s.gcr.io/csi-secrets-store/driver:v1.2.4',
+    'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1', 'k8s.gcr.io/sig-storage/livenessprobe:v2.7.0']
+- version: 1.1.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.2
+  images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v1.1.2', 'k8s.gcr.io/csi-secrets-store/driver:v1.1.2',
+    'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.6.0']
+- version: 1.0.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.1
+  images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v1.0.1', 'k8s.gcr.io/csi-secrets-store/driver:v1.0.1',
+    'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.5.0']
+- version: 0.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.3.0
+  images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v0.3.0', 'k8s.gcr.io/csi-secrets-store/driver:v0.3.0',
+    'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.4.0']
+- version: 0.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.2.0
+  images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v0.2.0', 'k8s.gcr.io/csi-secrets-store/driver:v0.2.0',
+    'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.3.0']
+- version: 0.1.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.1.0
+  images: ['k8s.gcr.io/csi-secrets-store/driver-crds:v0.1.0', 'k8s.gcr.io/csi-secrets-store/driver:v0.1.0',
+    'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0', 'k8s.gcr.io/sig-storage/livenessprobe:v2.3.0']
+- version: 0.0.23
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.0.23
+  images: ['k8s.gcr.io/csi-secrets-store/driver:v0.0.23', 'k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0',
+    'k8s.gcr.io/sig-storage/livenessprobe:v2.3.0']
+- version: 0.0.13
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.0.13
+  images: ['quay.io/k8scsi/csi-node-driver-registrar:v1.2.0', 'quay.io/k8scsi/livenessprobe:v2.0.0',
+    'us.gcr.io/k8s-artifacts-prod/csi-secrets-store/driver:v0.0.13']

--- a/utils/compatibility/scrapers/secrets-store-csi-driver.py
+++ b/utils/compatibility/scrapers/secrets-store-csi-driver.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from typing import Any
+
+import yaml
+from packaging.version import Version
+
+from utils import (
+    current_kube_version,
+    expand_kube_versions,
+    fetch_page,
+    print_error,
+    update_compatibility_info,
+    validate_semver,
+)
+
+
+APP_NAME = "secrets-store-csi-driver"
+HELM_INDEX_URL = "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts/index.yaml"
+TARGET_FILE = f"../../static/compatibilities/{APP_NAME}.yaml"
+KUBE_CONSTRAINT_RE = re.compile(
+    r"(?P<operator><=|>=|<|>)\s*v?(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?(?:-[0-9A-Za-z.-]+)?"
+)
+
+
+def _decode(content: bytes | str) -> str:
+    return content.decode("utf-8") if isinstance(content, bytes) else content
+
+
+def _minor(version: str) -> str:
+    parsed = validate_semver(version)
+    if not parsed:
+        raise ValueError(f"Invalid Kubernetes version: {version}")
+    return f"{parsed.major}.{parsed.minor}"
+
+
+def _previous_minor(version: str) -> str:
+    parsed = validate_semver(version)
+    if not parsed:
+        raise ValueError(f"Invalid Kubernetes version: {version}")
+    major = parsed.major
+    minor = parsed.minor - 1
+    if minor < 0:
+        major -= 1
+        minor = 99
+    return f"{major}.{minor}"
+
+
+def _newer_minor(left: str, right: str) -> str:
+    return str(max(Version(left), Version(right)))
+
+
+def _older_minor(left: str, right: str) -> str:
+    return str(min(Version(left), Version(right)))
+
+
+def kube_versions_from_constraint(constraint: str, latest_kube: str) -> list[str]:
+    """Convert Helm kubeVersion constraints into Plural's minor-version list."""
+    text = str(constraint or "").strip()
+    matches = list(KUBE_CONSTRAINT_RE.finditer(text))
+    if not matches:
+        raise ValueError(f"Unsupported kubeVersion constraint: {constraint!r}")
+
+    start = None
+    end = _minor(latest_kube)
+    for match in matches:
+        operator = match.group("operator")
+        version = f"{match.group('major')}.{match.group('minor')}.0"
+        minor = _minor(version)
+
+        if operator == ">=":
+            start = minor if start is None else _newer_minor(start, minor)
+        elif operator == ">":
+            next_minor = f"{match.group('major')}.{int(match.group('minor')) + 1}"
+            start = next_minor if start is None else _newer_minor(start, next_minor)
+        elif operator == "<":
+            end = _older_minor(end, _previous_minor(version))
+        elif operator == "<=":
+            end = _older_minor(end, minor)
+
+    if start is None:
+        raise ValueError(f"kubeVersion has no lower bound: {constraint!r}")
+    if Version(start) > Version(end):
+        return []
+    return expand_kube_versions(start, end)
+
+
+def _load_index(content: bytes | str) -> dict[str, Any]:
+    try:
+        index = yaml.safe_load(_decode(content))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Could not parse Secrets Store CSI Driver Helm index: {exc}") from exc
+
+    if not isinstance(index, dict):
+        raise ValueError("Unexpected Secrets Store CSI Driver Helm index payload")
+    entries = index.get("entries")
+    if not isinstance(entries, dict):
+        raise ValueError("Secrets Store CSI Driver Helm index has no entries map")
+    return index
+
+
+def build_rows(index_content: bytes | str, latest_kube: str) -> list[OrderedDict]:
+    index = _load_index(index_content)
+    entries = index["entries"].get(APP_NAME)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Secrets Store CSI Driver chart entries not found")
+
+    selected: dict[tuple[int, int, tuple[str, ...]], dict[str, Any]] = {}
+    for chart in entries:
+        if not isinstance(chart, dict):
+            continue
+
+        app_version = validate_semver(str(chart.get("appVersion", "")).lstrip("v"))
+        chart_version = validate_semver(str(chart.get("version", "")).lstrip("v"))
+        if not app_version or not chart_version:
+            continue
+
+        kube_versions = kube_versions_from_constraint(
+            str(chart.get("kubeVersion", "")), latest_kube
+        )
+        if not kube_versions:
+            continue
+
+        key = (app_version.major, app_version.minor, tuple(kube_versions))
+        current = selected.get(key)
+        if (
+            current is None
+            or app_version > current["_app_version"]
+            or (
+                app_version == current["_app_version"]
+                and chart_version > current["_chart_version"]
+            )
+        ):
+            selected[key] = {
+                "_app_version": app_version,
+                "_chart_version": chart_version,
+                "row": OrderedDict(
+                    [
+                        ("version", str(app_version)),
+                        ("kube", kube_versions),
+                        ("chart_version", str(chart_version)),
+                        ("images", []),
+                        ("requirements", []),
+                        ("incompatibilities", []),
+                    ]
+                ),
+            }
+
+    rows = [entry["row"] for entry in selected.values()]
+    rows.sort(key=lambda row: Version(row["version"]), reverse=True)
+    if not rows:
+        raise ValueError("No stable Secrets Store CSI Driver chart rows found")
+    return rows
+
+
+def scrape() -> None:
+    index_content = fetch_page(HELM_INDEX_URL)
+    if not index_content:
+        print_error("Failed to fetch Secrets Store CSI Driver Helm index.")
+        return
+
+    latest_kube = current_kube_version()
+    if not latest_kube:
+        print_error("Could not read current Kubernetes version.")
+        return
+
+    try:
+        rows = build_rows(index_content, latest_kube)
+    except ValueError as exc:
+        print_error(str(exc))
+        return
+
+    update_compatibility_info(TARGET_FILE, rows)

--- a/utils/compatibility/scrapers/secrets-store-csi-driver.py
+++ b/utils/compatibility/scrapers/secrets-store-csi-driver.py
@@ -21,7 +21,8 @@ APP_NAME = "secrets-store-csi-driver"
 HELM_INDEX_URL = "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts/index.yaml"
 TARGET_FILE = f"../../static/compatibilities/{APP_NAME}.yaml"
 KUBE_CONSTRAINT_RE = re.compile(
-    r"(?P<operator><=|>=|<|>)\s*v?(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?(?:-[0-9A-Za-z.-]+)?"
+    r"(?P<operator><=|>=|<|>)\s*v?(?P<major>\d+)\.(?P<minor>\d+)"
+    r"(?:\.(?P<patch>\d+))?(?:-[0-9A-Za-z.-]+)?"
 )
 
 
@@ -46,6 +47,10 @@ def _previous_minor(version: str) -> str:
         major -= 1
         minor = 99
     return f"{major}.{minor}"
+
+
+def _has_patch_room_below(match: re.Match) -> bool:
+    return int(match.group("patch") or 0) > 0
 
 
 def _newer_minor(left: str, right: str) -> str:
@@ -73,10 +78,10 @@ def kube_versions_from_constraint(constraint: str, latest_kube: str) -> list[str
         if operator == ">=":
             start = minor if start is None else _newer_minor(start, minor)
         elif operator == ">":
-            next_minor = f"{match.group('major')}.{int(match.group('minor')) + 1}"
-            start = next_minor if start is None else _newer_minor(start, next_minor)
+            start = minor if start is None else _newer_minor(start, minor)
         elif operator == "<":
-            end = _older_minor(end, _previous_minor(version))
+            boundary = minor if _has_patch_room_below(match) else _previous_minor(version)
+            end = _older_minor(end, boundary)
         elif operator == "<=":
             end = _older_minor(end, minor)
 

--- a/utils/compatibility/tests/test_secrets_store_csi_driver.py
+++ b/utils/compatibility/tests/test_secrets_store_csi_driver.py
@@ -1,0 +1,143 @@
+"""Offline regressions for the Secrets Store CSI Driver compatibility scraper."""
+
+import importlib
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import yaml
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+scraper = importlib.import_module("scrapers.secrets-store-csi-driver")
+
+
+def index(entries):
+    return yaml.safe_dump({"entries": {scraper.APP_NAME: entries}}).encode()
+
+
+class SecretsStoreCSIDriverScraperTests(unittest.TestCase):
+    def test_kube_constraint_lower_bounds_expand_to_current_minor(self):
+        self.assertEqual(
+            scraper.kube_versions_from_constraint(">=1.30.0-0", "1.36"),
+            ["1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36"],
+        )
+        self.assertEqual(
+            scraper.kube_versions_from_constraint(">=1.16.0-0", "1.18"),
+            ["1.16", "1.17", "1.18"],
+        )
+
+    def test_kube_constraint_with_upper_bound(self):
+        self.assertEqual(
+            scraper.kube_versions_from_constraint(">=1.26.0-0 <1.29.0-0", "1.36"),
+            ["1.26", "1.27", "1.28"],
+        )
+        self.assertEqual(
+            scraper.kube_versions_from_constraint(">=1.26.0-0 <=1.29.0", "1.36"),
+            ["1.26", "1.27", "1.28", "1.29"],
+        )
+
+    def test_unsupported_constraints_fail_closed(self):
+        for constraint in ("", "1.30+", "<1.30.0", "not-a-version"):
+            with self.subTest(constraint=constraint):
+                with self.assertRaises(ValueError):
+                    scraper.kube_versions_from_constraint(constraint, "1.36")
+
+    def test_build_rows_keeps_newest_patch_per_minor_and_kube_boundary(self):
+        rows = scraper.build_rows(
+            index(
+                [
+                    {"version": "1.6.0", "appVersion": "1.6.0", "kubeVersion": ">=1.30.0-0"},
+                    {"version": "1.5.6", "appVersion": "1.5.6", "kubeVersion": ">=1.16.0-0"},
+                    {"version": "1.5.5", "appVersion": "1.5.5", "kubeVersion": ">=1.16.0-0"},
+                    {"version": "0.0.23", "appVersion": "0.0.23", "kubeVersion": ">=1.16.0-0"},
+                    {"version": "0.0.13", "appVersion": "0.0.13", "kubeVersion": ">=1.15.0-0"},
+                    {
+                        "version": "1.7.0-rc.1",
+                        "appVersion": "1.7.0-rc.1",
+                        "kubeVersion": ">=1.31.0-0",
+                    },
+                ]
+            ),
+            "1.36",
+        )
+
+        self.assertEqual(
+            [(row["version"], row["chart_version"]) for row in rows],
+            [
+                ("1.6.0", "1.6.0"),
+                ("1.5.6", "1.5.6"),
+                ("0.0.23", "0.0.23"),
+                ("0.0.13", "0.0.13"),
+            ],
+        )
+        self.assertEqual(
+            rows[0]["kube"],
+            ["1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36"],
+        )
+        self.assertEqual(
+            rows[-1]["kube"],
+            [
+                "1.15",
+                "1.16",
+                "1.17",
+                "1.18",
+                "1.19",
+                "1.20",
+                "1.21",
+                "1.22",
+                "1.23",
+                "1.24",
+                "1.25",
+                "1.26",
+                "1.27",
+                "1.28",
+                "1.29",
+                "1.30",
+                "1.31",
+                "1.32",
+                "1.33",
+                "1.34",
+                "1.35",
+                "1.36",
+            ],
+        )
+
+    def test_missing_chart_entries_fail_closed(self):
+        with self.assertRaisesRegex(ValueError, "chart entries not found"):
+            scraper.build_rows(yaml.safe_dump({"entries": {}}).encode(), "1.36")
+
+    def test_bad_index_payload_fails_closed(self):
+        for payload in (b"[]", b"entries:\n  secrets-store-csi-driver: not-a-list"):
+            with self.subTest(payload=payload):
+                with self.assertRaises(ValueError):
+                    scraper.build_rows(payload, "1.36")
+
+    def test_scrape_wires_official_index_and_target_file(self):
+        payload = index(
+            [
+                {"version": "1.6.0", "appVersion": "1.6.0", "kubeVersion": ">=1.30.0-0"},
+            ]
+        )
+        with patch.object(scraper, "fetch_page", Mock(return_value=payload)) as fetch, \
+                patch.object(scraper, "current_kube_version", Mock(return_value="1.36")), \
+                patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+
+        fetch.assert_called_once_with(scraper.HELM_INDEX_URL)
+        path, rows = update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/secrets-store-csi-driver.yaml")
+        self.assertEqual(rows[0]["version"], "1.6.0")
+        self.assertEqual(rows[0]["chart_version"], "1.6.0")
+
+    def test_scrape_source_failure_does_not_write(self):
+        with patch.object(scraper, "fetch_page", Mock(return_value=None)), \
+                patch.object(scraper, "update_compatibility_info") as update, \
+                patch.object(scraper, "print_error"):
+            scraper.scrape()
+        update.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_secrets_store_csi_driver.py
+++ b/utils/compatibility/tests/test_secrets_store_csi_driver.py
@@ -38,6 +38,20 @@ class SecretsStoreCSIDriverScraperTests(unittest.TestCase):
             ["1.26", "1.27", "1.28", "1.29"],
         )
 
+    def test_strict_patch_bounds_keep_partially_compatible_minors(self):
+        self.assertEqual(
+            scraper.kube_versions_from_constraint(">1.30.0", "1.36"),
+            ["1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36"],
+        )
+        self.assertEqual(
+            scraper.kube_versions_from_constraint(">=1.26.0-0 <1.29.5", "1.36"),
+            ["1.26", "1.27", "1.28", "1.29"],
+        )
+        self.assertEqual(
+            scraper.kube_versions_from_constraint(">=1.26.0-0 <1.29.0", "1.36"),
+            ["1.26", "1.27", "1.28"],
+        )
+
     def test_unsupported_constraints_fail_closed(self):
         for constraint in ("", "1.30+", "<1.30.0", "not-a-version"):
             with self.subTest(constraint=constraint):


### PR DESCRIPTION
Adds Secrets Store CSI Driver to the compatibility tables.

The scraper reads the official Kubernetes SIGs Helm chart index and converts its `kubeVersion` constraints into the Kubernetes minor versions used by the Plural compatibility UI. It keeps the latest stable chart for each release line, plus the older 0.0.x boundary where the chart moved from Kubernetes 1.15 to 1.16.

I generated the checked-in table from the live chart index and Helm templates so the rows include chart versions and images.

Validation:
- `python -m unittest tests.test_secrets_store_csi_driver -v`
- `python -m unittest discover -s tests -p 'test_*.py' -v`
- `git diff --check`
