### PR TITLE
Add Artifact Hub Helm-constraint scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,243 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://artifacthub.github.io/helm-charts/logo.png
+  git_url: https://github.com/artifacthub/hub
+  release_url: https://github.com/artifacthub/hub/releases/tag/v{vsn}
+  readme_url: https://github.com/artifacthub/hub/tree/master/charts/artifact-hub
+  helm_repository_url: https://artifacthub.github.io/helm-charts
+  chart_name: artifact-hub
+  versions:
+  - version: 1.23.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.23.0
+    images: []
+  - version: 1.22.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.22.0
+    images: []
+  - version: 1.21.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.21.0
+    images: []
+  - version: 1.20.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.20.0
+    images: []
+  - version: 1.19.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.19.0
+    images: []
+  - version: 1.18.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.18.0
+    images: []
+  - version: 1.17.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.17.0
+    images: []
+  - version: 1.16.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.16.0
+    images: []
+  - version: 1.15.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.15.0
+    images: []
+  - version: 1.14.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.14.0
+    images: []
+  - version: 1.13.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.13.0
+    images: []
+  - version: 1.12.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.12.0
+    images: []
+  - version: 1.11.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.11.0
+    images: []
+  - version: 1.10.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.10.0
+    images: []
+  - version: 1.9.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.9.0
+    images: []
+  - version: 1.8.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.8.0
+    images: []
+  - version: 1.7.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.7.0
+    images: []
+  - version: 1.6.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.6.0
+    images: []
+  - version: 1.5.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.5.0
+    images: []
+  - version: 1.4.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.4.0
+    images: []
+  - version: 1.3.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17', '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.3.0
+    images: []
+  - version: 1.2.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17', '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.2.0
+    images: []
+  - version: 1.1.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17', '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.1.0
+    images: []
+  - version: 1.0.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17', '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.0
+    images: []
+  - version: 0.20.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17', '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.20.0
+    images: []
+  - version: 0.19.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17', '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.19.0
+    images: []
+  - version: 0.18.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17', '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.18.0
+    images: []
+  - version: 0.17.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18',
+      '1.17', '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.17.0
+    images: []
+  name: artifact-hub

--- a/static/compatibilities/artifact-hub.yaml
+++ b/static/compatibilities/artifact-hub.yaml
@@ -1,0 +1,241 @@
+# Helm installation eligibility; not an upstream-tested Kubernetes matrix.
+# See utils/compatibility/tests/fixtures/artifact-hub-source.md.
+icon: https://artifacthub.github.io/helm-charts/logo.png
+git_url: https://github.com/artifacthub/hub
+release_url: https://github.com/artifacthub/hub/releases/tag/v{vsn}
+readme_url: https://github.com/artifacthub/hub/tree/master/charts/artifact-hub
+helm_repository_url: https://artifacthub.github.io/helm-charts
+chart_name: artifact-hub
+versions:
+- version: 1.23.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.23.0
+  images: []
+- version: 1.22.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.22.0
+  images: []
+- version: 1.21.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.21.0
+  images: []
+- version: 1.20.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.20.0
+  images: []
+- version: 1.19.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.19.0
+  images: []
+- version: 1.18.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.18.0
+  images: []
+- version: 1.17.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.17.0
+  images: []
+- version: 1.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.16.0
+  images: []
+- version: 1.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.15.0
+  images: []
+- version: 1.14.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.14.0
+  images: []
+- version: 1.13.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.13.0
+  images: []
+- version: 1.12.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.12.0
+  images: []
+- version: 1.11.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.11.0
+  images: []
+- version: 1.10.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.10.0
+  images: []
+- version: 1.9.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.9.0
+  images: []
+- version: 1.8.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.8.0
+  images: []
+- version: 1.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.7.0
+  images: []
+- version: 1.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.6.0
+  images: []
+- version: 1.5.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.0
+  images: []
+- version: 1.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.4.0
+  images: []
+- version: 1.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.0
+  images: []
+- version: 1.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.0
+  images: []
+- version: 1.1.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.0
+  images: []
+- version: 1.0.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.0
+  images: []
+- version: 0.20.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.20.0
+  images: []
+- version: 0.19.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.19.0
+  images: []
+- version: 0.18.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.18.0
+  images: []
+- version: 0.17.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.17.0
+  images: []

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -1,6 +1,7 @@
 names:
 - kubevirt
 - argo-rollouts
+- artifact-hub
 - aws-ebs-csi-driver
 - aws-efs-csi-driver
 - aws-load-balancer-controller

--- a/utils/compatibility/scrapers/artifact-hub.py
+++ b/utils/compatibility/scrapers/artifact-hub.py
@@ -1,0 +1,100 @@
+"""Read Artifact Hub's Helm installation constraints, not its tested CI matrix."""
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from typing import Any
+
+import requests
+import yaml
+from semantic_version import Version
+
+from utils import current_kube_version, update_compatibility_info
+
+APP_NAME = "artifact-hub"
+INDEX_URL = "https://artifacthub.github.io/helm-charts/index.yaml"
+FIRST_CONSTRAINED_CHART = Version("0.17.0")
+MINOR = r"(?:0|[1-9][0-9]*)"
+FLOOR = re.compile(rf">=\s*1\.({MINOR})\.0(?:-0)?")
+
+
+def _version(value: Any) -> Version:
+    if not isinstance(value, str):
+        raise ValueError("Artifact Hub versions must be strings")
+    return Version(value.removeprefix("v"))
+
+
+def _select_charts(entries: list) -> dict[Version, dict]:
+    """Select the latest stable chart for each app without relying on index order."""
+    selected = {}
+    seen = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Invalid Artifact Hub chart entry")
+        chart = _version(entry.get("version"))
+        app = _version(entry.get("appVersion"))
+        if chart.prerelease or app.prerelease or chart.build or app.build:
+            continue
+        # Earlier published charts omit kubeVersion. Do not infer their support.
+        if chart < FIRST_CONSTRAINED_CHART:
+            continue
+        candidate = {
+            "version": str(app),
+            "chart_version": str(chart),
+            "constraint": entry.get("kubeVersion"),
+        }
+        if chart in seen and seen[chart] != candidate:
+            raise ValueError(f"Conflicting Artifact Hub chart {chart}")
+        seen[chart] = candidate
+        previous = selected.get(app)
+        if previous is None or chart > Version(previous["chart_version"]):
+            selected[app] = candidate
+    return selected
+
+
+def _kube_minors(constraint: Any, maximum: int) -> list[str]:
+    # Only expand the source's observed whole-minor lower-bound grammar.
+    # Patch floors, upper bounds and disjunctions need explicit handling first.
+    match = FLOOR.fullmatch(constraint.strip()) if isinstance(constraint, str) else None
+    if match is None:
+        raise ValueError(f"Unsupported Artifact Hub kubeVersion constraint: {constraint!r}")
+    minimum = int(match[1])
+    if minimum > maximum:
+        raise ValueError("Artifact Hub Kubernetes minimum exceeds KUBE_VERSION")
+    return [f"1.{minor}" for minor in range(maximum, minimum - 1, -1)]
+
+
+def build_rows(content: str | bytes, kube_version: str) -> list[OrderedDict]:
+    """Validate all candidates before returning rows for the existing update helper."""
+    cap = re.fullmatch(rf"1\.({MINOR})", kube_version) if isinstance(kube_version, str) else None
+    if cap is None:
+        raise ValueError("KUBE_VERSION must be a Kubernetes 1.x minor")
+    document = yaml.safe_load(content)
+    entries = document.get("entries") if isinstance(document, dict) else None
+    charts = entries.get(APP_NAME) if isinstance(entries, dict) else None
+    if not isinstance(charts, list) or not charts:
+        raise ValueError("Artifact Hub chart index is missing or empty")
+    selected = _select_charts(charts)
+    rows = []
+    for version in sorted(selected, reverse=True):
+        candidate = selected[version]
+        rows.append(OrderedDict([
+            ("version", str(version)),
+            ("kube", _kube_minors(candidate["constraint"], int(cap[1]))),
+            ("chart_version", candidate["chart_version"]),
+            ("images", []),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ]))
+    if not rows:
+        raise ValueError("No stable Artifact Hub charts with documented constraints")
+    return rows
+
+
+def scrape() -> None:
+    response = requests.get(INDEX_URL, timeout=30)
+    response.raise_for_status()
+    rows = build_rows(response.text, current_kube_version())
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", rows)
+

--- a/utils/compatibility/tests/fixtures/artifact-hub-index.yaml
+++ b/utils/compatibility/tests/fixtures/artifact-hub-index.yaml
@@ -1,0 +1,122 @@
+# Reduced from https://artifacthub.github.io/helm-charts/index.yaml on 2026-09-08.
+# Full-source SHA256: 76e95d59f2653171ef4cfd2fc8c460c3f3a854fab8afa3ed4fd3220c4caffe26
+apiVersion: v1
+entries:
+  artifact-hub:
+  - version: 1.23.0
+    appVersion: 1.23.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.22.0
+    appVersion: 1.22.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.21.0
+    appVersion: 1.21.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.20.0
+    appVersion: 1.20.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.19.0
+    appVersion: 1.19.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.18.0
+    appVersion: 1.18.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.17.0
+    appVersion: 1.17.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.16.0
+    appVersion: 1.16.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.15.0
+    appVersion: 1.15.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.14.0
+    appVersion: 1.14.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.13.0
+    appVersion: 1.13.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.12.0
+    appVersion: 1.12.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.11.0
+    appVersion: 1.11.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.10.0
+    appVersion: 1.10.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.9.0
+    appVersion: 1.9.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.8.0
+    appVersion: 1.8.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.7.0
+    appVersion: 1.7.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.6.0
+    appVersion: 1.6.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.5.0
+    appVersion: 1.5.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.4.0
+    appVersion: 1.4.0
+    kubeVersion: '>= 1.19.0-0'
+  - version: 1.3.0
+    appVersion: 1.3.0
+    kubeVersion: '>= 1.14.0-0'
+  - version: 1.2.0
+    appVersion: 1.2.0
+    kubeVersion: '>= 1.14.0-0'
+  - version: 1.1.1
+    appVersion: 1.1.1
+    kubeVersion: '>= 1.14.0-0'
+  - version: 1.1.0
+    appVersion: 1.1.0
+    kubeVersion: '>= 1.14.0-0'
+  - version: 1.0.0
+    appVersion: 1.0.0
+    kubeVersion: '>= 1.14.0-0'
+  - version: 0.20.0
+    appVersion: 0.20.0
+    kubeVersion: '>= 1.14.0-0'
+  - version: 0.19.0
+    appVersion: 0.19.0
+    kubeVersion: '>= 1.14.0-0'
+  - version: 0.18.0
+    appVersion: 0.18.0
+    kubeVersion: '>= 1.14.0-0'
+  - version: 0.17.0
+    appVersion: 0.17.0
+    kubeVersion: '>= 1.14.0-0'
+  - version: 0.16.0
+    appVersion: 0.16.0
+  - version: 0.15.0
+    appVersion: 0.15.0
+  - version: 0.14.0
+    appVersion: 0.14.0
+  - version: 0.13.0
+    appVersion: 0.13.0
+  - version: 0.12.0
+    appVersion: 0.12.0
+  - version: 0.11.0
+    appVersion: 0.11.0
+  - version: 0.10.0
+    appVersion: 0.10.0
+  - version: 0.9.0
+    appVersion: 0.9.0
+  - version: 0.8.0
+    appVersion: 0.8.0
+  - version: 0.7.0
+    appVersion: 0.7.0
+  - version: 0.6.0
+    appVersion: 0.6.0
+  - version: 0.5.0
+    appVersion: 0.5.0
+  - version: 0.4.0
+    appVersion: 0.4.0
+  - version: 0.3.0
+    appVersion: 0.3.0
+  - version: 0.2.0
+    appVersion: 0.2.0

--- a/utils/compatibility/tests/fixtures/artifact-hub-source.md
+++ b/utils/compatibility/tests/fixtures/artifact-hub-source.md
@@ -1,0 +1,29 @@
+# Artifact Hub source fixture
+
+The YAML fixture retains only `version`, `appVersion`, and `kubeVersion` from
+the official [Helm index](https://artifacthub.github.io/helm-charts/index.yaml),
+retrieved September 8, 2026. Its comment records the full downloaded file's
+SHA-256. All 44 entries are retained, including 15 historical charts without
+`kubeVersion`.
+
+These constraints describe Helm installation eligibility. They do not establish
+which Kubernetes versions upstream tested, or whether optional dependencies run
+on every eligible version. The open lower bounds are capped at the repository's
+`KUBE_VERSION` when generating minor-version rows. Maintainer agreement to this
+interpretation is pending in [#4228](https://github.com/pluralsh/console/issues/4228).
+
+Charts before 0.17.0 have no declared constraint and are omitted. Later charts
+must declare a recognized whole-minor lower bound; missing values and unfamiliar
+constraint syntax fail before updating the compatibility file. Only the latest
+stable chart for each stable application version is selected. Conflicting
+duplicate chart versions fail instead of relying on index ordering.
+
+To run the offline tests, install the compatibility requirements and pytest,
+then run from the repository root:
+
+```sh
+python -m pytest utils/compatibility/tests/test_artifact_hub.py
+```
+
+The fetch and update boundaries are mocked in scraper tests. No chart is
+installed, no Kubernetes cluster is contacted, and no paid AI service is used.

--- a/utils/compatibility/tests/test_artifact_hub.py
+++ b/utils/compatibility/tests/test_artifact_hub.py
@@ -1,0 +1,161 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+import yaml
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+spec = importlib.util.spec_from_file_location(
+    "artifact_hub_scraper", COMPATIBILITY / "scrapers" / "artifact-hub.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+FIXTURE = Path(__file__).parent / "fixtures" / "artifact-hub-index.yaml"
+
+
+def chart(version="1.23.0", app_version="1.23.0", constraint=">= 1.19.0-0"):
+    return {"version": version, "appVersion": app_version, "kubeVersion": constraint}
+
+
+def index(*entries):
+    return yaml.safe_dump({"entries": {"artifact-hub": list(entries)}})
+
+
+def test_official_index_retains_both_historical_floors_and_omits_unknown_legacy():
+    rows = scraper.build_rows(FIXTURE.read_text(), "1.36")
+    by_version = {row["version"]: row for row in rows}
+    assert len(rows) == 29
+    assert rows[0]["version"] == "1.23.0"
+    assert rows[-1]["version"] == "0.17.0"
+    assert by_version["1.23.0"]["kube"] == [f"1.{n}" for n in range(36, 18, -1)]
+    assert by_version["1.3.0"]["kube"] == [f"1.{n}" for n in range(36, 13, -1)]
+    assert "0.16.0" not in by_version
+
+
+def test_same_floor_as_cap_has_no_extra_minor():
+    assert scraper.build_rows(index(chart()), "1.19")[0]["kube"] == ["1.19"]
+
+
+def test_duplicate_app_uses_highest_stable_chart_independent_of_order():
+    entries = [chart("1.23.1"), chart(), chart("1.23.10"), chart("1.24.0-rc.1")]
+    forward = scraper.build_rows(index(*entries), "1.36")
+    assert forward == scraper.build_rows(index(*reversed(entries)), "1.36")
+    assert len(forward) == 1
+    assert forward[0]["chart_version"] == "1.23.10"
+
+
+def test_prerelease_app_does_not_override_stable_row():
+    rows = scraper.build_rows(index(chart(), chart("1.24.0", "1.24.0-rc.1")), "1.36")
+    assert [row["version"] for row in rows] == ["1.23.0"]
+
+
+def test_conflicting_duplicate_chart_rejected():
+    with pytest.raises(ValueError, match="Conflicting"):
+        scraper.build_rows(index(chart(), chart(constraint=">= 1.20.0-0")), "1.36")
+
+
+@pytest.mark.parametrize("constraint", [
+    None, "", 1.19, ">=1.19.1", "^1.19.0", ">=1.19.0 <1.30.0",
+    ">=1.19.0 || >=2.0.0", ">=1.19.0-rc.1", ">=2.0.0", ">=1.019.0",
+])
+def test_unsupported_constraint_rejected(constraint):
+    with pytest.raises(ValueError, match="constraint"):
+        scraper.build_rows(index(chart(constraint=constraint)), "1.36")
+
+
+@pytest.mark.parametrize("cap", [None, "", "2.0", "1.36.0", "1.18", "1.036"])
+def test_invalid_or_lower_cap_rejected(cap):
+    with pytest.raises(ValueError):
+        scraper.build_rows(index(chart()), cap)
+
+
+@pytest.mark.parametrize("content", [
+    "", "[]", "entries: []", "entries: {}", index(), index(None), index({}),
+    index(chart(version=1.23)), index(chart(app_version="invalid")),
+    index(chart(version="1.24.0-rc.1")), "entries: [",
+])
+def test_empty_malformed_or_no_stable_candidates_rejected(content):
+    with pytest.raises((ValueError, yaml.YAMLError)):
+        scraper.build_rows(content, "1.36")
+
+
+def test_missing_new_constraint_does_not_use_an_older_chart():
+    with pytest.raises(ValueError, match="constraint"):
+        scraper.build_rows(index(chart(), chart("1.23.1", constraint=None)), "1.36")
+
+
+def test_scrape_fetches_with_timeout_and_passes_complete_rows(monkeypatch):
+    response = Mock(text=FIXTURE.read_text())
+    get = Mock(return_value=response)
+    update = Mock()
+    monkeypatch.setattr(scraper.requests, "get", get)
+    monkeypatch.setattr(scraper, "current_kube_version", lambda: "1.36")
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+    scraper.scrape()
+    get.assert_called_once_with(scraper.INDEX_URL, timeout=30)
+    response.raise_for_status.assert_called_once_with()
+    assert len(update.call_args.args[1]) == 29
+
+
+@pytest.mark.parametrize("failure", ["http", "timeout", "yaml", "constraint"])
+def test_scrape_failure_never_reaches_writer(monkeypatch, failure):
+    response = Mock(text=FIXTURE.read_text())
+    get = Mock(return_value=response)
+    if failure == "http":
+        response.raise_for_status.side_effect = requests.HTTPError("503")
+    elif failure == "timeout":
+        get.side_effect = requests.Timeout("timeout")
+    elif failure == "yaml":
+        response.text = "entries: ["
+    else:
+        response.text = index(chart(), chart("1.24.0", "1.24.0", "^1.20.0"))
+    update = Mock()
+    monkeypatch.setattr(scraper.requests, "get", get)
+    monkeypatch.setattr(scraper, "current_kube_version", lambda: "1.36")
+    monkeypatch.setattr(scraper, "update_compatibility_info", update)
+    with pytest.raises((requests.RequestException, ValueError, yaml.YAMLError)):
+        scraper.scrape()
+    update.assert_not_called()
+
+
+def test_real_update_preserves_metadata_and_serializes_rows(tmp_path, monkeypatch):
+    import utils
+
+    target = tmp_path / "artifact-hub.yaml"
+    target.write_text(yaml.safe_dump({
+        "git_url": "https://github.com/artifacthub/hub",
+        "helm_repository_url": "https://artifacthub.github.io/helm-charts",
+        "chart_name": "artifact-hub",
+        "versions": [],
+    }))
+    monkeypatch.setattr(utils, "summarization_enabled", lambda: False)
+    images = Mock(return_value=[])
+    monkeypatch.setattr(utils, "get_chart_images", images)
+    rows = scraper.build_rows(FIXTURE.read_text(), "1.36")
+    utils.update_compatibility_info(str(target), rows)
+    saved = yaml.safe_load(target.read_text())
+    assert saved["git_url"] == "https://github.com/artifacthub/hub"
+    assert saved["chart_name"] == "artifact-hub"
+    assert saved["versions"] == [dict(row) for row in utils.reduce_versions(rows)]
+    assert saved["versions"][0]["kube"][-1] == "1.19"
+    assert images.call_count == len(saved["versions"])
+
+
+def test_static_table_and_aggregate_match_source():
+    import utils
+
+    root = COMPATIBILITY.parents[1]
+    addon = yaml.safe_load((root / "static/compatibilities/artifact-hub.yaml").read_text())
+    cap = (root / "KUBE_VERSION").read_text().strip()
+    expected = utils.reduce_versions(scraper.build_rows(FIXTURE.read_text(), cap))
+    assert addon["versions"] == [dict(row) for row in expected]
+    aggregate = yaml.safe_load((root / "static/compatibilities.yaml").read_text())
+    assert [row for row in aggregate["addons"] if row["name"] == "artifact-hub"] == [
+        {**addon, "name": "artifact-hub"}
+    ]
+    manifest = yaml.safe_load((root / "static/compatibilities/manifest.yaml").read_text())
+    assert manifest["names"].count("artifact-hub") == 1


### PR DESCRIPTION
Related inquiry: https://github.com/pluralsh/console/issues/4228

Artifact Hub is absent from the compatibility manifest. This adds a scraper and initial table derived from its official Helm index, plus its entry in the aggregate table.

**Scope decision pending:** `kubeVersion` is a Helm installation constraint, not an upstream-tested Kubernetes support matrix. This draft expands the published whole-minor lower bounds only through the repository's `KUBE_VERSION`. It should remain a draft until maintainers confirm this is useful compatibility data. Optional chart dependencies and live cluster behavior have not been validated.

The parser selects the latest stable chart per stable application version without depending on index order. It handles both published historical lower bounds, skips charts before 0.17.0 that lack constraints, and rejects malformed data, conflicting duplicate charts, and unfamiliar selected constraints before invoking the updater. The full source has 44 entries; 29 have usable constraints, reduced to 28 stored rows by the existing helper.

Sources:
- https://artifacthub.github.io/helm-charts/index.yaml
- https://github.com/artifacthub/hub/blob/master/charts/artifact-hub/Chart.yaml
- Fixture provenance and limits: `utils/compatibility/tests/fixtures/artifact-hub-source.md`

Validation on macOS / Python 3.14.7:
- Full compatibility tests: **167 passed, 81 subtests passed**.
- New Artifact Hub tests: **40 passed**. Initial 38-test run covered 100% of new scraper statements.
- Schema validation: addon, manifest and aggregate pass.
- Ruff E4/E7/E9/F checks and `git diff --check` pass.
- Independent Python review found no blocking correctness/security issue. Broader Ruff rules note the repository-style hyphenated module name and ValueError versus TypeError conventions.

Tests exercise the real YAML update helper with chart-image lookup and AI summarization mocked. No live Helm rendering, Kubernetes installation, or paid API call was performed. Empty image lists are unverified, not a claim that the charts contain no images.

Prepared with OpenAI Codex. This draft makes no claim of assignment, sponsor acceptance, award approval, or payment. The README's new-scraper award and private PayPal eligibility remain subject to maintainer confirmation in #4228. No payment address or credentials are included.
