### PR TITLE
feat: add VolSync Helm compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,123 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://raw.githubusercontent.com/backube/volsync/main/docs/media/volsync.svg
+  git_url: https://github.com/backube/volsync
+  release_url: https://github.com/backube/volsync/releases/tag/v{vsn}
+  helm_repository_url: https://backube.github.io/helm-charts
+  readme_url: https://volsync.readthedocs.io/en/stable/installation/index.html
+  versions:
+  - version: 0.16.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.16.0
+    images: ['quay.io/backube/volsync:0.16.0']
+  - version: 0.15.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.15.0
+    images: ['quay.io/backube/volsync:0.15.0']
+  - version: 0.14.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.14.0
+    images: ['quay.io/backube/volsync:0.14.0', 'quay.io/brancz/kube-rbac-proxy:v0.19.0']
+  - version: 0.13.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.13.0
+    images: ['quay.io/backube/volsync:0.13.0', 'quay.io/brancz/kube-rbac-proxy:v0.19.0']
+  - version: 0.12.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.12.0
+    images: ['quay.io/backube/volsync:0.12.0', 'quay.io/brancz/kube-rbac-proxy:v0.18.2']
+  - version: 0.11.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.11.0
+    images: ['quay.io/backube/volsync:0.11.0', 'quay.io/brancz/kube-rbac-proxy:v0.18.0']
+  - version: 0.10.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.10.0
+    images: ['quay.io/backube/volsync:0.10.0', 'quay.io/brancz/kube-rbac-proxy:v0.17.1']
+  - version: 0.9.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.9.0
+    images: ['quay.io/backube/volsync:0.9.0', 'quay.io/brancz/kube-rbac-proxy:v0.14.0']
+  - version: 0.8.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.8.0
+    images: ['quay.io/backube/volsync:0.8.0', 'quay.io/brancz/kube-rbac-proxy:v0.14.0']
+  - version: 0.7.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.7.0
+    images: ['quay.io/backube/volsync:0.7.0', 'quay.io/brancz/kube-rbac-proxy:v0.14.0']
+  - version: 0.6.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.6.0
+    images: ['quay.io/backube/volsync:0.6.0', 'quay.io/brancz/kube-rbac-proxy:v0.13.1']
+  - version: 0.5.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.5.0
+    images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'quay.io/backube/volsync:0.5.0']
+  - version: 0.4.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.4.0
+    images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0', 'quay.io/backube/volsync:0.4.0']
+  - version: 0.3.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.3.0
+    images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0', 'quay.io/backube/volsync:0.3.0']
+  name: volsync

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- volsync

--- a/static/compatibilities/volsync.yaml
+++ b/static/compatibilities/volsync.yaml
@@ -1,0 +1,118 @@
+icon: https://raw.githubusercontent.com/backube/volsync/main/docs/media/volsync.svg
+git_url: https://github.com/backube/volsync
+release_url: https://github.com/backube/volsync/releases/tag/v{vsn}
+helm_repository_url: https://backube.github.io/helm-charts
+readme_url: https://volsync.readthedocs.io/en/stable/installation/index.html
+versions:
+- version: 0.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.0
+  images: ['quay.io/backube/volsync:0.16.0']
+- version: 0.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.0
+  images: ['quay.io/backube/volsync:0.15.0']
+- version: 0.14.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.0
+  images: ['quay.io/backube/volsync:0.14.0', 'quay.io/brancz/kube-rbac-proxy:v0.19.0']
+- version: 0.13.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.13.0
+  images: ['quay.io/backube/volsync:0.13.0', 'quay.io/brancz/kube-rbac-proxy:v0.19.0']
+- version: 0.12.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.0
+  images: ['quay.io/backube/volsync:0.12.0', 'quay.io/brancz/kube-rbac-proxy:v0.18.2']
+- version: 0.11.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.11.0
+  images: ['quay.io/backube/volsync:0.11.0', 'quay.io/brancz/kube-rbac-proxy:v0.18.0']
+- version: 0.10.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.0
+  images: ['quay.io/backube/volsync:0.10.0', 'quay.io/brancz/kube-rbac-proxy:v0.17.1']
+- version: 0.9.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.9.0
+  images: ['quay.io/backube/volsync:0.9.0', 'quay.io/brancz/kube-rbac-proxy:v0.14.0']
+- version: 0.8.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.0
+  images: ['quay.io/backube/volsync:0.8.0', 'quay.io/brancz/kube-rbac-proxy:v0.14.0']
+- version: 0.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.7.0
+  images: ['quay.io/backube/volsync:0.7.0', 'quay.io/brancz/kube-rbac-proxy:v0.14.0']
+- version: 0.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.6.0
+  images: ['quay.io/backube/volsync:0.6.0', 'quay.io/brancz/kube-rbac-proxy:v0.13.1']
+- version: 0.5.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.5.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'quay.io/backube/volsync:0.5.0']
+- version: 0.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.4.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0', 'quay.io/backube/volsync:0.4.0']
+- version: 0.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.3.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0', 'quay.io/backube/volsync:0.3.0']

--- a/utils/compatibility/scrapers/volsync.py
+++ b/utils/compatibility/scrapers/volsync.py
@@ -1,0 +1,94 @@
+"""VolSync's published Helm installation constraints, not a runtime test matrix."""
+
+import re
+from collections import OrderedDict
+
+import yaml
+
+APP_NAME = "volsync"
+INDEX_URL = "https://backube.github.io/helm-charts/index.yaml"
+OUTPUT_PATH = "../../static/compatibilities/volsync.yaml"
+
+
+def stable_version(value):
+    """Only accept full stable semantic versions; exclude RCs and build variants."""
+    if not isinstance(value, str):
+        return None
+    match = re.fullmatch(r"v?((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))", value)
+    return match.group(1) if match else None
+
+
+def version_key(value):
+    return tuple(int(part) for part in value.split("."))
+
+
+def declared_kube_versions(constraint, current):
+    """Expand VolSync's published caret constraints only through Plural's cap.
+
+    Helm's ^1.N.0-0 includes stable 1.N.0 and later 1.x releases, but not 2.x.
+    Refuse other syntax instead of silently losing an upper bound or patch floor.
+    This expresses chart eligibility; it does not certify storage or CSI support.
+    """
+    match = re.fullmatch(r"\^1\.(0|[1-9]\d*)\.0-0", str(constraint))
+    cap = re.fullmatch(r"1\.(0|[1-9]\d*)", str(current))
+    if not match:
+        raise ValueError(f"Unsupported VolSync kubeVersion constraint: {constraint!r}")
+    if not cap:
+        raise ValueError(f"Unsupported Plural Kubernetes version: {current!r}")
+    minimum, maximum = int(match.group(1)), int(cap.group(1))
+    if minimum > maximum:
+        raise ValueError("VolSync minimum Kubernetes version exceeds Plural's cap")
+    return [f"1.{minor}" for minor in range(maximum, minimum - 1, -1)]
+
+
+def build_rows(content, current):
+    try:
+        index = yaml.safe_load(content)
+    except (yaml.YAMLError, UnicodeError) as exc:
+        raise ValueError("Could not parse VolSync Helm index") from exc
+    entries = index.get("entries") if isinstance(index, dict) else None
+    charts = entries.get(APP_NAME) if isinstance(entries, dict) else None
+    if not isinstance(charts, list) or not charts:
+        raise ValueError("VolSync chart entries not found")
+
+    selected = {}
+    seen = {}
+    for chart in charts:
+        if not isinstance(chart, dict):
+            raise ValueError("Malformed VolSync chart entry")
+        app_version = stable_version(chart.get("appVersion"))
+        chart_version = stable_version(chart.get("version"))
+        if not app_version or not chart_version:
+            continue
+        constraint = chart.get("kubeVersion")
+        # A duplicate chart version with different metadata is ambiguous.
+        identity = (app_version, constraint)
+        if chart_version in seen and seen[chart_version] != identity:
+            raise ValueError(f"Conflicting VolSync chart metadata for {chart_version}")
+        seen[chart_version] = identity
+        kube = declared_kube_versions(constraint, current)
+        previous = selected.get(app_version)
+        if previous and version_key(previous["chart_version"]) >= version_key(chart_version):
+            continue
+        selected[app_version] = OrderedDict([
+            ("version", app_version),
+            ("kube", kube),
+            ("chart_version", chart_version),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ])
+
+    if not selected:
+        raise ValueError("No stable VolSync compatibility rows generated")
+    return [selected[version] for version in sorted(selected, key=version_key, reverse=True)]
+
+
+def scrape():
+    from utils import current_kube_version, fetch_page, update_compatibility_info
+
+    content = fetch_page(INDEX_URL)
+    if not content:
+        raise ValueError("Could not fetch VolSync Helm index; existing data unchanged")
+    # Validate every selected source row before calling the shared writer.
+    rows = build_rows(content, current_kube_version())
+    update_compatibility_info(OUTPUT_PATH, rows)

--- a/utils/compatibility/tests/VOLSYNC.md
+++ b/utils/compatibility/tests/VOLSYNC.md
@@ -1,0 +1,66 @@
+# VolSync compatibility source and tests
+
+The scraper reads the official [Backube Helm index](https://backube.github.io/helm-charts/index.yaml).
+It records the Kubernetes installation constraint declared by each published chart.
+This is not a matrix of Kubernetes versions tested by VolSync, nor a guarantee
+that a cluster has the required storage capabilities.
+
+The [v0.16.0 chart](https://github.com/backube/volsync/blob/v0.16.0/helm/volsync/Chart.yaml)
+declares `^1.20.0-0`. The historical
+[v0.3.0 chart](https://github.com/backube/volsync/blob/v0.3.0/helm/volsync/Chart.yaml)
+declares `^1.17.0-0`. For these caret constraints, the scraper enumerates stable
+Kubernetes 1.x minors from the declared floor through this repository's
+`KUBE_VERSION`. It rejects other constraint syntax instead of dropping a possible
+upper bound or patch requirement. The `-0` permits Kubernetes prereleases in
+Helm; the compatibility table itself contains only stable minor numbers.
+
+The [installation documentation](https://volsync.readthedocs.io/en/stable/installation/index.html)
+requires a snapshot controller and describes CSI snapshot/clone prerequisites.
+Those requirements are independent of the Kubernetes version range. No
+snapshot-controller version is invented in the `requirements` field.
+
+All 21 stable application versions in the 2026-09-08 index are parsed, including
+0.3.0 through 0.16.0. The shared `reduce_versions` helper retains 14 representative
+rows when equal compatibility within a minor can be collapsed. Prerelease app
+versions and prerelease charts are excluded. If multiple stable charts target the
+same application version, the newest chart wins regardless of index order.
+
+Run the deterministic tests from the repository root:
+
+```sh
+python -m unittest discover -s utils/compatibility/tests -p test_volsync.py -v
+```
+
+`fixtures/volsync-index.yaml` preserves selected official index fields for old,
+current, and prerelease charts. Tests also cover malformed/empty inputs,
+unsupported constraints, inconsistent duplicate chart metadata, and failure to
+write partial results. They do not contact a cluster.
+
+To run the normal scraper with the dependencies from `requirements.txt` and
+Helm installed:
+
+```sh
+cd utils/compatibility
+python -c 'import importlib; importlib.import_module("scrapers.volsync").scrape()'
+```
+
+The shared writer performs Helm image extraction. Optional paid summarization
+is enabled by the existing framework only when its API keys are configured.
+
+To reproduce only the generated compatibility rows from a downloaded index,
+without Helm or optional summarization:
+
+```python
+from pathlib import Path
+from importlib import import_module
+from utils import read_yaml, reduce_versions, write_yaml
+
+scraper = import_module("scrapers.volsync")
+rows = scraper.build_rows(
+    Path("/path/to/downloaded/index.yaml").read_bytes(),
+    Path("../../KUBE_VERSION").read_text().strip(),
+)
+data = read_yaml(scraper.OUTPUT_PATH)
+data["versions"] = reduce_versions(rows)
+write_yaml(scraper.OUTPUT_PATH, data)
+```

--- a/utils/compatibility/tests/fixtures/volsync-index.yaml
+++ b/utils/compatibility/tests/fixtures/volsync-index.yaml
@@ -1,0 +1,17 @@
+# Relevant fields copied from https://backube.github.io/helm-charts/index.yaml
+# Retrieved 2026-09-08. This is a reduced fixture, not the complete release list.
+apiVersion: v1
+entries:
+  volsync:
+    - appVersion: 0.3.0
+      version: 0.3.0
+      kubeVersion: ^1.17.0-0
+    - appVersion: 0.16.0
+      version: 0.16.0
+      kubeVersion: ^1.20.0-0
+    - appVersion: 0.15.0-rc.1
+      version: 0.15.0-rc.1
+      kubeVersion: ^1.20.0-0
+    - appVersion: 0.9.1
+      version: 0.9.1
+      kubeVersion: ^1.20.0-0

--- a/utils/compatibility/tests/test_volsync.py
+++ b/utils/compatibility/tests/test_volsync.py
@@ -1,0 +1,117 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import yaml
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "volsync.py"
+spec = importlib.util.spec_from_file_location("volsync", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+FIXTURE = Path(__file__).parent / "fixtures" / "volsync-index.yaml"
+
+
+class VolSyncTests(unittest.TestCase):
+    def setUp(self):
+        self.index = FIXTURE.read_text()
+
+    def test_historical_minimum_is_not_replaced_by_current_chart_constraint(self):
+        rows = {r["version"]: r for r in scraper.build_rows(self.index, "1.22")}
+        self.assertEqual(rows["0.3.0"]["kube"], ["1.22", "1.21", "1.20", "1.19", "1.18", "1.17"])
+        self.assertEqual(rows["0.16.0"]["kube"], ["1.22", "1.21", "1.20"])
+
+    def test_stable_releases_sorted_semantically_without_rcs(self):
+        rows = scraper.build_rows(self.index, "1.20")
+        self.assertEqual([r["version"] for r in rows], ["0.16.0", "0.9.1", "0.3.0"])
+        self.assertEqual(rows[0]["chart_version"], "0.16.0")
+
+    def test_single_minor_boundary_is_inclusive(self):
+        self.assertEqual(scraper.declared_kube_versions("^1.20.0-0", "1.20"), ["1.20"])
+
+    def test_cap_does_not_invent_future_minors(self):
+        self.assertEqual(scraper.declared_kube_versions("^1.20.0-0", "1.21"), ["1.21", "1.20"])
+
+    def test_unsupported_constraints_fail_closed(self):
+        for constraint in [None, "", ">=1.20.0 <1.23.0", "^1.20.1-0", "^2.0.0-0", "^1.20.0-0 || ^2.0.0-0"]:
+            with self.subTest(constraint=constraint), self.assertRaises(ValueError):
+                scraper.declared_kube_versions(constraint, "1.36")
+
+    def test_invalid_or_future_cap_fails_closed(self):
+        for cap in [None, "", "garbage", "1.20.1", "2.0", "1.19"]:
+            with self.subTest(cap=cap), self.assertRaises(ValueError):
+                scraper.declared_kube_versions("^1.20.0-0", cap)
+
+    def test_newest_chart_for_same_application_wins_independent_of_index_order(self):
+        index = yaml.safe_load(self.index)
+        entries = index["entries"]["volsync"]
+        entries.extend([
+            {"appVersion": "0.16.0", "version": "0.16.2", "kubeVersion": "^1.21.0-0"},
+            {"appVersion": "0.16.0", "version": "0.16.1", "kubeVersion": "^1.20.0-0"},
+        ])
+        first = scraper.build_rows(yaml.safe_dump(index), "1.22")
+        entries.reverse()
+        self.assertEqual(first, scraper.build_rows(yaml.safe_dump(index), "1.22"))
+        self.assertEqual(first[0]["chart_version"], "0.16.2")
+        self.assertEqual(first[0]["kube"], ["1.22", "1.21"])
+
+    def test_conflicting_duplicate_chart_version_fails_closed(self):
+        index = yaml.safe_load(self.index)
+        index["entries"]["volsync"].append({
+            "appVersion": "0.16.0", "version": "0.16.0", "kubeVersion": "^1.21.0-0",
+        })
+        with self.assertRaisesRegex(ValueError, "Conflicting"):
+            scraper.build_rows(yaml.safe_dump(index), "1.22")
+
+    def test_invalid_source_structure_fails_closed(self):
+        for content in ["", "[]", "entries: []", "entries: {}", "entries: {volsync: [null]}", "entries: ["]:
+            with self.subTest(content=content), self.assertRaises(ValueError):
+                scraper.build_rows(content, "1.36")
+
+    def test_excludes_nonstable_or_incomplete_application_and_chart_versions(self):
+        for app, chart in [("0.16.0-rc.1", "0.16.0"), ("0.16.0", "0.16.0-rc.1"), ("0.16.0+build", "0.16.0"), ("0.16", "0.16.0"), (None, "0.16.0")]:
+            content = yaml.safe_dump({"entries": {"volsync": [{
+                "appVersion": app, "version": chart, "kubeVersion": "^1.20.0-0",
+            }]}})
+            with self.subTest(app=app, chart=chart), self.assertRaisesRegex(ValueError, "No stable"):
+                scraper.build_rows(content, "1.36")
+
+    def helpers(self, content):
+        helpers = ModuleType("utils")
+        helpers.fetch_page = Mock(return_value=content)
+        helpers.current_kube_version = Mock(return_value="1.22")
+        helpers.update_compatibility_info = Mock()
+        return helpers
+
+    def test_scrape_passes_verified_rows_to_existing_writer(self):
+        helpers = self.helpers(self.index.encode())
+        with patch.dict(sys.modules, {"utils": helpers}):
+            scraper.scrape()
+        helpers.fetch_page.assert_called_once_with(scraper.INDEX_URL)
+        helpers.update_compatibility_info.assert_called_once_with(
+            scraper.OUTPUT_PATH, scraper.build_rows(self.index, "1.22"),
+        )
+
+    def test_retrieval_or_parse_failure_never_calls_writer(self):
+        for content in [None, b"", b"entries: [", b"\xff", b"entries: {}"]:
+            helpers = self.helpers(content)
+            with self.subTest(content=content), patch.dict(sys.modules, {"utils": helpers}):
+                with self.assertRaises(ValueError):
+                    scraper.scrape()
+                helpers.update_compatibility_info.assert_not_called()
+
+    def test_invalid_later_row_does_not_write_partial_results(self):
+        index = yaml.safe_load(self.index)
+        index["entries"]["volsync"].append({
+            "appVersion": "0.17.0", "version": "0.17.0", "kubeVersion": "unknown",
+        })
+        helpers = self.helpers(yaml.safe_dump(index))
+        with patch.dict(sys.modules, {"utils": helpers}), self.assertRaises(ValueError):
+            scraper.scrape()
+        helpers.update_compatibility_info.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add VolSync to the compatibility catalog and automate updates from the official Backube Helm index. The scraper handles the historical Kubernetes 1.17 floor for VolSync 0.3.0 and the 1.20 floor for later charts, excludes prereleases, chooses the newest stable chart for each application version, and refuses unsupported constraints or malformed source data before writing.

Includes the scraper, source fixture and tests, application metadata, manifest registration, and aggregate catalog entry. The current index has 21 stable application versions; the existing shared reducer retains 14 representative rows. Existing aggregate entries are unchanged.

**Source semantics:** `kube` records the chart's declared Helm installation constraint, capped at this repository's `KUBE_VERSION`. It is not an upstream tested-runtime matrix or a claim that a cluster has suitable CSI storage or a snapshot controller. This follows the existing Longhorn scraper's source model.

Authoritative sources:

- [Official Helm index](https://backube.github.io/helm-charts/index.yaml).
- Tagged charts for [VolSync 0.16.0](https://github.com/backube/volsync/blob/v0.16.0/helm/volsync/Chart.yaml) and [0.3.0](https://github.com/backube/volsync/blob/v0.3.0/helm/volsync/Chart.yaml).
- [Installation and storage prerequisites](https://volsync.readthedocs.io/en/stable/installation/index.html).

Related: #4216, including confirmation of scope and Contributor Program eligibility. No bounty acceptance or payment is assumed.

## Test Plan

- Compatibility Python suite: **140 passed**, including 13 new VolSync tests.
- Live official-index retrieval through the real scraper/shared writer, with Helm **3.21.4** rendering and image extraction for all 14 generated rows: passed.
- Repository JSON schema: new application YAML, manifest, and aggregate catalog all validate; all 53 pre-existing aggregate entries are unchanged.
- `git diff --check`: passed.

Environment: Linux, Python 3.14.4. No Kubernetes cluster was deployed; Helm validation was local chart rendering. Optional API-backed summarization was disabled. Frontend/Elixir suites were not run for this Python/catalog change.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (not applicable: no deployment-agent code changed).

Disclosure: implementation, tests, and this PR were prepared with OpenAI Codex. Automated code review was performed; no personal human-review attestation is being made.

Plural Flow: console
