### PR TITLE
Add ClickHouse Operator compatibility scraper

### DIFF
--- a/static/compatibilities/clickhouse-operator.yaml
+++ b/static/compatibilities/clickhouse-operator.yaml
@@ -1,47 +1,35 @@
-icon: https://avatars.githubusercontent.com/u/28471076?s=48&v=4
+icon: https://avatars.githubusercontent.com/u/54801242?s=48&v=4
 git_url: https://github.com/Altinity/clickhouse-operator
 release_url: https://github.com/Altinity/clickhouse-operator/releases/tag/release-{vsn}
 helm_repository_url: https://altinity.github.io/helm-charts
 chart_name: altinity-clickhouse-operator
 versions:
 - version: 0.27.3
-  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
-    '1.26', '1.25']
+  kube: ['1.36', '1.35', '1.34']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 0.27.3
 - version: 0.27.0
-  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
-    '1.26', '1.25']
+  kube: ['1.36', '1.35', '1.34']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 0.27.0
-- version: 0.26.2
-  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
-    '1.26', '1.25']
-  requirements: []
-  incompatibilities: []
-  summary: null
-  chart_version: 0.26.2
 - version: 0.26.0
-  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
-    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  kube: ['1.36', '1.35', '1.34']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 0.26.0
 - version: 0.25.0
-  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
-    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  kube: ['1.36', '1.35', '1.34']
   requirements: []
   incompatibilities: []
   summary: null
   chart_version: 0.25.0
 - version: 0.24.1
-  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
-    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  kube: ['1.36', '1.35', '1.34']
   requirements: []
   incompatibilities: []
   summary: null

--- a/static/compatibilities/clickhouse-operator.yaml
+++ b/static/compatibilities/clickhouse-operator.yaml
@@ -1,0 +1,48 @@
+icon: https://avatars.githubusercontent.com/u/28471076?s=48&v=4
+git_url: https://github.com/Altinity/clickhouse-operator
+release_url: https://github.com/Altinity/clickhouse-operator/releases/tag/release-{vsn}
+helm_repository_url: https://altinity.github.io/helm-charts
+chart_name: altinity-clickhouse-operator
+versions:
+- version: 0.27.3
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.27.3
+- version: 0.27.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.27.0
+- version: 0.26.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.26.2
+- version: 0.26.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.26.0
+- version: 0.25.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.25.0
+- version: 0.24.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.24.1

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -10,6 +10,7 @@ names:
 - cert-manager
 - cilium
 - chaos-mesh
+- clickhouse-operator
 - contour
 - coredns
 - cloudnative-pg

--- a/utils/compatibility/scrapers/clickhouse-operator.py
+++ b/utils/compatibility/scrapers/clickhouse-operator.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from typing import Optional
+
+from utils import (
+    expand_kube_versions,
+    fetch_page,
+    get_github_releases,
+    latest_kube_version,
+    print_error,
+    print_warning,
+    read_yaml,
+    update_chart_versions,
+    update_compatibility_info,
+    validate_semver,
+)
+
+app_name = "clickhouse-operator"
+
+REPO_OWNER = "Altinity"
+REPO_NAME = "clickhouse-operator"
+CHART_NAME = "altinity-clickhouse-operator"
+MAX_RELEASES = 20
+
+# Strict form: a line that states only the requirement, e.g.
+#   " * Kubernetes 1.25+"
+#   "- Kubernetes 1.19 or later"
+_STRICT_REQ_RE = re.compile(
+    r"(?im)^\s*(?:\*|-)?\s*Kubernetes\s+v?(1\.\d+)\s*(?:\+|or\s+(?:later|above|newer))?\s*$"
+)
+# Loose fallback: any "Kubernetes 1.25+" mention
+_LOOSE_REQ_RE = re.compile(r"(?i)kubernetes\s+v?(1\.\d+)\s*(?:\+|or\s+(?:later|above|newer))")
+
+
+def _release_versions() -> list[str]:
+    """Latest stable release versions, newest first (release-0.27.3 -> 0.27.3)."""
+    try:
+        tags = get_github_releases(REPO_OWNER, REPO_NAME)
+    except Exception as e:
+        print_error(f"Failed to fetch releases: {e}")
+        return []
+    seen = set()
+    versions = []
+    for tag in tags:
+        m = re.fullmatch(r"release-v?(\d+\.\d+\.\d+)", tag)
+        if not m or m.group(1) in seen:
+            continue
+        seen.add(m.group(1))
+        versions.append(m.group(1))
+    return versions[:MAX_RELEASES]
+
+
+def _kube_floor(version: str) -> Optional[str]:
+    """Read the minimum supported Kubernetes version from the release-tag README."""
+    url = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/release-{version}/README.md"
+    content = fetch_page(url)
+    if not content:
+        print_warning(f"No README found for release-{version}")
+        return None
+    text = content.decode("utf-8", errors="ignore")
+    m = _STRICT_REQ_RE.search(text) or _LOOSE_REQ_RE.search(text)
+    if not m:
+        print_warning(f"No Kubernetes requirement found in release-{version} README")
+        return None
+    v = validate_semver(m.group(1))
+    return f"{v.major}.{v.minor}" if v else None
+
+
+def scrape() -> None:
+    latest = latest_kube_version()
+    latest_minor = f"{latest.major}.{latest.minor}" if latest else None
+    if not latest_minor:
+        print_error("Could not determine the latest Kubernetes version")
+        return
+
+    rows: list[OrderedDict[str, object]] = []
+    for version in _release_versions():
+        floor = _kube_floor(version)
+        if not floor:
+            continue
+        floor_v = validate_semver(floor)
+        latest_v = validate_semver(latest_minor)
+        if floor_v and latest_v and floor_v > latest_v:
+            floor = latest_minor
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", version),
+                    ("kube", expand_kube_versions(floor, latest_minor)),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    if not rows:
+        print_error("No compatibility information found for ClickHouse Operator")
+        return
+
+    output_path = f"../../static/compatibilities/{app_name}.yaml"
+    update_compatibility_info(output_path, rows)
+
+    compatibility_yaml = read_yaml(output_path)
+    if compatibility_yaml and compatibility_yaml.get("helm_repository_url"):
+        update_chart_versions(app_name, CHART_NAME)

--- a/utils/compatibility/scrapers/clickhouse-operator.py
+++ b/utils/compatibility/scrapers/clickhouse-operator.py
@@ -23,6 +23,8 @@ REPO_OWNER = "Altinity"
 REPO_NAME = "clickhouse-operator"
 CHART_NAME = "altinity-clickhouse-operator"
 MAX_RELEASES = 20
+# The compatibility matrix tracks the three newest Kubernetes minors per row.
+LATEST_KUBE_MINORS = 3
 
 # Strict form: a line that states only the requirement, e.g.
 #   " * Kubernetes 1.25+"
@@ -68,6 +70,19 @@ def _kube_floor(version: str) -> Optional[str]:
     return f"{v.major}.{v.minor}" if v else None
 
 
+def _kube_list(floor: str, latest_minor: str) -> list[str]:
+    """Newest supported Kubernetes minors for a release, descending.
+
+    The documented requirement is a floor ("Kubernetes 1.25+"); the matrix
+    tracks only the three newest stable minors, so intersect the expanded
+    range with that window. Entries newer than the latest stable release are
+    dropped (expand_kube_versions can overshoot when start == end).
+    """
+    expanded = expand_kube_versions(floor, latest_minor)
+    supported = [v for v in expanded if v <= latest_minor]
+    return supported[-LATEST_KUBE_MINORS:][::-1]
+
+
 def scrape() -> None:
     latest = latest_kube_version()
     latest_minor = f"{latest.major}.{latest.minor}" if latest else None
@@ -88,7 +103,7 @@ def scrape() -> None:
             OrderedDict(
                 [
                     ("version", version),
-                    ("kube", expand_kube_versions(floor, latest_minor)),
+                    ("kube", _kube_list(floor, latest_minor)),
                     ("requirements", []),
                     ("incompatibilities", []),
                 ]

--- a/utils/compatibility/scrapers/clickhouse-operator.py
+++ b/utils/compatibility/scrapers/clickhouse-operator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from collections import OrderedDict
-from typing import Optional
+from typing import Callable, Optional
 
 from utils import (
     expand_kube_versions,
@@ -25,6 +25,9 @@ CHART_NAME = "altinity-clickhouse-operator"
 MAX_RELEASES = 20
 # The compatibility matrix tracks the three newest Kubernetes minors per row.
 LATEST_KUBE_MINORS = 3
+
+GIT_REPO_URL = "https://github.com/Altinity/clickhouse-operator"
+README_URL = "https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-{version}/README.md"
 
 # Strict form: a line that states only the requirement, e.g.
 #   " * Kubernetes 1.25+"
@@ -54,33 +57,86 @@ def _release_versions() -> list[str]:
     return versions[:MAX_RELEASES]
 
 
-def _kube_floor(version: str) -> Optional[str]:
-    """Read the minimum supported Kubernetes version from the release-tag README."""
-    url = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/release-{version}/README.md"
-    content = fetch_page(url)
-    if not content:
-        print_warning(f"No README found for release-{version}")
-        return None
-    text = content.decode("utf-8", errors="ignore")
+def parse_min_kubernetes(text: str) -> str:
+    """Extract the minimum supported Kubernetes minor from a release README.
+
+    Raises ValueError when no documented requirement is present (fail closed).
+    """
     m = _STRICT_REQ_RE.search(text) or _LOOSE_REQ_RE.search(text)
     if not m:
-        print_warning(f"No Kubernetes requirement found in release-{version} README")
-        return None
+        raise ValueError("Kubernetes requirement not found in README")
     v = validate_semver(m.group(1))
-    return f"{v.major}.{v.minor}" if v else None
+    if not v:
+        raise ValueError(f"Invalid Kubernetes version in README: {m.group(1)}")
+    return f"{v.major}.{v.minor}"
 
 
-def _kube_list(floor: str, latest_minor: str) -> list[str]:
-    """Newest supported Kubernetes minors for a release, descending.
+def expand_minimum(floor: str, latest: str) -> list[str]:
+    """Kubernetes minors tracked for a release, newest first.
 
-    The documented requirement is a floor ("Kubernetes 1.25+"); the matrix
-    tracks only the three newest stable minors, so intersect the expanded
-    range with that window. Entries newer than the latest stable release are
-    dropped (expand_kube_versions can overshoot when start == end).
+    The documented requirement is a floor ("Kubernetes 1.25+"). The matrix
+    tracks only the three newest stable minors, so the floor constrains a
+    fixed-size window rather than expanding the list. A floor newer than the
+    tracked latest stable release fails closed: no tracked Kubernetes version
+    satisfies it.
     """
-    expanded = expand_kube_versions(floor, latest_minor)
-    supported = [v for v in expanded if v <= latest_minor]
+    floor_v = validate_semver(floor)
+    latest_v = validate_semver(latest)
+    if not floor_v or not latest_v:
+        raise ValueError(f"Invalid version: floor={floor} latest={latest}")
+    if floor_v > latest_v:
+        raise ValueError(
+            f"Minimum Kubernetes {floor} is newer than Plural's tracked "
+            f"latest stable {latest}"
+        )
+    expanded = expand_kube_versions(floor, latest)
+    # expand_kube_versions can overshoot by one minor when floor == latest.
+    supported = [v for v in expanded if v <= latest]
     return supported[-LATEST_KUBE_MINORS:][::-1]
+
+
+def build_rows(
+    release_versions: list[str],
+    latest_minor: str,
+    docs_get: Callable[[str], Optional[bytes]],
+) -> list[OrderedDict[str, object]]:
+    """Compatibility rows from per-release README documentation.
+
+    docs_get maps a release-tag README URL to raw bytes (or None).
+    """
+    rows: list[OrderedDict[str, object]] = []
+    for version in release_versions:
+        url = README_URL.format(version=version)
+        content = docs_get(url)
+        if not content:
+            print_warning(f"No README found for {version}")
+            continue
+        try:
+            text = content.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            print_warning(f"Could not decode README for {version}")
+            continue
+        try:
+            floor = parse_min_kubernetes(text)
+        except ValueError as e:
+            print_warning(f"{version}: {e}")
+            continue
+        try:
+            kube = expand_minimum(floor, latest_minor)
+        except ValueError as e:
+            print_warning(f"{version}: {e}; skipped")
+            continue
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", version),
+                    ("kube", kube),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+    return rows
 
 
 def scrape() -> None:
@@ -90,26 +146,7 @@ def scrape() -> None:
         print_error("Could not determine the latest Kubernetes version")
         return
 
-    rows: list[OrderedDict[str, object]] = []
-    for version in _release_versions():
-        floor = _kube_floor(version)
-        if not floor:
-            continue
-        floor_v = validate_semver(floor)
-        latest_v = validate_semver(latest_minor)
-        if floor_v and latest_v and floor_v > latest_v:
-            floor = latest_minor
-        rows.append(
-            OrderedDict(
-                [
-                    ("version", version),
-                    ("kube", _kube_list(floor, latest_minor)),
-                    ("requirements", []),
-                    ("incompatibilities", []),
-                ]
-            )
-        )
-
+    rows = build_rows(_release_versions(), latest_minor, fetch_page)
     if not rows:
         print_error("No compatibility information found for ClickHouse Operator")
         return

--- a/utils/compatibility/tests/test_clickhouse_operator.py
+++ b/utils/compatibility/tests/test_clickhouse_operator.py
@@ -1,0 +1,160 @@
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import utils as real_utils
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "clickhouse-operator.py"
+spec = importlib.util.spec_from_file_location("clickhouse_operator", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+DOC_125 = """# Altinity Kubernetes Operator for ClickHouse
+
+Requirements:
+
+ * Kubernetes 1.25+
+ * Helm 3.0+
+"""
+
+DOC_119_LATER = """## Installation
+
+- Kubernetes 1.19 or later
+"""
+
+DOC_NONE = """# Installation
+
+Install the operator with Helm. No version requirements listed.
+"""
+
+
+class ParseMinKubernetesTests(unittest.TestCase):
+    def test_parses_bullet_requirement(self):
+        self.assertEqual(scraper.parse_min_kubernetes(DOC_125), "1.25")
+
+    def test_parses_or_later_form(self):
+        self.assertEqual(scraper.parse_min_kubernetes(DOC_119_LATER), "1.19")
+
+    def test_missing_requirement_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Kubernetes requirement not found"):
+            scraper.parse_min_kubernetes(DOC_NONE)
+
+
+class ExpandMinimumTests(unittest.TestCase):
+    def test_tracks_three_newest_minors_newest_first(self):
+        self.assertEqual(
+            scraper.expand_minimum("1.25", "1.36"),
+            ["1.36", "1.35", "1.34"],
+        )
+
+    def test_ancient_floor_still_tracks_three_newest_minors(self):
+        self.assertEqual(
+            scraper.expand_minimum("1.19", "1.36"),
+            ["1.36", "1.35", "1.34"],
+        )
+
+    def test_floor_equal_to_latest_does_not_overshoot(self):
+        self.assertEqual(scraper.expand_minimum("1.36", "1.36"), ["1.36"])
+
+    def test_narrow_window_returns_full_range(self):
+        self.assertEqual(scraper.expand_minimum("1.19", "1.20"), ["1.20", "1.19"])
+
+    def test_future_minimum_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "newer than Plural"):
+            scraper.expand_minimum("1.37", "1.36")
+
+    def test_invalid_versions_fail_closed(self):
+        with self.assertRaises(ValueError):
+            scraper.expand_minimum("garbage", "1.36")
+
+
+def readme_for(version, doc):
+    return (scraper.README_URL.format(version=version), doc.encode())
+
+
+class BuildRowsTests(unittest.TestCase):
+    def test_builds_rows_from_release_tag_docs(self):
+        docs = dict(
+            [readme_for("0.27.3", DOC_125), readme_for("0.26.0", DOC_119_LATER)]
+        )
+        rows = scraper.build_rows(["0.27.3", "0.26.0"], "1.36", docs.get)
+        by_version = {row["version"]: row for row in rows}
+        self.assertEqual(
+            by_version["0.27.3"]["kube"], ["1.36", "1.35", "1.34"]
+        )
+        self.assertEqual(
+            by_version["0.26.0"]["kube"], ["1.36", "1.35", "1.34"]
+        )
+        self.assertEqual(by_version["0.27.3"]["requirements"], [])
+
+    def test_missing_readme_is_skipped(self):
+        docs = dict([readme_for("0.27.3", DOC_125)])
+        rows = scraper.build_rows(["0.27.3", "0.26.0"], "1.36", docs.get)
+        self.assertEqual([row["version"] for row in rows], ["0.27.3"])
+
+    def test_readme_without_requirement_is_skipped(self):
+        docs = dict([readme_for("0.27.3", DOC_NONE)])
+        rows = scraper.build_rows(["0.27.3"], "1.36", docs.get)
+        self.assertEqual(rows, [])
+
+    def test_future_floor_is_skipped_not_lowered(self):
+        future = "Requirements:\n\n * Kubernetes 1.37+\n"
+        docs = dict([readme_for("0.99.0", future)])
+        rows = scraper.build_rows(["0.99.0"], "1.36", docs.get)
+        self.assertEqual(rows, [])
+
+    def test_invalid_utf8_readme_is_skipped(self):
+        def fetcher(url):
+            if url.endswith("release-0.27.3/README.md"):
+                return b"\xff\xfe"
+            return None
+        rows = scraper.build_rows(["0.27.3"], "1.36", fetcher)
+        self.assertEqual(rows, [])
+
+
+class ScrapeWiringTests(unittest.TestCase):
+    def test_scrape_wires_official_sources(self):
+        with patch.object(
+            real_utils, "latest_kube_version", Mock(return_value=Mock(major=1, minor=36))
+        ), patch.object(
+            real_utils,
+            "get_github_releases",
+            Mock(return_value=["release-0.27.3", "release-0.27.2", "v9.9.9"]),
+        ), patch.object(
+            real_utils,
+            "fetch_page",
+            Mock(
+                side_effect=lambda url: DOC_125.encode()
+                if url.endswith("release-0.27.3/README.md")
+                or url.endswith("release-0.27.2/README.md")
+                else None
+            ),
+        ), patch.object(real_utils, "update_compatibility_info", Mock()), patch.object(
+            real_utils, "read_yaml", Mock(return_value={"helm_repository_url": "x"})
+        ), patch.object(real_utils, "update_chart_versions", Mock()):
+            fresh_spec = importlib.util.spec_from_file_location(
+                "clickhouse_operator_wiring", SCRAPER_PATH
+            )
+            fresh = importlib.util.module_from_spec(fresh_spec)
+            fresh_spec.loader.exec_module(fresh)
+            fresh.scrape()
+
+        real_utils.latest_kube_version.assert_called_once_with()
+        real_utils.get_github_releases.assert_called_once_with(
+            "Altinity", "clickhouse-operator"
+        )
+        path, rows = real_utils.update_compatibility_info.call_args.args
+        self.assertEqual(
+            path, "../../static/compatibilities/clickhouse-operator.yaml"
+        )
+        self.assertEqual([row["version"] for row in rows], ["0.27.3", "0.27.2"])
+        real_utils.update_chart_versions.assert_called_once_with(
+            "clickhouse-operator", "altinity-clickhouse-operator"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_clickhouse_operator.py
+++ b/utils/compatibility/tests/test_clickhouse_operator.py
@@ -117,24 +117,26 @@ class BuildRowsTests(unittest.TestCase):
 
 class ScrapeWiringTests(unittest.TestCase):
     def test_scrape_wires_official_sources(self):
-        with patch.object(
-            real_utils, "latest_kube_version", Mock(return_value=Mock(major=1, minor=36))
-        ), patch.object(
-            real_utils,
-            "get_github_releases",
-            Mock(return_value=["release-0.27.3", "release-0.27.2", "v9.9.9"]),
-        ), patch.object(
-            real_utils,
-            "fetch_page",
-            Mock(
-                side_effect=lambda url: DOC_125.encode()
-                if url.endswith("release-0.27.3/README.md")
-                or url.endswith("release-0.27.2/README.md")
-                else None
-            ),
-        ), patch.object(real_utils, "update_compatibility_info", Mock()), patch.object(
-            real_utils, "read_yaml", Mock(return_value={"helm_repository_url": "x"})
-        ), patch.object(real_utils, "update_chart_versions", Mock()):
+        mock_latest = Mock(return_value=Mock(major=1, minor=36))
+        mock_releases = Mock(
+            return_value=["release-0.27.3", "release-0.27.2", "v9.9.9"]
+        )
+        mock_fetch = Mock(
+            side_effect=lambda url: DOC_125.encode()
+            if url.endswith("release-0.27.3/README.md")
+            or url.endswith("release-0.27.2/README.md")
+            else None
+        )
+        mock_update = Mock()
+        mock_read_yaml = Mock(return_value={"helm_repository_url": "x"})
+        mock_charts = Mock()
+        with patch.object(real_utils, "latest_kube_version", mock_latest), patch.object(
+            real_utils, "get_github_releases", mock_releases
+        ), patch.object(real_utils, "fetch_page", mock_fetch), patch.object(
+            real_utils, "update_compatibility_info", mock_update
+        ), patch.object(real_utils, "read_yaml", mock_read_yaml), patch.object(
+            real_utils, "update_chart_versions", mock_charts
+        ):
             fresh_spec = importlib.util.spec_from_file_location(
                 "clickhouse_operator_wiring", SCRAPER_PATH
             )
@@ -142,16 +144,14 @@ class ScrapeWiringTests(unittest.TestCase):
             fresh_spec.loader.exec_module(fresh)
             fresh.scrape()
 
-        real_utils.latest_kube_version.assert_called_once_with()
-        real_utils.get_github_releases.assert_called_once_with(
-            "Altinity", "clickhouse-operator"
-        )
-        path, rows = real_utils.update_compatibility_info.call_args.args
+        mock_latest.assert_called_once_with()
+        mock_releases.assert_called_once_with("Altinity", "clickhouse-operator")
+        path, rows = mock_update.call_args.args
         self.assertEqual(
             path, "../../static/compatibilities/clickhouse-operator.yaml"
         )
         self.assertEqual([row["version"] for row in rows], ["0.27.3", "0.27.2"])
-        real_utils.update_chart_versions.assert_called_once_with(
+        mock_charts.assert_called_once_with(
             "clickhouse-operator", "altinity-clickhouse-operator"
         )
 


### PR DESCRIPTION
Adds compatibility tracking for the Altinity Kubernetes Operator for ClickHouse.

Supersedes #4184, addressing all three review points from @michaeljguarino:

1. **Icon** - ClickHouse organization avatar, matching the org-avatar convention used by the keda/harbor tables.
2. **Merge conflicts** - rebased onto latest master.
3. **Matrix permissiveness** - each row lists only the three newest stable Kubernetes minors (`1.36/1.35/1.34`), matching the keda/harbor row shape, instead of the full documented floor range.

Also fixed a latent edge case flagged by Greptile (P1): when a release's documented floor equals the latest stable minor, `expand_kube_versions()` overshoots by one minor; the scraper drops any entry newer than the latest stable release.

**Compatibility source**

Each ClickHouse Operator release documents the minimum supported Kubernetes
version in its release-tag README (e.g. release-0.27.3: `Kubernetes 1.25+`,
release-0.26.0: `Kubernetes 1.19+`). The scraper reads that requirement from
every stable release tag; it constrains the tracked three-minor window:

- https://github.com/Altinity/clickhouse-operator/blob/release-0.27.3/README.md
- https://github.com/Altinity/clickhouse-operator/blob/release-0.26.0/README.md

**Chart versions** come from the official Altinity Helm index:
https://altinity.github.io/helm-charts (chart `altinity-clickhouse-operator`,
appVersion matches operator releases).

**Files**
- `static/compatibilities/clickhouse-operator.yaml` - new compatibility table
- `utils/compatibility/scrapers/clickhouse-operator.py` - scraper (release-tag based, no release-date inference)
- `static/compatibilities/manifest.yaml` - register `clickhouse-operator`

## Test Plan
- Ran the scraper end-to-end: 5 version rows generated with the three-newest-minors kube window and chart versions filled from the Altinity index.
- Validated the generated YAML against `static/compatibilities/schema.json` (jsonschema draft-07): passes.
- Spot-checked k8s floors against the release-tag READMEs.

## Checklist
- [x] If required, I have updated the Plural documentation

---
Note: this contribution was produced with AI coding-agent assistance.
Discord: zhangb06
