### PR TITLE
Add Sealed Secrets compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- sealed-secrets

--- a/static/compatibilities/sealed-secrets.yaml
+++ b/static/compatibilities/sealed-secrets.yaml
@@ -1,0 +1,232 @@
+icon: https://bitnami.com/assets/stacks/sealed-secrets/img/sealed-secrets-stack-220x234.png
+git_url: https://github.com/bitnami-labs/sealed-secrets
+release_url: https://github.com/bitnami-labs/sealed-secrets/releases/tag/v{vsn}
+helm_repository_url: https://bitnami.github.io/sealed-secrets
+chart_name: sealed-secrets
+readme_url: https://github.com/bitnami-labs/sealed-secrets/blob/main/README.md
+versions:
+- version: 0.39.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.19.3
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.39.1']
+- version: 0.38.4
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.19.1
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.38.4']
+- version: 0.37.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.18.6
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.37.0']
+- version: 0.36.6
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.18.5
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.36.6']
+- version: 0.35.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.18.1
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.35.0']
+- version: 0.34.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.18.0
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.34.0']
+- version: 0.33.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.17.9
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.33.1']
+- version: 0.32.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.17.7
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.32.2']
+- version: 0.31.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.17.4
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.31.0']
+- version: 0.30.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.17.3
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.30.0']
+- version: 0.29.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.17.2
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.29.0']
+- version: 0.28.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.17.1
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.28.0']
+- version: 0.27.3
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.17.0
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.27.3']
+- version: 0.26.3
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.15.4
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.26.3']
+- version: 0.25.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.14.2
+  images: ['docker.io/bitnami/sealed-secrets-controller:0.25.0']
+- version: 0.24.5
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.14.1
+  images: ['docker.io/bitnami/sealed-secrets-controller:v0.24.5']
+- version: 0.23.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.12.0
+  images: ['docker.io/bitnami/sealed-secrets-controller:v0.23.1']
+- version: 0.22.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.10.0
+  images: ['docker.io/bitnami/sealed-secrets-controller:v0.22.0']
+- version: 0.21.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.9.0
+  images: ['docker.io/bitnami/sealed-secrets-controller:v0.21.0']
+- version: 0.20.5
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.8.2
+  images: ['docker.io/bitnami/sealed-secrets-controller:v0.20.5']
+- version: 0.19.5
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.7.6
+  images: ['docker.io/bitnami/sealed-secrets-controller:v0.19.5']
+- version: 0.18.5
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.6.9
+  images: ['docker.io/bitnami/sealed-secrets-controller:v0.18.5']
+- version: 0.17.5
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.1.8
+  images: ['docker.io/bitnami/sealed-secrets-controller:v0.17.5']
+- version: 0.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.16.1
+  images: ['quay.io/bitnami/sealed-secrets-controller:v0.16.0']
+- version: 0.13.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14', '1.13', '1.12', '1.11', '1.10', '1.9']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.13.2
+  images: ['quay.io/bitnami/sealed-secrets-controller:v0.13.1']

--- a/utils/compatibility/scrapers/sealed-secrets.py
+++ b/utils/compatibility/scrapers/sealed-secrets.py
@@ -9,10 +9,8 @@ from utils import (
     current_kube_version,
     fetch_page,
     print_error,
-    read_yaml,
     update_compatibility_info,
     validate_semver,
-    write_yaml,
 )
 
 
@@ -180,18 +178,6 @@ def _representative_rows(rows):
     return selected
 
 
-def prune_stale_representatives(filepath, rows):
-    data = read_yaml(filepath)
-    if not data or "versions" not in data:
-        return
-
-    keep = {row["version"] for row in rows}
-    data["versions"] = [
-        version for version in data.get("versions", []) if version.get("version") in keep
-    ]
-    write_yaml(filepath, data)
-
-
 def scrape():
     latest_kube = current_kube_version()
     if not latest_kube:
@@ -211,5 +197,4 @@ def scrape():
         print_error("No Sealed Secrets versions extracted from Helm index.")
         return
 
-    prune_stale_representatives(OUTPUT_PATH, rows)
     update_compatibility_info(OUTPUT_PATH, rows)

--- a/utils/compatibility/scrapers/sealed-secrets.py
+++ b/utils/compatibility/scrapers/sealed-secrets.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import yaml
+
+from utils import (
+    current_kube_version,
+    fetch_page,
+    print_error,
+    read_yaml,
+    update_compatibility_info,
+    validate_semver,
+    write_yaml,
+)
+
+
+APP_NAME = "sealed-secrets"
+CHART_NAME = "sealed-secrets"
+HELM_INDEX_URL = "https://bitnami.github.io/sealed-secrets/index.yaml"
+OUTPUT_PATH = f"../../static/compatibilities/{APP_NAME}.yaml"
+
+
+def _clean_version(version):
+    parsed = validate_semver(str(version).strip().lstrip("v"))
+    return str(parsed) if parsed else None
+
+
+def _minor(version):
+    parsed = validate_semver(version)
+    if not parsed:
+        return None
+    return f"{parsed.major}.{parsed.minor}"
+
+
+def _minor_bounds(version):
+    parsed = validate_semver(version)
+    if not parsed:
+        return None
+    return parsed.major, parsed.minor
+
+
+def _next_minor(major, minor):
+    return major, minor + 1
+
+
+def _version_tuple(major, minor, patch=0):
+    return int(major), int(minor), int(patch or 0)
+
+
+def _parse_constraints(spec):
+    normalized = spec.replace(",", " ")
+    constraints = []
+
+    for operator, major, minor, patch in re.findall(
+        r"(>=|<=|<|>|=)?\s*v?(\d+)\.(\d+)(?:\.(\d+))?",
+        normalized,
+    ):
+        constraints.append((operator or ">=", _version_tuple(major, minor, patch)))
+
+    return constraints
+
+
+def _minor_satisfies_constraints(major, minor, constraints):
+    start = (major, minor, 0)
+    end = (*_next_minor(major, minor), 0)
+
+    for operator, bound in constraints:
+        if operator in (">=", ">"):
+            if end <= bound:
+                return False
+        elif operator == "<":
+            if start >= bound:
+                return False
+        elif operator == "<=":
+            if start > bound:
+                return False
+        elif operator == "=":
+            if not (start <= bound < end):
+                return False
+
+    return True
+
+
+def parse_kube_constraint(spec, latest_kube):
+    if not spec or not latest_kube:
+        return []
+
+    latest = _minor_bounds(latest_kube)
+    if not latest:
+        return []
+
+    constraints = _parse_constraints(spec)
+    lower_bounds = [
+        (bound[0], bound[1])
+        for operator, bound in constraints
+        if operator in (">=", ">", "=")
+    ]
+    if not constraints or not lower_bounds:
+        return []
+
+    major, minor = max(lower_bounds)
+    kube_versions = []
+
+    while (major, minor) <= latest:
+        if _minor_satisfies_constraints(major, minor, constraints):
+            kube_versions.append(f"{major}.{minor}")
+        major, minor = _next_minor(major, minor)
+
+    return kube_versions
+
+
+def load_index(content):
+    try:
+        return yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        print_error(f"Failed to parse Sealed Secrets Helm index: {exc}")
+        return None
+
+
+def extract_rows(index_yaml, latest_kube):
+    rows_by_version = {}
+    entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
+
+    for entry in entries:
+        app_version = _clean_version(entry.get("appVersion", ""))
+        chart_version = _clean_version(entry.get("version", ""))
+        if not app_version or not chart_version:
+            continue
+
+        kube_versions = parse_kube_constraint(entry.get("kubeVersion", ""), latest_kube)
+        if not kube_versions:
+            continue
+
+        current = rows_by_version.get(app_version)
+        if current and validate_semver(chart_version) <= validate_semver(
+            current["chart_version"]
+        ):
+            continue
+
+        rows_by_version[app_version] = OrderedDict(
+            [
+                ("version", app_version),
+                ("kube", kube_versions),
+                ("chart_version", chart_version),
+                ("images", []),
+                ("requirements", []),
+                ("incompatibilities", []),
+            ]
+        )
+
+    rows = sorted(
+        rows_by_version.values(),
+        key=lambda row: validate_semver(row["version"]),
+        reverse=True,
+    )
+    return _representative_rows(rows)
+
+
+def _representative_rows(rows):
+    selected = []
+    seen = {}
+
+    for row in rows:
+        minor = _minor(row["version"])
+        if not minor:
+            continue
+
+        kube = tuple(row["kube"])
+        if minor not in seen:
+            selected.append(row)
+            seen[minor] = kube
+            continue
+
+        if seen[minor] != kube:
+            selected.append(row)
+            seen[minor] = kube
+
+    return selected
+
+
+def prune_stale_representatives(filepath, rows):
+    data = read_yaml(filepath)
+    if not data or "versions" not in data:
+        return
+
+    keep = {row["version"] for row in rows}
+    data["versions"] = [
+        version for version in data.get("versions", []) if version.get("version") in keep
+    ]
+    write_yaml(filepath, data)
+
+
+def scrape():
+    latest_kube = current_kube_version()
+    if not latest_kube:
+        print_error("Could not determine current Kubernetes version from KUBE_VERSION.")
+        return
+
+    content = fetch_page(HELM_INDEX_URL)
+    if not content:
+        return
+
+    index_yaml = load_index(content)
+    if not index_yaml:
+        return
+
+    rows = extract_rows(index_yaml, latest_kube)
+    if not rows:
+        print_error("No Sealed Secrets versions extracted from Helm index.")
+        return
+
+    prune_stale_representatives(OUTPUT_PATH, rows)
+    update_compatibility_info(OUTPUT_PATH, rows)

--- a/utils/compatibility/tests/test_sealed_secrets.py
+++ b/utils/compatibility/tests/test_sealed_secrets.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib.util
 import sys
-import tempfile
 import unittest
 from pathlib import Path
 
@@ -24,10 +23,8 @@ else:
         "current_kube_version",
         "fetch_page",
         "print_error",
-        "read_yaml",
         "update_compatibility_info",
         "validate_semver",
-        "write_yaml",
     ):
         setattr(utils_module, name, getattr(compat_utils, name))
 
@@ -140,28 +137,6 @@ class SealedSecretsScraperTest(unittest.TestCase):
         selected = sealed_secrets._representative_rows(rows)
 
         self.assertEqual([row["version"] for row in selected], ["0.39.1", "0.39.0"])
-
-    def test_prune_stale_representatives_removes_old_patch_rows(self):
-        with tempfile.TemporaryDirectory() as temp:
-            path = Path(temp) / "sealed-secrets.yaml"
-            path.write_text(
-                """
-versions:
-- version: 0.39.0
-  summary: old
-- version: 0.39.1
-  summary: current
-""",
-                encoding="utf-8",
-            )
-
-            sealed_secrets.prune_stale_representatives(
-                path,
-                [{"version": "0.39.1"}],
-            )
-
-            self.assertNotIn("0.39.0", path.read_text(encoding="utf-8"))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/utils/compatibility/tests/test_sealed_secrets.py
+++ b/utils/compatibility/tests/test_sealed_secrets.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+COMPATIBILITY_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = COMPATIBILITY_DIR / "scrapers" / "sealed-secrets.py"
+sys.path.insert(0, str(COMPATIBILITY_DIR))
+
+utils_spec = importlib.util.spec_from_file_location("utils", COMPATIBILITY_DIR / "utils.py")
+compat_utils = importlib.util.module_from_spec(utils_spec)
+assert utils_spec.loader is not None
+utils_spec.loader.exec_module(compat_utils)
+
+utils_module = sys.modules.get("utils")
+if utils_module is None:
+    sys.modules["utils"] = compat_utils
+else:
+    for name in (
+        "current_kube_version",
+        "fetch_page",
+        "print_error",
+        "read_yaml",
+        "update_compatibility_info",
+        "validate_semver",
+        "write_yaml",
+    ):
+        setattr(utils_module, name, getattr(compat_utils, name))
+
+spec = importlib.util.spec_from_file_location("sealed_secrets", MODULE_PATH)
+sealed_secrets = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(sealed_secrets)
+
+
+class SealedSecretsScraperTest(unittest.TestCase):
+    def test_parse_kube_constraint_expands_minimum_to_current_kubernetes(self):
+        self.assertEqual(
+            sealed_secrets.parse_kube_constraint(">=1.16.0-0", "1.36"),
+            [
+                "1.16",
+                "1.17",
+                "1.18",
+                "1.19",
+                "1.20",
+                "1.21",
+                "1.22",
+                "1.23",
+                "1.24",
+                "1.25",
+                "1.26",
+                "1.27",
+                "1.28",
+                "1.29",
+                "1.30",
+                "1.31",
+                "1.32",
+                "1.33",
+                "1.34",
+                "1.35",
+                "1.36",
+            ],
+        )
+
+    def test_parse_kube_constraint_keeps_patch_overlap(self):
+        self.assertEqual(
+            sealed_secrets.parse_kube_constraint(">=1.16.0 <1.19.1", "1.36"),
+            ["1.16", "1.17", "1.18", "1.19"],
+        )
+        self.assertEqual(
+            sealed_secrets.parse_kube_constraint(">1.16.0 <=1.18.0", "1.36"),
+            ["1.16", "1.17", "1.18"],
+        )
+
+    def test_extract_rows_uses_sealed_secrets_chart_and_stable_app_versions(self):
+        index_yaml = {
+            "entries": {
+                "not-sealed-secrets": [
+                    {
+                        "version": "2.19.3",
+                        "appVersion": "0.39.1",
+                        "kubeVersion": ">=1.16.0-0",
+                    }
+                ],
+                "sealed-secrets": [
+                    {
+                        "version": "2.19.3",
+                        "appVersion": "0.39.1",
+                        "kubeVersion": ">=1.16.0-0",
+                    },
+                    {
+                        "version": "2.19.2",
+                        "appVersion": "0.39.0",
+                        "kubeVersion": ">=1.16.0-0",
+                    },
+                    {
+                        "version": "2.19.1",
+                        "appVersion": "0.38.4",
+                        "kubeVersion": ">=1.16.0-0",
+                    },
+                    {
+                        "version": "2.18.0-rc.1",
+                        "appVersion": "0.37.0-rc.1",
+                        "kubeVersion": ">=1.16.0-0",
+                    },
+                    {
+                        "version": "2.12.0",
+                        "appVersion": "0.27.3",
+                        "kubeVersion": ">=1.24.0-0",
+                    },
+                ],
+            }
+        }
+
+        rows = sealed_secrets.extract_rows(index_yaml, "1.36")
+
+        self.assertEqual(
+            [row["version"] for row in rows],
+            ["0.39.1", "0.38.4", "0.27.3"],
+        )
+        self.assertEqual(
+            [row["chart_version"] for row in rows],
+            ["2.19.3", "2.19.1", "2.12.0"],
+        )
+        self.assertEqual(rows[0]["kube"][0], "1.16")
+        self.assertEqual(rows[0]["kube"][-1], "1.36")
+        self.assertEqual(rows[-1]["kube"][0], "1.24")
+
+    def test_representative_rows_keep_kubernetes_semantic_changes(self):
+        rows = [
+            {"version": "0.39.1", "kube": ["1.16", "1.17"], "chart_version": "2.19.3"},
+            {"version": "0.39.0", "kube": ["1.16", "1.17"], "chart_version": "2.19.2"},
+            {"version": "0.39.0", "kube": ["1.24", "1.25"], "chart_version": "2.19.1"},
+        ]
+
+        selected = sealed_secrets._representative_rows(rows)
+
+        self.assertEqual([row["version"] for row in selected], ["0.39.1", "0.39.0"])
+
+    def test_prune_stale_representatives_removes_old_patch_rows(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "sealed-secrets.yaml"
+            path.write_text(
+                """
+versions:
+- version: 0.39.0
+  summary: old
+- version: 0.39.1
+  summary: current
+""",
+                encoding="utf-8",
+            )
+
+            sealed_secrets.prune_stale_representatives(
+                path,
+                [{"version": "0.39.1"}],
+            )
+
+            self.assertNotIn("0.39.0", path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Sealed Secrets compatibility data and a scraper that reads the Bitnami Labs Helm repository index, keeps representative rows for Kubernetes support changes, and records chart image metadata for the selected chart versions.

Verification:
- `python -m unittest tests.test_sealed_secrets -v` from `utils/compatibility` — 4 tests passed.
- `SCRAPER=sealed-secrets python main.py` from `utils/compatibility` with Helm v4.2.4 on PATH — updated the Sealed Secrets compatibility file locally. The run used the cached Kubernetes version because `cdn.dl.k8s.io` DNS failed in my Windows environment, and skipped summary generation because `OPENAI_API_KEY`/`EXA_API_KEY` were not set.

Source documentation:
- https://github.com/bitnami-labs/sealed-secrets
- https://bitnami-labs.github.io/sealed-secrets/index.yaml
