### PR TITLE
feat: add LitmusChaos compatibility scraper and test suite

### DIFF
--- a/static/compatibilities/litmus.yaml
+++ b/static/compatibilities/litmus.yaml
@@ -1,0 +1,451 @@
+icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/litmus/icon/color/litmus-icon-color.svg
+git_url: https://github.com/litmuschaos/litmus
+release_url: https://github.com/litmuschaos/litmus/releases/tag/{vsn}
+helm_repository_url: https://litmuschaos.github.io/litmus-helm
+chart_name: litmus
+versions:
+- version: 3.30.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.30.0
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.30.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.30.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.30.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.29.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.29.1
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.29.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.29.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.29.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.28.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.28.0
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.28.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.28.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.28.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.27.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.27.0
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.27.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.27.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.27.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.26.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.26.0
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.26.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.26.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.26.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.25.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.25.0
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.25.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.25.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.25.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.24.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.24.1
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.24.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.24.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.24.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.23.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.23.0
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.23.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.23.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.23.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.22.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.22.0
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.22.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.22.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.22.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.21.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.21.2
+  images: ['docker.io/bitnamilegacy/mongodb:8.0.13-debian-12-r0', 'docker.io/bitnamilegacy/os-shell:12-debian-12-r51',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.21.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.21.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.21.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.20.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.20.0
+  images: ['docker.io/bitnami/mongodb:5.0.8-debian-10-r24', 'docker.io/bitnami/os-shell:12-debian-12-r47',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.20.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.20.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.20.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.19.0
+  kube: ['1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.19.1
+  images: ['docker.io/bitnami/mongodb:5.0.8-debian-10-r24', 'docker.io/bitnami/os-shell:12-debian-12-r47',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.19.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.19.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.19.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.18.0
+  kube: ['1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.18.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.18.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.18.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.18.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.16.0
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.16.1
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.16.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.16.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.16.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.15.0
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.15.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.15.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.15.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.15.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.14.0
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.14.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.14.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.14.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.14.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.13.0
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.13.1
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.13.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.13.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.13.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.12.0
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.12.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.12.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.12.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.12.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.11.0
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.11.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.11.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.11.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.11.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.10.0
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.10.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.10.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.10.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.10.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.9.0
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.9.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.9.1', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.9.1',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.9.1', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.8.0
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.8.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.8.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.8.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.8.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.7.0
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.7.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.7.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.7.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.7.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.6.0
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.6.0
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.6.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.6.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.6.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.5.0
+  kube: ['1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.5.1
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.5.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.5.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.5.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.1.0
+  kube: ['1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.1.1
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.1.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.1.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.1.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6']
+- version: 3.0.0
+  kube: ['1.28', '1.27', '1.26']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.0.3
+  images: ['docker.io/bitnami/bitnami-shell:10-debian-10-r431', 'docker.io/bitnami/mongodb:5.0.8-debian-10-r24',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-auth-server:3.0.0', 'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-frontend:3.0.0',
+    'litmuschaos.docker.scarf.sh/litmuschaos/litmusportal-server:3.0.0', 'litmuschaos.docker.scarf.sh/litmuschaos/mongo:6',
+    'litmuschaos.docker.scarf.sh/litmuschaos/upgrade-agent-cp:3.0.0']
+- version: 2.14.0
+  kube: ['1.28', '1.27', '1.26']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.15.11
+  images: ['docker.io/bitnami/mongodb:5.0.8-debian-10-r24', 'litmuschaos/curl:2.14.0',
+    'litmuschaos/litmusportal-auth-server:2.14.0', 'litmuschaos/litmusportal-frontend:2.14.0',
+    'litmuschaos/litmusportal-server:2.14.0', 'litmuschaos/upgrade-agent-cp:2.14.0']
+- version: 2.13.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.14.1
+  images: ['docker.io/bitnami/mongodb:5.0.8-debian-10-r24', 'litmuschaos/curl:2.12.0',
+    'litmuschaos/litmusportal-auth-server:2.13.0', 'litmuschaos/litmusportal-frontend:2.13.0',
+    'litmuschaos/litmusportal-server:2.13.0', 'litmuschaos/upgrade-agent-cp:2.13.0']
+- version: 2.12.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.13.1
+  images: ['docker.io/bitnami/mongodb:5.0.8-debian-10-r24', 'litmuschaos/curl:2.11.0',
+    'litmuschaos/litmusportal-auth-server:2.12.0', 'litmuschaos/litmusportal-frontend:2.12.0',
+    'litmuschaos/litmusportal-server:2.12.0', 'litmuschaos/upgrade-agent-cp:2.12.0']
+- version: 2.11.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.12.1
+  images: ['docker.io/bitnami/mongodb:5.0.8-debian-10-r24', 'litmuschaos/curl:2.10.0',
+    'litmuschaos/litmusportal-auth-server:2.11.0', 'litmuschaos/litmusportal-frontend:2.11.0',
+    'litmuschaos/litmusportal-server:2.11.0', 'litmuschaos/upgrade-agent-cp:2.11.0']
+- version: 2.10.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.10.3
+  images: ['litmuschaos/curl:2.9.0', 'litmuschaos/litmusportal-auth-server:2.10.0',
+    'litmuschaos/litmusportal-frontend:2.10.0', 'litmuschaos/litmusportal-server:2.10.0',
+    'litmuschaos/mongo:4.2.8', 'litmuschaos/upgrade-agent-cp:2.10.0']
+- version: 2.9.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.9.2
+  images: ['litmuschaos/curl:2.9.0', 'litmuschaos/litmusportal-auth-server:2.9.0',
+    'litmuschaos/litmusportal-frontend:2.9.0', 'litmuschaos/litmusportal-server:2.9.0',
+    'litmuschaos/mongo:4.2.8', 'litmuschaos/upgrade-agent-cp:2.9.0']
+- version: 2.8.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.8.2
+  images: ['litmuschaos/curl:2.6.0', 'litmuschaos/litmusportal-auth-server:2.8.0',
+    'litmuschaos/litmusportal-frontend:2.8.0', 'litmuschaos/litmusportal-server:2.8.0',
+    'litmuschaos/mongo:4.2.8', 'litmuschaos/upgrade-agent-cp:2.8.0']
+- version: 2.7.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.7.3
+  images: ['litmuschaos/curl:2.6.0', 'litmuschaos/litmusportal-auth-server:2.7.0',
+    'litmuschaos/litmusportal-frontend:2.7.0', 'litmuschaos/litmusportal-server:2.7.0',
+    'litmuschaos/mongo:4.2.8', 'litmuschaos/upgrade-agent-cp:2.7.0']
+- version: 2.6.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.6.5
+  images: ['litmuschaos/curl:2.5.0', 'litmuschaos/litmusportal-auth-server:2.6.0',
+    'litmuschaos/litmusportal-frontend:2.6.0', 'litmuschaos/litmusportal-server:2.6.0',
+    'litmuschaos/mongo:4.2.8', 'litmuschaos/upgrade-agent-cp:2.6.0']
+- version: 2.5.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.5.2
+  images: ['litmuschaos/curl:latest', 'litmuschaos/litmusportal-auth-server:2.5.0',
+    'litmuschaos/litmusportal-frontend:2.5.0', 'litmuschaos/litmusportal-server:2.5.0',
+    'litmuschaos/mongo:4.2.8', 'litmuschaos/upgrade-agent-cp:2.5.0']
+- version: 2.4.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.4.4
+  images: ['litmuschaos/curl:latest', 'litmuschaos/litmusportal-auth-server:2.4.0',
+    'litmuschaos/litmusportal-frontend:2.4.0', 'litmuschaos/litmusportal-server:2.4.0',
+    'litmuschaos/mongo:4.2.8', 'litmuschaos/upgrade-agent-cp:2.4.0']
+- version: 2.3.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.4.1
+  images: ['litmuschaos/curl:latest', 'litmuschaos/litmusportal-auth-server:2.3.0',
+    'litmuschaos/litmusportal-frontend:2.3.0', 'litmuschaos/litmusportal-server:2.3.0',
+    'litmuschaos/mongo-utils:latest', 'litmuschaos/mongo:4.2.8', 'litmuschaos/upgrade-agent-cp:ci']
+- version: 2.1.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.1.0
+  images: ['litmuschaos/litmusportal-auth-server:2.0.0', 'litmuschaos/litmusportal-frontend:2.0.0',
+    'litmuschaos/litmusportal-server:2.0.0', 'litmuschaos/mongo:4.2.8']
+- version: 2.0.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.0.33
+  images: ['litmuschaos/litmusportal-auth-server:2.0.0', 'litmuschaos/litmusportal-frontend:2.0.0',
+    'litmuschaos/litmusportal-server:2.0.0', 'litmuschaos/mongo:4.2.8']
+- version: 1.13.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.13.2
+  images: ['litmuschaos/chaos-operator:1.13.0']
+- version: 1.11.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.11.0
+  images: ['litmuschaos/chaos-operator:1.11.0']
+- version: 1.10.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.10.1
+  images: ['litmuschaos/chaos-operator:1.10.0']
+- version: 1.9.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.9.0
+  images: ['litmuschaos/chaos-operator:1.9.0']
+- version: 1.8.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.8.0
+  images: ['litmuschaos/chaos-operator:1.8.0']
+- version: 1.7.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.7.0
+  images: ['litmuschaos/chaos-operator:1.7.0']
+- version: 1.6.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.6.0
+  images: ['litmuschaos/chaos-operator:1.6.0']
+- version: 1.5.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.0
+  images: ['litmuschaos/chaos-operator:1.5.0']
+- version: 1.4.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.4.0
+  images: ['litmuschaos/chaos-operator:1.4.0']
+- version: 1.3.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.4
+  images: ['litmuschaos/chaos-operator:1.3.0']
+- version: 1.2.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.0
+  images: ['litmuschaos/chaos-operator:1.2.0']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- litmus

--- a/utils/compatibility/scrapers/litmus.py
+++ b/utils/compatibility/scrapers/litmus.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from utils import (
+    clean_kube_version,
+    find_last_n_releases,
+    get_chart_versions,
+    get_github_releases_timestamps,
+    get_kube_release_info,
+    update_compatibility_info,
+)
+
+app_name = "litmus"
+chart_name = "litmus"
+
+
+def scrape():
+    kube_releases = get_kube_release_info()
+    litmus_releases = list(
+        reversed(list(get_github_releases_timestamps("litmuschaos", "litmus")))
+    )
+
+    chart_versions = get_chart_versions(app_name, chart_name)
+    versions = []
+    pruned_releases = [
+        (r[0].lstrip("v"), r[1])
+        for r in litmus_releases
+        if "-" not in r[0]
+        and not any(pre in r[0].lower() for pre in ["rc", "alpha", "beta"])
+    ]
+    for idx, litmus_release in enumerate(pruned_releases):
+        release_vsn = litmus_release[0]
+        future_release = litmus_release
+        if idx < len(pruned_releases) - 1:
+            future_release = pruned_releases[idx + 1]
+
+        compatible_kube_releases = find_last_n_releases(
+            kube_releases, future_release[1], n=3
+        )
+        chart_version = chart_versions.get(release_vsn)
+        if not chart_version:
+            continue
+        vsn = {
+            "version": release_vsn,
+            "kube": [
+                clean_kube_version(kube_release[0])
+                for kube_release in compatible_kube_releases
+                if clean_kube_version(kube_release[0])
+            ],
+            "chart_version": chart_version,
+            "requirements": [],
+            "incompatibilities": [],
+        }
+        versions.append(vsn)
+
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", versions)

--- a/utils/compatibility/tests/test_litmus.py
+++ b/utils/compatibility/tests/test_litmus.py
@@ -1,0 +1,143 @@
+"""Offline regressions: python -m unittest discover -s tests -p 'test_litmus.py'."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+
+spec = importlib.util.spec_from_file_location(
+    "litmus_scraper", COMPATIBILITY / "scrapers/litmus.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(scraper)
+
+
+class LitmusScraperTests(unittest.TestCase):
+    def setUp(self):
+        self.kube_releases = [
+            ("1.33.0", "2025-08-01T00:00:00Z"),
+            ("1.34.0", "2026-01-01T00:00:00Z"),
+            ("1.35.0", "2026-04-01T00:00:00Z"),
+            ("1.36.0", "2026-08-01T00:00:00Z"),
+        ]
+        self.mock_github_releases = [
+            ("3.30.0", "2026-08-20T00:00:00Z"),
+            ("3.30.0-rc.1", "2026-08-10T00:00:00Z"),
+            ("3.29.0", "2026-05-01T00:00:00Z"),
+            ("3.29.0-alpha.1", "2026-04-15T00:00:00Z"),
+            ("3.28.0", "2026-01-01T00:00:00Z"),
+        ]
+        self.mock_chart_versions = {
+            "3.30.0": "3.30.0",
+            "3.29.0": "3.29.1",
+            "3.28.0": "3.28.0",
+        }
+
+    def test_scraper_app_name_and_chart_name(self):
+        self.assertEqual(scraper.app_name, "litmus")
+        self.assertEqual(scraper.chart_name, "litmus")
+
+    def test_prerelease_filtering(self):
+        releases = [("3.30.0-rc.1", "2026-08-10T00:00:00Z"), ("3.30.0", "2026-08-20T00:00:00Z")]
+        filtered = [
+            r for r in releases
+            if "-" not in r[0] and not any(pre in r[0].lower() for pre in ["rc", "alpha", "beta"])
+        ]
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0][0], "3.30.0")
+
+    @patch.object(scraper, "update_compatibility_info")
+    @patch.object(scraper, "get_chart_versions")
+    @patch.object(scraper, "get_github_releases_timestamps")
+    @patch.object(scraper, "get_kube_release_info")
+    def test_scrape_builds_valid_version_list(
+        self, mock_kube, mock_gh, mock_charts, mock_update
+    ):
+        mock_kube.return_value = self.kube_releases
+        mock_gh.return_value = self.mock_github_releases
+        mock_charts.return_value = self.mock_chart_versions
+
+        scraper.scrape()
+
+        mock_update.assert_called_once()
+        args = mock_update.call_args[0]
+        filepath, versions = args[0], args[1]
+
+        self.assertEqual(filepath, "../../static/compatibilities/litmus.yaml")
+        # Should filter out 3.30.0-rc.1 and 3.29.0-alpha.1
+        self.assertEqual(len(versions), 3)
+
+        v3_30 = next(v for v in versions if v["version"] == "3.30.0")
+        self.assertEqual(v3_30["chart_version"], "3.30.0")
+        self.assertIn("1.36", v3_30["kube"])
+        self.assertIn("1.35", v3_30["kube"])
+        self.assertIn("1.34", v3_30["kube"])
+        self.assertEqual(v3_30["requirements"], [])
+        self.assertEqual(v3_30["incompatibilities"], [])
+
+    @patch.object(scraper, "update_compatibility_info")
+    @patch.object(scraper, "get_chart_versions")
+    @patch.object(scraper, "get_github_releases_timestamps")
+    @patch.object(scraper, "get_kube_release_info")
+    def test_scrape_skips_releases_without_charts(
+        self, mock_kube, mock_gh, mock_charts, mock_update
+    ):
+        mock_kube.return_value = self.kube_releases
+        mock_gh.return_value = [("3.30.0", "2026-08-20T00:00:00Z"), ("9.9.9", "2026-08-20T00:00:00Z")]
+        mock_charts.return_value = {"3.30.0": "3.30.0"}
+
+        scraper.scrape()
+
+        mock_update.assert_called_once()
+        versions = mock_update.call_args[0][1]
+        self.assertEqual(len(versions), 1)
+        self.assertEqual(versions[0]["version"], "3.30.0")
+
+    def test_manifest_includes_litmus(self):
+        from utils import read_yaml
+        manifest_path = COMPATIBILITY.parent.parent / "static/compatibilities/manifest.yaml"
+        manifest = read_yaml(str(manifest_path))
+        self.assertIsNotNone(manifest)
+        self.assertIn("litmus", manifest.get("names", []))
+
+    def test_catalog_yaml_structure_and_images(self):
+        from utils import read_yaml
+        yaml_path = COMPATIBILITY.parent.parent / "static/compatibilities/litmus.yaml"
+        data = read_yaml(str(yaml_path))
+        self.assertIsNotNone(data)
+        self.assertIn("icon", data)
+        self.assertIn("git_url", data)
+        self.assertIn("release_url", data)
+        self.assertIn("helm_repository_url", data)
+        self.assertIn("chart_name", data)
+        self.assertIn("versions", data)
+        self.assertGreater(len(data["versions"]), 0)
+
+        for v in data["versions"]:
+            self.assertIn("version", v)
+            self.assertIn("kube", v)
+            self.assertIsInstance(v["kube"], list)
+            self.assertGreater(len(v["kube"]), 0)
+            self.assertIn("chart_version", v)
+            self.assertIn("images", v)
+            self.assertIsInstance(v["images"], list)
+            self.assertGreater(
+                len(v["images"]), 0, f"Version {v['version']} has empty images list"
+            )
+            # Verify Litmus container images are present
+            has_litmus_component = any("litmus" in img or "mongo" in img for img in v["images"])
+            self.assertTrue(
+                has_litmus_component,
+                f"Version {v['version']} images do not contain expected litmus components: {v['images']}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Contributor Program: New Compatibility Scraper ($300)

This PR adds **LitmusChaos** (`litmus`) to the Plural Console add-on compatibility catalog, implementing an automated Python scraper, catalog metadata, compatibility matrix with resolved container images, and offline unit test suite according to the Contributor Program guidelines.

### Overview of Changes
1. **Compatibility Scraper**: Added `utils/compatibility/scrapers/litmus.py` which fetches Litmus GitHub releases and Helm chart versions from the official repository, matching releases against active Kubernetes minor versions.
2. **Catalog Metadata & Matrix**: Added `static/compatibilities/litmus.yaml` with full metadata (Helm repo URL, Git URL, release URL, official CNCF brand icon, and generated version matrix covering v1.2.0 through v3.30.0 with container images pre-resolved from Helm templates).
3. **Manifest Entry**: Registered `litmus` in `static/compatibilities/manifest.yaml`.
4. **Unit Test Suite**: Added `utils/compatibility/tests/test_litmus.py` covering release filtering, pre-release rejection, chart mapping, mock scrape validation, manifest entry, and resolved catalog container images.

### References & Documentation
- **Git Repository**: https://github.com/litmuschaos/litmus
- **Helm Repository**: https://litmuschaos.github.io/litmus-helm
- **Releases**: https://github.com/litmuschaos/litmus/releases
- **Brand Icon**: https://raw.githubusercontent.com/cncf/artwork/main/projects/litmus/icon/color/litmus-icon-color.svg
- **Documentation**: https://docs.litmuschaos.io

### Verification
- Ran offline regressions: `python -m unittest discover -s utils/compatibility/tests -p 'test_litmus.py'` (6/6 tests pass).
- Full compatibility test suite passed: 107/107 tests pass.
- Verified Helm templating and container image extraction across all 52 catalog releases.
