### PR TITLE
Add SPIRE compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- spire

--- a/static/compatibilities/spire.yaml
+++ b/static/compatibilities/spire.yaml
@@ -24,13 +24,13 @@ versions:
   requirements: []
   incompatibilities: []
   summary: null
-  chart_version: 0.30.0
-  images: ['busybox:1.37.0-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:90041f375e30f41aa7e0390075d8a69dc61900771d52fa98d63ee5d03d866a58',
-    'cgr.dev/chainguard/min-toolkit-debug:latest@sha256:9e45e6836c28489a6e57ca1210ec66927e88eca2409e403616a1278e210e86c9',
-    'docker.io/smallstep/step-cli:0.30.2', 'ghcr.io/spiffe/oidc-discovery-provider:1.15.2',
+  chart_version: 0.28.4
+  images: ['busybox:1.37.0-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:ef209fd7d231ead12bf24287db24991bdd979669f4df2e037698f94545816d3e',
+    'cgr.dev/chainguard/min-toolkit-debug:latest@sha256:6ba4fb1b19bb35fa0b7e6bf08b308379a5b865727e50b7b3068efb824b39ebba',
+    'docker.io/smallstep/step-cli:0.30.2', 'ghcr.io/spiffe/oidc-discovery-provider:1.14.5',
     'ghcr.io/spiffe/spiffe-csi-driver:0.2.7', 'ghcr.io/spiffe/spiffe-helper:0.11.0',
-    'ghcr.io/spiffe/spire-agent:1.15.2', 'ghcr.io/spiffe/spire-controller-manager:0.7.0',
-    'ghcr.io/spiffe/spire-server:1.15.2', 'registry.k8s.io/kubectl:v1.36', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0']
+    'ghcr.io/spiffe/spire-agent:1.14.5', 'ghcr.io/spiffe/spire-controller-manager:0.6.4',
+    'ghcr.io/spiffe/spire-server:1.14.5', 'registry.k8s.io/kubectl:v1.36', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4']
 - version: 1.13.2
   kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
     '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
@@ -134,13 +134,12 @@ versions:
     'docker.io/rancher/kubectl:v1.36', 'ghcr.io/spiffe/spiffe-csi-driver:0.2.3', 'ghcr.io/spiffe/spire-agent:1.6.4',
     'ghcr.io/spiffe/spire-controller-manager:0.2.2', 'ghcr.io/spiffe/spire-server:1.6.4',
     'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0']
-- version: 1.5.5
+- version: 1.5.4
   kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
     '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
   requirements: []
   incompatibilities: []
   summary: null
-  chart_version: 0.5.0
-  images: [busybox, 'cgr.dev/chainguard/wait-for-it:latest-20230113', 'ghcr.io/spiffe/spiffe-csi-driver:0.2.3',
-    'ghcr.io/spiffe/spire-agent:1.6.0', 'ghcr.io/spiffe/spire-controller-manager:0.2.2',
-    'ghcr.io/spiffe/spire-server:1.6.0', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2']
+  chart_version: 0.1.0
+  images: [busybox, 'cgr.dev/chainguard/wait-for-it:latest-20230113', 'ghcr.io/spiffe/spiffe-csi-driver:0.2.1',
+    'ghcr.io/spiffe/spire-agent:1.5.4', 'ghcr.io/spiffe/spire-server:1.5.4', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2']

--- a/static/compatibilities/spire.yaml
+++ b/static/compatibilities/spire.yaml
@@ -1,0 +1,146 @@
+icon: https://spiffe.io/img/logos/spire/icon/color/spire-icon-color.png
+git_url: https://github.com/spiffe/spire
+release_url: https://github.com/spiffe/spire/releases/tag/v{vsn}
+helm_repository_url: https://spiffe.github.io/helm-charts-hardened
+chart_name: spire
+readme_url: https://github.com/spiffe/spire/blob/main/README.md
+versions:
+- version: 1.15.3
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.30.1
+  images: ['busybox:1.37.0-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:90041f375e30f41aa7e0390075d8a69dc61900771d52fa98d63ee5d03d866a58',
+    'cgr.dev/chainguard/min-toolkit-debug:latest@sha256:9e45e6836c28489a6e57ca1210ec66927e88eca2409e403616a1278e210e86c9',
+    'docker.io/smallstep/step-cli:0.30.2', 'ghcr.io/spiffe/oidc-discovery-provider:1.15.3',
+    'ghcr.io/spiffe/spiffe-csi-driver:0.2.7', 'ghcr.io/spiffe/spiffe-helper:0.11.0',
+    'ghcr.io/spiffe/spire-agent:1.15.3', 'ghcr.io/spiffe/spire-controller-manager:0.7.0',
+    'ghcr.io/spiffe/spire-server:1.15.3', 'registry.k8s.io/kubectl:v1.36', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0']
+- version: 1.14.5
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.30.0
+  images: ['busybox:1.37.0-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:90041f375e30f41aa7e0390075d8a69dc61900771d52fa98d63ee5d03d866a58',
+    'cgr.dev/chainguard/min-toolkit-debug:latest@sha256:9e45e6836c28489a6e57ca1210ec66927e88eca2409e403616a1278e210e86c9',
+    'docker.io/smallstep/step-cli:0.30.2', 'ghcr.io/spiffe/oidc-discovery-provider:1.15.2',
+    'ghcr.io/spiffe/spiffe-csi-driver:0.2.7', 'ghcr.io/spiffe/spiffe-helper:0.11.0',
+    'ghcr.io/spiffe/spire-agent:1.15.2', 'ghcr.io/spiffe/spire-controller-manager:0.7.0',
+    'ghcr.io/spiffe/spire-server:1.15.2', 'registry.k8s.io/kubectl:v1.36', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.15.0']
+- version: 1.13.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.27.1
+  images: ['busybox:1.37.0-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:d965934bc289d795540aa1204f39b2586cd023cc9deb2695e4e284b21492c77c',
+    'cgr.dev/chainguard/min-toolkit-debug:latest@sha256:a24a6a1c506cd9fc5a2a3661294393fafe74b0a3993b11050179081be122b855',
+    'docker.io/smallstep/step-cli:0.28.7', 'ghcr.io/spiffe/oidc-discovery-provider:1.13.2',
+    'ghcr.io/spiffe/spiffe-csi-driver:0.2.7', 'ghcr.io/spiffe/spiffe-helper:0.11.0',
+    'ghcr.io/spiffe/spire-agent:1.13.2', 'ghcr.io/spiffe/spire-controller-manager:0.6.2',
+    'ghcr.io/spiffe/spire-server:1.13.2', 'registry.k8s.io/kubectl:v1.36', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4']
+- version: 1.12.4
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.26.1
+  images: ['busybox:1.37.0-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:809764150d09e67cc6ea8b7051555ff620381b7e900306d1374137a69855145b',
+    'cgr.dev/chainguard/min-toolkit-debug:latest@sha256:f3fdb9fb32e0dd9fe474e077047712044f6faa04a2f9a4fb3a91543b2736f6f4',
+    'docker.io/smallstep/step-cli:0.28.7', 'ghcr.io/spiffe/oidc-discovery-provider:1.12.4',
+    'ghcr.io/spiffe/spiffe-csi-driver:0.2.7', 'ghcr.io/spiffe/spiffe-helper:0.10.1',
+    'ghcr.io/spiffe/spire-agent:1.12.4', 'ghcr.io/spiffe/spire-controller-manager:0.6.2',
+    'ghcr.io/spiffe/spire-server:1.12.4', 'registry.k8s.io/kubectl:v1.36', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4']
+- version: 1.11.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.24.2
+  images: ['busybox:1.37.0-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:bcaf350e298d474d12901adf9a1e78d8cf470d4434a82e0c718d514fc2032fa7',
+    'cgr.dev/chainguard/min-toolkit-debug:latest@sha256:2f8ac6547029ed217bb40167bf39883b4bc606b3b747ecaf710fab9779ef786f',
+    'docker.io/rancher/kubectl:v1.36', 'docker.io/smallstep/step-cli:0.28.3', 'ghcr.io/spiffe/oidc-discovery-provider:1.11.2',
+    'ghcr.io/spiffe/spiffe-csi-driver:0.2.3', 'ghcr.io/spiffe/spiffe-helper:0.9.1',
+    'ghcr.io/spiffe/spire-agent:1.11.2', 'ghcr.io/spiffe/spire-controller-manager:0.6.0',
+    'ghcr.io/spiffe/spire-server:1.11.2', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4']
+- version: 1.10.3
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.23.0
+  images: ['busybox:1.36.1-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:f5c85affd2aa0f55fc1ead7dc07952577ad82741bbbba742ead0fd9dde2de14a',
+    'cgr.dev/chainguard/min-toolkit-debug:latest@sha256:5420e15d91112458fc573755954c9174dbf4db8d802c4de3aac18145f5a78a17',
+    'docker.io/rancher/kubectl:v1.36', 'docker.io/smallstep/step-cli:0.27.2', 'ghcr.io/spiffe/oidc-discovery-provider:1.10.3',
+    'ghcr.io/spiffe/spiffe-csi-driver:0.2.3', 'ghcr.io/spiffe/spiffe-helper:nightly@sha256:8cee346ffdcee5c996d394f1c3bb761c2c06834a0e779a78db6dc6a46fd13ae6',
+    'ghcr.io/spiffe/spire-agent:1.10.3', 'ghcr.io/spiffe/spire-controller-manager:0.5.0',
+    'ghcr.io/spiffe/spire-server:1.10.3', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4']
+- version: 1.9.6
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.21.0
+  images: ['busybox:1.36.1-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:8c9e5cbb641ced8112c637eb3611dab29bf65448a9d884a03938baf1b352dc4d',
+    'cgr.dev/chainguard/min-toolkit-debug:latest@sha256:d94454739d8be0239cfe93453df79c88d25d38b7a97084d81a49e9403a90d07c',
+    'docker.io/rancher/kubectl:v1.36', 'docker.io/smallstep/step-cli:0.26.1', 'ghcr.io/spiffe/oidc-discovery-provider:1.9.6',
+    'ghcr.io/spiffe/spiffe-csi-driver:0.2.3', 'ghcr.io/spiffe/spiffe-helper:nightly@sha256:8cee346ffdcee5c996d394f1c3bb761c2c06834a0e779a78db6dc6a46fd13ae6',
+    'ghcr.io/spiffe/spire-agent:1.9.6', 'ghcr.io/spiffe/spire-controller-manager:0.5.0',
+    'ghcr.io/spiffe/spire-server:1.9.6', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.4']
+- version: 1.8.7
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.2
+  images: ['busybox:1.36.1-uclibc', 'cgr.dev/chainguard/bash:latest@sha256:07d2662ef699e9ceafab3f39624083193dfcb7b768ee86860dbdd5cb4473dcea',
+    'cgr.dev/chainguard/bash:latest@sha256:1b4e8389d2582d0b013fad55d7ad799a67bbdcbfbae0a053258ae24c8b03a19f',
+    'cgr.dev/chainguard/slim-toolkit-debug:latest@sha256:9198d9e7e83ab4078df6f53dfa3e8e1e8f60d5718cc21fefa2ccb6604283e049',
+    'cgr.dev/chainguard/wait-for-it:latest@sha256:64ba1b49313924643dec6a03e15a1c6cfc24046cff96b0b3c0003cabbad2f60d',
+    'docker.io/rancher/kubectl:v1.36', 'docker.io/smallstep/step-cli:0.25.2', 'ghcr.io/spiffe/oidc-discovery-provider:1.8.7',
+    'ghcr.io/spiffe/spiffe-csi-driver:0.2.3', 'ghcr.io/spiffe/spiffe-helper:nightly@sha256:8cee346ffdcee5c996d394f1c3bb761c2c06834a0e779a78db6dc6a46fd13ae6',
+    'ghcr.io/spiffe/spire-agent:1.8.7', 'ghcr.io/spiffe/spire-controller-manager:0.4.2',
+    'ghcr.io/spiffe/spire-server:1.8.7', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.3']
+- version: 1.7.4
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.13.2
+  images: ['cgr.dev/chainguard/bash:latest@sha256:96ab1600d945b4a99c8610b5c8b31e346da63dc20573a26bb0777dd0190db5d4',
+    'cgr.dev/chainguard/wait-for-it:latest@sha256:deeaccb164a67a4d7f585c4d416641b1f422c029911a29d72beae28221f823df',
+    'docker.io/rancher/kubectl:v1.36', 'ghcr.io/spiffe/spiffe-csi-driver:0.2.3', 'ghcr.io/spiffe/spire-agent:1.7.4',
+    'ghcr.io/spiffe/spire-controller-manager:0.2.3', 'ghcr.io/spiffe/spire-server:1.7.4',
+    'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0']
+- version: 1.6.4
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.1
+  images: ['cgr.dev/chainguard/bash:latest', 'cgr.dev/chainguard/wait-for-it:latest-20230517',
+    'docker.io/rancher/kubectl:v1.36', 'ghcr.io/spiffe/spiffe-csi-driver:0.2.3', 'ghcr.io/spiffe/spire-agent:1.6.4',
+    'ghcr.io/spiffe/spire-controller-manager:0.2.2', 'ghcr.io/spiffe/spire-server:1.6.4',
+    'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0']
+- version: 1.5.5
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.5.0
+  images: [busybox, 'cgr.dev/chainguard/wait-for-it:latest-20230113', 'ghcr.io/spiffe/spiffe-csi-driver:0.2.3',
+    'ghcr.io/spiffe/spire-agent:1.6.0', 'ghcr.io/spiffe/spire-controller-manager:0.2.2',
+    'ghcr.io/spiffe/spire-server:1.6.0', 'registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.2']

--- a/utils/compatibility/scrapers/spire.py
+++ b/utils/compatibility/scrapers/spire.py
@@ -8,6 +8,7 @@ import yaml
 from utils import (
     current_kube_version,
     fetch_page,
+    get_chart_images,
     print_error,
     read_yaml,
     update_compatibility_info,
@@ -18,7 +19,8 @@ from utils import (
 
 APP_NAME = "spire"
 CHART_NAME = "spire"
-HELM_INDEX_URL = "https://spiffe.github.io/helm-charts-hardened/index.yaml"
+HELM_REPOSITORY_URL = "https://spiffe.github.io/helm-charts-hardened"
+HELM_INDEX_URL = f"{HELM_REPOSITORY_URL}/index.yaml"
 OUTPUT_PATH = f"../../static/compatibilities/{APP_NAME}.yaml"
 
 
@@ -119,6 +121,26 @@ def load_index(content):
         return None
 
 
+def _spire_workload_tags(images):
+    tags = set()
+
+    for image in images:
+        match = re.search(r"ghcr\.io/spiffe/spire-(?:server|agent):([^@]+)", image)
+        if match:
+            tags.add(match.group(1).lstrip("v"))
+
+    return tags
+
+
+def _chart_images_for_version(chart_version):
+    return get_chart_images(HELM_REPOSITORY_URL, CHART_NAME, chart_version) or []
+
+
+def _chart_matches_app_version(app_version, chart_version):
+    images = _chart_images_for_version(chart_version)
+    return _spire_workload_tags(images) == {app_version}, images
+
+
 def extract_rows(index_yaml, latest_kube):
     rows_by_version = {}
     entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
@@ -133,10 +155,14 @@ def extract_rows(index_yaml, latest_kube):
         if not kube_versions:
             continue
 
-        current = rows_by_version.get(app_version)
-        if current and validate_semver(chart_version) <= validate_semver(
-            current["chart_version"]
-        ):
+        if app_version in rows_by_version:
+            continue
+
+        matches_app_version, images = _chart_matches_app_version(
+            app_version,
+            chart_version,
+        )
+        if not matches_app_version:
             continue
 
         rows_by_version[app_version] = OrderedDict(
@@ -144,7 +170,7 @@ def extract_rows(index_yaml, latest_kube):
                 ("version", app_version),
                 ("kube", kube_versions),
                 ("chart_version", chart_version),
-                ("images", []),
+                ("images", images),
                 ("requirements", []),
                 ("incompatibilities", []),
             ]
@@ -187,9 +213,19 @@ def prune_stale_representatives(filepath, rows):
 
     keep = {row["version"] for row in rows}
     data["versions"] = [
-        version for version in data.get("versions", []) if version.get("version") in keep
+        version
+        for version in data.get("versions", [])
+        if version.get("version") in keep or _has_curated_metadata(version)
     ]
     write_yaml(filepath, data)
+
+
+def _has_curated_metadata(version):
+    return bool(
+        version.get("requirements")
+        or version.get("incompatibilities")
+        or version.get("summary")
+    )
 
 
 def scrape():

--- a/utils/compatibility/scrapers/spire.py
+++ b/utils/compatibility/scrapers/spire.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import yaml
+
+from utils import (
+    current_kube_version,
+    fetch_page,
+    print_error,
+    read_yaml,
+    update_compatibility_info,
+    validate_semver,
+    write_yaml,
+)
+
+
+APP_NAME = "spire"
+CHART_NAME = "spire"
+HELM_INDEX_URL = "https://spiffe.github.io/helm-charts-hardened/index.yaml"
+OUTPUT_PATH = f"../../static/compatibilities/{APP_NAME}.yaml"
+
+
+def _clean_version(version):
+    parsed = validate_semver(str(version).strip().lstrip("v"))
+    return str(parsed) if parsed else None
+
+
+def _minor(version):
+    parsed = validate_semver(version)
+    if not parsed:
+        return None
+    return f"{parsed.major}.{parsed.minor}"
+
+
+def _minor_bounds(version):
+    parsed = validate_semver(version)
+    if not parsed:
+        return None
+    return parsed.major, parsed.minor
+
+
+def _next_minor(major, minor):
+    return major, minor + 1
+
+
+def _version_tuple(major, minor, patch=0):
+    return int(major), int(minor), int(patch or 0)
+
+
+def _parse_constraints(spec):
+    normalized = spec.replace(",", " ")
+    constraints = []
+
+    for operator, major, minor, patch in re.findall(
+        r"(>=|<=|<|>|=)?\s*v?(\d+)\.(\d+)(?:\.(\d+))?",
+        normalized,
+    ):
+        constraints.append((operator or ">=", _version_tuple(major, minor, patch)))
+
+    return constraints
+
+
+def _minor_satisfies_constraints(major, minor, constraints):
+    start = (major, minor, 0)
+    end = (*_next_minor(major, minor), 0)
+
+    for operator, bound in constraints:
+        if operator in (">=", ">"):
+            if end <= bound:
+                return False
+        elif operator == "<":
+            if start >= bound:
+                return False
+        elif operator == "<=":
+            if start > bound:
+                return False
+        elif operator == "=":
+            if not (start <= bound < end):
+                return False
+
+    return True
+
+
+def parse_kube_constraint(spec, latest_kube):
+    if not spec or not latest_kube:
+        return []
+
+    latest = _minor_bounds(latest_kube)
+    if not latest:
+        return []
+
+    constraints = _parse_constraints(spec)
+    lower_bounds = [
+        (bound[0], bound[1])
+        for operator, bound in constraints
+        if operator in (">=", ">", "=")
+    ]
+    if not constraints or not lower_bounds:
+        return []
+
+    major, minor = max(lower_bounds)
+    kube_versions = []
+
+    while (major, minor) <= latest:
+        if _minor_satisfies_constraints(major, minor, constraints):
+            kube_versions.append(f"{major}.{minor}")
+        major, minor = _next_minor(major, minor)
+
+    return kube_versions
+
+
+def load_index(content):
+    try:
+        return yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        print_error(f"Failed to parse SPIRE Helm index: {exc}")
+        return None
+
+
+def extract_rows(index_yaml, latest_kube):
+    rows_by_version = {}
+    entries = index_yaml.get("entries", {}).get(CHART_NAME, [])
+
+    for entry in entries:
+        app_version = _clean_version(entry.get("appVersion", ""))
+        chart_version = _clean_version(entry.get("version", ""))
+        if not app_version or not chart_version:
+            continue
+
+        kube_versions = parse_kube_constraint(entry.get("kubeVersion", ""), latest_kube)
+        if not kube_versions:
+            continue
+
+        current = rows_by_version.get(app_version)
+        if current and validate_semver(chart_version) <= validate_semver(
+            current["chart_version"]
+        ):
+            continue
+
+        rows_by_version[app_version] = OrderedDict(
+            [
+                ("version", app_version),
+                ("kube", kube_versions),
+                ("chart_version", chart_version),
+                ("images", []),
+                ("requirements", []),
+                ("incompatibilities", []),
+            ]
+        )
+
+    rows = sorted(
+        rows_by_version.values(),
+        key=lambda row: validate_semver(row["version"]),
+        reverse=True,
+    )
+    return _representative_rows(rows)
+
+
+def _representative_rows(rows):
+    selected = []
+    seen = {}
+
+    for row in rows:
+        minor = _minor(row["version"])
+        if not minor:
+            continue
+
+        kube = tuple(row["kube"])
+        if minor not in seen:
+            selected.append(row)
+            seen[minor] = kube
+            continue
+
+        if seen[minor] != kube:
+            selected.append(row)
+            seen[minor] = kube
+
+    return selected
+
+
+def prune_stale_representatives(filepath, rows):
+    data = read_yaml(filepath)
+    if not data or "versions" not in data:
+        return
+
+    keep = {row["version"] for row in rows}
+    data["versions"] = [
+        version for version in data.get("versions", []) if version.get("version") in keep
+    ]
+    write_yaml(filepath, data)
+
+
+def scrape():
+    latest_kube = current_kube_version()
+    if not latest_kube:
+        print_error("Could not determine current Kubernetes version from KUBE_VERSION.")
+        return
+
+    content = fetch_page(HELM_INDEX_URL)
+    if not content:
+        return
+
+    index_yaml = load_index(content)
+    if not index_yaml:
+        return
+
+    rows = extract_rows(index_yaml, latest_kube)
+    if not rows:
+        print_error("No SPIRE versions extracted from Helm index.")
+        return
+
+    prune_stale_representatives(OUTPUT_PATH, rows)
+    update_compatibility_info(OUTPUT_PATH, rows)

--- a/utils/compatibility/tests/test_spire.py
+++ b/utils/compatibility/tests/test_spire.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+COMPATIBILITY_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = COMPATIBILITY_DIR / "scrapers" / "spire.py"
+sys.path.insert(0, str(COMPATIBILITY_DIR))
+
+utils_spec = importlib.util.spec_from_file_location("utils", COMPATIBILITY_DIR / "utils.py")
+compat_utils = importlib.util.module_from_spec(utils_spec)
+assert utils_spec.loader is not None
+utils_spec.loader.exec_module(compat_utils)
+
+utils_module = sys.modules.get("utils")
+if utils_module is None:
+    sys.modules["utils"] = compat_utils
+else:
+    for name in (
+        "current_kube_version",
+        "fetch_page",
+        "print_error",
+        "read_yaml",
+        "update_compatibility_info",
+        "validate_semver",
+        "write_yaml",
+    ):
+        setattr(utils_module, name, getattr(compat_utils, name))
+
+spec = importlib.util.spec_from_file_location("spire", MODULE_PATH)
+spire = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(spire)
+
+
+class SpireScraperTest(unittest.TestCase):
+    def test_parse_kube_constraint_expands_minimum_to_current_kubernetes(self):
+        self.assertEqual(
+            spire.parse_kube_constraint(">=1.21.0-0", "1.36"),
+            [
+                "1.21",
+                "1.22",
+                "1.23",
+                "1.24",
+                "1.25",
+                "1.26",
+                "1.27",
+                "1.28",
+                "1.29",
+                "1.30",
+                "1.31",
+                "1.32",
+                "1.33",
+                "1.34",
+                "1.35",
+                "1.36",
+            ],
+        )
+
+    def test_parse_kube_constraint_keeps_patch_overlap(self):
+        self.assertEqual(
+            spire.parse_kube_constraint(">=1.21.0 <1.24.1", "1.36"),
+            ["1.21", "1.22", "1.23", "1.24"],
+        )
+        self.assertEqual(
+            spire.parse_kube_constraint(">1.21.0 <=1.23.0", "1.36"),
+            ["1.21", "1.22", "1.23"],
+        )
+
+    def test_extract_rows_uses_spire_chart_and_newest_chart_for_app_version(self):
+        index_yaml = {
+            "entries": {
+                "spire-agent": [
+                    {
+                        "version": "0.30.1",
+                        "appVersion": "1.15.3",
+                        "kubeVersion": ">=1.21.0-0",
+                    }
+                ],
+                "spire": [
+                    {
+                        "version": "0.30.1",
+                        "appVersion": "1.15.3",
+                        "kubeVersion": ">=1.21.0-0",
+                    },
+                    {
+                        "version": "0.30.0",
+                        "appVersion": "1.14.5",
+                        "kubeVersion": ">=1.21.0-0",
+                    },
+                    {
+                        "version": "0.29.0",
+                        "appVersion": "1.14.5",
+                        "kubeVersion": ">=1.21.0-0",
+                    },
+                    {
+                        "version": "0.28.0-rc.1",
+                        "appVersion": "1.14.1-rc.1",
+                        "kubeVersion": ">=1.21.0-0",
+                    },
+                    {
+                        "version": "0.20.0",
+                        "appVersion": "1.8.7",
+                        "kubeVersion": ">=1.19.0-0",
+                    },
+                ],
+            }
+        }
+
+        rows = spire.extract_rows(index_yaml, "1.36")
+
+        self.assertEqual(
+            [row["version"] for row in rows],
+            ["1.15.3", "1.14.5", "1.8.7"],
+        )
+        self.assertEqual(
+            [row["chart_version"] for row in rows],
+            ["0.30.1", "0.30.0", "0.20.0"],
+        )
+        self.assertEqual(rows[0]["kube"][0], "1.21")
+        self.assertEqual(rows[0]["kube"][-1], "1.36")
+        self.assertEqual(rows[-1]["kube"][0], "1.19")
+
+    def test_representative_rows_keep_kubernetes_semantic_changes(self):
+        rows = [
+            {"version": "1.15.3", "kube": ["1.21", "1.22"], "chart_version": "0.30.1"},
+            {"version": "1.15.2", "kube": ["1.21", "1.22"], "chart_version": "0.30.0"},
+            {"version": "1.15.1", "kube": ["1.19", "1.20"], "chart_version": "0.29.0"},
+        ]
+
+        selected = spire._representative_rows(rows)
+
+        self.assertEqual([row["version"] for row in selected], ["1.15.3", "1.15.1"])
+
+    def test_prune_stale_representatives_removes_old_patch_rows(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "spire.yaml"
+            path.write_text(
+                """
+versions:
+- version: 1.15.2
+  summary: old
+- version: 1.15.3
+  summary: current
+""",
+                encoding="utf-8",
+            )
+
+            spire.prune_stale_representatives(path, [{"version": "1.15.3"}])
+
+            self.assertNotIn("1.15.2", path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_spire.py
+++ b/utils/compatibility/tests/test_spire.py
@@ -23,6 +23,7 @@ else:
     for name in (
         "current_kube_version",
         "fetch_page",
+        "get_chart_images",
         "print_error",
         "read_yaml",
         "update_compatibility_info",
@@ -111,7 +112,30 @@ class SpireScraperTest(unittest.TestCase):
             }
         }
 
-        rows = spire.extract_rows(index_yaml, "1.36")
+        original = spire._chart_images_for_version
+        spire._chart_images_for_version = lambda version: {
+            "0.30.1": [
+                "ghcr.io/spiffe/spire-server:1.15.3",
+                "ghcr.io/spiffe/spire-agent:1.15.3",
+            ],
+            "0.30.0": [
+                "ghcr.io/spiffe/spire-server:1.15.2",
+                "ghcr.io/spiffe/spire-agent:1.15.2",
+            ],
+            "0.29.0": [
+                "ghcr.io/spiffe/spire-server:1.14.5",
+                "ghcr.io/spiffe/spire-agent:1.14.5",
+            ],
+            "0.28.0-rc.1": ["ghcr.io/spiffe/spire-server:1.14.1-rc.1"],
+            "0.20.0": [
+                "ghcr.io/spiffe/spire-server:1.8.7",
+                "ghcr.io/spiffe/spire-agent:1.8.7",
+            ],
+        }.get(version, [])
+        try:
+            rows = spire.extract_rows(index_yaml, "1.36")
+        finally:
+            spire._chart_images_for_version = original
 
         self.assertEqual(
             [row["version"] for row in rows],
@@ -119,7 +143,7 @@ class SpireScraperTest(unittest.TestCase):
         )
         self.assertEqual(
             [row["chart_version"] for row in rows],
-            ["0.30.1", "0.30.0", "0.20.0"],
+            ["0.30.1", "0.29.0", "0.20.0"],
         )
         self.assertEqual(rows[0]["kube"][0], "1.21")
         self.assertEqual(rows[0]["kube"][-1], "1.36")
@@ -143,7 +167,7 @@ class SpireScraperTest(unittest.TestCase):
                 """
 versions:
 - version: 1.15.2
-  summary: old
+  summary: null
 - version: 1.15.3
   summary: current
 """,
@@ -153,6 +177,24 @@ versions:
             spire.prune_stale_representatives(path, [{"version": "1.15.3"}])
 
             self.assertNotIn("1.15.2", path.read_text(encoding="utf-8"))
+
+    def test_prune_stale_representatives_preserves_curated_rows(self):
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "spire.yaml"
+            path.write_text(
+                """
+versions:
+- version: 1.15.2
+  requirements: [manual note]
+- version: 1.15.3
+  summary: current
+""",
+                encoding="utf-8",
+            )
+
+            spire.prune_stale_representatives(path, [{"version": "1.15.3"}])
+
+            self.assertIn("1.15.2", path.read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds SPIRE compatibility data and a scraper that reads the SPIRE Helm chart index, keeps representative rows for Kubernetes support changes, and validates chart image metadata for the selected chart versions.

Verification:
- `python -m unittest tests.test_spire -v` from `utils/compatibility` — 6 tests passed.
- `SCRAPER=spire python main.py` from `utils/compatibility` with Helm v4.2.4 on PATH — updated the SPIRE compatibility file locally. The run used the cached Kubernetes version because `cdn.dl.k8s.io` DNS failed in my Windows environment, and skipped summary generation because `OPENAI_API_KEY`/`EXA_API_KEY` were not set.

Source documentation:
- https://github.com/spiffe/helm-charts-hardened
- https://spiffe.github.io/helm-charts-hardened/index.yaml
