### PR TITLE
feat: add KEDA HTTP Add-on compatibility scraper and test suite

### DIFF
--- a/static/compatibilities/keda-http-addon.yaml
+++ b/static/compatibilities/keda-http-addon.yaml
@@ -1,0 +1,140 @@
+icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/keda/icon/color/keda-icon-color.svg
+git_url: https://github.com/kedacore/http-add-on
+release_url: https://github.com/kedacore/http-add-on/releases/tag/v{vsn}
+helm_repository_url: https://kedacore.github.io/charts
+chart_name: keda-add-ons-http
+versions:
+- version: 0.15.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.15.0
+  images: ['ghcr.io/kedacore/http-add-on-interceptor:0.15.0', 'ghcr.io/kedacore/http-add-on-operator:0.15.0',
+    'ghcr.io/kedacore/http-add-on-scaler:0.15.0']
+- version: 0.14.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.14.1
+  images: ['ghcr.io/kedacore/http-add-on-interceptor:0.14.0', 'ghcr.io/kedacore/http-add-on-operator:0.14.0',
+    'ghcr.io/kedacore/http-add-on-scaler:0.14.0']
+- version: 0.13.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.13.0
+  images: ['ghcr.io/kedacore/http-add-on-interceptor:0.13.0', 'ghcr.io/kedacore/http-add-on-operator:0.13.0',
+    'ghcr.io/kedacore/http-add-on-scaler:0.13.0']
+- version: 0.12.0
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.0
+  images: ['ghcr.io/kedacore/http-add-on-interceptor:0.12.0', 'ghcr.io/kedacore/http-add-on-operator:0.12.0',
+    'ghcr.io/kedacore/http-add-on-scaler:0.12.0']
+- version: 0.11.1
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.11.1
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.11.1',
+    'ghcr.io/kedacore/http-add-on-operator:0.11.1', 'ghcr.io/kedacore/http-add-on-scaler:0.11.1']
+- version: 0.11.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.11.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.11.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.11.0', 'ghcr.io/kedacore/http-add-on-scaler:0.11.0']
+- version: 0.10.0
+  kube: ['1.34', '1.33', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.10.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.10.0', 'ghcr.io/kedacore/http-add-on-scaler:0.10.0']
+- version: 0.9.0
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.9.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.9.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.9.0', 'ghcr.io/kedacore/http-add-on-scaler:0.9.0']
+- version: 0.8.0
+  kube: ['1.32', '1.31', '1.30']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.8.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.8.0', 'ghcr.io/kedacore/http-add-on-scaler:0.8.0']
+- version: 0.7.0
+  kube: ['1.30', '1.29', '1.28']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.7.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.7.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.7.0', 'ghcr.io/kedacore/http-add-on-scaler:0.7.0']
+- version: 0.6.0
+  kube: ['1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.6.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.6.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.6.0', 'ghcr.io/kedacore/http-add-on-scaler:0.6.0']
+- version: 0.5.0
+  kube: ['1.28', '1.27', '1.26']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.5.3
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.5.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.5.0', 'ghcr.io/kedacore/http-add-on-scaler:0.5.0']
+- version: 0.4.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.4.1
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.4.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.4.0', 'ghcr.io/kedacore/http-add-on-scaler:0.4.0']
+- version: 0.3.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.3.1
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.3.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.3.0', 'ghcr.io/kedacore/http-add-on-scaler:0.3.0']
+- version: 0.2.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.2.2
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0', 'ghcr.io/kedacore/http-add-on-interceptor:0.2.0',
+    'ghcr.io/kedacore/http-add-on-operator:0.2.0', 'ghcr.io/kedacore/http-add-on-scaler:0.2.0']
+- version: 0.1.0
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.1.0
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0', 'ghcr.io/kedacore/http-add-on-operator:0.1.0']
+- version: 0.0.1
+  kube: ['1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.0.1
+  images: ['gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0', 'ghcr.io/kedacore/http-add-on-operator:vv0.1.0-v1alpha1']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- keda-http-addon

--- a/utils/compatibility/scrapers/keda-http-addon.py
+++ b/utils/compatibility/scrapers/keda-http-addon.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from utils import (
+    clean_kube_version,
+    find_last_n_releases,
+    get_chart_versions,
+    get_github_releases_timestamps,
+    get_kube_release_info,
+    update_compatibility_info,
+)
+
+app_name = "keda-http-addon"
+chart_name = "keda-add-ons-http"
+
+
+def scrape():
+    kube_releases = get_kube_release_info()
+    keda_releases = list(
+        reversed(
+            list(
+                get_github_releases_timestamps(
+                    "kedacore", "http-add-on"
+                )
+            )
+        )
+    )
+
+    chart_versions = get_chart_versions(app_name, chart_name)
+    versions = []
+    pruned_releases = [
+        (r[0].lstrip("v"), r[1])
+        for r in keda_releases
+        if "-" not in r[0]
+        and not any(pre in r[0].lower() for pre in ["rc", "alpha", "beta"])
+    ]
+    for idx, keda_release in enumerate(pruned_releases):
+        release_vsn = keda_release[0]
+        future_release = keda_release
+        if idx < len(pruned_releases) - 1:
+            future_release = pruned_releases[idx + 1]
+
+        compatible_kube_releases = find_last_n_releases(
+            kube_releases, future_release[1], n=3
+        )
+        chart_version = chart_versions.get(release_vsn)
+        if not chart_version:
+            continue
+        vsn = {
+            "version": release_vsn,
+            "kube": [
+                clean_kube_version(kube_release[0])
+                for kube_release in compatible_kube_releases
+                if clean_kube_version(kube_release[0])
+            ],
+            "chart_version": chart_version,
+            "requirements": [],
+            "incompatibilities": [],
+        }
+        versions.append(vsn)
+
+    update_compatibility_info(f"../../static/compatibilities/{app_name}.yaml", versions)

--- a/utils/compatibility/tests/test_keda_http_addon.py
+++ b/utils/compatibility/tests/test_keda_http_addon.py
@@ -1,0 +1,143 @@
+"""Offline regressions: python -m unittest discover -s tests -p 'test_keda_http_addon.py'."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+
+spec = importlib.util.spec_from_file_location(
+    "keda_http_addon_scraper", COMPATIBILITY / "scrapers/keda-http-addon.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(scraper)
+
+
+class KedaHttpAddonScraperTests(unittest.TestCase):
+    def setUp(self):
+        self.kube_releases = [
+            ("1.33.0", "2025-08-01T00:00:00Z"),
+            ("1.34.0", "2026-01-01T00:00:00Z"),
+            ("1.35.0", "2026-04-01T00:00:00Z"),
+            ("1.36.0", "2026-08-01T00:00:00Z"),
+        ]
+        self.mock_github_releases = [
+            ("v0.15.0", "2026-08-20T00:00:00Z"),
+            ("v0.15.0-rc.1", "2026-08-10T00:00:00Z"),
+            ("v0.14.0", "2026-05-01T00:00:00Z"),
+            ("v0.14.0-alpha.1", "2026-04-15T00:00:00Z"),
+            ("v0.13.0", "2026-01-01T00:00:00Z"),
+        ]
+        self.mock_chart_versions = {
+            "0.15.0": "0.15.0",
+            "0.14.0": "0.14.1",
+            "0.13.0": "0.13.0",
+        }
+
+    def test_scraper_app_name_and_chart_name(self):
+        self.assertEqual(scraper.app_name, "keda-http-addon")
+        self.assertEqual(scraper.chart_name, "keda-add-ons-http")
+
+    def test_prerelease_filtering(self):
+        releases = [("v0.15.0-rc.1", "2026-08-10T00:00:00Z"), ("v0.15.0", "2026-08-20T00:00:00Z")]
+        filtered = [
+            r for r in releases
+            if "-" not in r[0] and not any(pre in r[0].lower() for pre in ["rc", "alpha", "beta"])
+        ]
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0][0], "v0.15.0")
+
+    @patch.object(scraper, "update_compatibility_info")
+    @patch.object(scraper, "get_chart_versions")
+    @patch.object(scraper, "get_github_releases_timestamps")
+    @patch.object(scraper, "get_kube_release_info")
+    def test_scrape_builds_valid_version_list(
+        self, mock_kube, mock_gh, mock_charts, mock_update
+    ):
+        mock_kube.return_value = self.kube_releases
+        mock_gh.return_value = self.mock_github_releases
+        mock_charts.return_value = self.mock_chart_versions
+
+        scraper.scrape()
+
+        mock_update.assert_called_once()
+        args = mock_update.call_args[0]
+        filepath, versions = args[0], args[1]
+
+        self.assertEqual(filepath, "../../static/compatibilities/keda-http-addon.yaml")
+        # Should filter out v0.15.0-rc.1 and v0.14.0-alpha.1
+        self.assertEqual(len(versions), 3)
+
+        v0_15 = next(v for v in versions if v["version"] == "0.15.0")
+        self.assertEqual(v0_15["chart_version"], "0.15.0")
+        self.assertIn("1.36", v0_15["kube"])
+        self.assertIn("1.35", v0_15["kube"])
+        self.assertIn("1.34", v0_15["kube"])
+        self.assertEqual(v0_15["requirements"], [])
+        self.assertEqual(v0_15["incompatibilities"], [])
+
+    @patch.object(scraper, "update_compatibility_info")
+    @patch.object(scraper, "get_chart_versions")
+    @patch.object(scraper, "get_github_releases_timestamps")
+    @patch.object(scraper, "get_kube_release_info")
+    def test_scrape_skips_releases_without_charts(
+        self, mock_kube, mock_gh, mock_charts, mock_update
+    ):
+        mock_kube.return_value = self.kube_releases
+        mock_gh.return_value = [("v0.15.0", "2026-08-20T00:00:00Z"), ("v9.9.9", "2026-08-20T00:00:00Z")]
+        mock_charts.return_value = {"0.15.0": "0.15.0"}
+
+        scraper.scrape()
+
+        mock_update.assert_called_once()
+        versions = mock_update.call_args[0][1]
+        self.assertEqual(len(versions), 1)
+        self.assertEqual(versions[0]["version"], "0.15.0")
+
+    def test_manifest_includes_keda_http_addon(self):
+        from utils import read_yaml
+        manifest_path = COMPATIBILITY.parent.parent / "static/compatibilities/manifest.yaml"
+        manifest = read_yaml(str(manifest_path))
+        self.assertIsNotNone(manifest)
+        self.assertIn("keda-http-addon", manifest.get("names", []))
+
+    def test_catalog_yaml_structure_and_images(self):
+        from utils import read_yaml
+        yaml_path = COMPATIBILITY.parent.parent / "static/compatibilities/keda-http-addon.yaml"
+        data = read_yaml(str(yaml_path))
+        self.assertIsNotNone(data)
+        self.assertIn("icon", data)
+        self.assertIn("git_url", data)
+        self.assertIn("release_url", data)
+        self.assertIn("helm_repository_url", data)
+        self.assertIn("chart_name", data)
+        self.assertIn("versions", data)
+        self.assertGreater(len(data["versions"]), 0)
+
+        for v in data["versions"]:
+            self.assertIn("version", v)
+            self.assertIn("kube", v)
+            self.assertIsInstance(v["kube"], list)
+            self.assertGreater(len(v["kube"]), 0)
+            self.assertIn("chart_version", v)
+            self.assertIn("images", v)
+            self.assertIsInstance(v["images"], list)
+            self.assertGreater(
+                len(v["images"]), 0, f"Version {v['version']} has empty images list"
+            )
+            # Verify KEDA HTTP Add-on primary workload image is present
+            has_keda_http_img = any("http-add-on" in img for img in v["images"])
+            self.assertTrue(
+                has_keda_http_img,
+                f"Version {v['version']} images do not contain expected http-add-on workload image: {v['images']}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Contributor Program: New Compatibility Scraper ($300)

This PR adds **KEDA HTTP Add-on** (`keda-http-addon`) to the Plural Console add-on compatibility catalog, implementing an automated Python scraper, catalog metadata, compatibility matrix with resolved container images, and offline unit test suite according to the Contributor Program guidelines.

### Overview of Changes
1. **Compatibility Scraper**: Added `utils/compatibility/scrapers/keda-http-addon.py` which fetches KEDA HTTP Add-on GitHub releases and Helm chart versions (`keda-add-ons-http`) from the official repository, matching releases against active Kubernetes minor versions.
2. **Catalog Metadata & Matrix**: Added `static/compatibilities/keda-http-addon.yaml` with full metadata (Helm repo URL, Git URL, release URL, official CNCF brand icon, and generated version matrix covering v0.0.1 through v0.15.0 with container images pre-resolved from Helm templates: `http-add-on-interceptor`, `http-add-on-operator`, `http-add-on-scaler`).
3. **Manifest Entry**: Registered `keda-http-addon` in `static/compatibilities/manifest.yaml`.
4. **Unit Test Suite**: Added `utils/compatibility/tests/test_keda_http_addon.py` covering release filtering, pre-release rejection (`-rc`, `-alpha`, `-beta`), chart mapping, mock scrape validation, manifest entry, and resolved catalog container images (`ghcr.io/kedacore/http-add-on-*`).

### References & Documentation
- **Git Repository**: https://github.com/kedacore/http-add-on
- **Helm Repository**: https://kedacore.github.io/charts
- **Releases**: https://github.com/kedacore/http-add-on/releases
- **Brand Icon**: https://raw.githubusercontent.com/cncf/artwork/main/projects/keda/icon/color/keda-icon-color.svg
- **Documentation**: https://keda.sh/docs/latest/operate/http/

### Verification
- Ran offline regressions: `python -m unittest discover -s utils/compatibility/tests -p 'test_keda_http_addon.py'` (6/6 tests pass cleanly).
- Full compatibility test suite passed: 107/107 tests pass cleanly.
- Verified Helm templating and container image extraction across all 17 catalog releases.
