### PR TITLE
feat: add KubeVela compatibility scraper

### DIFF
--- a/static/compatibilities/kubevela.yaml
+++ b/static/compatibilities/kubevela.yaml
@@ -1,0 +1,13 @@
+icon: https://kubevela.io/img/logo.svg
+git_url: https://github.com/kubevela/kubevela
+release_url: https://github.com/kubevela/kubevela/releases/tag/v{vsn}
+helm_repository_url: https://kubevela.github.io/charts
+versions:
+- version: 1.11.0
+  kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.11.0
+  images: ['oamdev/vela-core:v1.11.0']
+name: kubevela

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- kubevela

--- a/utils/compatibility/scrapers/kubevela.py
+++ b/utils/compatibility/scrapers/kubevela.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+from packaging.version import InvalidVersion, Version
+
+APP_NAME = "kubevela"
+DOC_URL = "https://raw.githubusercontent.com/kubevela/kubevela.github.io/main/docs/installation/kubernetes.mdx"
+CHART_URL = "https://raw.githubusercontent.com/kubevela/kubevela/v{version}/charts/vela-core/Chart.yaml"
+
+_RANGE_RE = re.compile(
+    r"Kubernetes\s+cluster\s+`?>=\s*v?(1\.\d+)\s*&&\s*<=\s*v?(1\.\d+)`?",
+    re.IGNORECASE,
+)
+
+
+def _decode(payload: bytes | str, source: str) -> str:
+    if isinstance(payload, bytes):
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"Could not decode {source}") from exc
+    if isinstance(payload, str):
+        return payload
+    raise ValueError(f"Unexpected {source} payload type")
+
+
+def parse_kubernetes_range(document: bytes | str) -> tuple[str, str]:
+    text = _decode(document, "KubeVela installation documentation")
+    match = _RANGE_RE.search(text)
+    if not match:
+        raise ValueError("KubeVela Kubernetes range not found")
+    return match.group(1), match.group(2)
+
+
+def parse_chart_identity(chart: bytes | str) -> tuple[str, str]:
+    text = _decode(chart, "KubeVela Chart.yaml")
+    version = None
+    app_version = None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("version:") and version is None:
+            version = line.split(":", 1)[1].strip().strip('"\'')
+        elif line.startswith("appVersion:") and app_version is None:
+            app_version = line.split(":", 1)[1].strip().strip('"\'')
+    if not version or not app_version:
+        raise ValueError("KubeVela chart identity is incomplete")
+    if version.lstrip("v") != app_version.lstrip("v"):
+        raise ValueError(
+            f"KubeVela chart/app version mismatch: {version} != {app_version}"
+        )
+    return version.lstrip("v"), app_version.lstrip("v")
+
+
+def _minor(value: str) -> int:
+    match = re.fullmatch(r"1\.(\d+)", value.strip())
+    if not match:
+        raise ValueError(f"Unsupported Kubernetes version: {value!r}")
+    return int(match.group(1))
+
+
+def intersect_range(minimum: str, maximum: str, plural_current: str) -> list[str]:
+    low = _minor(minimum)
+    high = min(_minor(maximum), _minor(plural_current))
+    if low > high:
+        raise ValueError("KubeVela Kubernetes range does not intersect Plural support")
+    return [f"1.{minor}" for minor in range(high, low - 1, -1)]
+
+
+def latest_stable_release(releases) -> str:
+    candidates: list[Version] = []
+    for release in releases:
+        raw = release[0] if isinstance(release, (tuple, list)) else release
+        raw = str(raw).strip().lstrip("v")
+        try:
+            parsed = Version(raw)
+        except InvalidVersion:
+            continue
+        if parsed.is_prerelease or parsed.is_devrelease:
+            continue
+        candidates.append(parsed)
+    if not candidates:
+        raise ValueError("No stable KubeVela release found")
+    return str(max(candidates))
+
+
+def build_row(version: str, docs: bytes | str, chart: bytes | str, current: str):
+    chart_version, app_version = parse_chart_identity(chart)
+    if app_version != version:
+        raise ValueError(
+            f"KubeVela release/chart mismatch: release {version}, chart {app_version}"
+        )
+    minimum, maximum = parse_kubernetes_range(docs)
+    return OrderedDict(
+        [
+            ("version", version),
+            ("kube", intersect_range(minimum, maximum, current)),
+            ("chart_version", chart_version),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ]
+    )
+
+
+def scrape() -> None:
+    from utils import (
+        current_kube_version,
+        fetch_page,
+        get_github_releases_timestamps,
+        update_compatibility_info,
+    )
+
+    releases = get_github_releases_timestamps("kubevela", "kubevela")
+    version = latest_stable_release(releases)
+
+    docs = fetch_page(DOC_URL)
+    if not docs:
+        raise ValueError("Could not fetch KubeVela installation documentation")
+
+    chart = fetch_page(CHART_URL.format(version=version))
+    if not chart:
+        raise ValueError(f"Could not fetch KubeVela {version} Chart.yaml")
+
+    current = current_kube_version()
+    if not current:
+        raise ValueError("Plural current Kubernetes version is unavailable")
+
+    row = build_row(version, docs, chart, current)
+    update_compatibility_info(
+        f"../../static/compatibilities/{APP_NAME}.yaml",
+        [row],
+    )

--- a/utils/compatibility/tests/test_kubevela.py
+++ b/utils/compatibility/tests/test_kubevela.py
@@ -1,0 +1,108 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "kubevela.py"
+spec = importlib.util.spec_from_file_location("kubevela_scraper", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+DOC = """# Install KubeVela on Kubernetes
+
+* Kubernetes cluster `>= v1.19 && <= v1.31`
+"""
+
+CHART = """apiVersion: v2
+name: vela-core
+version: 1.11.0
+appVersion: 1.11.0
+"""
+
+
+class KubeVelaTests(unittest.TestCase):
+    def test_parses_documented_kubernetes_range(self):
+        self.assertEqual(scraper.parse_kubernetes_range(DOC), ("1.19", "1.31"))
+
+    def test_missing_range_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "range not found"):
+            scraper.parse_kubernetes_range("Kubernetes is required")
+
+    def test_parses_exact_chart_identity(self):
+        self.assertEqual(scraper.parse_chart_identity(CHART), ("1.11.0", "1.11.0"))
+
+    def test_mismatched_chart_identity_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "version mismatch"):
+            scraper.parse_chart_identity(
+                "version: 1.11.0\nappVersion: 1.10.0\n"
+            )
+
+    def test_intersects_upstream_range_with_plural_current(self):
+        self.assertEqual(
+            scraper.intersect_range("1.19", "1.31", "1.36"),
+            [f"1.{minor}" for minor in range(31, 18, -1)],
+        )
+        self.assertEqual(
+            scraper.intersect_range("1.19", "1.31", "1.28"),
+            [f"1.{minor}" for minor in range(28, 18, -1)],
+        )
+
+    def test_latest_stable_release_excludes_prereleases_and_bad_tags(self):
+        releases = [
+            ("v1.11.0-alpha.6", 3),
+            ("v1.10.2", 2),
+            ("junk", 1),
+            ("v1.11.0", 4),
+        ]
+        self.assertEqual(scraper.latest_stable_release(releases), "1.11.0")
+
+    def test_build_row_requires_release_chart_match(self):
+        row = scraper.build_row("1.11.0", DOC, CHART, "1.36")
+        self.assertEqual(row["version"], "1.11.0")
+        self.assertEqual(row["chart_version"], "1.11.0")
+        self.assertEqual(row["kube"][0], "1.31")
+        self.assertEqual(row["kube"][-1], "1.19")
+
+        with self.assertRaisesRegex(ValueError, "release/chart mismatch"):
+            scraper.build_row(
+                "1.10.0",
+                DOC,
+                CHART,
+                "1.36",
+            )
+
+    def test_scrape_wires_official_sources_without_module_leak(self):
+        helpers = ModuleType("utils")
+        helpers.get_github_releases_timestamps = Mock(
+            return_value=[("v1.10.2", 1), ("v1.11.0", 2)]
+        )
+        helpers.fetch_page = Mock(
+            side_effect=lambda url: DOC.encode()
+            if url == scraper.DOC_URL
+            else CHART.encode()
+        )
+        helpers.current_kube_version = Mock(return_value="1.36")
+        helpers.update_compatibility_info = Mock()
+
+        previous = sys.modules.get("utils")
+        try:
+            with patch.dict(sys.modules, {"utils": helpers}):
+                scraper.scrape()
+        finally:
+            if previous is None:
+                sys.modules.pop("utils", None)
+            else:
+                sys.modules["utils"] = previous
+
+        helpers.get_github_releases_timestamps.assert_called_once_with(
+            "kubevela", "kubevela"
+        )
+        path, rows = helpers.update_compatibility_info.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/kubevela.yaml")
+        self.assertEqual(rows[0]["version"], "1.11.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds KubeVela to Plural’s compatibility catalog with an automated compatibility scraper, generated compatibility data, manifest registration, and focused regression tests.

Authoritative sources

* KubeVela official repository: kubevela/kubevela
* Stable release: v1.11.0
* Tagged Helm chart: charts/vela-core
* Official KubeVela Kubernetes installation documentation
* Official Helm repository: https://kubevela.github.io/charts

The scraper uses KubeVela’s published Kubernetes support window and verifies release identity against the release-tagged vela-core Helm chart rather than inventing compatibility.

For the current documented support range, KubeVela supports Kubernetes versions 1.19 through 1.31. The scraper emits only Kubernetes versions within that upstream-declared range and Plural’s currently tracked range.

The implementation verifies that the tagged Helm chart version and application version correspond to the KubeVela release before emitting compatibility information. Missing, malformed, mismatched, or prerelease metadata fails closed rather than producing guessed compatibility data.

Changes

* Adds utils/compatibility/scrapers/kubevela.py
* Adds focused scraper tests in utils/compatibility/tests/test_kubevela.py
* Adds generated KubeVela compatibility metadata in static/compatibilities/kubevela.yaml
* Registers kubevela in static/compatibilities/manifest.yaml

Test Plan

Focused unit tests cover:

* supported Kubernetes range parsing
* lower and upper Kubernetes bounds
* tagged Helm chart/application version identity
* stable-release filtering
* malformed or missing upstream metadata
* version mismatch rejection
* scraper/update wiring

No live Kubernetes cluster deployment was performed because this change adds compatibility metadata and scraper logic rather than agent/runtime code.

Checklist

* [x]	I have added a meaningful title and summary to convey the impact of this PR to a user.
* [x]	If required, I have updated the relevant compatibility metadata.
* [x]	I have added tests to cover my changes.
* [ ]	I have deployed the agent to a test environment and verified that it works as expected — not applicable because no agent code is changed.

AI assistance disclosure: implemented with OpenAI ChatGPT/Codex under the GitHub account owner’s authorization.

Please consider this contribution under the README Contributor Program’s advertised $300 reward for a new compatibility scraper, subject to maintainer review, usefulness, merge, and contributor eligibility. No reward or payment is assumed.

Plural Flow: console