### PR TITLE
Add Kuma compatibility scraper for documented release families

### DIFF
--- a/static/compatibilities/kuma.yaml
+++ b/static/compatibilities/kuma.yaml
@@ -1,0 +1,97 @@
+icon: https://kuma.io/assets/images/brand/kuma-logo-new.svg
+git_url: https://github.com/kumahq/kuma
+release_url: https://github.com/kumahq/kuma/releases?q={vsn}
+readme_url: https://kuma.io/docs/latest/introduction/kuma-requirements/
+helm_repository_url: https://kumahq.github.io/charts
+versions:
+- version: 2.14.4
+  kube: ['1.35', '1.32']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.14.4
+  images: []
+- version: 2.13.10
+  kube: ['1.34', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.13.10
+  images: []
+- version: 2.12.14
+  kube: ['1.32', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.12.14
+  images: []
+- version: 2.11.18
+  kube: ['1.32', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.11.18
+  images: []
+- version: 2.10.11
+  kube: ['1.31', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.10.11
+  images: []
+- version: 2.9.19
+  kube: ['1.31', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.9.19
+  images: []
+- version: 2.8.8
+  kube: ['1.30', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.8.8
+  images: []
+- version: 2.7.29
+  kube: ['1.31', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.7.29
+  images: []
+- version: 2.6.15
+  kube: ['1.28', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.6.15
+  images: []
+- version: 2.5.11
+  kube: ['1.28', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.5.11
+  images: []
+- version: 2.4.10
+  kube: ['1.27', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.4.10
+  images: []
+- version: 2.3.7
+  kube: ['1.27', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.3.7
+  images: []
+- version: 2.2.9
+  kube: ['1.26', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.2.9
+  images: []

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- kuma

--- a/utils/compatibility/scrapers/kuma.py
+++ b/utils/compatibility/scrapers/kuma.py
@@ -1,0 +1,84 @@
+"""Read Kuma's documented Kubernetes test targets for each release family."""
+
+import re
+from collections import OrderedDict
+
+import requests
+import yaml
+
+from utils import fetch_page, get_chart_versions, update_compatibility_info, validate_semver
+
+app_name = "kuma"
+versions_url = "https://raw.githubusercontent.com/kumahq/kuma-website/master/app/_data/versions.yml"
+source_url = "https://raw.githubusercontent.com/kumahq/kuma/{tag}/mk/dev.mk"
+output_path = "../../static/compatibilities/kuma.yaml"
+
+
+def select_releases(catalog, chart_versions):
+    """Select the newest stable, chart-backed patch in each documented family."""
+    families = set()
+    for entry in catalog:
+        if entry.get("edition") != "kuma" or entry.get("label") == "dev":
+            continue
+        match = re.fullmatch(r"(\d+)\.(\d+)\.x", entry.get("release", ""))
+        if match:
+            families.add(tuple(map(int, match.groups())))
+    if not families:
+        raise ValueError("No released Kuma families found in the documentation catalog")
+
+    selected = {}
+    for version, chart_version in chart_versions.items():
+        app = validate_semver(version)
+        chart = validate_semver(chart_version)
+        if not app or not chart:
+            continue
+        family = (app.major, app.minor)
+        if family in families and (family not in selected or app > selected[family][0]):
+            selected[family] = (app, chart_version)
+    if families - selected.keys():
+        raise ValueError("A documented Kuma family has no stable Helm chart")
+    return sorted(selected.values(), key=lambda item: item[0], reverse=True)
+
+
+def parse_kube_versions(content):
+    """Keep the two tested targets, without interpolating the versions between."""
+    targets = {}
+    for line in content.splitlines():
+        match = re.fullmatch(
+            r"\s*K8S_(MIN|MAX)_VERSION\s*[:?]?=\s*v(\d+\.\d+)\.\d+"
+            r"(?:-[\w.-]+)?\s*(?:#.*)?", line
+        )
+        if match:
+            targets[match[1]] = match[2]
+    if set(targets) != {"MIN", "MAX"}:
+        raise ValueError("Missing Kuma Kubernetes test targets in mk/dev.mk")
+    return sorted(set(targets.values()), key=lambda value: tuple(map(int, value.split("."))), reverse=True)
+
+
+def fetch_release_targets(version):
+    # Kuma changed from unprefixed release tags to v-prefixed tags. Only a 404
+    # permits trying the older spelling; network/server failures must propagate.
+    response = requests.get(source_url.format(tag=f"v{version}"), timeout=30)
+    if response.status_code == 404:
+        response = requests.get(source_url.format(tag=version), timeout=30)
+    response.raise_for_status()
+    return parse_kube_versions(response.text)
+
+
+def scrape():
+    content = fetch_page(versions_url)
+    if not content:
+        raise ValueError("Could not fetch Kuma's release catalog")
+    releases = select_releases(yaml.safe_load(content), get_chart_versions(app_name))
+    rows = []
+    for version, chart_version in releases:
+        rows.append(OrderedDict([
+            ("version", str(version)),
+            ("kube", fetch_release_targets(str(version))),
+            ("chart_version", chart_version),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ]))
+    # Resolve all sources before invoking the shared writer, preserving the
+    # previous table if any selected release cannot be read or parsed.
+    update_compatibility_info(output_path, rows)

--- a/utils/compatibility/tests/test_kuma.py
+++ b/utils/compatibility/tests/test_kuma.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+
+from scrapers import kuma
+
+
+class KumaTests(unittest.TestCase):
+    def test_only_explicit_test_targets_are_included(self):
+        self.assertEqual(kuma.parse_kube_versions(
+            "K8S_MIN_VERSION = v1.20.15-k3s1\n"
+            "K8S_MAX_VERSION=v1.26.1-k3s1\n"
+            "KUBEBUILDER_ASSETS_VERSION=1.25\n"
+        ), ["1.26", "1.20"])
+
+    def test_missing_or_nonconcrete_target_is_rejected(self):
+        for text in ("", "K8S_MIN_VERSION=v1.30.0", "K8S_MIN_VERSION=$(VERSION)\nK8S_MAX_VERSION=v1.35.1"):
+            with self.subTest(text=text), self.assertRaises(ValueError):
+                kuma.parse_kube_versions(text)
+
+    def test_equal_targets_are_deduplicated(self):
+        self.assertEqual(kuma.parse_kube_versions(
+            "K8S_MIN_VERSION=v1.30.1\nK8S_MAX_VERSION=v1.30.2\n"
+        ), ["1.30"])
+
+    def test_latest_stable_chart_per_documented_family(self):
+        catalog = [
+            {"edition": "kuma", "release": "2.14.x"},
+            {"edition": "kuma", "release": "2.9.x"},
+            {"edition": "kuma", "release": "2.15.x", "label": "dev"},
+        ]
+        charts = {"2.14.0": "2.14.0", "2.14.4": "2.14.4", "2.14.5-rc.1": "2.14.5-rc.1",
+                  "2.14.6": "2.14.6-preview", "2.9.9": "2.9.9", "2.9.19": "2.9.19",
+                  "2.15.0": "2.15.0", "2.1.0": "2.1.0"}
+        self.assertEqual([(str(v), c) for v, c in kuma.select_releases(catalog, charts)],
+                         [("2.14.4", "2.14.4"), ("2.9.19", "2.9.19")])
+
+    def test_missing_chart_preserves_previous_table(self):
+        with patch.object(kuma, "fetch_page", return_value=b"- edition: kuma\n  release: 2.14.x\n"), \
+             patch.object(kuma, "get_chart_versions", return_value={}), \
+             patch.object(kuma, "update_compatibility_info") as writer:
+            with self.assertRaises(ValueError):
+                kuma.scrape()
+            writer.assert_not_called()
+
+    @patch.object(kuma.requests, "get")
+    def test_old_tag_spelling_is_used_only_on_404(self, get):
+        get.side_effect = [Mock(status_code=404), Mock(status_code=200,
+            text="K8S_MIN_VERSION=v1.20.1\nK8S_MAX_VERSION=v1.26.1")]
+        self.assertEqual(kuma.fetch_release_targets("2.2.9"), ["1.26", "1.20"])
+        self.assertIn("/v2.2.9/", get.call_args_list[0].args[0])
+        self.assertIn("/2.2.9/", get.call_args_list[1].args[0])
+
+    @patch.object(kuma.requests, "get")
+    def test_server_error_does_not_try_another_tag(self, get):
+        get.return_value = Mock(status_code=503)
+        get.return_value.raise_for_status.side_effect = requests.HTTPError("503")
+        with self.assertRaises(requests.HTTPError):
+            kuma.fetch_release_targets("2.14.4")
+        self.assertEqual(get.call_count, 1)
+
+    def test_source_failure_does_not_write_partial_results(self):
+        catalog = b"- edition: kuma\n  release: 2.14.x\n- edition: kuma\n  release: 2.13.x\n"
+        with patch.object(kuma, "fetch_page", return_value=catalog), \
+             patch.object(kuma, "get_chart_versions", return_value={"2.14.4": "2.14.4", "2.13.10": "2.13.10"}), \
+             patch.object(kuma, "fetch_release_targets", side_effect=[["1.35", "1.32"], ValueError("missing target")]), \
+             patch.object(kuma, "update_compatibility_info") as writer:
+            with self.assertRaises(ValueError):
+                kuma.scrape()
+            writer.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Kuma to the compatibility catalog and its scheduled scraper manifest. The scraper selects the latest stable Helm-backed patch in each release family listed in Kuma's documentation catalog, then reads that exact release's `mk/dev.mk` Kubernetes test targets.

Kuma's requirements explicitly say it is validated against **two** Kubernetes versions. Accordingly, this table records just those two minor versions, without treating the interval between them as tested. For example, Kuma 2.14.4 records Kubernetes 1.35 and 1.32. This is upstream-declared compatibility, not a claim that I deployed every pairing.

The initial table has 13 rows, from 2.2.9 through 2.14.4. It covers the newest chart-backed patch of each documented release family; it does not reconstruct every historical patch. Preview releases are excluded. Both observed upstream release-tag conventions are handled, with the unprefixed spelling attempted only after a 404. All selected sources must parse successfully before the existing shared writer is called.

Sources:

- [Kuma requirements](https://kuma.io/docs/latest/introduction/kuma-requirements/) links the Kubernetes test variables in `mk/dev.mk`.
- [Documentation release catalog](https://github.com/kumahq/kuma-website/blob/master/app/_data/versions.yml).
- [Official Helm index](https://kumahq.github.io/charts/index.yaml).
- [Kuma v2.14.4 test targets](https://github.com/kumahq/kuma/blob/v2.14.4/mk/dev.mk).
- [Kuma 2.2.9 test targets](https://github.com/kumahq/kuma/blob/2.2.9/mk/dev.mk).

## Test Plan

- `python -m unittest discover -s tests -p test_kuma.py -v` in `utils/compatibility`: 8 tests passed, covering explicit target parsing, missing targets, stable release selection, both tag conventions, and no partial write after a source failure.
- Ran the scraper against the live official release catalog, Helm index and all 13 selected tagged source files. The table was generated successfully.
- Validated the new table and updated manifest against `static/compatibilities/schema.json`.
- Image enrichment is **not verified**: Helm could fetch its repository index, but this environment could not download the release-asset chart archives (transport EOF). The shared writer left `images` empty. No Kubernetes cluster or deployed Console validation is claimed; this PR changes catalog data and its Python scraper only.

## Contributor program

This submission is intended for the README's $300 new-compatibility-scraper reward. Could you confirm whether Kuma and the documented-family scope above are eligible and useful for the catalog? I understand that payment requires acceptance and merge, and that the program permits one award per contributor per calendar month.

The account owner resides in Taiwan and does not currently have a Discord account. Is GitHub-based identity confirmation possible, and which USD payout method is available? No award or payment is being claimed yet.

Disclosure: prepared and tested by OpenAI Codex, an AI coding assistant acting with the GitHub account owner's authorization. I can respond to review feedback through this account with the owner's authorization.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have added tests to cover my changes.
- Documentation and deployed-agent checks are not applicable to this catalog-only contribution.
