### PR TITLE
feat: add Aerospike Kubernetes Operator compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,25 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://avatars0.githubusercontent.com/u/2214313?s=200&v=4
+  git_url: https://github.com/aerospike/aerospike-kubernetes-operator
+  release_url: https://github.com/aerospike/aerospike-kubernetes-operator/releases?q={vsn}&expanded=true
+  readme_url: https://aerospike.com/docs/kubernetes/install/helm/
+  helm_repository_url: https://aerospike.github.io/aerospike-kubernetes-enterprise
+  versions:
+  - version: 4.5.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 4.5.0
+    images: ['aerospike/aerospike-kubernetes-operator:4.5.0']
+  - version: 3.0.0
+    kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 3.0.0
+    images: ['aerospike/aerospike-kubernetes-operator:3.0.0', 'gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1']
+  name: aerospike-kubernetes-operator

--- a/static/compatibilities/aerospike-kubernetes-operator.yaml
+++ b/static/compatibilities/aerospike-kubernetes-operator.yaml
@@ -1,0 +1,21 @@
+icon: https://avatars0.githubusercontent.com/u/2214313?s=200&v=4
+git_url: https://github.com/aerospike/aerospike-kubernetes-operator
+release_url: https://github.com/aerospike/aerospike-kubernetes-operator/releases?q={vsn}&expanded=true
+readme_url: https://aerospike.com/docs/kubernetes/install/helm/
+helm_repository_url: https://aerospike.github.io/aerospike-kubernetes-enterprise
+versions:
+- version: 4.5.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 4.5.0
+  images: ['aerospike/aerospike-kubernetes-operator:4.5.0']
+- version: 3.0.0
+  kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.0.0
+  images: ['aerospike/aerospike-kubernetes-operator:3.0.0', 'gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- aerospike-kubernetes-operator

--- a/utils/compatibility/scrapers/aerospike-kubernetes-operator.py
+++ b/utils/compatibility/scrapers/aerospike-kubernetes-operator.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import requests
+import yaml
+from bs4 import BeautifulSoup
+from packaging.version import InvalidVersion, Version
+
+from utils import update_compatibility_info
+
+
+app_name = "aerospike-kubernetes-operator"
+compatibility_url = "https://aerospike.com/docs/kubernetes/install/requirements/"
+helm_install_url = "https://aerospike.com/docs/kubernetes/install/helm/"
+chart_index_url = "https://aerospike.github.io/aerospike-kubernetes-enterprise/index.yaml"
+chart_name = "aerospike-kubernetes-operator"
+compatibility_file = f"../../static/compatibilities/{app_name}.yaml"
+stable_version = re.compile(r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)")
+
+
+def fetch_page(url: str) -> bytes:
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
+def _decode(content: bytes | str, source: str) -> str:
+    if isinstance(content, str):
+        return content
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"Could not decode {source} as UTF-8") from exc
+
+
+def _normalize(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip().lower()
+
+
+def _content_scope(soup: BeautifulSoup):
+    """Return the document content, excluding navigation and footer text."""
+    return soup.find("main") or soup.find("article") or soup
+
+
+def _section_text(content: bytes | str, title: str, source: str) -> str:
+    soup = BeautifulSoup(_decode(content, source), "html.parser")
+    scope = _content_scope(soup)
+    headings = []
+    for heading in scope.find_all(["h1", "h2", "h3", "h4", "h5", "h6"]):
+        if heading.find_parent(["nav", "header", "footer"]):
+            continue
+        if _normalize(heading.get_text(" ", strip=True)) == _normalize(title):
+            headings.append(heading)
+    if len(headings) != 1:
+        raise ValueError(
+            f"Expected exactly one {title!r} section in the Aerospike source"
+        )
+
+    heading = headings[0]
+    heading_level = int(heading.name[1])
+    parts: list[str] = []
+
+    # Aerospike's docs put each section's elements beside its heading in one
+    # markdown-content container. Stop at the next heading of the same or
+    # higher level so unrelated sections cannot contribute version numbers.
+    for sibling in heading.next_siblings:
+        if getattr(sibling, "name", None):
+            sibling_level = re.fullmatch(r"h([1-6])", sibling.name)
+            if sibling_level and int(sibling_level.group(1)) <= heading_level:
+                break
+        text = getattr(sibling, "get_text", lambda *args, **kwargs: str(sibling))(
+            " ", strip=True
+        )
+        if text:
+            parts.append(text)
+
+    if not parts:
+        raise ValueError(f"Aerospike {title!r} section is empty")
+    return " ".join(parts)
+
+
+def parse_supported_kubernetes_versions(content: bytes | str) -> list[str]:
+    """Parse the bounded Supported Kubernetes versions section."""
+    section = _section_text(
+        content,
+        "Supported Kubernetes versions",
+        "Aerospike Kubernetes requirements page",
+    )
+    # Require the complete statement: exclusions or patch-level limits cannot
+    # safely be represented as an inclusive list of Kubernetes minor versions.
+    match = re.fullmatch(
+        r"\s*Kubernetes\s+v?(1\.\d+)\s*"
+        r"(?:to|through|[-\u2013\u2014])\s*"
+        r"v?(1\.\d+)\.?\s*",
+        section,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        raise ValueError(
+            "Aerospike Kubernetes requirements section has a missing or ambiguous "
+            "Kubernetes version range"
+        )
+
+    lower, upper = match.groups()
+    lower_minor = int(lower.split(".")[1])
+    upper_minor = int(upper.split(".")[1])
+    if lower_minor > upper_minor:
+        raise ValueError("Aerospike Kubernetes version range is reversed")
+    if upper_minor > 100:
+        raise ValueError("Aerospike Kubernetes version range exceeds the supported parser bound")
+    return [f"1.{minor}" for minor in range(upper_minor, lower_minor - 1, -1)]
+
+
+def parse_helm_install_version(content: bytes | str) -> str:
+    """Read the version explicitly used by Aerospike's Helm install docs."""
+    soup = BeautifulSoup(_decode(content, "Aerospike Helm install page"), "html.parser")
+    scope = _content_scope(soup)
+    commands = {
+        node.get_text(" ", strip=True)
+        for node in scope.find_all(["pre", "code"])
+        if re.search(
+            r"\bhelm\s+install\b.*\baerospike/aerospike-kubernetes-operator(?=\s|$)",
+            node.get_text(" ", strip=True),
+            flags=re.IGNORECASE,
+        )
+        and not node.find_parent(["nav", "header", "footer"])
+    }
+    version_pattern = re.compile(
+        r"--version\s*(?:=\s*|\s+)"
+        r"v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)"
+        r"(?![0-9A-Za-z.+-])",
+        flags=re.IGNORECASE,
+    )
+    versions = {
+        match.group(1)
+        for command in commands
+        for match in version_pattern.finditer(command)
+    }
+    if len(versions) != 1:
+        raise ValueError(
+            "Aerospike Helm install page has a missing or ambiguous current operator version"
+        )
+    version = next(iter(versions))
+    try:
+        parsed = Version(version)
+    except InvalidVersion as exc:
+        raise ValueError(f"Invalid Aerospike operator version: {version!r}") from exc
+    if parsed.is_prerelease or parsed.is_devrelease:
+        raise ValueError(f"Aerospike Helm install page names a pre-release: {version!r}")
+    if not stable_version.fullmatch(version):
+        raise ValueError(f"Unsupported Aerospike chart version: {version!r}")
+    return str(parsed)
+
+
+def _stable_version(value: object, source: str) -> str | None:
+    raw = str(value or "").strip().removeprefix("v")
+    if not raw:
+        raise ValueError(f"{source} is missing a version")
+    try:
+        parsed = Version(raw)
+    except InvalidVersion as exc:
+        raise ValueError(f"Invalid version in {source}: {raw!r}") from exc
+    if parsed.is_prerelease or parsed.is_devrelease:
+        return None
+    if not stable_version.fullmatch(raw):
+        raise ValueError(f"Unsupported stable version in {source}: {raw!r}")
+    return str(parsed)
+
+
+def parse_chart_versions(content: bytes | str) -> dict[str, str]:
+    """Return stable operator appVersion -> chart version mappings."""
+    try:
+        parsed = yaml.safe_load(_decode(content, "Aerospike Helm index"))
+    except yaml.YAMLError as exc:
+        raise ValueError("Could not parse Aerospike Helm index") from exc
+
+    if not isinstance(parsed, dict):
+        raise ValueError("Aerospike Helm index is empty or malformed")
+    entry_groups = parsed.get("entries")
+    if not isinstance(entry_groups, dict):
+        raise ValueError("Aerospike Helm index is missing chart entries")
+    entries = entry_groups.get(chart_name)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError(f"Aerospike Helm index has no {chart_name!r} chart entries")
+
+    versions: dict[str, str] = {}
+    chart_apps: dict[str, str] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Aerospike Helm index contains a malformed chart entry")
+        if entry.get("deprecated"):
+            continue
+
+        chart_version = _stable_version(
+            entry.get("version"), "Aerospike Helm chart entry"
+        )
+        if chart_version is None:
+            continue
+        app_version = _stable_version(
+            entry.get("appVersion"), "Aerospike Helm chart appVersion"
+        )
+        if app_version is None:
+            continue
+        if chart_version in chart_apps and chart_apps[chart_version] != app_version:
+            raise ValueError(f"Conflicting appVersion values for Aerospike chart {chart_version}")
+        chart_apps[chart_version] = app_version
+        previous = versions.get(app_version)
+        if previous is None or Version(chart_version) > Version(previous):
+            versions[app_version] = chart_version
+
+    if not versions:
+        raise ValueError("Aerospike Helm index contains no stable operator charts")
+    return versions
+
+
+def build_rows(
+    requirements_content: bytes | str,
+    chart_index_content: bytes | str,
+    helm_install_content: bytes | str,
+) -> list[OrderedDict[str, object]]:
+    """Build one current row; historical releases have no inferred support."""
+    kube_versions = parse_supported_kubernetes_versions(requirements_content)
+    chart_versions = parse_chart_versions(chart_index_content)
+    documented_chart = parse_helm_install_version(helm_install_content)
+
+    latest_chart = max(chart_versions.values(), key=Version)
+    if documented_chart != latest_chart:
+        raise ValueError(
+            "Aerospike Helm install docs and chart index disagree on the current "
+            f"chart version: {documented_chart} != {latest_chart}"
+        )
+
+    operator_versions = [
+        app_version
+        for app_version, chart_version in chart_versions.items()
+        if chart_version == documented_chart
+    ]
+    if len(operator_versions) != 1:
+        raise ValueError(
+            "Aerospike Helm index has a missing or ambiguous appVersion for chart "
+            f"{documented_chart}"
+        )
+    operator_version = operator_versions[0]
+
+    return [
+        OrderedDict(
+            [
+                ("version", operator_version),
+                ("kube", kube_versions),
+                ("chart_version", documented_chart),
+                ("requirements", []),
+                ("incompatibilities", []),
+            ]
+        )
+    ]
+
+
+def scrape() -> None:
+    requirements = fetch_page(compatibility_url)
+    if not requirements:
+        raise ValueError("Could not fetch Aerospike Kubernetes requirements page")
+
+    index = fetch_page(chart_index_url)
+    if not index:
+        raise ValueError("Could not fetch Aerospike Helm index")
+
+    helm_install = fetch_page(helm_install_url)
+    if not helm_install:
+        raise ValueError("Could not fetch Aerospike Helm install page")
+
+    rows = build_rows(requirements, index, helm_install)
+    update_compatibility_info(
+        compatibility_file,
+        rows,
+    )

--- a/utils/compatibility/tests/AEROSPIKE_OPERATOR.md
+++ b/utils/compatibility/tests/AEROSPIKE_OPERATOR.md
@@ -1,0 +1,48 @@
+# Aerospike Kubernetes Operator compatibility
+
+This entry lets Plural evaluate Aerospike operator deployments during Kubernetes upgrades. For example, the published range for operator 4.5.0 includes Kubernetes 1.35 but does not include 1.36. An absent catalog entry cannot provide that compatibility information.
+
+The scraper records the current operator release using three official sources:
+
+- [System requirements](https://aerospike.com/docs/kubernetes/install/requirements/): the bounded **Supported Kubernetes versions** section provides both endpoints of the supported Kubernetes range.
+- [Helm installation](https://aerospike.com/docs/kubernetes/install/helm/): the operator install command identifies the release to which the current documentation applies.
+- [Official Helm index](https://aerospike.github.io/aerospike-kubernetes-enterprise/index.yaml): confirms the stable chart and operator versions.
+
+At the time of this contribution, the documented operator and chart are **4.5.0**, with Kubernetes support **1.23–1.35**, inclusive. Kubernetes 1.36 is not included, even if the repository's `KUBE_VERSION` is newer. The chart and install documentation must agree before the scraper writes an update.
+
+## Historical coverage
+
+The current requirements page is not a historical compatibility matrix. The scraper therefore refreshes only the documented current release. It does not apply today's range to older charts or infer support from a chart's publication date. The shared compatibility updater retains verified historical entries as new releases are added.
+
+The committed table also contains a manually verified historical seed for **operator/chart 3.0.0**, Kubernetes **1.19–1.27**. The [archived official system requirements page](https://web.archive.org/web/20230924065830id_/https://docs.aerospike.com/cloud/kubernetes/operator/system-requirements) explicitly identifies its version as **Operator 3.0.0**, publishes that complete range, and reports an August 22, 2023 update date. It is not mapped by proximity to a release date. The historical page's supported range takes precedence over the chart README's less restrictive installation minimum.
+
+The archive is a source for the committed seed, not a dependency of the daily scraper. The integration test verifies that a current refresh preserves the historical range. Other older releases remain omitted: tagged chart READMEs document historical minimum Kubernetes versions, but those minimums do not establish maximum supported versions.
+
+The upstream [4.5.0 webhook test workflow](https://github.com/aerospike/aerospike-kubernetes-operator/blob/v4.5.0/.github/workflows/webhook-tests.yml) selects Kubernetes 1.23 and 1.35. These are useful corroborating endpoints; the requirements page, rather than an interpolation between CI jobs, is the authority for the inclusive range. Earlier workflows such as [4.4.1](https://github.com/aerospike/aerospike-kubernetes-operator/blob/v4.4.1/.github/workflows/webhook-tests.yml) do not provide an equivalent explicit range. Envtest defaults and Go module versions are not interpreted as historical platform support.
+
+## Update behavior
+
+Each source request has a 30-second timeout and raises on HTTP errors. The scraper rejects non-three-part stable versions, conflicting chart metadata, changed or ambiguous support statements, and disagreement between the documented chart and the latest stable index entry. Range expansion is bounded at Kubernetes minor 100 to reject malformed enormous ranges; it is never clamped to the local `KUBE_VERSION`.
+
+All source parsing completes before the shared updater is called. Source failures therefore leave the existing table alone. The scraper uses the repository's existing `update_compatibility_info` behavior for merging, image enrichment, and writing; it does not introduce a separate persistence implementation or change shared writer error handling.
+
+## Installation prerequisites
+
+The default chart creates cert-manager `Certificate` and `Issuer` resources. Aerospike's Helm installation page requires cert-manager but does not specify a version constraint, so the compatibility table does not invent one. The linked installation instructions also describe namespace permissions and supported Pod Security Admission settings. Aerospike documents Enterprise and Federal database editions, and excludes GKE Autopilot; this table is an upstream Kubernetes version declaration, not a certification of every deployment configuration.
+
+## Validation
+
+From `utils/compatibility`, with the repository's Python requirements and pytest installed:
+
+```sh
+python -m pytest tests/test_aerospike_kubernetes_operator.py -q
+python -m pytest tests -q
+```
+
+The small HTML fixtures are reduced examples of the linked official sections. The Helm-index fixture also includes synthetic prerelease, deprecated, and unrelated-chart entries to exercise filtering. Tests cover the parser and update boundary without requiring network access or a running Kubernetes cluster. For an actual refresh, install Helm, disable optional paid summarization, and run from the same directory:
+
+```sh
+EXA_API_KEY= OPENAI_API_KEY= python -c "import importlib; importlib.import_module('scrapers.aerospike-kubernetes-operator').scrape()"
+```
+
+The shared updater renders the official Helm chart to discover container images. Helm linting and rendering validate chart metadata and manifests; they do not constitute a live operator/database deployment test.

--- a/utils/compatibility/tests/fixtures/aerospike/helm-install.html
+++ b/utils/compatibility/tests/fixtures/aerospike/helm-install.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <body>
+    <main>
+      <h1>Install Aerospike Kubernetes Operator using Helm</h1>
+      <h2>Install AKO</h2>
+      <pre><code>helm install aerospike-kubernetes-operator aerospike/aerospike-kubernetes-operator \
+--namespace NAMESPACE_NAME --version=4.5.0 --set watchNamespaces="aerospike"</code></pre>
+      <p>Default operatorImage.tag: 4.5.0</p>
+    </main>
+  </body>
+</html>

--- a/utils/compatibility/tests/fixtures/aerospike/index.yaml
+++ b/utils/compatibility/tests/fixtures/aerospike/index.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+entries:
+  aerospike-kubernetes-operator:
+    - apiVersion: v2
+      appVersion: 4.5.0
+      name: aerospike-kubernetes-operator
+      version: 4.5.0
+      urls:
+        - https://aerospike.github.io/aerospike-kubernetes-operator/aerospike-kubernetes-operator-4.5.0.tgz
+    - apiVersion: v2
+      appVersion: 4.4.1
+      name: aerospike-kubernetes-operator
+      version: 4.4.1
+      urls:
+        - https://aerospike.github.io/aerospike-kubernetes-operator/aerospike-kubernetes-operator-4.4.1.tgz
+    - apiVersion: v2
+      appVersion: 4.6.0-rc.1
+      name: aerospike-kubernetes-operator
+      version: 4.6.0-rc.1
+      urls:
+        - https://aerospike.github.io/aerospike-kubernetes-operator/aerospike-kubernetes-operator-4.6.0-rc.1.tgz
+    - apiVersion: v2
+      appVersion: 9.9.9
+      name: aerospike-kubernetes-operator
+      version: 9.9.9
+      deprecated: true
+      urls:
+        - https://aerospike.github.io/aerospike-kubernetes-operator/aerospike-kubernetes-operator-9.9.9.tgz
+  aerospike-cluster:
+    - apiVersion: v2
+      appVersion: 99.0.0
+      name: aerospike-cluster
+      version: 99.0.0
+      urls:
+        - https://aerospike.github.io/aerospike-kubernetes-enterprise/aerospike-cluster-99.0.0.tgz

--- a/utils/compatibility/tests/fixtures/aerospike/requirements.html
+++ b/utils/compatibility/tests/fixtures/aerospike/requirements.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <body>
+    <h2 id="supported-kubernetes-versions">Supported Kubernetes versions</h2>
+    <p>Kubernetes 1.23 to 1.35.</p>
+    <h2>Unrelated version text</h2>
+    <p>The operator supports Aerospike Database 6.0 and later.</p>
+  </body>
+</html>

--- a/utils/compatibility/tests/test_aerospike_kubernetes_operator.py
+++ b/utils/compatibility/tests/test_aerospike_kubernetes_operator.py
@@ -1,0 +1,264 @@
+"""Offline source and safety tests for the Aerospike Kubernetes Operator scraper."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import yaml
+
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+import utils as compatibility_utils
+
+SCRAPER_PATH = COMPATIBILITY / "scrapers/aerospike-kubernetes-operator.py"
+spec = importlib.util.spec_from_file_location("aerospike_kubernetes_operator", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+FIXTURES = Path(__file__).parent / "fixtures/aerospike"
+REQUIREMENTS = (FIXTURES / "requirements.html").read_bytes()
+INDEX = (FIXTURES / "index.yaml").read_bytes()
+HELM_INSTALL = (FIXTURES / "helm-install.html").read_bytes()
+
+
+class AerospikeKubernetesOperatorTests(unittest.TestCase):
+    def test_requirements_are_bound_to_the_supported_kubernetes_heading(self):
+        self.assertEqual(
+            scraper.parse_supported_kubernetes_versions(REQUIREMENTS),
+            [f"1.{minor}" for minor in range(35, 22, -1)],
+        )
+
+    def test_missing_or_ambiguous_requirements_fail_closed(self):
+        sources = [
+            b"<html><p>Kubernetes 1.23 to 1.35.</p></html>",
+            b"<h2>Supported Kubernetes versions</h2><p>1.23</p>",
+            b"<h2>Supported Kubernetes versions</h2><p>1.23 to 1.35</p>"
+            b"<h2>Supported Kubernetes versions</h2><p>1.24 to 1.35</p>",
+            b"<h2>Supported Kubernetes versions</h2><p>1.23 or later</p>",
+            b"<h2>Supported Kubernetes versions</h2><p>Kubernetes 1.23 to 1.35 except 1.27.</p>",
+            b"<h2>Supported Kubernetes versions</h2><p>Kubernetes 1.23 to 1.35-rc.1.</p>",
+        ]
+        for source in sources:
+            with self.subTest(source=source), self.assertRaises(ValueError):
+                scraper.parse_supported_kubernetes_versions(source)
+
+    def test_requirements_range_has_a_reasonable_expansion_bound(self):
+        source = (
+            b"<h2>Supported Kubernetes versions</h2>"
+            b"<p>Kubernetes 1.23 to 1.101.</p>"
+        )
+        with self.assertRaisesRegex(ValueError, "parser bound"):
+            scraper.parse_supported_kubernetes_versions(source)
+
+    def test_chart_index_maps_app_version_to_chart_version_and_ignores_unstable(self):
+        self.assertEqual(
+            scraper.parse_chart_versions(INDEX),
+            {"4.5.0": "4.5.0", "4.4.1": "4.4.1"},
+        )
+
+    def test_chart_version_and_app_version_are_not_conflated(self):
+        index = yaml.safe_dump({
+            "entries": {
+                "aerospike-kubernetes-operator": [
+                    {"appVersion": "4.5.0", "version": "7.0.0"},
+                ],
+            },
+        }).encode()
+        self.assertEqual(scraper.parse_chart_versions(index), {"4.5.0": "7.0.0"})
+
+    def test_chart_and_app_versions_require_three_part_stable_versions(self):
+        for field in ("version", "appVersion"):
+            for value in ("4.5", "4.5.0.post1", "4.5.0+build"):
+                with self.subTest(field=field, value=value):
+                    entry = {"appVersion": "4.5.0", "version": "4.5.0"}
+                    entry[field] = value
+                    index = yaml.safe_dump({
+                        "entries": {"aerospike-kubernetes-operator": [entry]},
+                    }).encode()
+                    with self.assertRaises(ValueError):
+                        scraper.parse_chart_versions(index)
+
+    def test_chart_index_rejects_conflicting_app_versions_for_one_chart(self):
+        index = yaml.safe_dump({
+            "entries": {
+                "aerospike-kubernetes-operator": [
+                    {"appVersion": "4.5.0", "version": "4.5.0"},
+                    {"appVersion": "4.4.1", "version": "4.5.0"},
+                ],
+            },
+        }).encode()
+        with self.assertRaisesRegex(ValueError, "Conflicting appVersion"):
+            scraper.parse_chart_versions(index)
+
+    def test_missing_malformed_or_wrong_chart_entries_fail_closed(self):
+        sources = [
+            b"",
+            b"null",
+            b"entries: {}",
+            b"entries: []",
+            yaml.safe_dump({"entries": {"other-chart": [{"version": "4.5.0"}]}}).encode(),
+            yaml.safe_dump({"entries": {"aerospike-kubernetes-operator": [None]}}).encode(),
+            yaml.safe_dump({"entries": {"aerospike-kubernetes-operator": [{"version": "latest"}]}}).encode(),
+        ]
+        for source in sources:
+            with self.subTest(source=source), self.assertRaises(ValueError):
+                scraper.parse_chart_versions(source)
+
+    def test_install_page_provides_the_current_stable_operator_anchor(self):
+        self.assertEqual(scraper.parse_helm_install_version(HELM_INSTALL), "4.5.0")
+
+    def test_install_page_rejects_prerelease_and_unrelated_version_flags(self):
+        prerelease = HELM_INSTALL.replace(b"4.5.0", b"4.5.0-rc.1")
+        unrelated = (
+            b"<main><pre><code>helm dependency update --version=9.9.9</code></pre>"
+            b"</main>"
+        )
+        for source in (prerelease, unrelated):
+            with self.subTest(source=source), self.assertRaises(ValueError):
+                scraper.parse_helm_install_version(source)
+
+    def test_fetch_page_uses_timeout_and_propagates_http_errors(self):
+        response = Mock(content=b"source")
+        with patch.object(scraper.requests, "get", return_value=response) as get:
+            self.assertEqual(scraper.fetch_page("https://example.test/source"), b"source")
+        get.assert_called_once_with("https://example.test/source", timeout=30)
+        response.raise_for_status.assert_called_once_with()
+
+        response.raise_for_status.side_effect = scraper.requests.HTTPError("boom")
+        with patch.object(scraper.requests, "get", return_value=response):
+            with self.assertRaises(scraper.requests.HTTPError):
+                scraper.fetch_page("https://example.test/source")
+
+    def test_requirements_with_patch_versions_do_not_silently_truncate_to_minors(self):
+        source = (
+            b"<h2>Supported Kubernetes versions</h2>"
+            b"<p>Kubernetes 1.23 to 1.35.2.</p>"
+        )
+        with self.assertRaises(ValueError):
+            scraper.parse_supported_kubernetes_versions(source)
+
+    def test_build_rows_uses_current_supported_range_and_chart_mapping(self):
+        rows = scraper.build_rows(REQUIREMENTS, INDEX, HELM_INSTALL)
+        self.assertEqual([row["version"] for row in rows], ["4.5.0"])
+        self.assertEqual([row["chart_version"] for row in rows], ["4.5.0"])
+        self.assertEqual(rows[0]["kube"], [f"1.{minor}" for minor in range(35, 22, -1)])
+        # The install docs require cert-manager but publish no cert-manager version.
+        self.assertEqual(rows[0]["requirements"], [])
+
+    def test_build_rows_maps_documented_chart_to_a_distinct_operator_app_version(self):
+        index = yaml.safe_dump({
+            "entries": {
+                "aerospike-kubernetes-operator": [
+                    {"appVersion": "4.5.0", "version": "7.0.0"},
+                ],
+            },
+        }).encode()
+        helm_install = HELM_INSTALL.replace(b"--version=4.5.0", b"--version=7.0.0")
+        rows = scraper.build_rows(REQUIREMENTS, index, helm_install)
+        self.assertEqual(rows[0]["version"], "4.5.0")
+        self.assertEqual(rows[0]["chart_version"], "7.0.0")
+
+    def test_build_rows_rejects_a_newer_chart_than_the_documented_install_anchor(self):
+        index = yaml.safe_dump({
+            "entries": {
+                "aerospike-kubernetes-operator": [
+                    {"appVersion": "4.6.0", "version": "4.6.0"},
+                    {"appVersion": "4.5.0", "version": "4.5.0"},
+                ],
+            },
+        }).encode()
+        with self.assertRaisesRegex(ValueError, "disagree"):
+            scraper.build_rows(REQUIREMENTS, index, HELM_INSTALL)
+
+    def test_scrape_wires_all_official_sources_and_uses_the_expected_path(self):
+        sources = {
+            scraper.compatibility_url: REQUIREMENTS,
+            scraper.chart_index_url: INDEX,
+            scraper.helm_install_url: HELM_INSTALL,
+        }
+        fetch = Mock(side_effect=lambda url: sources[url])
+        with patch.object(scraper, "fetch_page", fetch), \
+                patch.object(scraper, "update_compatibility_info") as update:
+            scraper.scrape()
+
+        update.assert_called_once()
+        path, rows = update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/aerospike-kubernetes-operator.yaml")
+        self.assertEqual(rows[0]["version"], "4.5.0")
+        self.assertEqual(fetch.call_args_list[2].args[0], scraper.helm_install_url)
+
+    def test_scrape_preserves_seeded_historical_rows_with_the_real_updater(self):
+        seeded = {
+            "name": scraper.app_name,
+            "icon": "https://example.test/aerospike.png",
+            "git_url": "https://github.com/aerospike/aerospike-kubernetes-operator",
+            "release_url": "https://github.com/aerospike/aerospike-kubernetes-operator/releases",
+            "readme_url": scraper.helm_install_url,
+            "helm_repository_url": "https://charts.example.test/aerospike",
+            "chart_name": scraper.chart_name,
+            "versions": [
+                {
+                    "version": "3.0.0",
+                    "kube": ["1.27", "1.26", "1.25", "1.24", "1.23", "1.22", "1.21", "1.20", "1.19"],
+                    "chart_version": "3.0.0",
+                    "images": ["aerospike/operator:3.0.0"],
+                    "requirements": [],
+                    "incompatibilities": [],
+                },
+            ],
+        }
+        sources = {
+            scraper.compatibility_url: REQUIREMENTS,
+            scraper.chart_index_url: INDEX,
+            scraper.helm_install_url: HELM_INSTALL,
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / f"{scraper.app_name}.yaml"
+            output.write_text(yaml.safe_dump(seeded, sort_keys=False), encoding="utf-8")
+
+            def chart_images(_url, _chart, version, _values=None):
+                return [f"aerospike/operator:{version}"]
+
+            with patch.object(scraper, "compatibility_file", output.as_posix()), \
+                    patch.object(scraper, "fetch_page", side_effect=lambda url: sources[url]), \
+                    patch.object(compatibility_utils, "get_chart_images", side_effect=chart_images), \
+                    patch.object(compatibility_utils, "summarization_enabled", return_value=False), \
+                    patch.object(compatibility_utils, "print_warning"), \
+                    patch.object(compatibility_utils, "print_success"):
+                scraper.scrape()
+
+            result = yaml.safe_load(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            {version["version"] for version in result["versions"]},
+            {"3.0.0", "4.5.0"},
+        )
+        historical = next(row for row in result["versions"] if row["version"] == "3.0.0")
+        self.assertEqual(
+            historical["kube"],
+            ["1.27", "1.26", "1.25", "1.24", "1.23", "1.22", "1.21", "1.20", "1.19"],
+        )
+        self.assertEqual(historical["chart_version"], "3.0.0")
+        current = next(row for row in result["versions"] if row["version"] == "4.5.0")
+        self.assertEqual(current["kube"], [f"1.{minor}" for minor in range(35, 22, -1)])
+        self.assertEqual(current["images"], ["aerospike/operator:4.5.0"])
+        self.assertEqual(result["icon"], seeded["icon"])
+        self.assertEqual(result["helm_repository_url"], seeded["helm_repository_url"])
+
+    def test_source_failure_never_overwrites_existing_compatibility(self):
+        for source in (None, b"<html>changed</html>", b"<h2>Supported Kubernetes versions</h2><p>1.23 or later</p>"):
+            with self.subTest(source=source), \
+                    patch.object(scraper, "fetch_page", return_value=source), \
+                    patch.object(scraper, "update_compatibility_info") as update:
+                with self.assertRaises(ValueError):
+                    scraper.scrape()
+                update.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Aerospike Kubernetes Operator to Plural's Kubernetes upgrade compatibility catalog, with an automated scraper, metadata, manifest registration, and tests. For example, the new 4.5.0 entry records support for Kubernetes 1.35 but excludes 1.36, which is outside Aerospike's published range.

| Operator / chart | Kubernetes range | How maintained |
| --- | --- | --- |
| 4.5.0 | 1.23–1.35 | Generated from current official requirements and Helm documentation. |
| 3.0.0 | 1.19–1.27 | Verified historical seed from an archived official page explicitly labeled Operator 3.0.0; preserved during refreshes. |

The scraper reads the current chart version from the official install command and resolves its operator `appVersion` through the Helm index. Chart and operator versions are treated separately. Daily updates do not depend on archive availability.

Other historical releases are omitted because the available sources do not establish complete release-specific ranges. The scraper does not extrapolate to the repository's newer `KUBE_VERSION` or treat historical minimums and envtest defaults as complete support ranges.

Source requests use a 30-second timeout. Parsing rejects unsupported version formats, conflicting chart metadata, patch-specific or qualified support ranges, excessive range bounds, and disagreement between the chart index and installation documentation before calling the shared updater.

## Sources

- [Aerospike system requirements](https://aerospike.com/docs/kubernetes/install/requirements/)
- [Official Helm installation instructions](https://aerospike.com/docs/kubernetes/install/helm/)
- [Official Helm chart index](https://aerospike.github.io/aerospike-kubernetes-enterprise/index.yaml)
- [Operator 4.5.0 chart metadata](https://github.com/aerospike/aerospike-kubernetes-operator/blob/v4.5.0/helm-charts/aerospike-kubernetes-operator/Chart.yaml)
- [Release-tagged 4.5.0 webhook test endpoints](https://github.com/aerospike/aerospike-kubernetes-operator/blob/v4.5.0/.github/workflows/webhook-tests.yml), corroborating the documented range endpoints
- [Archived official Operator 3.0.0 system requirements](https://web.archive.org/web/20230924065830id_/https://docs.aerospike.com/cloud/kubernetes/operator/system-requirements), explicitly identifying the operator version and complete Kubernetes range

The linked installation instructions require cert-manager without specifying a version. This contribution documents that prerequisite without inventing a version constraint. Source rationale and reproduction commands are in `utils/compatibility/tests/AEROSPIKE_OPERATOR.md`.

## Test Plan

Test environment: local Windows, Python 3.12, Helm 3.19.0.

- `python -m pytest tests -q` from `utils/compatibility`: **145 passed, 105 subtests passed**, including 18 new Aerospike tests and a real shared-updater integration test preserving the historical entry.
- All **58** compatibility YAML files validate against the repository's JSON Schema; manifest, individual entry, and aggregate agree.
- Live scraper run against the three official sources completed successfully; a repeat run produced byte-for-byte identical output.
- Official 4.5.0 chart passes `helm lint` and renders successfully; its archive matches the SHA256 in the official index.
- Official 3.0.0 chart metadata and archive checksum validate; the shared updater renders both its operator and RBAC proxy sidecar images.
- Rendered operator image matches the catalog entry, and the public image tag resolves.
- `git diff --check` passes.

No live Kubernetes operator/database deployment was performed. These checks validate upstream-declared compatibility, parser behavior, and chart rendering.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly (source rationale and reproduction instructions included).
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (not applicable: this PR changes compatibility metadata and its Python scraper, not deployment agent code).

## Contributor program

AI assistance disclosure: developed and reviewed with OpenAI Codex under the submitting account owner's direction.

Please consider this contribution for the README Contributor Program's advertised **$300 new compatibility scraper reward**, subject to maintainer acceptance and contributor eligibility. I understand the one-award-per-contributor-per-calendar-month limit and the post-merge Discord claim process.

Discord handle for contributor verification: `dillydillerson`.

Plural Flow: console
