### PR TITLE
Add Vertical Pod Autoscaler compatibility scraper

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -14,6 +14,7 @@ names:
 - coredns
 - cloudnative-pg
 - cluster-autoscaler
+- vertical-pod-autoscaler
 - descheduler
 - external-dns
 - external-secrets

--- a/static/compatibilities/vertical-pod-autoscaler.yaml
+++ b/static/compatibilities/vertical-pod-autoscaler.yaml
@@ -1,0 +1,28 @@
+icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
+git_url: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
+release_url: https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-{vsn}
+readme_url: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/installation.md
+helm_repository_url: https://kubernetes.github.io/autoscaler
+chart_name: vertical-pod-autoscaler
+versions:
+- version: 1.7.1
+  kube: ['1.37', '1.36', '1.35']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.0
+  images: ['registry.k8s.io/autoscaling/vpa-admission-controller:1.7.1', 'registry.k8s.io/autoscaling/vpa-recommender:1.7.1', 'registry.k8s.io/autoscaling/vpa-updater:1.7.1', 'registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0']
+- version: 1.6.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.9.0
+  images: ['registry.k8s.io/autoscaling/vpa-admission-controller:1.6.0', 'registry.k8s.io/autoscaling/vpa-recommender:1.6.0', 'registry.k8s.io/autoscaling/vpa-updater:1.6.0', 'registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20231011-8b53cabe0']
+- version: 1.5.1
+  kube: ['1.35', '1.34', '1.33']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.0
+  images: ['registry.k8s.io/autoscaling/vpa-admission-controller:1.5.1', 'registry.k8s.io/autoscaling/vpa-recommender:1.5.1', 'registry.k8s.io/autoscaling/vpa-updater:1.5.1']

--- a/utils/compatibility/scrapers/vertical-pod-autoscaler.py
+++ b/utils/compatibility/scrapers/vertical-pod-autoscaler.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+from packaging.version import InvalidVersion, Version
+
+from utils import fetch_page, get_chart_versions, update_compatibility_info
+
+
+app_name = "vertical-pod-autoscaler"
+compatibility_url = (
+    "https://raw.githubusercontent.com/kubernetes/autoscaler/master/"
+    "vertical-pod-autoscaler/docs/installation.md"
+)
+compatibility_file = f"../../static/compatibilities/{app_name}.yaml"
+
+
+def _decode(content: bytes | str) -> str:
+    if isinstance(content, str):
+        return content
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError("Could not decode the VPA installation documentation as UTF-8") from exc
+
+
+def _expand_descending(start: str, end: str) -> list[str]:
+    start_major, start_minor = map(int, start.split("."))
+    end_major, end_minor = map(int, end.split("."))
+    if start_major != end_major or start_minor > end_minor:
+        raise ValueError(f"Unsupported VPA Kubernetes range: {start} - {end}")
+    if end_minor - start_minor > 50:
+        raise ValueError(f"VPA Kubernetes range is unexpectedly large: {start} - {end}")
+    return [f"{start_major}.{minor}" for minor in range(end_minor, start_minor - 1, -1)]
+
+
+def parse_compatibility_matrix(content: bytes | str) -> dict[str, list[str]]:
+    """Parse the bounded VPA/Kubernetes compatibility table from the official docs."""
+    text = _decode(content)
+    section_match = re.search(r"(?m)^## Compatibility\s*$", text)
+    if not section_match:
+        raise ValueError("VPA documentation is missing the Compatibility section")
+
+    section = text[section_match.end() :]
+    next_section = re.search(r"(?m)^##\s+", section)
+    if next_section:
+        section = section[: next_section.start()]
+
+    matrix: dict[str, list[str]] = {}
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        columns = [column.strip().strip("`") for column in stripped.strip("|").split("|")]
+        if len(columns) < 2:
+            continue
+
+        vpa_cell, kube_cell = columns[:2]
+        if vpa_cell.lower() == "vpa version" or set(vpa_cell) <= {"-", ":", " "}:
+            continue
+
+        version_match = re.fullmatch(r"(\d+\.\d+)\.x", vpa_cell)
+        if not version_match:
+            if re.search(r"\d", vpa_cell):
+                raise ValueError(f"Unrecognized VPA version cell: {vpa_cell!r}")
+            continue
+
+        range_match = re.fullmatch(
+            r"v?(\d+\.\d+)\s*[-\u2013\u2014]\s*v?(\d+\.\d+)", kube_cell
+        )
+        if not range_match:
+            raise ValueError(
+                f"Unrecognized Kubernetes compatibility range for VPA {vpa_cell}: {kube_cell!r}"
+            )
+
+        minor = version_match.group(1)
+        if minor in matrix:
+            raise ValueError(f"Duplicate VPA compatibility row for {minor}.x")
+        matrix[minor] = _expand_descending(*range_match.groups())
+
+    if not matrix:
+        raise ValueError("No VPA compatibility rows were found")
+    return matrix
+
+
+def _stable_version(value: str) -> Version | None:
+    try:
+        parsed = Version(value.lstrip("v"))
+    except InvalidVersion:
+        return None
+    if parsed.is_prerelease or parsed.is_devrelease:
+        return None
+    return parsed
+
+
+def build_rows(
+    compatibility_matrix: dict[str, list[str]], chart_versions: dict[str, str]
+) -> list[OrderedDict[str, object]]:
+    """Select the newest stable VPA patch represented by a chart for each documented minor."""
+    selected: dict[str, tuple[Version, str, str]] = {}
+
+    for raw_app_version, raw_chart_version in chart_versions.items():
+        app_version = _stable_version(str(raw_app_version))
+        chart_version = _stable_version(str(raw_chart_version))
+        if app_version is None or chart_version is None:
+            continue
+
+        minor = f"{app_version.major}.{app_version.minor}"
+        if minor not in compatibility_matrix:
+            continue
+
+        current = selected.get(minor)
+        if current is None or app_version > current[0]:
+            selected[minor] = (app_version, str(raw_app_version).lstrip("v"), str(raw_chart_version).lstrip("v"))
+
+    missing = sorted(set(compatibility_matrix) - set(selected), key=Version)
+    if missing:
+        raise ValueError(
+            "No stable VPA Helm chart mapping found for documented minor(s): "
+            + ", ".join(f"{minor}.x" for minor in missing)
+        )
+
+    rows: list[OrderedDict[str, object]] = []
+    for minor, (_, app_version, chart_version) in selected.items():
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", app_version),
+                    ("kube", compatibility_matrix[minor]),
+                    ("chart_version", chart_version),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    rows.sort(key=lambda row: Version(str(row["version"])), reverse=True)
+    return rows
+
+
+def scrape() -> None:
+    content = fetch_page(compatibility_url)
+    if not content:
+        raise ValueError("Could not fetch the VPA installation documentation")
+
+    matrix = parse_compatibility_matrix(content)
+    chart_versions = get_chart_versions(app_name)
+    if not chart_versions:
+        raise ValueError("Could not resolve VPA Helm chart versions")
+
+    rows = build_rows(matrix, chart_versions)
+    update_compatibility_info(compatibility_file, rows)

--- a/utils/compatibility/scrapers/vertical-pod-autoscaler.py
+++ b/utils/compatibility/scrapers/vertical-pod-autoscaler.py
@@ -22,7 +22,9 @@ def _decode(content: bytes | str) -> str:
     try:
         return content.decode("utf-8")
     except UnicodeDecodeError as exc:
-        raise ValueError("Could not decode the VPA installation documentation as UTF-8") from exc
+        raise ValueError(
+            "Could not decode the VPA installation documentation as UTF-8"
+        ) from exc
 
 
 def _expand_descending(start: str, end: str) -> list[str]:
@@ -31,12 +33,17 @@ def _expand_descending(start: str, end: str) -> list[str]:
     if start_major != end_major or start_minor > end_minor:
         raise ValueError(f"Unsupported VPA Kubernetes range: {start} - {end}")
     if end_minor - start_minor > 50:
-        raise ValueError(f"VPA Kubernetes range is unexpectedly large: {start} - {end}")
-    return [f"{start_major}.{minor}" for minor in range(end_minor, start_minor - 1, -1)]
+        raise ValueError(
+            f"VPA Kubernetes range is unexpectedly large: {start} - {end}"
+        )
+    return [
+        f"{start_major}.{minor}"
+        for minor in range(end_minor, start_minor - 1, -1)
+    ]
 
 
 def parse_compatibility_matrix(content: bytes | str) -> dict[str, list[str]]:
-    """Parse the bounded VPA/Kubernetes compatibility table from the official docs."""
+    """Parse the bounded compatibility table from the official VPA docs."""
     text = _decode(content)
     section_match = re.search(r"(?m)^## Compatibility\s*$", text)
     if not section_match:
@@ -52,7 +59,10 @@ def parse_compatibility_matrix(content: bytes | str) -> dict[str, list[str]]:
         stripped = line.strip()
         if not stripped.startswith("|"):
             continue
-        columns = [column.strip().strip("`") for column in stripped.strip("|").split("|")]
+        columns = [
+            column.strip().strip("`")
+            for column in stripped.strip("|").split("|")
+        ]
         if len(columns) < 2:
             continue
 
@@ -71,7 +81,8 @@ def parse_compatibility_matrix(content: bytes | str) -> dict[str, list[str]]:
         )
         if not range_match:
             raise ValueError(
-                f"Unrecognized Kubernetes compatibility range for VPA {vpa_cell}: {kube_cell!r}"
+                "Unrecognized Kubernetes compatibility range for VPA "
+                f"{vpa_cell}: {kube_cell!r}"
             )
 
         minor = version_match.group(1)
@@ -97,7 +108,7 @@ def _stable_version(value: str) -> Version | None:
 def build_rows(
     compatibility_matrix: dict[str, list[str]], chart_versions: dict[str, str]
 ) -> list[OrderedDict[str, object]]:
-    """Select the newest stable VPA patch represented by a chart for each documented minor."""
+    """Choose the newest stable VPA patch for each documented minor."""
     selected: dict[str, tuple[Version, str, str]] = {}
 
     for raw_app_version, raw_chart_version in chart_versions.items():
@@ -112,7 +123,11 @@ def build_rows(
 
         current = selected.get(minor)
         if current is None or app_version > current[0]:
-            selected[minor] = (app_version, str(raw_app_version).lstrip("v"), str(raw_chart_version).lstrip("v"))
+            selected[minor] = (
+                app_version,
+                str(raw_app_version).lstrip("v"),
+                str(raw_chart_version).lstrip("v"),
+            )
 
     missing = sorted(set(compatibility_matrix) - set(selected), key=Version)
     if missing:

--- a/utils/compatibility/tests/VERTICAL_POD_AUTOSCALER.md
+++ b/utils/compatibility/tests/VERTICAL_POD_AUTOSCALER.md
@@ -1,0 +1,40 @@
+# Vertical Pod Autoscaler compatibility source notes
+
+The scraper uses only first-party Kubernetes Autoscaler sources.
+
+## Compatibility source
+
+The authoritative VPA installation documentation publishes a maintained-release compatibility table:
+
+- VPA `1.7.x` supports Kubernetes `1.35` through `1.37`.
+- VPA `1.6.x` supports Kubernetes `1.34` through `1.36`.
+- VPA `1.5.x` supports Kubernetes `1.33` through `1.35`.
+
+Source: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/installation.md#compatibility
+
+The scraper parses only the bounded `## Compatibility` section and fails closed when a documented row or range is malformed.
+
+## Helm source
+
+The Kubernetes Autoscaler project publishes and supports the VPA Helm chart at:
+
+- repository: `https://kubernetes.github.io/autoscaler`
+- chart: `vertical-pod-autoscaler`
+
+The repository index supplies chart `appVersion` metadata. For each maintained VPA minor, the scraper selects the newest stable application patch that has a stable published chart. At the time this contribution was prepared, those mappings were:
+
+- VPA `1.7.1` -> chart `0.12.0`
+- VPA `1.6.0` -> chart `0.9.0`
+- VPA `1.5.1` -> chart `0.8.0`
+
+The scraper deliberately does not infer support for VPA release minors absent from the official compatibility table.
+
+## Focused validation
+
+From `utils/compatibility`:
+
+```sh
+python -m pytest tests/test_vertical_pod_autoscaler.py -q
+```
+
+A full live compatibility generation additionally requires Helm because the shared updater renders chart images.

--- a/utils/compatibility/tests/test_vertical_pod_autoscaler.py
+++ b/utils/compatibility/tests/test_vertical_pod_autoscaler.py
@@ -1,0 +1,134 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+spec = importlib.util.spec_from_file_location(
+    "vertical_pod_autoscaler_scraper",
+    COMPATIBILITY / "scrapers" / "vertical-pod-autoscaler.py",
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+OFFICIAL_SHAPED_MATRIX = """
+# Installation
+
+## Compatibility
+
+| VPA version     | Kubernetes version |
+| --------------- | ------------------ |
+| 1.7.x           | 1.35 – 1.37        |
+| 1.6.x           | 1.34 – 1.36        |
+| 1.5.x           | 1.33 – 1.35        |
+
+## Notice on CRD update (>=1.0.0)
+
+Unrelated text.
+"""
+
+
+def test_parses_official_compatibility_matrix():
+    assert scraper.parse_compatibility_matrix(OFFICIAL_SHAPED_MATRIX) == {
+        "1.7": ["1.37", "1.36", "1.35"],
+        "1.6": ["1.36", "1.35", "1.34"],
+        "1.5": ["1.35", "1.34", "1.33"],
+    }
+
+
+@pytest.mark.parametrize(
+    "content,match",
+    [
+        ("# Installation\n", "Compatibility section"),
+        (
+            "## Compatibility\n| VPA version | Kubernetes version |\n| - | - |\n| 1.7.x | >=1.35 |\n",
+            "Unrecognized Kubernetes compatibility range",
+        ),
+        (
+            "## Compatibility\n| VPA version | Kubernetes version |\n| - | - |\n| 1.7 | 1.35 – 1.37 |\n",
+            "Unrecognized VPA version cell",
+        ),
+    ],
+)
+def test_rejects_missing_or_ambiguous_matrix(content, match):
+    with pytest.raises(ValueError, match=match):
+        scraper.parse_compatibility_matrix(content)
+
+
+def test_rejects_duplicate_minor_rows():
+    content = """
+## Compatibility
+| VPA version | Kubernetes version |
+| - | - |
+| 1.7.x | 1.35 - 1.37 |
+| 1.7.x | 1.35 - 1.37 |
+"""
+    with pytest.raises(ValueError, match="Duplicate VPA compatibility row"):
+        scraper.parse_compatibility_matrix(content)
+
+
+def test_build_rows_selects_latest_stable_patch_for_each_documented_minor():
+    matrix = scraper.parse_compatibility_matrix(OFFICIAL_SHAPED_MATRIX)
+    charts = {
+        "1.7.0": "0.10.0",
+        "1.7.1": "0.12.0",
+        "1.7.2-rc.1": "0.13.0-rc.1",
+        "1.6.0": "0.9.0",
+        "1.5.1": "0.8.0",
+        "1.4.2": "0.4.0",
+    }
+
+    rows = scraper.build_rows(matrix, charts)
+
+    assert [(row["version"], row["chart_version"]) for row in rows] == [
+        ("1.7.1", "0.12.0"),
+        ("1.6.0", "0.9.0"),
+        ("1.5.1", "0.8.0"),
+    ]
+    assert rows[0]["kube"] == ["1.37", "1.36", "1.35"]
+    assert rows[1]["kube"] == ["1.36", "1.35", "1.34"]
+    assert rows[2]["kube"] == ["1.35", "1.34", "1.33"]
+
+
+def test_build_rows_fails_if_a_documented_minor_has_no_chart():
+    matrix = scraper.parse_compatibility_matrix(OFFICIAL_SHAPED_MATRIX)
+    charts = {"1.7.1": "0.12.0", "1.6.0": "0.9.0"}
+
+    with pytest.raises(ValueError, match="1.5.x"):
+        scraper.build_rows(matrix, charts)
+
+
+def test_scrape_writes_only_after_all_sources_are_valid(monkeypatch):
+    monkeypatch.setattr(scraper, "fetch_page", lambda _: OFFICIAL_SHAPED_MATRIX.encode())
+    monkeypatch.setattr(
+        scraper,
+        "get_chart_versions",
+        lambda _: {"1.7.1": "0.12.0", "1.6.0": "0.9.0", "1.5.1": "0.8.0"},
+    )
+    update = Mock()
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+
+    scraper.scrape()
+
+    update.assert_called_once()
+    path, rows = update.call_args.args
+    assert path == scraper.compatibility_file
+    assert [row["version"] for row in rows] == ["1.7.1", "1.6.0", "1.5.1"]
+
+
+def test_scrape_does_not_write_on_malformed_source(monkeypatch):
+    monkeypatch.setattr(scraper, "fetch_page", lambda _: b"## Compatibility\nnot a table")
+    monkeypatch.setattr(scraper, "get_chart_versions", Mock())
+    update = Mock()
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+
+    with pytest.raises(ValueError, match="No VPA compatibility rows"):
+        scraper.scrape()
+
+    scraper.get_chart_versions.assert_not_called()
+    update.assert_not_called()


### PR DESCRIPTION
## Summary

Adds Kubernetes Vertical Pod Autoscaler (VPA) to Plural's compatibility catalog with an automated scraper, catalog metadata, manifest registration, source notes, and focused regression tests.

The scraper reads the official Kubernetes Autoscaler VPA compatibility matrix and maps each maintained VPA minor to the newest stable application patch represented by the official Helm repository. It fails closed if the source becomes ambiguous or a documented minor cannot be matched to a stable chart.

Current mappings:

- VPA `1.7.1` / chart `0.12.0` → Kubernetes `1.35`–`1.37`
- VPA `1.6.0` / chart `0.9.0` → Kubernetes `1.34`–`1.36`
- VPA `1.5.1` / chart `0.8.0` → Kubernetes `1.33`–`1.35`

## Sources

- https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/docs/installation.md#compatibility
- https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
- https://kubernetes.github.io/autoscaler/index.yaml
- https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler/charts/vertical-pod-autoscaler

## Validation

Focused pytest coverage is included for matrix parsing, malformed and duplicate source rejection, stable patch selection, missing-chart failure, and fail-closed behavior.

GitHub CI is the authoritative execution environment for this submission; no local test-pass claim is made here.

Source rationale and the focused validation command are documented in `utils/compatibility/tests/VERTICAL_POD_AUTOSCALER.md`.

## Contributor program

Please consider this contribution for the README Contributor Program's advertised **$300 new compatibility scraper reward**, subject to maintainer review, merge, contributor eligibility, and reward confirmation.

Discord: `restored1xt`

Plural Flow: console