### PR TITLE
Add YuniKorn compatibility scraper and catalog

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- yunikorn

--- a/static/compatibilities/yunikorn.yaml
+++ b/static/compatibilities/yunikorn.yaml
@@ -1,0 +1,122 @@
+icon: https://raw.githubusercontent.com/apache/yunikorn-site/master/static/img/logo/yunikorn_logo.svg
+git_url: https://github.com/apache/yunikorn-k8shim
+release_url: https://yunikorn.apache.org/release-announce/{vsn}/
+readme_url: https://yunikorn.apache.org/docs/get_started/version/
+helm_repository_url: https://apache.github.io/yunikorn-release
+chart_name: yunikorn
+versions:
+- version: 1.9.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26',
+    '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.9.0
+  images: ['apache/yunikorn:admission-1.9.0', 'apache/yunikorn:scheduler-1.9.0', 'apache/yunikorn:web-1.9.0']
+- version: 1.8.0
+  kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25',
+    '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.8.0
+  images: ['apache/yunikorn:admission-1.8.0', 'apache/yunikorn:scheduler-1.8.0', 'apache/yunikorn:web-1.8.0']
+- version: 1.7.0
+  kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.7.0
+  images: ['apache/yunikorn:admission-1.7.0', 'apache/yunikorn:scheduler-1.7.0', 'apache/yunikorn:web-1.7.0']
+- version: 1.6.0
+  kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.6.0
+  images: ['apache/yunikorn:admission-1.6.0', 'apache/yunikorn:scheduler-1.6.0', 'apache/yunikorn:web-1.6.0']
+- version: 1.5.0
+  kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.0
+  images: ['apache/yunikorn:admission-1.5.0', 'apache/yunikorn:scheduler-1.5.0', 'apache/yunikorn:web-1.5.0']
+- version: 1.4.0
+  kube: ['1.28', '1.27', '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.4.0
+  images: ['apache/yunikorn:admission-1.4.0', 'apache/yunikorn:scheduler-1.4.0', 'apache/yunikorn:web-1.4.0']
+- version: 1.3.0
+  kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.0
+  images: ['apache/yunikorn:admission-1.3.0', 'apache/yunikorn:scheduler-1.3.0', 'apache/yunikorn:web-1.3.0']
+- version: 1.2.0
+  kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.0
+  images: ['apache/yunikorn:admission-1.2.0', 'apache/yunikorn:scheduler-1.2.0', 'apache/yunikorn:web-1.2.0']
+- version: 1.1.0
+  kube: ['1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.0
+  images: ['apache/yunikorn:admission-1.1.0', 'apache/yunikorn:scheduler-1.1.0', 'apache/yunikorn:web-1.1.0']
+- version: 1.0.0
+  kube: ['1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.0
+  images: ['apache/yunikorn:admission-1.0.0', 'apache/yunikorn:scheduler-1.0.0', 'apache/yunikorn:web-1.0.0']
+- version: 0.12.2
+  kube: ['1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.2
+  images: ['apache/yunikorn:admission-0.12.2', 'apache/yunikorn:scheduler-0.12.2',
+    'apache/yunikorn:web-0.12.2']
+- version: 0.12.1
+  kube: ['1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.12.1
+  images: ['apache/yunikorn:scheduler-0.12.1', 'apache/yunikorn:web-0.12.1', 'curlimages/curl:latest']
+- version: 0.11.0
+  kube: ['1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.11.0
+  images: ['apache/yunikorn:scheduler-0.11.0', 'apache/yunikorn:web-0.11.0', 'curlimages/curl:latest']
+- version: 0.10.0
+  kube: ['1.18', '1.17', '1.16', '1.15', '1.14', '1.13']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.0
+  images: ['apache/yunikorn:scheduler-0.10.0', 'apache/yunikorn:web-0.10.0', 'curlimages/curl:latest']
+- version: 0.9.0
+  kube: ['1.15', '1.14', '1.13']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.9.0
+  images: ['apache/yunikorn:scheduler-0.9.0', 'apache/yunikorn:web-0.9.0', 'curlimages/curl:latest']
+- version: 0.8.0
+  kube: ['1.15', '1.14', '1.13']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.0
+  images: ['apache/yunikorn:scheduler-0.8.0', 'apache/yunikorn:web-0.8.0', 'curlimages/curl:latest']

--- a/utils/compatibility/scrapers/yunikorn.py
+++ b/utils/compatibility/scrapers/yunikorn.py
@@ -1,0 +1,78 @@
+import re
+from collections import OrderedDict
+
+from bs4 import BeautifulSoup
+
+from utils import fetch_page, get_chart_versions, update_compatibility_info, validate_semver
+
+
+APP_NAME = "yunikorn"
+SUPPORT_URL = "https://yunikorn.apache.org/docs/get_started/version/"
+
+
+def parse_support_ranges(content):
+    soup = BeautifulSoup(content, "html.parser")
+    for table in soup.find_all("table"):
+        headers = [cell.get_text(" ", strip=True) for cell in table.find_all("th")]
+        if headers != ["K8s Version", "Supported from version", "Support ended"]:
+            continue
+
+        ranges = []
+        for row in table.find_all("tr"):
+            cells = [cell.get_text(" ", strip=True) for cell in row.find_all("td")]
+            if not cells:
+                continue
+            if len(cells) != 3:
+                raise ValueError(f"Unexpected YuniKorn support row: {cells}")
+            kube, start, end = cells
+            if start == end == "-":
+                continue  # The upstream table explicitly marks these versions unsupported.
+            match = re.fullmatch(r"(\d+\.\d+)\.x", kube)
+            first = validate_semver(start)
+            last = None if end == "-" else validate_semver(end)
+            if not match or first is None or (end != "-" and last is None):
+                raise ValueError(f"Invalid YuniKorn support range: {cells}")
+            if last is not None and last < first:
+                raise ValueError(f"Reversed YuniKorn support range: {cells}")
+            ranges.append((match.group(1), first, last))
+
+        if ranges:
+            return ranges
+    raise ValueError("YuniKorn Kubernetes support table is missing or empty")
+
+
+def build_rows(chart_versions, support_ranges):
+    rows = []
+    for app_version, chart_version in chart_versions.items():
+        version = validate_semver(app_version)
+        if version is None or validate_semver(chart_version) is None:
+            continue
+        # "Support ended" is inclusive: the 1.3.0 release announcement explicitly
+        # identifies 1.3.0 as the last release supporting Kubernetes 1.21-1.23.
+        kube = [
+            kube_version
+            for kube_version, first, last in support_ranges
+            if first <= version and (last is None or version <= last)
+        ]
+        if kube:
+            rows.append(OrderedDict([
+                ("version", str(version)),
+                ("kube", kube),
+                ("chart_version", chart_version),
+                ("images", []),
+                ("requirements", []),
+                ("incompatibilities", []),
+            ]))
+    return rows
+
+
+def scrape():
+    content = fetch_page(SUPPORT_URL)
+    if not content:
+        raise ValueError("Failed to fetch YuniKorn Kubernetes support table")
+    ranges = parse_support_ranges(content)
+    charts = get_chart_versions(APP_NAME)
+    rows = build_rows(charts, ranges)
+    if not rows:
+        raise ValueError("No stable YuniKorn charts match the support table")
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", rows)

--- a/utils/compatibility/tests/test_yunikorn.py
+++ b/utils/compatibility/tests/test_yunikorn.py
@@ -1,0 +1,85 @@
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+yunikorn = importlib.import_module("scrapers.yunikorn")
+
+SUPPORT_TABLE = """
+<table><thead><tr><th>K8s Version</th>
+<th>Supported <br/>from version</th><th>Support ended</th></tr></thead><tbody>
+<tr><td>1.12.x (or earlier)</td><td>-</td><td>-</td></tr>
+<tr><td>1.21.x</td><td>0.12.1</td><td>1.3.0</td></tr>
+<tr><td>1.23.x</td><td>0.12.2</td><td>1.3.0</td></tr>
+<tr><td>1.24.x</td><td>1.0.0</td><td>-</td></tr>
+<tr><td>1.35.x</td><td>1.9.0</td><td>-</td></tr>
+</tbody></table>
+"""
+
+
+class YuniKornScraperTest(unittest.TestCase):
+    def test_support_start_and_end_are_inclusive(self):
+        rows = yunikorn.build_rows(
+            {v: v for v in ["0.12.1", "0.12.2", "1.3.0", "1.4.0", "1.9.0"]},
+            yunikorn.parse_support_ranges(SUPPORT_TABLE),
+        )
+        by_version = {row["version"]: row["kube"] for row in rows}
+        self.assertEqual(by_version["0.12.1"], ["1.21"])
+        self.assertEqual(by_version["0.12.2"], ["1.21", "1.23"])
+        self.assertEqual(by_version["1.3.0"], ["1.21", "1.23", "1.24"])
+        self.assertEqual(by_version["1.4.0"], ["1.24"])
+        self.assertEqual(by_version["1.9.0"], ["1.24", "1.35"])
+
+    def test_ignores_unrelated_tables(self):
+        unrelated = "<table><tr><th>Version</th></tr><tr><td>99.0.0</td></tr></table>"
+        ranges = yunikorn.parse_support_ranges(unrelated + SUPPORT_TABLE)
+        self.assertEqual([row[0] for row in ranges], ["1.21", "1.23", "1.24", "1.35"])
+
+    def test_only_stable_supported_charts_are_emitted(self):
+        rows = yunikorn.build_rows(
+            {"1.9.0": "1.9.1", "1.10.0-rc.1": "1.10.0-rc.1",
+             "1.8.0": "1.8.1-rc.1", "0.1.0": "0.1.0", "invalid": "1.0.0"},
+            yunikorn.parse_support_ranges(SUPPORT_TABLE),
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["version"], "1.9.0")
+        self.assertEqual(rows[0]["chart_version"], "1.9.1")
+
+    def test_malformed_source_does_not_update_catalog(self):
+        invalid_sources = [
+            None,
+            "<html>Service unavailable</html>",
+            SUPPORT_TABLE.replace("0.12.1", "unknown"),
+            SUPPORT_TABLE.replace("<td>1.3.0</td>", "<td>0.1.0</td>"),
+            SUPPORT_TABLE.replace("<td>1.35.x</td>", "<td>1.35-1.40</td>"),
+        ]
+        for content in invalid_sources:
+            with self.subTest(content=content), patch.object(yunikorn, "fetch_page", return_value=content), \
+                    patch.object(yunikorn, "update_compatibility_info") as update:
+                with self.assertRaises(ValueError):
+                    yunikorn.scrape()
+                update.assert_not_called()
+
+    def test_missing_charts_do_not_update_catalog(self):
+        with patch.object(yunikorn, "fetch_page", return_value=SUPPORT_TABLE), \
+                patch.object(yunikorn, "get_chart_versions", return_value={}), \
+                patch.object(yunikorn, "update_compatibility_info") as update:
+            with self.assertRaises(ValueError):
+                yunikorn.scrape()
+            update.assert_not_called()
+
+    def test_scrape_passes_mapped_rows_to_existing_writer(self):
+        with patch.object(yunikorn, "fetch_page", return_value=SUPPORT_TABLE), \
+                patch.object(yunikorn, "get_chart_versions", return_value={"1.9.0": "1.9.0"}), \
+                patch.object(yunikorn, "update_compatibility_info") as update:
+            yunikorn.scrape()
+            path, rows = update.call_args.args
+            self.assertEqual(path, "../../static/compatibilities/yunikorn.yaml")
+            self.assertEqual(rows[0]["kube"], ["1.24", "1.35"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Apache YuniKorn to the compatibility catalog, with an automated scraper and metadata for its official Helm chart.

The scraper maps stable chart application versions to the upstream Kubernetes support table. Both support endpoints are inclusive: the 1.3.0 announcement explicitly confirms that 1.3.0 still supports Kubernetes 1.21–1.23. Prerelease applications/charts and explicitly unsupported combinations are excluded. Invalid or missing source data stops the scraper before it calls the existing catalog writer.

Sources:
- [Official support table](https://yunikorn.apache.org/docs/get_started/version/)
- [1.3.0 release announcement confirming the inclusive endpoint](https://yunikorn.apache.org/release-announce/1.3.0/)
- [Official Helm repository](https://apache.github.io/yunikorn-release/index.yaml)

Validation:
- `python -m unittest discover -s utils/compatibility/tests -p test_yunikorn.py -v`: 6 tests passed, covering support boundaries, stable chart mapping, source failures, and writer integration.
- Generated from the current stable support page and 21 published stable charts. The existing writer reduces these to 16 catalog rows, all checked against the source ranges and rendered with Helm 3.19.0 to populate images.
- Catalog and manifest pass the repository's JSON schema; `git diff --cached --check` passes.

Local network limitation: the canonical GitHub Pages Helm hostname failed TLS on this machine. Generation used the same official publication at `https://raw.githubusercontent.com/apache/yunikorn-release/gh-pages/index.yaml`, and Helm was registered against that published branch locally. The contributed metadata retains the canonical Helm repository, and no shared helpers or production code were changed for this workaround. These are documentation and Helm-template checks, not Kubernetes cluster deployment tests.

Implementation and validation were AI-assisted with OpenAI Codex. Submitted for consideration under the README's new compatibility scraper contributor program; no reward is claimed before acceptance and merge.
