### PR TITLE
feat: add release-backed Headlamp compatibility scraper

### DIFF
--- a/static/compatibilities/headlamp.yaml
+++ b/static/compatibilities/headlamp.yaml
@@ -1,0 +1,113 @@
+icon: https://raw.githubusercontent.com/kubernetes-sigs/headlamp/main/docs/headlamp_light.svg
+git_url: https://github.com/kubernetes-sigs/headlamp
+release_url: https://github.com/kubernetes-sigs/headlamp/releases/tag/v{vsn}
+helm_repository_url: https://kubernetes-sigs.github.io/headlamp
+versions:
+- version: 0.45.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.45.0
+  requirements: []
+  incompatibilities: []
+- version: 0.44.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.44.0
+  requirements: []
+  incompatibilities: []
+- version: 0.43.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.43.0
+  requirements: []
+  incompatibilities: []
+- version: 0.42.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.42.0
+  requirements: []
+  incompatibilities: []
+- version: 0.41.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.41.0
+  requirements: []
+  incompatibilities: []
+- version: 0.40.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.40.1
+  requirements: []
+  incompatibilities: []
+- version: 0.39.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.39.0
+  requirements: []
+  incompatibilities: []
+- version: 0.38.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.38.0
+  requirements: []
+  incompatibilities: []
+- version: 0.37.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.37.0
+  requirements: []
+  incompatibilities: []
+- version: 0.36.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.36.0
+  requirements: []
+  incompatibilities: []
+- version: 0.35.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.35.0
+  requirements: []
+  incompatibilities: []
+- version: 0.34.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.34.0
+  requirements: []
+  incompatibilities: []
+- version: 0.33.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.33.0
+  requirements: []
+  incompatibilities: []
+- version: 0.32.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.32.1
+  requirements: []
+  incompatibilities: []
+- version: 0.31.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.31.1
+  requirements: []
+  incompatibilities: []
+- version: 0.30.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.30.1
+  requirements: []
+  incompatibilities: []
+- version: 0.29.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.29.1
+  requirements: []
+  incompatibilities: []
+- version: 0.28.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  chart_version: 0.28.1
+  requirements: []
+  incompatibilities: []

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- headlamp

--- a/utils/compatibility/scrapers/headlamp.py
+++ b/utils/compatibility/scrapers/headlamp.py
@@ -1,0 +1,139 @@
+"""Read Headlamp compatibility from checksum-verified, release-packaged docs."""
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import tarfile
+from urllib.parse import urlparse
+
+import yaml
+from packaging.version import InvalidVersion, Version
+
+app_name = "headlamp"
+helm_index_url = "https://kubernetes-sigs.github.io/headlamp/index.yaml"
+# Earlier published charts have no Kubernetes prerequisite in their README.
+MIN_DOCUMENTED_CHART = Version("0.28.0")
+
+
+def stable_charts(index_payload: bytes | str) -> list[dict]:
+    index = yaml.safe_load(index_payload)
+    if not isinstance(index, dict) or not isinstance(index.get("entries"), dict):
+        raise ValueError("Malformed Headlamp Helm index")
+    entries = index["entries"].get(app_name)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Headlamp chart entries not found")
+    selected = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Malformed Headlamp chart entry")
+        try:
+            chart = Version(str(entry.get("version", "")))
+            app = Version(str(entry.get("appVersion", "")))
+        except InvalidVersion:
+            continue
+        if any(v.is_prerelease or v.is_devrelease or v.local for v in (chart, app)):
+            continue
+        if chart < MIN_DOCUMENTED_CHART:
+            continue
+        key = (app.major, app.minor)
+        # Application version is the row identity; chart version is independent.
+        rank = (app, chart)
+        previous = selected.get(key)
+        if previous is None or rank > previous[0]:
+            selected[key] = (rank, entry)
+        elif rank == previous[0] and entry != previous[1]:
+            raise ValueError("Conflicting duplicate Headlamp chart entry")
+    if not selected:
+        raise ValueError("No documented stable Headlamp charts found")
+    return [selected[key][1] for key in sorted(selected, reverse=True)]
+
+
+def parse_minimum(readme: str) -> str:
+    # Do not mistake optional feature requirements (e.g. PDB >=1.27) for
+    # the application's Kubernetes minimum.
+    section = re.search(r"(?mi)^## Prerequisites\s*\n(.*?)(?=^## |\Z)", readme, re.S)
+    if not section:
+        raise ValueError("Headlamp Prerequisites section not found")
+    matches = re.findall(r"(?m)^- Kubernetes (1\.\d+)\+\s*$", section.group(1))
+    if len(matches) != 1:
+        raise ValueError("Expected one explicit Headlamp Kubernetes minimum")
+    return matches[0]
+
+
+def expand_minimum(minimum: str, current: str) -> list[str]:
+    versions = []
+    for value in (minimum, current):
+        match = re.fullmatch(r"1\.(\d+)", value)
+        if not match:
+            raise ValueError(f"Unsupported Kubernetes minor: {value!r}")
+        versions.append(int(match.group(1)))
+    start, end = versions
+    if start > end:
+        raise ValueError("Headlamp Kubernetes minimum is newer than Plural")
+    return [f"1.{minor}" for minor in range(end, start - 1, -1)]
+
+
+def archive_url(entry: dict) -> str:
+    urls = entry.get("urls")
+    if not isinstance(urls, list) or not urls or not isinstance(urls[0], str):
+        raise ValueError("Headlamp chart URL missing")
+    parsed = urlparse(urls[0])
+    if (parsed.scheme != "https" or parsed.netloc != "github.com"
+            or not parsed.path.startswith(("/kubernetes-sigs/headlamp/releases/download/",
+                                           "/headlamp-k8s/headlamp/releases/download/",
+                                           "/kinvolk/headlamp/releases/download/"))):
+        raise ValueError("Headlamp chart URL is not an official release archive")
+    return urls[0]
+
+
+def packaged_minimum(entry: dict, payload: bytes) -> str:
+    digest = entry.get("digest", "")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise ValueError("Headlamp chart SHA256 missing or malformed")
+    if hashlib.sha256(payload).hexdigest() != digest:
+        raise ValueError("Headlamp chart SHA256 mismatch")
+    with tarfile.open(fileobj=io.BytesIO(payload), mode="r:gz") as archive:
+        def read(name):
+            matches = [member for member in archive.getmembers() if member.name == name]
+            if len(matches) != 1 or not matches[0].isfile() or matches[0].size > 2_000_000:
+                raise ValueError(f"Invalid or missing chart member: {name}")
+            # Read the two expected files in memory; never extract archive paths.
+            return archive.extractfile(matches[0]).read().decode("utf-8")
+        chart = yaml.safe_load(read("headlamp/Chart.yaml"))
+        if not isinstance(chart, dict) or chart.get("name") != app_name:
+            raise ValueError("Unexpected packaged chart")
+        for key in ("version", "appVersion"):
+            if str(chart.get(key)) != str(entry.get(key)):
+                raise ValueError(f"Packaged Headlamp {key} differs from index")
+        return parse_minimum(read("headlamp/README.md"))
+
+
+def build_rows(index_payload: bytes | str, current_kube: str, fetcher) -> list[dict]:
+    rows = []
+    for entry in stable_charts(index_payload):
+        url = archive_url(entry)
+        payload = fetcher(url)
+        if not isinstance(payload, bytes) or not payload:
+            raise ValueError(f"Could not fetch Headlamp chart {entry['version']}")
+        minimum = packaged_minimum(entry, payload)
+        rows.append({
+            "version": str(entry["appVersion"]),
+            "kube": expand_minimum(minimum, current_kube),
+            "chart_version": str(entry["version"]),
+            "requirements": [],
+            "incompatibilities": [],
+        })
+    return rows
+
+
+def scrape() -> None:
+    from utils import current_kube_version, fetch_page, update_compatibility_info
+    index = fetch_page(helm_index_url)
+    if not index:
+        raise ValueError("Could not fetch Headlamp Helm index")
+    current = current_kube_version()
+    if not current:
+        raise ValueError("Plural current Kubernetes version unavailable")
+    rows = build_rows(index, current, fetch_page)
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", rows)

--- a/utils/compatibility/tests/HEADLAMP.md
+++ b/utils/compatibility/tests/HEADLAMP.md
@@ -1,0 +1,34 @@
+# Headlamp compatibility source and coverage
+
+The scraper uses the [official Helm index](https://kubernetes-sigs.github.io/headlamp/index.yaml) and the `headlamp/README.md` and `headlamp/Chart.yaml` files inside each selected release archive. It checks the index's SHA256 digest and verifies chart name, chart version and application version before reading requirements. Archives are read in memory, never extracted to disk.
+
+## Interpretation
+
+Only the `Prerequisites` section supplies the Kubernetes minimum. Optional feature requirements elsewhere in the README (such as the pod disruption budget field requiring Kubernetes 1.27) do not replace the baseline. The documented minimum is expanded through the repository's `KUBE_VERSION`, following the existing minimum-based scraper convention. This records declared requirements, not evidence of testing every cluster version or every optional configuration.
+
+Each application minor uses its latest stable application patch, then its latest stable chart. Application and chart versions are distinct: Headlamp 0.32.0 uses chart 0.32.1. Prereleases are excluded.
+
+## Initial evidence, 2026-09-08
+
+All 54 archives in the current index were inspected and their digests verified. Charts before 0.28.0 do not declare a Kubernetes prerequisite in their packaged README; they are deliberately excluded rather than assigning today's minimum retroactively. The initial table contains 18 application minors, 0.28.1 through 0.45.0, each declaring Kubernetes 1.21 or later. A missing/changed prerequisite on a newly eligible chart is an error, not a reason to invent a range or write partial results.
+
+Representative immutable release archives:
+
+- [Chart 0.45.0 / application 0.45.0](https://github.com/kubernetes-sigs/headlamp/releases/download/headlamp-helm-0.45.0/headlamp-0.45.0.tgz)
+- [Chart 0.32.1 / application 0.32.0](https://github.com/kubernetes-sigs/headlamp/releases/download/headlamp-helm-0.32.1/headlamp-0.32.1.tgz)
+- [Chart 0.28.1 / application 0.28.1](https://github.com/kubernetes-sigs/headlamp/releases/download/headlamp-helm-0.28.1/headlamp-0.28.1.tgz)
+- [Chart 0.27.0, excluded](https://github.com/kubernetes-sigs/headlamp/releases/download/headlamp-helm-0.27.0/headlamp-0.27.0.tgz)
+
+The index may use historical `headlamp-k8s` or `kinvolk` GitHub release URLs; the scraper also accepts those original upstream locations.
+
+## Verification
+
+From the repository root, with compatibility requirements installed:
+
+```sh
+python -m unittest discover -s utils/compatibility/tests -p test_headlamp.py -v
+```
+
+The tests cover release ordering, chart/application identity, per-release minimums, optional-feature separation, checksum validation, missing members, unsupported archive hosts, missing prerequisites, future Kubernetes floors, and writer integration. They use in-memory chart archives and do not call the network or external AI services.
+
+The production entry point is `SCRAPER=headlamp python main.py` from `utils/compatibility`. The existing runner also performs shared image enrichment and aggregate generation; those are not replaced by this scraper.

--- a/utils/compatibility/tests/test_headlamp.py
+++ b/utils/compatibility/tests/test_headlamp.py
@@ -1,0 +1,128 @@
+import hashlib
+import importlib.util
+import io
+from pathlib import Path
+import tarfile
+from types import ModuleType
+import sys
+import unittest
+from unittest.mock import Mock, patch
+import yaml
+
+spec = importlib.util.spec_from_file_location("headlamp", Path(__file__).parents[1] / "scrapers/headlamp.py")
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+DOC = "# Headlamp\n\n## Prerequisites\n\n- Kubernetes 1.21+\n- Helm 3.x\n\n## Optional features\nKubernetes >= 1.27 for unhealthyPodEvictionPolicy.\n"
+
+
+def fixture(chart="0.32.1", app="0.32.0", doc=DOC):
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for name, text in {"Chart.yaml": yaml.safe_dump({"name":"headlamp", "version":chart, "appVersion":app}), "README.md":doc}.items():
+            data = text.encode()
+            member = tarfile.TarInfo("headlamp/" + name)
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+    payload = buffer.getvalue()
+    entry = {"version":chart, "appVersion":app,"digest":hashlib.sha256(payload).hexdigest(),"urls":[f"https://github.com/kubernetes-sigs/headlamp/releases/download/headlamp-helm-{chart}/headlamp-{chart}.tgz"]}
+    return entry, payload
+
+
+def index(*entries):
+    return yaml.safe_dump({"entries":{"headlamp":list(entries)}})
+
+
+class HeadlampTests(unittest.TestCase):
+    def test_uses_prerequisite_not_optional_feature(self):
+        self.assertEqual(scraper.parse_minimum(DOC), "1.21")
+
+    def test_missing_or_ambiguous_prerequisite_rejected(self):
+        for doc in ["Kubernetes 1.21+", DOC.replace("- Kubernetes 1.21+", ""), DOC.replace("- Kubernetes 1.21+", "- Kubernetes 1.21+\n- Kubernetes 1.22+")]:
+            with self.subTest(doc=doc), self.assertRaises(ValueError):
+                scraper.parse_minimum(doc)
+
+    def test_selects_latest_stable_app_then_chart_per_minor(self):
+        entries = [fixture(c,a)[0] for c,a in [("0.32.0","0.32.0"),("0.32.1","0.32.0"),("0.31.0","0.31.0"),("0.31.1","0.31.1"),("0.33.0-rc.1","0.33.0"),("0.34.0","0.34.0-rc.1"),("0.27.0","0.27.0")]]
+        self.assertEqual([e['version'] for e in scraper.stable_charts(index(*reversed(entries)))], ["0.32.1","0.31.1"])
+
+    def test_duplicate_conflict_rejected(self):
+        e,_=fixture()
+        with self.assertRaisesRegex(ValueError, "Conflicting"):
+            scraper.stable_charts(index(e,{**e,"digest":"0"*64}))
+
+    def test_empty_or_invalid_index_rejected(self):
+        for data in ["[]", "entries: {}", index(), index(fixture("0.27.0","0.27.0")[0])]:
+            with self.subTest(data=data), self.assertRaises(ValueError):
+                scraper.stable_charts(data)
+
+    def test_chart_and_application_version_stay_distinct(self):
+        e,p=fixture()
+        rows=scraper.build_rows(index(e),"1.23",lambda _:p)
+        self.assertEqual(rows,[{"version":"0.32.0","kube":["1.23","1.22","1.21"],"chart_version":"0.32.1","requirements":[],"incompatibilities":[]}])
+
+    def test_each_archive_supplies_its_own_minimum(self):
+        e1,p1=fixture("0.32.1","0.32.0")
+        e2,p2=fixture("0.31.1","0.31.1",DOC.replace("1.21+","1.20+"))
+        rows=scraper.build_rows(index(e2,e1),"1.22",{e1['urls'][0]:p1,e2['urls'][0]:p2}.get)
+        self.assertEqual(rows[0]['kube'],["1.22","1.21"])
+        self.assertEqual(rows[1]['kube'],["1.22","1.21","1.20"])
+
+    def test_digest_mismatch_and_missing_digest_rejected(self):
+        e,p=fixture()
+        for bad in [{**e,"digest":"0"*64},{**e,"digest":""}]:
+            with self.assertRaisesRegex(ValueError,"SHA256"):
+                scraper.packaged_minimum(bad,p)
+
+    def test_archive_identity_mismatch_rejected(self):
+        e,p=fixture()
+        with self.assertRaisesRegex(ValueError,"differs"):
+            scraper.packaged_minimum({**e,"appVersion":"0.32.1"},p)
+
+    def test_missing_archive_member_rejected(self):
+        e,p=fixture()
+        empty=io.BytesIO()
+        with tarfile.open(fileobj=empty,mode='w:gz'):
+            pass
+        payload=empty.getvalue()
+        with self.assertRaisesRegex(ValueError,"missing chart member"):
+            scraper.packaged_minimum({**e,"digest":hashlib.sha256(payload).hexdigest()},payload)
+
+    def test_untrusted_archive_url_rejected(self):
+        e,_=fixture()
+        for url in ['http://github.com/kubernetes-sigs/headlamp/releases/download/a','https://example.com/headlamp.tgz','https://github.com/other/repo/releases/download/a']:
+            with self.assertRaisesRegex(ValueError,"official release"):
+                scraper.archive_url({**e,"urls":[url]})
+
+    def test_future_and_malformed_kube_versions_rejected(self):
+        for minimum,current in [('1.40','1.36'),('1.21','2.0'),('1.21.0','1.36')]:
+            with self.assertRaises(ValueError):
+                scraper.expand_minimum(minimum,current)
+
+    def test_failed_fetch_does_not_generate_partial_rows(self):
+        e,_=fixture()
+        with self.assertRaisesRegex(ValueError,"Could not fetch"):
+            scraper.build_rows(index(e),'1.36',lambda _:None)
+
+    def test_scrape_passes_verified_rows_to_existing_writer(self):
+        e,p=fixture()
+        fake=ModuleType('utils')
+        fake.fetch_page=Mock(side_effect=lambda url:index(e).encode() if url==scraper.helm_index_url else p)
+        fake.current_kube_version=Mock(return_value='1.22')
+        fake.update_compatibility_info=Mock()
+        with patch.dict(sys.modules,{'utils':fake}):
+            scraper.scrape()
+        path,rows=fake.update_compatibility_info.call_args.args
+        self.assertEqual(path,'../../static/compatibilities/headlamp.yaml')
+        self.assertEqual(rows[0]['kube'],['1.22','1.21'])
+
+    def test_scrape_failure_never_calls_writer(self):
+        fake=ModuleType('utils')
+        fake.fetch_page=Mock(return_value=None)
+        fake.update_compatibility_info=Mock()
+        fake.current_kube_version=Mock(return_value='1.36')
+        with patch.dict(sys.modules,{'utils':fake}), self.assertRaises(ValueError):
+            scraper.scrape()
+        fake.update_compatibility_info.assert_not_called()
+
+if __name__=='__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Headlamp is absent from the compatibility catalog. This adds a registered scraper and 18 application-minor entries using the Kubernetes minimum in each release's packaged Helm README. Chart and application versions stay distinct (for example, chart 0.32.1 packages application 0.32.0).

The scraper verifies the chart SHA256 against the official index, checks packaged chart identity, and reads only the `Prerequisites` section. Optional feature requirements do not become the baseline. Charts older than 0.28.0 lack that prerequisite in their packaged README and are omitted; their compatibility is not inferred from current documentation. Declared minimums are expanded through `KUBE_VERSION`, following the existing minimum-based scraper convention, rather than claiming every combination was cluster-tested.

Sources:
- [Official Headlamp Helm index](https://kubernetes-sigs.github.io/headlamp/index.yaml)
- [0.45.0 chart archive](https://github.com/kubernetes-sigs/headlamp/releases/download/headlamp-helm-0.45.0/headlamp-0.45.0.tgz): `headlamp/README.md` and `headlamp/Chart.yaml`
- [0.32.1 chart archive](https://github.com/kubernetes-sigs/headlamp/releases/download/headlamp-helm-0.32.1/headlamp-0.32.1.tgz): application/chart version distinction
- [0.27.0 chart archive](https://github.com/kubernetes-sigs/headlamp/releases/download/headlamp-helm-0.27.0/headlamp-0.27.0.tgz): historical coverage boundary

The metadata includes the official icon, Git repository, release link, and Helm repository. `utils/compatibility/tests/HEADLAMP.md` documents the extraction and coverage boundary.

## Test Plan

- `python -m pytest utils/compatibility/tests -q`: **142 passed**, including 15 new offline Headlamp tests.
- Inspected all 54 chart archives in the current official index and verified their SHA256 digests; generated 18 rows for application minors 0.28–0.45.
- Validated the Headlamp table and updated manifest against `static/compatibilities/schema.json`.
- `git diff --check` passed.
- No cluster deployment or shared Helm image-enrichment run was performed; this changes catalog data and scraper code only.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (not applicable: no agent code changes).

AI assistance disclosure: this contribution was implemented and tested by Codex acting for the account owner. No manual human review is claimed.

Plural Flow: console
