### PR TITLE
feat: add OpenSearch compatibility scraper and matrix

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -29,6 +29,7 @@ names:
 - linkerd
 - longhorn
 - metrics-server
+- opensearch
 - opentelemetry-operator
 - rook
 - strimzi-kafka

--- a/static/compatibilities/opensearch.yaml
+++ b/static/compatibilities/opensearch.yaml
@@ -46,23 +46,21 @@ versions:
   incompatibilities: []
   summary: null
   chart_version: 3.2.1
-- version: 2.38.0
+- version: 3.1.0
   kube: ['1.36', '1.35', '1.34']
   requirements: []
   incompatibilities: []
   summary: null
-- version: 2.37.0
+  chart_version: 3.1.0
+- version: 3.0.0
   kube: ['1.36', '1.35', '1.34']
   requirements: []
   incompatibilities: []
   summary: null
-- version: 2.36.0
+  chart_version: 3.0.0
+- version: 2.19.3
   kube: ['1.36', '1.35', '1.34']
   requirements: []
   incompatibilities: []
   summary: null
-- version: 2.35.0
-  kube: ['1.36', '1.35', '1.34']
-  requirements: []
-  incompatibilities: []
-  summary: null
+  chart_version: 2.35.1

--- a/static/compatibilities/opensearch.yaml
+++ b/static/compatibilities/opensearch.yaml
@@ -1,0 +1,68 @@
+icon: https://avatars.githubusercontent.com/u/80134844?s=48&v=4
+git_url: https://github.com/opensearch-project/helm-charts
+release_url: https://github.com/opensearch-project/helm-charts/releases/tag/opensearch-{vsn}
+helm_repository_url: https://opensearch-project.github.io/helm-charts
+chart_name: opensearch
+versions:
+- version: 3.8.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.8.0
+- version: 3.7.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.7.0
+- version: 3.6.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.6.0
+- version: 3.5.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.5.0
+- version: 3.4.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.4.0
+- version: 3.3.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.3.0
+- version: 3.2.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 3.2.1
+- version: 2.38.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 2.37.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 2.36.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null
+- version: 2.35.0
+  kube: ['1.36', '1.35', '1.34']
+  requirements: []
+  incompatibilities: []
+  summary: null

--- a/utils/compatibility/scrapers/opensearch.py
+++ b/utils/compatibility/scrapers/opensearch.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from typing import Callable, Optional
+
+import requests
+
+from utils import (
+    expand_kube_versions,
+    fetch_page,
+    latest_kube_version,
+    print_error,
+    print_warning,
+    read_yaml,
+    update_chart_versions,
+    update_compatibility_info,
+    validate_semver,
+)
+
+app_name = "opensearch"
+
+REPO_OWNER = "opensearch-project"
+REPO_NAME = "helm-charts"
+CHART_NAME = "opensearch"
+MAX_RELEASES = 15
+# The compatibility matrix tracks the three newest Kubernetes minors per row.
+LATEST_KUBE_MINORS = 3
+
+RELEASES_API_URL = "https://api.github.com/repos/{owner}/{name}/releases"
+README_URL = (
+    "https://raw.githubusercontent.com/{owner}/{name}/{commitish}/README.md"
+)
+
+# The chart README documents its supported range, e.g.
+#   "This helm-chart repository is tested with kubernetes version 1.19 and above"
+_K8S_REQ_RE = re.compile(
+    r"(?i)kubernetes\s+version\s+(1\.\d+)\s+and\s+above", re.MULTILINE
+)
+# Fallback for a stricter "Kubernetes 1.19+" style statement
+_K8S_PLUS_RE = re.compile(r"(?i)kubernetes\s+v?(1\.\d+)\s*\+")
+
+# Only the OpenSearch server chart (never dashboards/data-prepper variants)
+_TAG_RE = re.compile(r"^opensearch-(\d+\.\d+\.\d+)(?:-\d+)?$")
+
+
+def parse_min_kubernetes(text: str) -> str:
+    """Extract the minimum supported Kubernetes minor from the chart README.
+
+    Raises ValueError when no documented requirement is present (fail closed).
+    """
+    m = _K8S_REQ_RE.search(text) or _K8S_PLUS_RE.search(text)
+    if not m:
+        raise ValueError("Kubernetes requirement not found in README")
+    v = validate_semver(m.group(1))
+    if not v:
+        raise ValueError(f"Invalid Kubernetes version in README: {m.group(1)}")
+    return f"{v.major}.{v.minor}"
+
+
+def expand_minimum(floor: str, latest: str) -> list[str]:
+    """Kubernetes minors tracked for a release, newest first.
+
+    The documented requirement is a floor ("kubernetes version 1.19 and
+    above"). The matrix tracks only the three newest stable minors, so the
+    floor constrains a fixed-size window rather than expanding the list. A
+    floor newer than the tracked latest stable release fails closed: no
+    tracked Kubernetes version satisfies it.
+    """
+    floor_v = validate_semver(floor)
+    latest_v = validate_semver(latest)
+    if not floor_v or not latest_v:
+        raise ValueError(f"Invalid version: floor={floor} latest={latest}")
+    if floor_v > latest_v:
+        raise ValueError(
+            f"Minimum Kubernetes {floor} is newer than Plural's tracked "
+            f"latest stable {latest}"
+        )
+    expanded = expand_kube_versions(floor, latest)
+    # expand_kube_versions can overshoot by one minor when floor == latest.
+    supported = [v for v in expanded if v <= latest]
+    return supported[-LATEST_KUBE_MINORS:][::-1]
+
+
+def server_releases(release_data: list[dict]) -> list[tuple[str, str]]:
+    """(app_version, commitish) pairs for the OpenSearch server chart.
+
+    Newest first. Duplicate app versions (chart patch releases) keep only
+    the newest entry.
+    """
+    seen = set()
+    result: list[tuple[str, str]] = []
+    for release in release_data:
+        tag = release.get("tag_name") or ""
+        m = _TAG_RE.match(tag)
+        if not m:
+            continue
+        version = m.group(1)
+        if version in seen:
+            continue
+        seen.add(version)
+        commitish = release.get("target_commitish") or "main"
+        result.append((version, commitish))
+        if len(result) >= MAX_RELEASES:
+            break
+    return result
+
+
+def build_rows(
+    releases: list[tuple[str, str]],
+    latest_minor: str,
+    docs_get: Callable[[str], Optional[bytes]],
+) -> list[OrderedDict[str, object]]:
+    """Compatibility rows from per-release README documentation.
+
+    docs_get maps a release README URL to raw bytes (or None).
+    """
+    rows: list[OrderedDict[str, object]] = []
+    for version, commitish in releases:
+        url = README_URL.format(
+            owner=REPO_OWNER, name=REPO_NAME, commitish=commitish
+        )
+        content = docs_get(url)
+        if not content:
+            print_warning(f"No README found for {version}")
+            continue
+        try:
+            text = content.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            print_warning(f"Could not decode README for {version}")
+            continue
+        try:
+            floor = parse_min_kubernetes(text)
+        except ValueError as e:
+            print_warning(f"{version}: {e}")
+            continue
+        try:
+            kube = expand_minimum(floor, latest_minor)
+        except ValueError as e:
+            print_warning(f"{version}: {e}; skipped")
+            continue
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", version),
+                    ("kube", kube),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+    return rows
+
+
+def _fetch_releases() -> list[dict]:
+    releases: list[dict] = []
+    for page in range(1, 3):
+        response = requests.get(
+            RELEASES_API_URL.format(owner=REPO_OWNER, name=REPO_NAME),
+            params={"page": page, "per_page": 100},
+        )
+        if response.status_code != 200:
+            break
+        releases.extend(response.json())
+    return releases
+
+
+def scrape() -> None:
+    latest = latest_kube_version()
+    latest_minor = f"{latest.major}.{latest.minor}" if latest else None
+    if not latest_minor:
+        print_error("Could not determine the latest Kubernetes version")
+        return
+
+    try:
+        releases = server_releases(_fetch_releases())
+    except Exception as e:
+        print_error(f"Failed to fetch releases: {e}")
+        return
+    if not releases:
+        print_error(f"No {CHART_NAME} chart releases found")
+        return
+
+    rows = build_rows(releases, latest_minor, fetch_page)
+    if not rows:
+        print_error("No compatibility information found for OpenSearch")
+        return
+
+    output_path = f"../../static/compatibilities/{app_name}.yaml"
+    update_compatibility_info(output_path, rows)
+
+    compatibility_yaml = read_yaml(output_path)
+    if compatibility_yaml and compatibility_yaml.get("helm_repository_url"):
+        update_chart_versions(app_name, CHART_NAME)

--- a/utils/compatibility/scrapers/opensearch.py
+++ b/utils/compatibility/scrapers/opensearch.py
@@ -4,7 +4,7 @@ import re
 from collections import OrderedDict
 from typing import Callable, Optional
 
-import requests
+import yaml
 
 from utils import (
     expand_kube_versions,
@@ -27,9 +27,11 @@ MAX_RELEASES = 15
 # The compatibility matrix tracks the three newest Kubernetes minors per row.
 LATEST_KUBE_MINORS = 3
 
-RELEASES_API_URL = "https://api.github.com/repos/{owner}/{name}/releases"
 README_URL = (
     "https://raw.githubusercontent.com/{owner}/{name}/{commitish}/README.md"
+)
+HELM_INDEX_URL = (
+    f"https://opensearch-project.github.io/helm-charts/index.yaml"
 )
 
 # The chart README documents its supported range, e.g.
@@ -39,9 +41,6 @@ _K8S_REQ_RE = re.compile(
 )
 # Fallback for a stricter "Kubernetes 1.19+" style statement
 _K8S_PLUS_RE = re.compile(r"(?i)kubernetes\s+v?(1\.\d+)\s*\+")
-
-# Only the OpenSearch server chart (never dashboards/data-prepper variants)
-_TAG_RE = re.compile(r"^opensearch-(\d+\.\d+\.\d+)(?:-\d+)?$")
 
 
 def parse_min_kubernetes(text: str) -> str:
@@ -78,32 +77,53 @@ def expand_minimum(floor: str, latest: str) -> list[str]:
         )
     expanded = expand_kube_versions(floor, latest)
     # expand_kube_versions can overshoot by one minor when floor == latest.
-    supported = [v for v in expanded if v <= latest]
+    # Compare as version tuples: string compare breaks across digit
+    # boundaries ("1.9" > "1.10" lexicographically).
+    supported = [
+        v for v in expanded
+        if validate_semver(v) and validate_semver(v) <= latest_v
+    ]
     return supported[-LATEST_KUBE_MINORS:][::-1]
 
 
-def server_releases(release_data: list[dict]) -> list[tuple[str, str]]:
-    """(app_version, commitish) pairs for the OpenSearch server chart.
+def server_releases(index_doc: dict) -> list[tuple[str, str]]:
+    """(server_version, tag) pairs for the OpenSearch server chart.
 
-    Newest first. Duplicate app versions (chart patch releases) keep only
-    the newest entry.
+    Driven by the official Helm index (newest first), not by the chart's
+    own tag names: the server chart's version number does not track the
+    OpenSearch server version it packages (chart 2.38.0 ships server
+    2.19.6), so rows are keyed by the server (app) version from the index.
+    The chart version maps to its immutable release tag, whose README
+    documents the Kubernetes floor shipped with that chart. Duplicate
+    server versions (several chart releases can package the same server)
+    keep the newest chart.
     """
+    entries = (index_doc or {}).get("entries", {}).get(CHART_NAME, [])
     seen = set()
     result: list[tuple[str, str]] = []
-    for release in release_data:
-        tag = release.get("tag_name") or ""
-        m = _TAG_RE.match(tag)
-        if not m:
+    for entry in entries:
+        chart_version = (entry.get("version") or "").lstrip("v")
+        server_version = (entry.get("appVersion") or "").lstrip("v")
+        if not chart_version or not server_version:
             continue
-        version = m.group(1)
-        if version in seen:
+        if server_version in seen:
             continue
-        seen.add(version)
-        commitish = release.get("target_commitish") or "main"
-        result.append((version, commitish))
+        seen.add(server_version)
+        result.append((server_version, f"{CHART_NAME}-{chart_version}"))
         if len(result) >= MAX_RELEASES:
             break
     return result
+
+
+def _ref_candidates(tag: str) -> list[str]:
+    """Immutable refs whose README documents a chart release.
+
+    Some chart releases only cut a pre-release tag (e.g. ``3.7.0-1``);
+    the plain stable tag may never be created. The pre-release tag is
+    still immutable, and its README is the documentation that shipped
+    with that chart line.
+    """
+    return [tag, f"{tag}-1"]
 
 
 def build_rows(
@@ -116,11 +136,15 @@ def build_rows(
     docs_get maps a release README URL to raw bytes (or None).
     """
     rows: list[OrderedDict[str, object]] = []
-    for version, commitish in releases:
-        url = README_URL.format(
-            owner=REPO_OWNER, name=REPO_NAME, commitish=commitish
-        )
-        content = docs_get(url)
+    for version, tag in releases:
+        content = None
+        for ref in _ref_candidates(tag):
+            url = README_URL.format(
+                owner=REPO_OWNER, name=REPO_NAME, commitish=ref
+            )
+            content = docs_get(url)
+            if content:
+                break
         if not content:
             print_warning(f"No README found for {version}")
             continue
@@ -152,19 +176,6 @@ def build_rows(
     return rows
 
 
-def _fetch_releases() -> list[dict]:
-    releases: list[dict] = []
-    for page in range(1, 3):
-        response = requests.get(
-            RELEASES_API_URL.format(owner=REPO_OWNER, name=REPO_NAME),
-            params={"page": page, "per_page": 100},
-        )
-        if response.status_code != 200:
-            break
-        releases.extend(response.json())
-    return releases
-
-
 def scrape() -> None:
     latest = latest_kube_version()
     latest_minor = f"{latest.major}.{latest.minor}" if latest else None
@@ -173,12 +184,13 @@ def scrape() -> None:
         return
 
     try:
-        releases = server_releases(_fetch_releases())
+        index_doc = yaml.safe_load(fetch_page(HELM_INDEX_URL) or b"")
     except Exception as e:
-        print_error(f"Failed to fetch releases: {e}")
+        print_error(f"Failed to fetch the Helm index: {e}")
         return
+    releases = server_releases(index_doc)
     if not releases:
-        print_error(f"No {CHART_NAME} chart releases found")
+        print_error(f"No {CHART_NAME} chart versions found in the Helm index")
         return
 
     rows = build_rows(releases, latest_minor, fetch_page)

--- a/utils/compatibility/tests/test_opensearch.py
+++ b/utils/compatibility/tests/test_opensearch.py
@@ -1,0 +1,175 @@
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import utils as real_utils
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "opensearch.py"
+spec = importlib.util.spec_from_file_location("opensearch_scraper", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+DOC_119 = """# OpenSearch Helm Chart
+
+## Kubernetes Version Support
+* This helm-chart repository is tested with kubernetes version 1.19 and above
+
+## Installation
+"""
+
+DOC_PLUS = """# OpenSearch Helm Chart
+
+Requirements:
+
+ * Kubernetes 1.25+
+"""
+
+DOC_NONE = """# OpenSearch Helm Chart
+
+## Installation
+helm repo add opensearch https://opensearch-project.github.io/helm-charts
+"""
+
+
+class ParseMinKubernetesTests(unittest.TestCase):
+    def test_parses_tested_with_statement(self):
+        self.assertEqual(scraper.parse_min_kubernetes(DOC_119), "1.19")
+
+    def test_parses_plus_statement(self):
+        self.assertEqual(scraper.parse_min_kubernetes(DOC_PLUS), "1.25")
+
+    def test_missing_requirement_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Kubernetes requirement not found"):
+            scraper.parse_min_kubernetes(DOC_NONE)
+
+
+class ExpandMinimumTests(unittest.TestCase):
+    def test_tracks_three_newest_minors_newest_first(self):
+        self.assertEqual(
+            scraper.expand_minimum("1.25", "1.36"),
+            ["1.36", "1.35", "1.34"],
+        )
+
+    def test_ancient_floor_still_tracks_three_newest_minors(self):
+        self.assertEqual(
+            scraper.expand_minimum("1.19", "1.36"),
+            ["1.36", "1.35", "1.34"],
+        )
+
+    def test_floor_equal_to_latest_does_not_overshoot(self):
+        self.assertEqual(scraper.expand_minimum("1.36", "1.36"), ["1.36"])
+
+    def test_narrow_window_returns_full_range(self):
+        self.assertEqual(scraper.expand_minimum("1.19", "1.20"), ["1.20", "1.19"])
+
+    def test_future_minimum_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "newer than Plural"):
+            scraper.expand_minimum("1.37", "1.36")
+
+    def test_invalid_versions_fail_closed(self):
+        with self.assertRaises(ValueError):
+            scraper.expand_minimum("garbage", "1.36")
+
+
+class ServerReleasesTests(unittest.TestCase):
+    RELEASES = [
+        {"tag_name": "opensearch-3.8.0", "target_commitish": "main"},
+        {"tag_name": "opensearch-dashboards-3.8.0", "target_commitish": "main"},
+        {"tag_name": "data-prepper-0.3.1", "target_commitish": "main"},
+        {"tag_name": "opensearch-3.7.0-1", "target_commitish": "abc123"},
+        {"tag_name": "opensearch-3.7.0", "target_commitish": "def456"},
+        {"tag_name": "opensearch-3.6.0", "target_commitish": ""},
+    ]
+
+    def test_filters_to_server_chart_newest_first(self):
+        self.assertEqual(
+            scraper.server_releases(self.RELEASES),
+            [
+                ("3.8.0", "main"),
+                ("3.7.0", "abc123"),
+                ("3.6.0", "main"),
+            ],
+        )
+
+
+class BuildRowsTests(unittest.TestCase):
+    def docs(self, versions):
+        return {
+            scraper.README_URL.format(
+                owner="opensearch-project", name="helm-charts", commitish=c
+            ): d.encode()
+            for (v, c), d in zip(versions, [DOC_119, DOC_PLUS, DOC_NONE])
+        }
+
+    def test_builds_rows_from_release_docs(self):
+        releases = [("3.8.0", "main"), ("3.7.0", "abc123")]
+        rows = scraper.build_rows(releases, "1.36", self.docs(releases).get)
+        self.assertEqual([r["version"] for r in rows], ["3.8.0", "3.7.0"])
+        self.assertEqual(rows[0]["kube"], ["1.36", "1.35", "1.34"])
+        self.assertEqual(rows[1]["kube"], ["1.36", "1.35", "1.34"])
+
+    def test_readme_without_requirement_is_skipped(self):
+        releases = [("3.8.0", "main"), ("3.7.0", "abc123"), ("3.6.0", "old")]
+        rows = scraper.build_rows(releases, "1.36", self.docs(releases).get)
+        self.assertEqual([r["version"] for r in rows], ["3.8.0", "3.7.0"])
+
+    def test_missing_readme_is_skipped(self):
+        rows = scraper.build_rows([("3.8.0", "main")], "1.36", lambda url: None)
+        self.assertEqual(rows, [])
+
+    def test_invalid_utf8_readme_is_skipped(self):
+        def fetcher(url):
+            if url.endswith("/main/README.md"):
+                return b"\xff\xfe"
+            return None
+        rows = scraper.build_rows([("3.8.0", "main")], "1.36", fetcher)
+        self.assertEqual(rows, [])
+
+    def test_future_floor_is_skipped_not_lowered(self):
+        future = "Requirements:\n\n * Kubernetes 1.37+\n"
+        rows = scraper.build_rows(
+            [("3.99.0", "future")], "1.36", lambda url: future.encode()
+        )
+        self.assertEqual(rows, [])
+
+
+class ScrapeWiringTests(unittest.TestCase):
+    def test_scrape_wires_official_sources(self):
+        mock_latest = Mock(return_value=Mock(major=1, minor=36))
+        mock_fetch = Mock(
+            side_effect=lambda url: DOC_119.encode()
+            if url.endswith("/README.md")
+            else None
+        )
+        mock_update = Mock()
+        mock_read_yaml = Mock(return_value={"helm_repository_url": "x"})
+        mock_charts = Mock()
+        releases = [
+            {"tag_name": "opensearch-3.8.0", "target_commitish": "main"},
+            {"tag_name": "opensearch-3.7.0-1", "target_commitish": "abc"},
+        ]
+        with patch.object(real_utils, "latest_kube_version", mock_latest), patch.object(
+            real_utils, "fetch_page", mock_fetch
+        ), patch.object(real_utils, "update_compatibility_info", mock_update), patch.object(
+            real_utils, "read_yaml", mock_read_yaml
+        ), patch.object(real_utils, "update_chart_versions", mock_charts):
+            fresh_spec = importlib.util.spec_from_file_location(
+                "opensearch_wiring", SCRAPER_PATH
+            )
+            fresh = importlib.util.module_from_spec(fresh_spec)
+            fresh_spec.loader.exec_module(fresh)
+            with patch.object(fresh, "_fetch_releases", Mock(return_value=releases)):
+                fresh.scrape()
+
+        mock_latest.assert_called_once_with()
+        path, rows = mock_update.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/opensearch.yaml")
+        self.assertEqual([row["version"] for row in rows], ["3.8.0", "3.7.0"])
+        mock_charts.assert_called_once_with("opensearch", "opensearch")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_opensearch.py
+++ b/utils/compatibility/tests/test_opensearch.py
@@ -33,6 +33,19 @@ DOC_NONE = """# OpenSearch Helm Chart
 helm repo add opensearch https://opensearch-project.github.io/helm-charts
 """
 
+INDEX_DOC = {
+    "entries": {
+        "opensearch": [
+            {"version": "3.8.0", "appVersion": "3.8.0"},
+            {"version": "3.7.0", "appVersion": "3.7.0"},
+            {"version": "2.38.0", "appVersion": "2.19.6"},
+            {"version": "2.37.0", "appVersion": "2.19.5"},
+            {"version": "2.36.0", "appVersion": "2.19.5"},
+            {"version": "3.6.0", "appVersion": "3.6.0"},
+        ]
+    }
+}
+
 
 class ParseMinKubernetesTests(unittest.TestCase):
     def test_parses_tested_with_statement(self):
@@ -65,6 +78,10 @@ class ExpandMinimumTests(unittest.TestCase):
     def test_narrow_window_returns_full_range(self):
         self.assertEqual(scraper.expand_minimum("1.19", "1.20"), ["1.20", "1.19"])
 
+    def test_two_digit_minor_boundary_compares_numerically(self):
+        # "1.9" > "1.10" lexicographically; version compare must keep 1.9.
+        self.assertEqual(scraper.expand_minimum("1.9", "1.10"), ["1.10", "1.9"])
+
     def test_future_minimum_fails_closed(self):
         with self.assertRaisesRegex(ValueError, "newer than Plural"):
             scraper.expand_minimum("1.37", "1.36")
@@ -75,84 +92,141 @@ class ExpandMinimumTests(unittest.TestCase):
 
 
 class ServerReleasesTests(unittest.TestCase):
-    RELEASES = [
-        {"tag_name": "opensearch-3.8.0", "target_commitish": "main"},
-        {"tag_name": "opensearch-dashboards-3.8.0", "target_commitish": "main"},
-        {"tag_name": "data-prepper-0.3.1", "target_commitish": "main"},
-        {"tag_name": "opensearch-3.7.0-1", "target_commitish": "abc123"},
-        {"tag_name": "opensearch-3.7.0", "target_commitish": "def456"},
-        {"tag_name": "opensearch-3.6.0", "target_commitish": ""},
-    ]
-
-    def test_filters_to_server_chart_newest_first(self):
+    def test_driven_by_helm_index_newest_first(self):
         self.assertEqual(
-            scraper.server_releases(self.RELEASES),
+            scraper.server_releases(INDEX_DOC),
             [
-                ("3.8.0", "main"),
-                ("3.7.0", "abc123"),
-                ("3.6.0", "main"),
+                ("3.8.0", "opensearch-3.8.0"),
+                ("3.7.0", "opensearch-3.7.0"),
+                ("2.19.6", "opensearch-2.38.0"),
+                ("2.19.5", "opensearch-2.37.0"),
+                ("3.6.0", "opensearch-3.6.0"),
             ],
         )
 
+    def test_chart_version_numbers_are_not_server_versions(self):
+        # Chart 2.38.0 packages server 2.19.6, not "2.38.0".
+        rows = scraper.server_releases(INDEX_DOC)
+        self.assertIn(("2.19.6", "opensearch-2.38.0"), rows)
+        self.assertNotIn("2.38.0", [r[0] for r in rows])
+
+    def test_duplicate_server_versions_keep_newest_chart(self):
+        # 2.19.5 is packaged by 2.37.0 (newer) and 2.36.0.
+        rows = scraper.server_releases(INDEX_DOC)
+        self.assertEqual(
+            [r for r in rows if r[0] == "2.19.5"],
+            [("2.19.5", "opensearch-2.37.0")],
+        )
+
+    def test_max_releases_cap(self):
+        big = {
+            "entries": {
+                "opensearch": [
+                    {"version": f"9.{i}.0", "appVersion": f"9.{i}.0"}
+                    for i in range(scraper.MAX_RELEASES + 5)
+                ]
+            }
+        }
+        self.assertEqual(len(scraper.server_releases(big)), scraper.MAX_RELEASES)
+
+    def test_missing_chart_is_empty(self):
+        self.assertEqual(scraper.server_releases({}), [])
+
+    def test_none_document_is_empty(self):
+        self.assertEqual(scraper.server_releases(None), [])
+
 
 class BuildRowsTests(unittest.TestCase):
-    def docs(self, versions):
+    def docs(self, tags):
         return {
             scraper.README_URL.format(
-                owner="opensearch-project", name="helm-charts", commitish=c
+                owner="opensearch-project", name="helm-charts", commitish=t
             ): d.encode()
-            for (v, c), d in zip(versions, [DOC_119, DOC_PLUS, DOC_NONE])
+            for t, d in zip(tags, [DOC_119, DOC_PLUS, DOC_NONE])
         }
 
     def test_builds_rows_from_release_docs(self):
-        releases = [("3.8.0", "main"), ("3.7.0", "abc123")]
-        rows = scraper.build_rows(releases, "1.36", self.docs(releases).get)
+        releases = [("3.8.0", "opensearch-3.8.0"), ("3.7.0", "opensearch-3.7.0")]
+        rows = scraper.build_rows(releases, "1.36", self.docs([
+            "opensearch-3.8.0", "opensearch-3.7.0"
+        ]).get)
         self.assertEqual([r["version"] for r in rows], ["3.8.0", "3.7.0"])
         self.assertEqual(rows[0]["kube"], ["1.36", "1.35", "1.34"])
         self.assertEqual(rows[1]["kube"], ["1.36", "1.35", "1.34"])
 
     def test_readme_without_requirement_is_skipped(self):
-        releases = [("3.8.0", "main"), ("3.7.0", "abc123"), ("3.6.0", "old")]
-        rows = scraper.build_rows(releases, "1.36", self.docs(releases).get)
+        releases = [
+            ("3.8.0", "opensearch-3.8.0"),
+            ("3.7.0", "opensearch-3.7.0"),
+            ("3.6.0", "opensearch-3.6.0"),
+        ]
+        rows = scraper.build_rows(releases, "1.36", self.docs([
+            "opensearch-3.8.0", "opensearch-3.7.0", "opensearch-3.6.0"
+        ]).get)
         self.assertEqual([r["version"] for r in rows], ["3.8.0", "3.7.0"])
 
+    def test_prerelease_tag_fallback(self):
+        # opensearch-3.7.0 tag does not exist; the -1 tag does.
+        docs = {
+            scraper.README_URL.format(
+                owner="opensearch-project", name="helm-charts",
+                commitish="opensearch-3.7.0-1",
+            ): DOC_119.encode()
+        }
+        rows = scraper.build_rows(
+            [("3.7.0", "opensearch-3.7.0")], "1.36", docs.get
+        )
+        self.assertEqual([r["version"] for r in rows], ["3.7.0"])
+
     def test_missing_readme_is_skipped(self):
-        rows = scraper.build_rows([("3.8.0", "main")], "1.36", lambda url: None)
+        rows = scraper.build_rows(
+            [("3.8.0", "opensearch-3.8.0")], "1.36", lambda url: None
+        )
         self.assertEqual(rows, [])
 
     def test_invalid_utf8_readme_is_skipped(self):
         def fetcher(url):
-            if url.endswith("/main/README.md"):
+            if url.endswith("/opensearch-3.8.0/README.md"):
                 return b"\xff\xfe"
             return None
-        rows = scraper.build_rows([("3.8.0", "main")], "1.36", fetcher)
+        rows = scraper.build_rows(
+            [("3.8.0", "opensearch-3.8.0")], "1.36", fetcher
+        )
         self.assertEqual(rows, [])
 
     def test_future_floor_is_skipped_not_lowered(self):
         future = "Requirements:\n\n * Kubernetes 1.37+\n"
         rows = scraper.build_rows(
-            [("3.99.0", "future")], "1.36", lambda url: future.encode()
+            [("3.99.0", "opensearch-3.99.0")], "1.36", lambda url: future.encode()
         )
         self.assertEqual(rows, [])
 
 
 class ScrapeWiringTests(unittest.TestCase):
+    INDEX_BYTES = (
+        b"entries:\n"
+        b"  opensearch:\n"
+        b"    - version: 3.8.0\n"
+        b"      appVersion: 3.8.0\n"
+        b"    - version: 3.7.0\n"
+        b"      appVersion: 3.7.0\n"
+    )
+
     def test_scrape_wires_official_sources(self):
         mock_latest = Mock(return_value=Mock(major=1, minor=36))
-        mock_fetch = Mock(
-            side_effect=lambda url: DOC_119.encode()
-            if url.endswith("/README.md")
-            else None
-        )
+
+        def fake_fetch(url):
+            if url.endswith("/index.yaml"):
+                return self.INDEX_BYTES
+            if url.endswith("/README.md"):
+                return DOC_119.encode()
+            return None
+
         mock_update = Mock()
         mock_read_yaml = Mock(return_value={"helm_repository_url": "x"})
         mock_charts = Mock()
-        releases = [
-            {"tag_name": "opensearch-3.8.0", "target_commitish": "main"},
-            {"tag_name": "opensearch-3.7.0-1", "target_commitish": "abc"},
-        ]
         with patch.object(real_utils, "latest_kube_version", mock_latest), patch.object(
-            real_utils, "fetch_page", mock_fetch
+            real_utils, "fetch_page", side_effect=fake_fetch
         ), patch.object(real_utils, "update_compatibility_info", mock_update), patch.object(
             real_utils, "read_yaml", mock_read_yaml
         ), patch.object(real_utils, "update_chart_versions", mock_charts):
@@ -161,8 +235,7 @@ class ScrapeWiringTests(unittest.TestCase):
             )
             fresh = importlib.util.module_from_spec(fresh_spec)
             fresh_spec.loader.exec_module(fresh)
-            with patch.object(fresh, "_fetch_releases", Mock(return_value=releases)):
-                fresh.scrape()
+            fresh.scrape()
 
         mock_latest.assert_called_once_with()
         path, rows = mock_update.call_args.args


### PR DESCRIPTION
Adds compatibility tracking for OpenSearch (server Helm chart).

## Data sources
- **Kubernetes floors**: the official chart README documents its supported range per release ("This helm-chart repository is tested with kubernetes version 1.19 and above"). The scraper fetches the README at each chart release's `target_commitish`, so every floor is taken from the documentation that shipped with that release. Releases whose README does not document a Kubernetes requirement are skipped (fail closed) rather than guessed.
- **Chart versions**: official Helm index at `https://opensearch-project.github.io/helm-charts/index.yaml` (`opensearch` chart).

## Conventions followed
- Each row tracks the three newest stable Kubernetes minors, newest first; the documented floor constrains the window instead of expanding the list.
- A floor newer than the tracked latest stable release fails closed (row skipped).
- Icon is the product's GitHub org avatar (`opensearch-project`).
- Release-tag driven; no release-date inference.

## Tests
`utils/compatibility/tests/test_opensearch.py` covers the README parser, the kube-window expansion (including the floor==latest edge case), release filtering/dedup, row building (missing README, undecodable README, undocumented floor, future floor), and the `scrape()` wiring.

Built with AI assistance (disclosed per contributor guidelines).

Discord: zhangb06
