### PR TITLE
feat: add Tetragon compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -9,6 +9,7 @@ names:
 - calico
 - cert-manager
 - cilium
+- tetragon
 - chaos-mesh
 - contour
 - coredns

--- a/static/compatibilities/tetragon.yaml
+++ b/static/compatibilities/tetragon.yaml
@@ -1,0 +1,91 @@
+icon: https://tetragon.io/images/tetragon-shield.png
+git_url: https://github.com/cilium/tetragon
+release_url: https://github.com/cilium/tetragon/releases/tag/v{vsn}
+helm_repository_url: https://helm.cilium.io
+chart_name: tetragon
+versions:
+- version: 1.7.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.7.1
+  images: []
+- version: 1.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.7.0
+  images: []
+- version: 1.6.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.6.1
+  images: []
+- version: 1.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.6.0
+  images: []
+- version: 1.5.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.0
+  images: []
+- version: 1.4.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.4.1
+  images: []
+- version: 1.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.4.0
+  images: []
+- version: 1.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.0
+  images: []
+- version: 1.2.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.1
+  images: []
+- version: 1.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.0
+  images: []
+- version: 1.1.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.2
+  images: []
+- version: 1.1.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.0
+  images: []
+name: tetragon

--- a/utils/compatibility/scrapers/tetragon.py
+++ b/utils/compatibility/scrapers/tetragon.py
@@ -1,0 +1,221 @@
+"""Build Tetragon compatibility rows from release-tagged upstream sources."""
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import yaml
+from packaging.version import InvalidVersion, Version
+
+
+APP_NAME = "tetragon"
+CHART_NAME = "tetragon"
+HELM_INDEX_URL = "https://helm.cilium.io/index.yaml"
+CHART_URL = (
+    "https://raw.githubusercontent.com/cilium/tetragon/"
+    "{tag}/install/kubernetes/tetragon/Chart.yaml"
+)
+VERSION_URL = (
+    "https://raw.githubusercontent.com/cilium/tetragon/"
+    "{tag}/pkg/k8s/version/version.go"
+)
+OUTPUT_PATH = f"../../static/compatibilities/{APP_NAME}.yaml"
+
+_MINIMUM_VERSION_RE = re.compile(
+    r"\bMinimalVersionConstraint\s*=\s*[\"'](v?\d+\.\d+\.\d+)[\"']"
+)
+
+
+def _decode(payload: bytes | str, source: str) -> str:
+    if isinstance(payload, bytes):
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"Could not decode {source}") from exc
+    if isinstance(payload, str):
+        return payload
+    raise ValueError(f"Unexpected {source} payload type")
+
+
+def _stable_version(value: object) -> Version | None:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip().lstrip("v")
+    try:
+        parsed = Version(raw)
+    except InvalidVersion:
+        return None
+    if parsed.is_prerelease or parsed.is_devrelease:
+        return None
+    return parsed
+
+
+def _release_version(value: object) -> str | None:
+    raw = value[0] if isinstance(value, (tuple, list)) else value
+    parsed = _stable_version(raw)
+    return str(parsed) if parsed else None
+
+
+def parse_chart_identity(content: bytes | str) -> tuple[str, str]:
+    """Return the stable chart and application versions from Chart.yaml."""
+    text = _decode(content, "Tetragon Chart.yaml")
+    try:
+        chart = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ValueError("Could not parse Tetragon Chart.yaml") from exc
+
+    if not isinstance(chart, dict):
+        raise ValueError("Unexpected Tetragon Chart.yaml structure")
+
+    name = chart.get("name")
+    chart_version = _stable_version(chart.get("version"))
+    app_version = _stable_version(chart.get("appVersion"))
+    if (
+        name != CHART_NAME
+        or not chart_version
+        or not app_version
+        or chart_version != app_version
+    ):
+        raise ValueError("Tetragon chart identity is incomplete or unstable")
+    return str(chart_version), str(app_version)
+
+
+def parse_chart_index(content: bytes | str) -> dict[str, str]:
+    """Map stable Tetragon application versions to their chart versions."""
+    text = _decode(content, "Tetragon Helm index")
+    try:
+        index = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ValueError("Could not parse Tetragon Helm index") from exc
+
+    entries = (
+        index.get("entries", {}).get(CHART_NAME)
+        if isinstance(index, dict)
+        else None
+    )
+    if not isinstance(entries, list):
+        raise ValueError("Tetragon Helm chart entries not found")
+
+    versions: dict[str, tuple[Version, str]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Malformed Tetragon Helm chart entry")
+        chart_version = _stable_version(entry.get("version"))
+        app_version = _stable_version(entry.get("appVersion"))
+        if not chart_version or not app_version:
+            continue
+        app_key = str(app_version)
+        current = versions.get(app_key)
+        if current is None or chart_version > current[0]:
+            versions[app_key] = (chart_version, str(chart_version))
+
+    if not versions:
+        raise ValueError("No stable Tetragon Helm chart entries found")
+    return {app: chart for app, (_, chart) in versions.items()}
+
+
+def parse_minimum_kubernetes(content: bytes | str) -> str:
+    """Read Tetragon's release-tagged minimum Kubernetes minor version."""
+    text = _decode(content, "Tetragon version source")
+    match = _MINIMUM_VERSION_RE.search(text)
+    if not match:
+        raise ValueError("Tetragon minimum Kubernetes constraint not found")
+
+    version = _stable_version(match.group(1))
+    if not version or version.major != 1:
+        raise ValueError("Tetragon minimum Kubernetes constraint is invalid")
+    return f"{version.major}.{version.minor}"
+
+
+def _minor_number(value: str) -> int:
+    match = re.fullmatch(r"1\.(\d+)", value.strip().lstrip("v"))
+    if not match:
+        raise ValueError(f"Unsupported Kubernetes minor version: {value!r}")
+    return int(match.group(1))
+
+
+def expand_minimum(minimum: str, current: str) -> list[str]:
+    """Expand a documented floor through Plural's current Kubernetes ceiling."""
+    start = _minor_number(minimum)
+    end = _minor_number(current)
+    if start > end:
+        raise ValueError(
+            f"Tetragon minimum Kubernetes {minimum} is newer than Plural {current}"
+        )
+    return [f"1.{minor}" for minor in range(end, start - 1, -1)]
+
+
+def stable_releases(releases) -> list[str]:
+    """Return unique stable release versions, newest first."""
+    versions = {_release_version(release) for release in releases}
+    versions.discard(None)
+    return sorted(versions, key=Version, reverse=True)
+
+
+def build_rows(releases, chart_index, fetcher, current_kube: str) -> list[OrderedDict]:
+    """Build rows only when release, chart, and source evidence agree."""
+    charts = (
+        parse_chart_index(chart_index)
+        if not isinstance(chart_index, dict)
+        else chart_index
+    )
+    rows: list[OrderedDict] = []
+
+    for version in stable_releases(releases):
+        chart_version = charts.get(version)
+        if not chart_version:
+            continue
+
+        tag = f"v{version}"
+        chart = fetcher(CHART_URL.format(tag=tag))
+        source = fetcher(VERSION_URL.format(tag=tag))
+        if not chart or not source:
+            # A missing source is not evidence for compatibility. Preserve the
+            # ability to process other release tags instead of guessing.
+            continue
+
+        tagged_chart, tagged_app = parse_chart_identity(chart)
+        if tagged_app != version or tagged_chart != chart_version:
+            raise ValueError(
+                "Tetragon release/chart identity mismatch for "
+                f"{version}: index {chart_version}, tag {tagged_chart}/{tagged_app}"
+            )
+
+        minimum = parse_minimum_kubernetes(source)
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", version),
+                    ("kube", expand_minimum(minimum, current_kube)),
+                    ("chart_version", chart_version),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    if not rows:
+        raise ValueError("No chart-backed Tetragon compatibility rows generated")
+    return rows
+
+
+def scrape() -> None:
+    from utils import (
+        current_kube_version,
+        fetch_page,
+        get_github_releases_timestamps,
+        update_compatibility_info,
+    )
+
+    index = fetch_page(HELM_INDEX_URL)
+    if not index:
+        raise ValueError("Could not fetch the official Tetragon Helm index")
+
+    current = current_kube_version()
+    if not current:
+        raise ValueError("Plural current Kubernetes version is unavailable")
+
+    releases = get_github_releases_timestamps("cilium", "tetragon")
+    rows = build_rows(releases, index, fetch_page, current)
+    update_compatibility_info(OUTPUT_PATH, rows)

--- a/utils/compatibility/tests/test_tetragon.py
+++ b/utils/compatibility/tests/test_tetragon.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+import importlib.util
+import sys
+import unittest
+from types import ModuleType
+from unittest.mock import Mock, patch
+
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+spec = importlib.util.spec_from_file_location(
+    "tetragon_scraper", COMPATIBILITY / "scrapers/tetragon.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(scraper)
+
+
+INDEX = """apiVersion: v1
+entries:
+  tetragon:
+  - version: 1.7.1
+    appVersion: 1.7.1
+  - version: 1.7.0
+    appVersion: 1.7.0
+  - version: 1.7.0-rc.1
+    appVersion: 1.7.0-rc.1
+"""
+
+CHART = """apiVersion: v2
+name: tetragon
+version: 1.7.1
+appVersion: 1.7.1
+"""
+
+CHART_170 = CHART.replace("1.7.1", "1.7.0")
+SOURCE = 'const (\n\tMinimalVersionConstraint = "1.16.0"\n)\n'
+SOURCE_170 = 'const (\n\tMinimalVersionConstraint = "1.20.0"\n)\n'
+
+
+class TetragonScraperTests(unittest.TestCase):
+    def test_chart_identity_requires_matching_stable_versions(self):
+        self.assertEqual(scraper.parse_chart_identity(CHART), ("1.7.1", "1.7.1"))
+        with self.assertRaisesRegex(ValueError, "identity"):
+            scraper.parse_chart_identity(
+                "name: tetragon\nversion: 1.7.1\nappVersion: 1.7.0\n"
+            )
+        with self.assertRaisesRegex(ValueError, "identity"):
+            scraper.parse_chart_identity(
+                "name: other\nversion: 1.7.1\nappVersion: 1.7.1\n"
+            )
+
+    def test_chart_index_ignores_prereleases(self):
+        self.assertEqual(
+            scraper.parse_chart_index(INDEX),
+            {"1.7.1": "1.7.1", "1.7.0": "1.7.0"},
+        )
+
+    def test_minimum_parser_requires_the_release_constant(self):
+        self.assertEqual(scraper.parse_minimum_kubernetes(SOURCE), "1.16")
+        with self.assertRaisesRegex(ValueError, "constraint not found"):
+            scraper.parse_minimum_kubernetes('const Other = "1.16.0"')
+
+    def test_expand_minimum_is_descending_and_bounded(self):
+        self.assertEqual(
+            scraper.expand_minimum("1.16", "1.36"),
+            [f"1.{minor}" for minor in range(36, 15, -1)],
+        )
+        with self.assertRaisesRegex(ValueError, "newer than Plural"):
+            scraper.expand_minimum("1.37", "1.36")
+
+    def test_stable_releases_are_unique_and_newest_first(self):
+        self.assertEqual(
+            scraper.stable_releases(
+                [("v1.7.0", 1), "v1.7.1", "v1.7.1-rc.1", "bad"]
+            ),
+            ["1.7.1", "1.7.0"],
+        )
+
+    def test_build_rows_uses_tagged_sources_and_chart_identity(self):
+        sources = {
+            scraper.CHART_URL.format(tag="v1.7.1"): CHART.encode(),
+            scraper.VERSION_URL.format(tag="v1.7.1"): SOURCE.encode(),
+            scraper.CHART_URL.format(tag="v1.7.0"): CHART_170.encode(),
+            scraper.VERSION_URL.format(tag="v1.7.0"): SOURCE_170.encode(),
+        }
+        rows = scraper.build_rows(
+            ["v1.7.1", "v1.7.0"],
+            INDEX,
+            sources.get,
+            "1.36",
+        )
+        self.assertEqual([row["version"] for row in rows], ["1.7.1", "1.7.0"])
+        self.assertEqual(rows[0]["chart_version"], "1.7.1")
+        self.assertEqual(rows[0]["kube"][0], "1.36")
+        self.assertEqual(rows[0]["kube"][-1], "1.16")
+        self.assertEqual(rows[1]["kube"][-1], "1.20")
+
+    def test_build_rows_rejects_index_and_tag_mismatch(self):
+        bad_chart = CHART.replace("version: 1.7.1", "version: 1.7.0")
+        sources = {
+            scraper.CHART_URL.format(tag="v1.7.1"): bad_chart.encode(),
+            scraper.VERSION_URL.format(tag="v1.7.1"): SOURCE.encode(),
+        }
+        with self.assertRaisesRegex(ValueError, "identity"):
+            scraper.build_rows(["v1.7.1"], INDEX, sources.get, "1.36")
+
+    def test_scrape_wires_official_sources(self):
+        helpers = ModuleType("utils")
+        helpers.current_kube_version = Mock(return_value="1.36")
+        helpers.get_github_releases_timestamps = Mock(return_value=[("v1.7.1", 1)])
+        helpers.update_compatibility_info = Mock()
+
+        def fetch(url):
+            if url == scraper.HELM_INDEX_URL:
+                return INDEX.encode()
+            return {
+                scraper.CHART_URL.format(tag="v1.7.1"): CHART.encode(),
+                scraper.VERSION_URL.format(tag="v1.7.1"): SOURCE.encode(),
+            }.get(url)
+
+        helpers.fetch_page = Mock(side_effect=fetch)
+        previous = sys.modules.get("utils")
+        try:
+            with patch.dict(sys.modules, {"utils": helpers}):
+                scraper.scrape()
+        finally:
+            if previous is None:
+                sys.modules.pop("utils", None)
+            else:
+                sys.modules["utils"] = previous
+
+        helpers.update_compatibility_info.assert_called_once()
+        path, rows = helpers.update_compatibility_info.call_args.args
+        self.assertEqual(path, scraper.OUTPUT_PATH)
+        self.assertEqual(rows[0]["version"], "1.7.1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds Cilium Tetragon to the Plural compatibility catalog with a release-pinned scraper and generated compatibility data.

Related to #4204.

## Implementation

- Registers `tetragon` in `static/compatibilities/manifest.yaml`.
- Adds the official Helm metadata and 12 stable chart-backed Tetragon releases in `static/compatibilities/tetragon.yaml`.
- Adds `utils/compatibility/scrapers/tetragon.py`.
  - Reads stable Tetragon release tags and the official Cilium Helm index.
  - Requires exact chart/application identity at each release tag.
  - Reads each tag's `MinimalVersionConstraint` from `pkg/k8s/version/version.go`.
  - Expands only the documented minimum through Plural's current Kubernetes ceiling.
  - Skips prereleases and missing source evidence, and fails closed on malformed or mismatched metadata.
- Adds focused offline regression tests for parser behavior, release-specific floors, source mismatches, prerelease filtering, and scraper wiring.

## Source evidence

- Tetragon v1.7.1 chart: https://github.com/cilium/tetragon/blob/v1.7.1/install/kubernetes/tetragon/Chart.yaml
- Tetragon v1.7.1 Kubernetes constraint: https://github.com/cilium/tetragon/blob/v1.7.1/pkg/k8s/version/version.go
- Official chart index: https://helm.cilium.io/index.yaml

## Test plan

- `python -m unittest discover -s tests -p 'test_*.py'` (109 tests pass locally)
- Live source comparison confirms all 12 checked-in rows against the upstream release tags and chart index.
- Compatibility YAML and manifest validate against `static/compatibilities/schema.json`.
- No live Helm rendering was performed locally because Helm is not installed; this change adds compatibility metadata and scraper logic, not agent/runtime code.

The issue describes this as the published `$300` new-scraper contributor tier. Please confirm that this scope qualifies and confirm an accepted payment rail through the documented Discord process before treating the reward as earned; no payment is assumed by this PR.

Plural Flow: console
