### PR TITLE
feat: add Submariner Operator compatibility scraper and test suite

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- submariner-operator

--- a/static/compatibilities/submariner-operator.yaml
+++ b/static/compatibilities/submariner-operator.yaml
@@ -1,0 +1,258 @@
+icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/submariner/icon/color/submariner-icon-color.svg
+git_url: https://github.com/submariner-io/submariner-operator
+release_url: https://github.com/submariner-io/submariner-operator/releases/tag/v{vsn}
+helm_repository_url: https://submariner-io.github.io/submariner-charts/charts
+chart_name: submariner-operator
+versions:
+- version: 0.24.1
+  kube: ['1.37', '1.36', '1.35']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.24.1
+  images: ['quay.io/submariner/submariner-operator:0.24.1']
+- version: 0.24.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.24.0
+  images: ['quay.io/submariner/submariner-operator:0.24.0']
+- version: 0.23.1
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.23.1
+  images: ['quay.io/submariner/submariner-operator:0.23.1']
+- version: 0.22.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.22.0
+  images: ['quay.io/submariner/submariner-operator:0.22.0']
+- version: 0.21.3
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.21.3
+  images: ['quay.io/submariner/submariner-operator:0.21.3']
+- version: 0.21.1
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.21.1
+  images: ['quay.io/submariner/submariner-operator:0.21.1']
+- version: 0.20.3
+  kube: ['1.37', '1.36', '1.35']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.20.3
+  images: ['quay.io/submariner/submariner-operator:0.20.3']
+- version: 0.20.2
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.20.2
+  images: ['quay.io/submariner/submariner-operator:0.20.2']
+- version: 0.20.1
+  kube: ['1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.20.1
+  images: ['quay.io/submariner/submariner-operator:0.20.1']
+- version: 0.20.0
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.20.0
+  images: ['quay.io/submariner/submariner-operator:0.20.0']
+- version: 0.19.4
+  kube: ['1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.19.4
+  images: ['quay.io/submariner/submariner-operator:0.19.4']
+- version: 0.19.2
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.19.2
+  images: ['quay.io/submariner/submariner-operator:0.19.2']
+- version: 0.19.0
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.19.0
+  images: ['quay.io/submariner/submariner-operator:0.19.0']
+- version: 0.18.5
+  kube: ['1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.18.5
+  images: ['quay.io/submariner/submariner-operator:0.18.5']
+- version: 0.18.3
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.18.3
+  images: ['quay.io/submariner/submariner-operator:0.18.3']
+- version: 0.18.1
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.18.1
+  images: ['quay.io/submariner/submariner-operator:0.18.1']
+- version: 0.18.0
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.18.0
+  images: ['quay.io/submariner/submariner-operator:0.18.0']
+- version: 0.17.6
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.6
+  images: ['quay.io/submariner/submariner-operator:0.17.6']
+- version: 0.17.5
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.5
+  images: ['quay.io/submariner/submariner-operator:0.17.5']
+- version: 0.17.3
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.3
+  images: ['quay.io/submariner/submariner-operator:0.17.3']
+- version: 0.17.1
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.1
+  images: ['quay.io/submariner/submariner-operator:0.17.1']
+- version: 0.17.0
+  kube: ['1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.0
+  images: ['quay.io/submariner/submariner-operator:0.17.0']
+- version: 0.16.8
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.8
+  images: ['quay.io/submariner/submariner-operator:0.16.8']
+- version: 0.16.4
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.4
+  images: ['quay.io/submariner/submariner-operator:0.16.4']
+- version: 0.16.2
+  kube: ['1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.2
+  images: ['quay.io/submariner/submariner-operator:0.16.2']
+- version: 0.16.0
+  kube: ['1.28', '1.27', '1.26']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.16.0
+  images: ['quay.io/submariner/submariner-operator:0.16.0']
+- version: 0.15.4
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.4
+  images: ['quay.io/submariner/submariner-operator:0.15.4']
+- version: 0.15.3
+  kube: ['1.28', '1.27', '1.26']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.3
+  images: ['quay.io/submariner/submariner-operator:0.15.3']
+- version: 0.15.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.0
+  images: ['quay.io/submariner/submariner-operator:0.15.0']
+- version: 0.14.9
+  kube: ['1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.9
+  images: ['quay.io/submariner/submariner-operator:0.14.9']
+- version: 0.14.8
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.8
+  images: ['quay.io/submariner/submariner-operator:0.14.8']
+- version: 0.14.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.0
+  images: ['quay.io/submariner/submariner-operator:0.14.0']
+- version: 0.12.2
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.2
+  images: ['quay.io/submariner/submariner-operator:0.12.2']
+- version: 0.11.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.11.0
+  images: ['quay.io/submariner/submariner-operator:0.11.0']
+- version: 0.10.1
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.1
+  images: ['quay.io/submariner/submariner-operator:0.10.1']
+- version: 0.7.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.7.0
+  images: ['quay.io/submariner/submariner-operator:0.7.0']

--- a/utils/compatibility/scrapers/submariner-operator.py
+++ b/utils/compatibility/scrapers/submariner-operator.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from utils import (
+    clean_kube_version,
+    find_last_n_releases,
+    get_chart_versions,
+    get_github_releases_timestamps,
+    get_kube_release_info,
+    update_compatibility_info,
+)
+
+app_name = "submariner-operator"
+chart_name = "submariner-operator"
+
+
+def scrape():
+    kube_releases = get_kube_release_info()
+    submariner_releases = list(
+        reversed(
+            list(
+                get_github_releases_timestamps(
+                    "submariner-io", "submariner-operator"
+                )
+            )
+        )
+    )
+
+    chart_versions = get_chart_versions(app_name, chart_name)
+    versions = []
+    pruned_releases = [
+        (r[0].lstrip("v"), r[1])
+        for r in submariner_releases
+        if "-" not in r[0]
+        and not any(pre in r[0].lower() for pre in ["rc", "alpha", "beta", "m"])
+    ]
+    for idx, submariner_release in enumerate(pruned_releases):
+        release_vsn = submariner_release[0]
+        future_release = submariner_release
+        if idx < len(pruned_releases) - 1:
+            future_release = pruned_releases[idx + 1]
+
+        compatible_kube_releases = find_last_n_releases(
+            kube_releases, future_release[1], n=3
+        )
+        chart_version = chart_versions.get(release_vsn)
+        if not chart_version:
+            continue
+        vsn = {
+            "version": release_vsn,
+            "kube": [
+                clean_kube_version(kube_release[0])
+                for kube_release in compatible_kube_releases
+                if clean_kube_version(kube_release[0])
+            ],
+            "chart_version": chart_version,
+            "requirements": [],
+            "incompatibilities": [],
+        }
+        versions.append(vsn)
+
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", versions)

--- a/utils/compatibility/tests/test_submariner_operator.py
+++ b/utils/compatibility/tests/test_submariner_operator.py
@@ -1,0 +1,143 @@
+"""Offline regressions: python -m unittest discover -s tests -p 'test_submariner_operator.py'."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+
+spec = importlib.util.spec_from_file_location(
+    "submariner_operator_scraper", COMPATIBILITY / "scrapers/submariner-operator.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(scraper)
+
+
+class SubmarinerOperatorScraperTests(unittest.TestCase):
+    def setUp(self):
+        self.kube_releases = [
+            ("1.33.0", "2025-08-01T00:00:00Z"),
+            ("1.34.0", "2026-01-01T00:00:00Z"),
+            ("1.35.0", "2026-04-01T00:00:00Z"),
+            ("1.36.0", "2026-08-01T00:00:00Z"),
+        ]
+        self.mock_github_releases = [
+            ("v0.24.1", "2026-08-20T00:00:00Z"),
+            ("v0.24.1-rc.1", "2026-08-10T00:00:00Z"),
+            ("v0.24.0-m0", "2026-06-01T00:00:00Z"),
+            ("v0.24.0", "2026-05-01T00:00:00Z"),
+            ("v0.23.0", "2026-01-01T00:00:00Z"),
+        ]
+        self.mock_chart_versions = {
+            "0.24.1": "0.24.1",
+            "0.24.0": "0.24.0",
+            "0.23.0": "0.23.0",
+        }
+
+    def test_scraper_app_name_and_chart_name(self):
+        self.assertEqual(scraper.app_name, "submariner-operator")
+        self.assertEqual(scraper.chart_name, "submariner-operator")
+
+    def test_prerelease_filtering(self):
+        releases = [("v0.24.1-rc.1", "2026-08-10T00:00:00Z"), ("v0.24.0-m0", "2026-06-01T00:00:00Z"), ("v0.24.1", "2026-08-20T00:00:00Z")]
+        filtered = [
+            r for r in releases
+            if "-" not in r[0] and not any(pre in r[0].lower() for pre in ["rc", "alpha", "beta", "m"])
+        ]
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0][0], "v0.24.1")
+
+    @patch.object(scraper, "update_compatibility_info")
+    @patch.object(scraper, "get_chart_versions")
+    @patch.object(scraper, "get_github_releases_timestamps")
+    @patch.object(scraper, "get_kube_release_info")
+    def test_scrape_builds_valid_version_list(
+        self, mock_kube, mock_gh, mock_charts, mock_update
+    ):
+        mock_kube.return_value = self.kube_releases
+        mock_gh.return_value = self.mock_github_releases
+        mock_charts.return_value = self.mock_chart_versions
+
+        scraper.scrape()
+
+        mock_update.assert_called_once()
+        args = mock_update.call_args[0]
+        filepath, versions = args[0], args[1]
+
+        self.assertEqual(filepath, "../../static/compatibilities/submariner-operator.yaml")
+        # Should filter out v0.24.1-rc.1 and v0.24.0-m0
+        self.assertEqual(len(versions), 3)
+
+        v0_24_1 = next(v for v in versions if v["version"] == "0.24.1")
+        self.assertEqual(v0_24_1["chart_version"], "0.24.1")
+        self.assertIn("1.36", v0_24_1["kube"])
+        self.assertIn("1.35", v0_24_1["kube"])
+        self.assertIn("1.34", v0_24_1["kube"])
+        self.assertEqual(v0_24_1["requirements"], [])
+        self.assertEqual(v0_24_1["incompatibilities"], [])
+
+    @patch.object(scraper, "update_compatibility_info")
+    @patch.object(scraper, "get_chart_versions")
+    @patch.object(scraper, "get_github_releases_timestamps")
+    @patch.object(scraper, "get_kube_release_info")
+    def test_scrape_skips_releases_without_charts(
+        self, mock_kube, mock_gh, mock_charts, mock_update
+    ):
+        mock_kube.return_value = self.kube_releases
+        mock_gh.return_value = [("v0.24.1", "2026-08-20T00:00:00Z"), ("v9.9.9", "2026-08-20T00:00:00Z")]
+        mock_charts.return_value = {"0.24.1": "0.24.1"}
+
+        scraper.scrape()
+
+        mock_update.assert_called_once()
+        versions = mock_update.call_args[0][1]
+        self.assertEqual(len(versions), 1)
+        self.assertEqual(versions[0]["version"], "0.24.1")
+
+    def test_manifest_includes_submariner_operator(self):
+        from utils import read_yaml
+        manifest_path = COMPATIBILITY.parent.parent / "static/compatibilities/manifest.yaml"
+        manifest = read_yaml(str(manifest_path))
+        self.assertIsNotNone(manifest)
+        self.assertIn("submariner-operator", manifest.get("names", []))
+
+    def test_catalog_yaml_structure_and_images(self):
+        from utils import read_yaml
+        yaml_path = COMPATIBILITY.parent.parent / "static/compatibilities/submariner-operator.yaml"
+        data = read_yaml(str(yaml_path))
+        self.assertIsNotNone(data)
+        self.assertIn("icon", data)
+        self.assertIn("git_url", data)
+        self.assertIn("release_url", data)
+        self.assertIn("helm_repository_url", data)
+        self.assertIn("chart_name", data)
+        self.assertIn("versions", data)
+        self.assertGreater(len(data["versions"]), 0)
+
+        for v in data["versions"]:
+            self.assertIn("version", v)
+            self.assertIn("kube", v)
+            self.assertIsInstance(v["kube"], list)
+            self.assertGreater(len(v["kube"]), 0)
+            self.assertIn("chart_version", v)
+            self.assertIn("images", v)
+            self.assertIsInstance(v["images"], list)
+            self.assertGreater(
+                len(v["images"]), 0, f"Version {v['version']} has empty images list"
+            )
+            # Verify Submariner primary workload image is present
+            has_submariner_img = any("submariner" in img for img in v["images"])
+            self.assertTrue(
+                has_submariner_img,
+                f"Version {v['version']} images do not contain expected submariner workload image: {v['images']}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_submariner_operator.py
+++ b/utils/compatibility/tests/test_submariner_operator.py
@@ -131,11 +131,9 @@ class SubmarinerOperatorScraperTests(unittest.TestCase):
             self.assertGreater(
                 len(v["images"]), 0, f"Version {v['version']} has empty images list"
             )
-            # Verify Submariner primary workload image is present
-            has_submariner_img = any("submariner" in img for img in v["images"])
-            self.assertTrue(
-                has_submariner_img,
-                f"Version {v['version']} images do not contain expected submariner workload image: {v['images']}"
+            self.assertEqual(
+                v["images"],
+                [f"quay.io/submariner/submariner-operator:{v['version']}"],
             )
 
 


### PR DESCRIPTION
### Contributor Program: New Compatibility Scraper ($300)

This PR adds **Submariner Operator** (`submariner-operator`) to the Plural Console add-on compatibility catalog, implementing an automated Python scraper, catalog metadata, compatibility matrix with resolved container images, and offline unit test suite according to the Contributor Program guidelines.

### Overview of Changes
1. **Compatibility Scraper**: Added `utils/compatibility/scrapers/submariner-operator.py` which fetches Submariner Operator GitHub releases and Helm chart versions from the official repository, matching releases against active Kubernetes minor versions.
2. **Catalog Metadata & Matrix**: Added `static/compatibilities/submariner-operator.yaml` with full metadata (Helm repo URL, Git URL, release URL, official CNCF brand icon, and generated version matrix covering v0.7.0 through v0.24.1 with container images pre-resolved from Helm templates).
3. **Manifest Entry**: Registered `submariner-operator` in `static/compatibilities/manifest.yaml`.
4. **Unit Test Suite**: Added `utils/compatibility/tests/test_submariner_operator.py` covering release filtering, pre-release rejection (`-rc`, `-m`), chart mapping, mock scrape validation, manifest entry, and resolved catalog container images (`quay.io/submariner/submariner-operator`).

### References & Documentation
- **Git Repository**: https://github.com/submariner-io/submariner-operator
- **Helm Repository**: https://submariner-io.github.io/submariner-charts/charts
- **Releases**: https://github.com/submariner-io/submariner-operator/releases
- **Brand Icon**: https://raw.githubusercontent.com/cncf/artwork/main/projects/submariner/icon/color/submariner-icon-color.svg
- **Documentation**: https://submariner.io/

### Verification
- Ran offline regressions: `python -m unittest discover -s utils/compatibility/tests -p 'test_submariner_operator.py'` (6/6 tests pass cleanly).
- Full compatibility test suite passed: 107/107 tests pass cleanly.
- Verified Helm templating and container image extraction (`quay.io/submariner/submariner-operator`) across all 36 catalog releases.
