### PR TITLE
feat: add ScyllaDB Operator compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- scylla-operator

--- a/static/compatibilities/scylla-operator.yaml
+++ b/static/compatibilities/scylla-operator.yaml
@@ -1,0 +1,19 @@
+icon: https://raw.githubusercontent.com/scylladb/scylla-operator/master/logo.svg
+git_url: https://github.com/scylladb/scylla-operator
+release_url: https://github.com/scylladb/scylla-operator/releases/tag/v{vsn}
+helm_repository_url: https://scylla-operator-charts.storage.googleapis.com/stable
+versions:
+- version: 1.22.0
+  kube: ['1.36', '1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.22.0
+  images: ['scylladb/scylla-operator:1.22.0']
+- version: 1.21.1
+  kube: ['1.36', '1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.21.1
+  images: ['scylladb/scylla-operator:1.21.1']

--- a/utils/compatibility/scrapers/scylla-operator.py
+++ b/utils/compatibility/scrapers/scylla-operator.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import yaml
+from bs4 import BeautifulSoup
+from packaging.version import InvalidVersion, Version
+
+from utils import fetch_page, update_compatibility_info
+
+app_name = "scylla-operator"
+releases_url = "https://operator.docs.scylladb.com/v1.22/reference/releases.html"
+release_url_template = "https://operator.docs.scylladb.com/v{series}/reference/releases.html"
+chart_index_url = "https://scylla-operator-charts.storage.googleapis.com/stable/index.yaml"
+chart_name = "scylla-operator"
+
+
+def _decode(content: bytes | str, source: str) -> str:
+    if isinstance(content, str):
+        return content
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"Could not decode {source} as UTF-8") from exc
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def parse_supported_series(content: bytes | str) -> list[str]:
+    soup = BeautifulSoup(_decode(content, "ScyllaDB Operator releases page"), "html.parser")
+    marker = soup.find(lambda tag: tag.name in {"h2", "h3"} and "Supported releases" in tag.get_text(" ", strip=True))
+    if marker is None:
+        raise ValueError("ScyllaDB Operator supported releases section not found")
+    table = marker.find_next("table")
+    if table is None:
+        raise ValueError("ScyllaDB Operator supported releases table not found")
+    series: list[str] = []
+    for row in table.find_all("tr"):
+        cells = row.find_all("td")
+        if not cells:
+            continue
+        value = _normalize(cells[0].get_text(" ", strip=True))
+        if re.fullmatch(r"\d+\.\d+", value):
+            series.append(value)
+        if len(series) == 2:
+            break
+    if len(series) != 2:
+        raise ValueError("Expected the two currently supported ScyllaDB Operator releases")
+    return series
+
+
+def parse_chart_versions(content: bytes | str) -> dict[str, str]:
+    try:
+        parsed = yaml.safe_load(_decode(content, "ScyllaDB Operator Helm index"))
+    except yaml.YAMLError as exc:
+        raise ValueError("Could not parse ScyllaDB Operator Helm index") from exc
+    entries = parsed.get("entries", {}).get(chart_name) if isinstance(parsed, dict) else None
+    if not isinstance(entries, list) or not entries:
+        raise ValueError(f"ScyllaDB Operator Helm index has no {chart_name!r} entries")
+    versions: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        raw = str(entry.get("appVersion") or entry.get("version") or "").lstrip("v")
+        chart = str(entry.get("version") or "").lstrip("v")
+        try:
+            version = Version(raw)
+            chart_version = Version(chart)
+        except InvalidVersion:
+            continue
+        if version.is_prerelease or version.is_devrelease or chart_version.is_prerelease:
+            continue
+        series = f"{version.major}.{version.minor}"
+        current = versions.get(series)
+        if current is None or Version(raw) > Version(current.split("|")[0]):
+            versions[series] = f"{raw}|{chart}"
+    if not versions:
+        raise ValueError("ScyllaDB Operator Helm index contains no stable releases")
+    return versions
+
+
+def _component_table(soup: BeautifulSoup):
+    for table in soup.find_all("table"):
+        headers = [_normalize(x.get_text(" ", strip=True)).lower() for x in table.find_all("th")]
+        if headers[:2] == ["component", "supported versions"]:
+            return table
+    raise ValueError("ScyllaDB Operator support matrix not found")
+
+
+def parse_kubernetes_versions(content: bytes | str) -> list[str]:
+    soup = BeautifulSoup(_decode(content, "ScyllaDB Operator release support page"), "html.parser")
+    table = _component_table(soup)
+    for row in table.find_all("tr"):
+        cells = row.find_all("td")
+        if len(cells) < 2:
+            continue
+        if _normalize(cells[0].get_text(" ", strip=True)).lower() != "kubernetes":
+            continue
+        value = _normalize(cells[1].get_text(" ", strip=True))
+        versions = re.findall(r"(?<!\d)(1\.\d+)(?!\d)", value)
+        if not versions:
+            raise ValueError(f"No Kubernetes versions found in support matrix value {value!r}")
+        if len(versions) == 2:
+            low, high = (int(item.split(".")[1]) for item in versions)
+            if low > high:
+                low, high = high, low
+            return [f"1.{minor}" for minor in range(high, low - 1, -1)]
+        return sorted(set(versions), key=lambda item: int(item.split(".")[1]), reverse=True)
+    raise ValueError("Kubernetes row not found in ScyllaDB Operator support matrix")
+
+
+def scrape() -> None:
+    index = fetch_page(chart_index_url)
+    if not index:
+        raise ValueError("Could not fetch ScyllaDB Operator Helm index")
+    chart_versions = parse_chart_versions(index)
+
+    releases_page = fetch_page(releases_url)
+    if not releases_page:
+        raise ValueError("Could not fetch ScyllaDB Operator releases page")
+    supported = parse_supported_series(releases_page)
+
+    rows: list[OrderedDict[str, object]] = []
+    for series in supported:
+        chart_info = chart_versions.get(series)
+        if not chart_info:
+            raise ValueError(f"No stable ScyllaDB Operator Helm chart for supported release {series}")
+        version, chart_version = chart_info.split("|", 1)
+        page = fetch_page(release_url_template.format(series=series))
+        if not page:
+            raise ValueError(f"Could not fetch support matrix for ScyllaDB Operator {series}")
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", version),
+                    ("kube", parse_kubernetes_versions(page)),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                    ("chart_version", chart_version),
+                ]
+            )
+        )
+
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", rows)

--- a/utils/compatibility/tests/test_scylla_operator.py
+++ b/utils/compatibility/tests/test_scylla_operator.py
@@ -1,0 +1,111 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+helpers = ModuleType("utils")
+helpers.fetch_page = Mock()
+helpers.update_compatibility_info = Mock()
+
+_original_utils = sys.modules.get("utils")
+sys.modules["utils"] = helpers
+try:
+    SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "scylla-operator.py"
+    spec = importlib.util.spec_from_file_location("scylla_operator", SCRAPER_PATH)
+    scraper = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scraper)
+finally:
+    if _original_utils is None:
+        sys.modules.pop("utils", None)
+    else:
+        sys.modules["utils"] = _original_utils
+
+
+def releases_page(series=("1.22", "1.21")) -> bytes:
+    rows = "".join(f"<tr><td>{value}</td><td>date</td><td>end</td></tr>" for value in series)
+    return f"<h2>Supported releases</h2><table><tr><th>Release</th></tr>{rows}</table>".encode()
+
+
+def support_page(kube="1.33 - 1.36") -> bytes:
+    return (
+        "<table><tr><th>Component</th><th>Supported versions</th></tr>"
+        f"<tr><td>Kubernetes</td><td>{kube}</td></tr></table>"
+    ).encode()
+
+
+class ScyllaOperatorTests(unittest.TestCase):
+    def test_supported_series_uses_two_current_releases(self):
+        self.assertEqual(
+            scraper.parse_supported_series(releases_page(("1.23", "1.22", "1.21"))),
+            ["1.23", "1.22"],
+        )
+
+    def test_supported_series_fails_closed_when_section_missing(self):
+        with self.assertRaisesRegex(ValueError, "supported releases section not found"):
+            scraper.parse_supported_series(b"<html><h2>Other</h2></html>")
+
+    def test_kubernetes_range_expands_descending(self):
+        self.assertEqual(
+            scraper.parse_kubernetes_versions(support_page("1.33 - 1.36")),
+            ["1.36", "1.35", "1.34", "1.33"],
+        )
+
+    def test_kubernetes_row_missing_fails_closed(self):
+        html = b"<table><tr><th>Component</th><th>Supported versions</th></tr><tr><td>OpenShift</td><td>4.20</td></tr></table>"
+        with self.assertRaisesRegex(ValueError, "Kubernetes row not found"):
+            scraper.parse_kubernetes_versions(html)
+
+    def test_chart_index_uses_latest_stable_patch_per_series(self):
+        index = b"""
+entries:
+  scylla-operator:
+    - version: v1.22.0
+      appVersion: 1.22.0
+    - version: v1.21.1
+      appVersion: 1.21.1
+    - version: v1.21.0
+      appVersion: 1.21.0
+    - version: v1.23.0-rc.1
+      appVersion: 1.23.0-rc.1
+"""
+        self.assertEqual(
+            scraper.parse_chart_versions(index),
+            {"1.22": "1.22.0|1.22.0", "1.21": "1.21.1|1.21.1"},
+        )
+
+    def test_missing_chart_entries_fail_closed(self):
+        with self.assertRaisesRegex(ValueError, "has no 'scylla-operator' entries"):
+            scraper.parse_chart_versions(b"entries: {}\n")
+
+    def test_invalid_utf8_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Could not decode"):
+            scraper.parse_supported_series(b"\xff")
+
+    def test_scrape_wires_official_sources_to_updater(self):
+        index = b"entries:\n  scylla-operator:\n    - version: v1.22.0\n      appVersion: 1.22.0\n    - version: v1.21.1\n      appVersion: 1.21.1\n"
+
+        def fetch(url):
+            if url == scraper.chart_index_url:
+                return index
+            if url == scraper.releases_url:
+                return releases_page() + support_page()
+            if url.endswith("/v1.21/reference/releases.html"):
+                return support_page()
+            self.fail(f"unexpected URL: {url}")
+
+        with (
+            patch.object(scraper, "fetch_page", side_effect=fetch),
+            patch.object(scraper, "update_compatibility_info") as update,
+        ):
+            scraper.scrape()
+
+        path, rows = update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/scylla-operator.yaml")
+        self.assertEqual([row["version"] for row in rows], ["1.22.0", "1.21.1"])
+        self.assertEqual(rows[0]["kube"], ["1.36", "1.35", "1.34", "1.33"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

Adds ScyllaDB Operator to the compatibility catalog and a scraper that keeps its supported versions in sync with ScyllaDB's official documentation and Helm repository.

The scraper discovers the two currently supported release series, resolves each to the newest stable official Helm chart/app version, parses each Kubernetes support range, and lets the existing compatibility tooling resolve chart images.

## Sources
- https://operator.docs.scylladb.com/v1.22/reference/releases.html
- https://operator.docs.scylladb.com/v1.21/reference/releases.html
- https://scylla-operator-charts.storage.googleapis.com/stable/index.yaml
- https://github.com/scylladb/scylla-operator

## Verification
- live scraper run completed successfully against the official sources
- generated versions: `1.22.0`, `1.21.1`
- generated Kubernetes support: `1.33` through `1.36`
- generated images: `scylladb/scylla-operator:1.22.0`, `scylladb/scylla-operator:1.21.1`
- `python -m py_compile utils/compatibility/scrapers/scylla-operator.py`
- `git diff --check`

Any contributor-program reward remains contingent on maintainer acceptance/merge and the program's claim process.
