### PR TITLE
Add Capsule compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -11564,6 +11564,83 @@ addons:
     chart_version: 3.20.6
     images: ['quay.io/tigera/operator:v1.20.9']
   name: calico
+- icon: https://github.com/projectcapsule/capsule/raw/main/assets/logo/capsule_small.png
+  git_url: https://github.com/projectcapsule/capsule
+  release_url: https://github.com/projectcapsule/capsule/releases/tag/v{vsn}
+  readme_url: https://projectcapsule.dev/docs/operating/setup/installation/
+  helm_repository_url: oci://ghcr.io/projectcapsule/charts/capsule
+  versions:
+  - version: 0.14.4
+    kube: ['1.36']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.14.4
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.14.4']
+  - version: 0.14.0
+    kube: ['1.36']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.14.0
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.14.0']
+  - version: 0.13.0
+    kube: ['1.35']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.13.0
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.13.0']
+  - version: 0.12.0
+    kube: ['1.34']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.12.0
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.12.0']
+  - version: 0.11.0
+    kube: ['1.34']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.11.0
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.11.0']
+  - version: 0.10.9
+    kube: ['1.34']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.10.9
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.10.9']
+  - version: 0.10.0
+    kube: ['1.33']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.10.0
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.10.0']
+  - version: 0.9.0
+    kube: ['1.33']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.9.0
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.9.0']
+  - version: 0.8.0
+    kube: ['1.33']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.8.0
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.8.0']
+  - version: 0.7.4
+    kube: ['1.31']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.7.4
+    images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.7.4']
+  name: capsule
 - icon: https://raw.githubusercontent.com/cert-manager/cert-manager/d53c0b9270f8cd90d908460d69502694e1838f5f/logo/logo-small.png
   git_url: https://github.com/cert-manager/cert-manager
   release_url: https://github.com/cert-manager/cert-manager/releases/tag/v{vsn}

--- a/static/compatibilities/capsule.yaml
+++ b/static/compatibilities/capsule.yaml
@@ -1,0 +1,76 @@
+icon: https://github.com/projectcapsule/capsule/raw/main/assets/logo/capsule_small.png
+git_url: https://github.com/projectcapsule/capsule
+release_url: https://github.com/projectcapsule/capsule/releases/tag/v{vsn}
+readme_url: https://projectcapsule.dev/docs/operating/setup/installation/
+helm_repository_url: oci://ghcr.io/projectcapsule/charts/capsule
+versions:
+- version: 0.14.4
+  kube: ['1.36']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.4
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.14.4']
+- version: 0.14.0
+  kube: ['1.36']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.0
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.14.0']
+- version: 0.13.0
+  kube: ['1.35']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.13.0
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.13.0']
+- version: 0.12.0
+  kube: ['1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.0
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.12.0']
+- version: 0.11.0
+  kube: ['1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.11.0
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.11.0']
+- version: 0.10.9
+  kube: ['1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.9
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.10.9']
+- version: 0.10.0
+  kube: ['1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.0
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.10.0']
+- version: 0.9.0
+  kube: ['1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.9.0
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.9.0']
+- version: 0.8.0
+  kube: ['1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.0
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.8.0']
+- version: 0.7.4
+  kube: ['1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.7.4
+  images: ['docker.io/clastix/kubectl:v1.36', 'ghcr.io/projectcapsule/capsule:v0.7.4']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -7,6 +7,7 @@ names:
 - bigbang
 - amazon-vpc-cni-k8s
 - calico
+- capsule
 - cert-manager
 - cilium
 - chaos-mesh

--- a/utils/compatibility/scrapers/capsule.py
+++ b/utils/compatibility/scrapers/capsule.py
@@ -1,0 +1,119 @@
+import re
+import subprocess
+
+import requests
+import yaml
+
+from utils import reduce_versions, update_compatibility_info
+
+
+APP_NAME = "capsule"
+RELEASES_URL = "https://api.github.com/repos/projectcapsule/capsule/releases"
+CHART_URL = "oci://ghcr.io/projectcapsule/charts/capsule"
+TARGET_FILE = f"../../static/compatibilities/{APP_NAME}.yaml"
+
+
+def parse_compatibility(body):
+    """Read the explicit release table, not the moving 'latest Kubernetes' policy."""
+    marker = re.search(r"Kubernetes compatibility", body, re.IGNORECASE)
+    if marker is None:
+        # Older releases do not publish this table. Do not infer their support.
+        return []
+
+    lines = [line.lstrip("> ").strip() for line in body[marker.end():].splitlines()]
+    header = "| Kubernetes version | Minimum required |"
+    for index, line in enumerate(lines):
+        if re.sub(r"\s+", " ", line) == header:
+            break
+    else:
+        raise ValueError("Capsule compatibility section has no recognized table")
+
+    if index + 1 >= len(lines) or not re.fullmatch(r"\|[\s:|-]+\|", lines[index + 1]):
+        raise ValueError("Malformed Capsule compatibility table header")
+
+    kube_versions = []
+    for line in lines[index + 2:]:
+        if not line.startswith("|"):
+            break
+        cells = [cell.strip().strip("`").strip() for cell in line.strip("|").split("|")]
+        if len(cells) != 2:
+            raise ValueError(f"Malformed Capsule compatibility row: {line}")
+        kube = re.fullmatch(r"v?(\d+\.\d+)", cells[0])
+        minimum = re.fullmatch(r">=\s*v?(\d+\.\d+)\.0", cells[1])
+        if not kube or not minimum or kube[1] != minimum[1]:
+            # The catalog records minors, so a nonzero minimum patch cannot be
+            # represented accurately. Fail rather than advertise the whole minor.
+            raise ValueError(f"Unsupported Capsule compatibility row: {line}")
+        if kube[1] in kube_versions:
+            raise ValueError(f"Duplicate Kubernetes version: {kube[1]}")
+        kube_versions.append(kube[1])
+
+    if not kube_versions:
+        raise ValueError("Empty Capsule compatibility table")
+    return kube_versions
+
+
+def fetch_releases():
+    releases = []
+    page = 1
+    while True:
+        response = requests.get(RELEASES_URL, params={"per_page": 100, "page": page}, timeout=30)
+        response.raise_for_status()
+        batch = response.json()
+        if not isinstance(batch, list):
+            raise ValueError("Expected a list of Capsule releases")
+        releases.extend(batch)
+        if len(batch) < 100:
+            return releases
+        page += 1
+
+
+def extract_versions(releases):
+    versions = []
+    seen = set()
+    for release in releases:
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        tag = release["tag_name"]
+        if not re.fullmatch(r"v\d+\.\d+\.\d+", tag):
+            continue
+        version = tag[1:]
+        if version in seen:
+            raise ValueError(f"Duplicate Capsule release: {tag}")
+        seen.add(version)
+        kube = parse_compatibility(release.get("body") or "")
+        if kube:
+            versions.append({"version": version, "kube": kube})
+
+    if not versions:
+        raise ValueError("No explicit Capsule compatibility information found")
+    # Keep every minor/compatibility boundary and the newest patch, following
+    # the shared catalog convention, before resolving their published charts.
+    return reduce_versions(versions)
+
+
+def chart_version_for(version):
+    # Source Chart.yaml contains 0.0.0 placeholders. Verify the published OCI
+    # package instead; the release workflow stamps its version and appVersion.
+    result = subprocess.run(
+        ["helm", "show", "chart", CHART_URL, "--version", version],
+        capture_output=True, text=True, check=True, timeout=120,
+    )
+    chart = yaml.safe_load(result.stdout)
+    if (
+        not isinstance(chart, dict)
+        or chart.get("name") != APP_NAME
+        or str(chart.get("appVersion", "")).lstrip("v") != version
+        or str(chart.get("version", "")) != version
+    ):
+        raise ValueError(f"Published Capsule chart does not match release {version}")
+    return version
+
+
+def scrape():
+    versions = extract_versions(fetch_releases())
+    for version in versions:
+        version["chart_version"] = chart_version_for(version["version"])
+    # Resolve every chart before updating the table. A failed request or a
+    # changed upstream format must not result in a partial compatibility write.
+    update_compatibility_info(TARGET_FILE, versions)

--- a/utils/compatibility/scrapers/capsule.py
+++ b/utils/compatibility/scrapers/capsule.py
@@ -116,4 +116,4 @@ def scrape():
         version["chart_version"] = chart_version_for(version["version"])
     # Resolve every chart before updating the table. A failed request or a
     # changed upstream format must not result in a partial compatibility write.
-    update_compatibility_info(TARGET_FILE, versions)
+    update_compatibility_info(TARGET_FILE, versions, require_images=True)

--- a/utils/compatibility/tests/fixtures/capsule/README.md
+++ b/utils/compatibility/tests/fixtures/capsule/README.md
@@ -1,0 +1,16 @@
+# Capsule fixtures
+
+Retrieved September 8, 2026 from the upstream project.
+
+- `releases.json` contains the release flags and the exact Kubernetes compatibility sections from [v0.14.4](https://github.com/projectcapsule/capsule/releases/tag/v0.14.4) and [v0.7.4](https://github.com/projectcapsule/capsule/releases/tag/v0.7.4), returned by the GitHub releases API. These exercise the quoted and unquoted table formats. The surrounding changelogs are omitted.
+- `chart.yaml` is the output of `helm show chart oci://ghcr.io/projectcapsule/charts/capsule --version 0.14.4`. Helm reported manifest digest `sha256:1da7a5742a2b30ed30e71832cf875becbc6a49551d020c940db52cf34045644e`. The published package has real version fields; the source tree's Chart.yaml has `0.0.0` placeholders.
+
+Run from `utils/compatibility` with the compatibility requirements installed:
+
+```sh
+python -m unittest discover -s tests -p 'test_capsule.py' -v
+```
+
+The tests make no network requests and deploy no clusters. They mock the HTTP and Helm boundaries and exercise the real parser, version reduction, and YAML writer. Live chart lookup/rendering is a separate validation step.
+
+The scraper only records minors explicitly named in each release's table. A `>= 1.36.0` minimum within a `v1.36` row does not establish support for 1.37. Releases without a compatibility section are omitted. If a future table requires a nonzero Kubernetes patch, it is rejected because this catalog cannot represent that requirement accurately using minor versions alone.

--- a/utils/compatibility/tests/fixtures/capsule/chart.yaml
+++ b/utils/compatibility/tests/fixtures/capsule/chart.yaml
@@ -1,0 +1,42 @@
+annotations:
+  artifacthub.io/category: security
+  artifacthub.io/changes: |
+    - kind: added
+      description: added toggles for podSecurityContexts and securityContexts
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://projectcapsule.dev/
+  artifacthub.io/maintainers: |
+    - name: capsule-maintainers
+      email: cncf-capsule-maintainers@lists.cncf.io
+  artifacthub.io/operator: "true"
+  artifacthub.io/prerelease: "false"
+apiVersion: v2
+appVersion: 0.14.4
+dependencies:
+- alias: proxy
+  condition: proxy.enabled
+  name: capsule-proxy
+  repository: oci://ghcr.io/projectcapsule/charts
+  version: 0.14.1
+description: A Helm chart to deploy the Capsule Operator for easily implementing,
+  managing, and maintaining multitenancy and access control in Kubernetes.
+home: https://projectcapsule.dev/
+icon: https://github.com/projectcapsule/capsule/raw/main/assets/logo/capsule_small.png
+keywords:
+- kubernetes
+- operator
+- multi-tenancy
+- multi-tenant
+- multitenancy
+- multitenant
+- namespace
+maintainers:
+- email: cncf-capsule-maintainers@lists.cncf.io
+  name: capsule-maintainers
+name: capsule
+sources:
+- https://github.com/projectcapsule/capsule
+type: application
+version: 0.14.4

--- a/utils/compatibility/tests/fixtures/capsule/releases.json
+++ b/utils/compatibility/tests/fixtures/capsule/releases.json
@@ -1,0 +1,14 @@
+[
+  {
+    "tag_name": "v0.14.4",
+    "draft": false,
+    "prerelease": false,
+    "body": "Kubernetes compatibility**\r\n>\r\n> Note that the Capsule project offers support only for the latest minor version of Kubernetes.\r\n> Backwards compatibility with older versions of Kubernetes and OpenShift is [offered by vendors](https://projectcapsule.dev/support/).\r\n>\r\n> | Kubernetes version | Minimum required |\r\n> |--------------------|------------------|\r\n> | `v1.36`            | `>= 1.36.0`      |"
+  },
+  {
+    "tag_name": "v0.7.4",
+    "draft": false,
+    "prerelease": false,
+    "body": "Kubernetes compatibility**\n\n[!IMPORTANT]\nNote that the Capsule project offers support only for the latest minor version of Kubernetes.\nBackwards compatibility with older versions of Kubernetes and OpenShift is [offered by vendors](https://projectcapsule.dev/support/).\n\n| Kubernetes version | Minimum required |\n|--------------------|------------------|\n| `v1.31`            | `>= 1.31.0`      |"
+  }
+]

--- a/utils/compatibility/tests/test_capsule.py
+++ b/utils/compatibility/tests/test_capsule.py
@@ -1,0 +1,149 @@
+import copy
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from scrapers import capsule
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "capsule"
+RELEASES = json.loads((FIXTURES / "releases.json").read_text())
+
+
+def release(version, kube="1.36"):
+    result = copy.deepcopy(RELEASES[0])
+    result["tag_name"] = "v" + version
+    result["body"] = result["body"].replace("1.36", kube)
+    return result
+
+
+class CapsuleTests(unittest.TestCase):
+    def test_official_quoted_and_unquoted_tables(self):
+        self.assertEqual(capsule.parse_compatibility(RELEASES[0]["body"]), ["1.36"])
+        self.assertEqual(capsule.parse_compatibility(RELEASES[1]["body"]), ["1.31"])
+
+    def test_no_future_or_older_versions_inferred(self):
+        # The prose says 'latest' and the minimum cell says >=; neither makes
+        # Kubernetes 1.37 or 1.35 part of the explicit 1.36 support row.
+        rows = capsule.extract_versions([release("0.14.4")])
+        self.assertEqual(rows[0]["kube"], ["1.36"])
+
+    def test_skips_unpublished_prerelease_and_undocumented_versions(self):
+        draft = release("0.15.0")
+        draft["draft"] = True
+        prerelease = release("0.16.0")
+        prerelease["prerelease"] = True
+        legacy = release("0.7.3")
+        legacy["body"] = "Bug fixes only."
+        rows = capsule.extract_versions([draft, prerelease, legacy, release("0.14.4-rc.1"), release("0.14.4")])
+        self.assertEqual([r["version"] for r in rows], ["0.14.4"])
+
+    def test_retains_minor_support_change_and_latest_boundaries(self):
+        releases = [release("0.13.0", "1.35"), release("0.13.1", "1.35"),
+                    release("0.14.0", "1.35"), release("0.14.1", "1.36"),
+                    release("0.14.2", "1.36"), release("0.14.4", "1.36")]
+        rows = capsule.extract_versions(list(reversed(releases)))
+        self.assertEqual([r["version"] for r in rows], ["0.14.4", "0.14.1", "0.14.0", "0.13.0"])
+        self.assertEqual([r["kube"] for r in rows], [["1.36"], ["1.36"], ["1.35"], ["1.35"]])
+
+    def test_rejects_inexpressible_or_malformed_tables(self):
+        body = RELEASES[0]["body"]
+        for bad in (
+            body.replace(">= 1.36.0", ">= 1.36.1"),
+            body.replace(">= 1.36.0", ">= 1.35.0"),
+            body.replace("`v1.36`", "`v1.36+`"),
+            body.replace("Minimum required", "Other heading"),
+            body.replace("| `v1.36`", "| extra | `v1.36`"),
+            "Kubernetes compatibility\n| Kubernetes version | Minimum required |\n|---|---|\n",
+        ):
+            with self.subTest(body=bad), self.assertRaises(ValueError):
+                capsule.parse_compatibility(bad)
+
+    def test_rejects_duplicate_versions_and_empty_results(self):
+        with self.assertRaises(ValueError):
+            capsule.extract_versions([release("0.14.4"), release("0.14.4")])
+        with self.assertRaises(ValueError):
+            capsule.extract_versions([])
+
+    def test_paginates_release_history(self):
+        first, second = Mock(), Mock()
+        first.json.return_value = [release("0.14.4")] * 100
+        second.json.return_value = [release("0.7.4")]
+        with patch.object(capsule.requests, "get", side_effect=[first, second]) as get:
+            self.assertEqual(len(capsule.fetch_releases()), 101)
+            self.assertEqual([c.kwargs["params"]["page"] for c in get.call_args_list], [1, 2])
+        first.raise_for_status.assert_called_once()
+        second.raise_for_status.assert_called_once()
+
+    def test_http_failure_and_invalid_response_abort_before_write(self):
+        response = Mock()
+        response.json.return_value = {"message": "rate limit"}
+        with patch.object(capsule.requests, "get", return_value=response), \
+             patch.object(capsule, "update_compatibility_info") as update:
+            with self.assertRaises(ValueError):
+                capsule.scrape()
+            update.assert_not_called()
+        response.raise_for_status.side_effect = requests.HTTPError("503")
+        with patch.object(capsule.requests, "get", return_value=response), \
+             patch.object(capsule, "update_compatibility_info") as update:
+            with self.assertRaises(requests.HTTPError):
+                capsule.scrape()
+            update.assert_not_called()
+
+    def test_published_chart_metadata_must_match(self):
+        chart = yaml.safe_load((FIXTURES / "chart.yaml").read_text())
+        result = subprocess.CompletedProcess([], 0, stdout=yaml.safe_dump(chart))
+        with patch.object(capsule.subprocess, "run", return_value=result):
+            self.assertEqual(capsule.chart_version_for("0.14.4"), "0.14.4")
+            with self.assertRaises(ValueError):
+                capsule.chart_version_for("0.14.3")
+        for field, value in (("name", "capsule-proxy"), ("appVersion", "0.0.0"), ("version", "0.0.0")):
+            bad = {**chart, field: value}
+            result.stdout = yaml.safe_dump(bad)
+            with self.subTest(field=field), patch.object(capsule.subprocess, "run", return_value=result), self.assertRaises(ValueError):
+                capsule.chart_version_for("0.14.4")
+
+    def test_missing_chart_or_malformed_release_never_partially_writes(self):
+        with patch.object(capsule, "fetch_releases", return_value=[release("0.14.4"), release("0.13.0", "1.35")]), \
+             patch.object(capsule, "chart_version_for", side_effect=["0.14.4", subprocess.TimeoutExpired("helm", 120)]), \
+             patch.object(capsule, "update_compatibility_info") as update:
+            with self.assertRaises(subprocess.TimeoutExpired):
+                capsule.scrape()
+            update.assert_not_called()
+        bad = release("0.13.0")
+        bad["body"] = "Kubernetes compatibility\nchanged format"
+        with patch.object(capsule, "fetch_releases", return_value=[release("0.14.4"), bad]), \
+             patch.object(capsule, "chart_version_for") as chart, \
+             patch.object(capsule, "update_compatibility_info") as update:
+            with self.assertRaises(ValueError):
+                capsule.scrape()
+            chart.assert_not_called()
+            update.assert_not_called()
+
+    def test_shared_writer_preserves_metadata_and_records_chart_images(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "capsule.yaml"
+            target.write_text(yaml.safe_dump({"icon": "capsule.png", "helm_repository_url": capsule.CHART_URL, "versions": []}))
+            with patch.object(capsule, "TARGET_FILE", str(target)), \
+                 patch.object(capsule, "fetch_releases", return_value=[release("0.14.4")]), \
+                 patch.object(capsule, "chart_version_for", return_value="0.14.4"), \
+                 patch("utils.get_chart_images", return_value=["ghcr.io/projectcapsule/capsule:0.14.4"]), \
+                 patch("utils.summarization_enabled", return_value=False):
+                capsule.scrape()
+            output = yaml.safe_load(target.read_text())
+            self.assertEqual(output["icon"], "capsule.png")
+            self.assertEqual(output["versions"][0]["kube"], ["1.36"])
+            self.assertEqual(output["versions"][0]["chart_version"], "0.14.4")
+            self.assertEqual(output["versions"][0]["images"], ["ghcr.io/projectcapsule/capsule:0.14.4"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_capsule.py
+++ b/utils/compatibility/tests/test_capsule.py
@@ -128,6 +128,38 @@ class CapsuleTests(unittest.TestCase):
             chart.assert_not_called()
             update.assert_not_called()
 
+    def test_later_render_failure_leaves_file_unchanged(self):
+        for failed_render in (
+            subprocess.CompletedProcess([], 1, stdout="", stderr="chart download failed"),
+            subprocess.CompletedProcess([], 0, stdout="kind: ConfigMap\n", stderr=""),
+        ):
+            with self.subTest(returncode=failed_render.returncode), tempfile.TemporaryDirectory() as directory:
+                target = Path(directory) / "capsule.yaml"
+                original = yaml.safe_dump({"icon": "capsule.png", "helm_repository_url": capsule.CHART_URL, "versions": []})
+                target.write_text(original)
+                rendered = subprocess.CompletedProcess([], 0, stdout="spec:\n  image: ghcr.io/projectcapsule/capsule:0.14.4\n", stderr="")
+                with patch.object(capsule, "TARGET_FILE", str(target)), \
+                     patch.object(capsule, "fetch_releases", return_value=[release("0.14.4"), release("0.13.0", "1.35")]), \
+                     patch.object(capsule, "chart_version_for", side_effect=lambda version: version), \
+                     patch("utils.subprocess.run", side_effect=[rendered, failed_render]) as render, \
+                     patch("utils.write_yaml") as write, \
+                     patch("utils.summarization_enabled") as summarize, \
+                     patch("utils.traceback.print_exc"):
+                    capsule.scrape()
+                    self.assertEqual(render.call_count, 2)
+                    write.assert_not_called()
+                    summarize.assert_not_called()
+                self.assertEqual(target.read_text(), original)
+
+    def test_shared_writer_keeps_optional_image_behavior_by_default(self):
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "other.yaml"
+            target.write_text(yaml.safe_dump({"helm_repository_url": capsule.CHART_URL, "versions": []}))
+            with patch("utils.get_chart_images", return_value=None), \
+                 patch("utils.summarization_enabled", return_value=False):
+                capsule.update_compatibility_info(str(target), [{"version": "0.14.4", "kube": ["1.36"], "chart_version": "0.14.4"}])
+            self.assertEqual(yaml.safe_load(target.read_text())["versions"][0]["version"], "0.14.4")
+
     def test_shared_writer_preserves_metadata_and_records_chart_images(self):
         with tempfile.TemporaryDirectory() as directory:
             target = Path(directory) / "capsule.yaml"

--- a/utils/compatibility/utils.py
+++ b/utils/compatibility/utils.py
@@ -506,7 +506,7 @@ def clean_kube_version(vsn):
         return None
     return f"{as_semver.major}.{as_semver.minor}"
 
-def update_compatibility_info(filepath, new_versions):
+def update_compatibility_info(filepath, new_versions, require_images=False):
     app_name = filepath.split("/")[-1].split(".")[0]
     try:
         data = read_yaml(filepath)
@@ -522,6 +522,8 @@ def update_compatibility_info(filepath, new_versions):
                     if "chart_version" in version:
                         print(f"Updating images for {app_name} {version['version']}")
                         imgs = get_chart_images(url, data.get('chart_name', app_name), version["chart_version"], data.get('helm_values'))
+                        if require_images and not imgs:
+                            raise ValueError(f"No chart images resolved for {app_name} {version['version']}")
                         if imgs:
                             version["images"] = imgs
         else:


### PR DESCRIPTION
Capsule is missing from the Kubernetes compatibility catalog. This adds its metadata and a scraper that reads the Kubernetes compatibility tables in official Capsule release notes, verifies the corresponding published OCI chart metadata, and generates compatibility and image data.

The catalog contains 10 release boundaries from 0.7.4 through 0.14.4. The scraper preserves changes within a minor series, including the Kubernetes support change at Capsule 0.10.9. It excludes drafts, prereleases, and historical releases without explicit compatibility tables. It records only named Kubernetes minors and rejects requirements that need patch-level precision. HTTP, parsing, or chart-resolution failures stop processing before the compatibility table is updated.

Capsule opts into required image resolution in the shared updater: failed or empty Helm renders abort before any file write or summarization. Other scrapers retain the existing default behavior. Regression tests cover a failed second render and unchanged-file behavior.

Sources:

- [Capsule installation and support policy](https://projectcapsule.dev/docs/operating/setup/installation/)
- [Capsule releases](https://github.com/projectcapsule/capsule/releases), including [0.14.4](https://github.com/projectcapsule/capsule/releases/tag/v0.14.4) and [0.7.4](https://github.com/projectcapsule/capsule/releases/tag/v0.7.4)
- Published chart: `oci://ghcr.io/projectcapsule/charts/capsule`

## Test Plan

- 13 offline unit/integration tests pass, covering actual upstream fixture formats, version boundaries, pagination, malformed/missing input, published-chart version mismatches, failure before writing, and the shared YAML writer.
- Live release retrieval succeeded: 81 releases, 64 stable releases, 37 explicit compatibility tables, reduced to 10 catalog entries.
- Published OCI metadata checks and Helm renders succeeded for all 10 retained charts. The generated image lists are nonempty.
- Schema validation passes for all 58 compatibility YAML files, including the aggregate and manifest.
- The 53 existing aggregate entries are preserved unchanged. The aggregate contains only the new Capsule block; unrelated pre-existing per-file/aggregate differences are excluded.
- `git diff --check` passes. No Kubernetes clusters were deployed and no runtime compatibility is claimed beyond the upstream release tables.

Run the offline tests from `utils/compatibility`:

```sh
python -m unittest discover -s tests -p 'test_capsule.py' -v
```

Prepared with OpenAI Codex assistance. Please assess this contribution under the published $300 new-compatibility-scraper tier and confirm reward eligibility and the payout process. No reward is assumed before your review and acceptance.

## Checklist

- [x] Meaningful title and summary explaining the change.
- [x] Tests cover the new scraper.
- Fixture provenance and test instructions are documented.
- No agent code changed; agent deployment verification is not applicable.

Plural Flow: console
