### PR TITLE
feat: refresh CoreDNS compatibility from kubeadm releases

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -15027,9 +15027,17 @@ addons:
     images: ['docker.io/bitnami/contour:1.20.1-debian-11-r0', 'docker.io/bitnami/envoy:1.21.2-debian-11-r0']
   name: contour
 - icon: https://avatars.githubusercontent.com/u/21110084?s=200&v=4
+  git_url: https://github.com/coredns/coredns
   release_url: https://github.com/coredns/coredns/releases/tag/{vsn}
   helm_repository_url: https://coredns.github.io/helm
   versions:
+  - version: 1.13.1
+    kube: ['1.35']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.46.2
+    images: ['coredns/coredns:1.13.1']
   - version: 1.12.0
     kube: ['1.36', '1.35', '1.34', '1.33']
     requirements: []

--- a/static/compatibilities/coredns.yaml
+++ b/static/compatibilities/coredns.yaml
@@ -1,7 +1,15 @@
 icon: https://avatars.githubusercontent.com/u/21110084?s=200&v=4
+git_url: https://github.com/coredns/coredns
 release_url: https://github.com/coredns/coredns/releases/tag/{vsn}
 helm_repository_url: https://coredns.github.io/helm
 versions:
+- version: 1.13.1
+  kube: ['1.35']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.46.2
+  images: ['coredns/coredns:1.13.1']
 - version: 1.12.0
   kube: ['1.36', '1.35', '1.34', '1.33']
   requirements: []

--- a/utils/compatibility/scrapers/coredns.py
+++ b/utils/compatibility/scrapers/coredns.py
@@ -13,6 +13,10 @@ app_name = "coredns"
 compatibility_url = (
     "https://raw.githubusercontent.com/coredns/deployment/master/kubernetes/CoreDNS-k8s_version.md"
 )
+kubeadm_constants_url = (
+    "https://raw.githubusercontent.com/kubernetes/kubernetes/"
+    "v{version}.0/cmd/kubeadm/app/constants/constants.go"
+)
 
 
 def parse_markdown_table(markdown: str) -> list[tuple[str, str]]:
@@ -101,6 +105,58 @@ def extract_table_data(table_rows: list[tuple[str, str]], chart_versions):
     return rows
 
 
+def extract_new_kubeadm_versions(table_rows, chart_versions, latest_kube, fetcher):
+    """Fill gaps after the upstream table using released kubeadm defaults.
+
+    These are exact bundled-version associations. Unlike the legacy table
+    processing above, do not extrapolate them to later Kubernetes releases.
+    Only include application versions with a matching official Helm chart.
+    """
+    documented = []
+    for kube_cell, _ in table_rows:
+        for part in re.split(r"&|,", kube_cell):
+            match = re.fullmatch(r"v?(\d+)\.(\d+)", part.strip())
+            if not match:
+                raise ValueError("Invalid Kubernetes version in CoreDNS table")
+            documented.append(tuple(map(int, match.groups())))
+    if not documented or not re.fullmatch(r"\d+\.\d+", latest_kube or ""):
+        raise ValueError("Cannot determine Kubernetes releases missing from CoreDNS table")
+
+    last_major, last_minor = max(documented)
+    latest_major, latest_minor = kube_version_key(latest_kube)
+    if latest_major != last_major:
+        raise ValueError("Unsupported Kubernetes major version transition")
+
+    combined = {}
+    for minor in range(last_minor + 1, latest_minor + 1):
+        kube_version = f"{last_major}.{minor}"
+        content = fetcher(kubeadm_constants_url.format(version=kube_version))
+        if not content:
+            raise ValueError(f"Missing kubeadm constants for Kubernetes {kube_version}")
+        source = content.decode("utf-8")
+        matches = re.findall(
+            r'^\s*CoreDNSVersion\s*=\s*"v?(\d+\.\d+\.\d+)"\s*(?://[^\n]*)?$',
+            source,
+            re.MULTILINE,
+        )
+        if len(matches) != 1:
+            raise ValueError(f"Invalid CoreDNS version in Kubernetes {kube_version}")
+        coredns_version = matches[0]
+        chart_version = chart_versions.get(coredns_version)
+        if not chart_version:
+            continue
+        entry = combined.setdefault(coredns_version, OrderedDict([
+            ("version", coredns_version),
+            ("kube", []),
+            ("chart_version", chart_version),
+            ("images", []),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ]))
+        entry["kube"].append(kube_version)
+    return list(combined.values())
+
+
 def scrape():
     page_content = fetch_page(compatibility_url)
     if not page_content:
@@ -115,6 +171,17 @@ def scrape():
 
     chart_versions = get_chart_versions(app_name)
     rows = extract_table_data(table_rows, chart_versions)
+    try:
+        additional_rows = extract_new_kubeadm_versions(
+            table_rows, chart_versions, current_kube_version(), fetch_page
+        )
+        # The writer replaces entries by app version. Preserve existing table
+        # entries if a subsequent kubeadm release bundles the same CoreDNS.
+        existing_versions = {row["version"] for row in rows}
+        rows.extend(row for row in additional_rows if row["version"] not in existing_versions)
+    except (ValueError, UnicodeError) as error:
+        print_error(str(error))
+        return
     if not rows:
         print_error("No compatibility information found.")
         return

--- a/utils/compatibility/tests/test_coredns.py
+++ b/utils/compatibility/tests/test_coredns.py
@@ -1,0 +1,103 @@
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "coredns.py"
+spec = importlib.util.spec_from_file_location("coredns", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+TABLE = """| Kubernetes Version | CoreDNS Version |
+| --- | --- |
+| v1.33 | v1.12.0 |
+"""
+CONSTANTS = {
+    "1.34": b'const (\n CoreDNSVersion = "v1.12.1"\n)\n',
+    "1.35": b'const (\n CoreDNSVersion = "v1.13.1"\n)\n',
+    "1.36": b'const (\n CoreDNSVersion = "v1.14.2"\n)\n',
+}
+
+
+def fetch_constants(url):
+    for kube, content in CONSTANTS.items():
+        if url == scraper.kubeadm_constants_url.format(version=kube):
+            return content
+    raise AssertionError(f"Unexpected URL {url}")
+
+
+class CoreDNSReleaseTests(unittest.TestCase):
+    def rows(self, chart_versions=None, latest="1.36", fetcher=fetch_constants):
+        return scraper.extract_new_kubeadm_versions(
+            scraper.parse_markdown_table(TABLE),
+            chart_versions if chart_versions is not None else {"1.13.1": "1.46.2"},
+            latest,
+            fetcher,
+        )
+
+    def test_adds_exact_release_pair_only_when_chart_exists(self):
+        rows = self.rows()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["version"], "1.13.1")
+        self.assertEqual(rows[0]["chart_version"], "1.46.2")
+        self.assertEqual(rows[0]["kube"], ["1.35"])
+
+    def test_does_not_fetch_already_documented_versions(self):
+        self.assertEqual(self.rows(latest="1.33", fetcher=lambda _: self.fail()), [])
+
+    def test_groups_same_app_only_at_documented_releases(self):
+        rows = self.rows(
+            latest="1.35", fetcher=lambda _: b'CoreDNSVersion = "v1.13.1"\n'
+        )
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["kube"], ["1.34", "1.35"])
+
+    def test_rejects_comment_prerelease_and_ambiguous_constants(self):
+        for content in [
+            b'// CoreDNSVersion = "v1.13.1"\n',
+            b'CoreDNSVersion = "v1.13.1-rc.1"\n',
+            b'CoreDNSVersion = "v1.13.1"\nCoreDNSVersion = "v1.14.2"\n',
+        ]:
+            with self.subTest(content=content):
+                with self.assertRaisesRegex(ValueError, "Invalid CoreDNS version"):
+                    self.rows(fetcher=lambda _: content)
+
+    def test_missing_source_aborts_before_catalog_write(self):
+        with patch.object(scraper, "fetch_page", side_effect=[TABLE.encode(), None]), \
+             patch.object(scraper, "get_chart_versions", return_value={"1.13.1": "1.46.2"}), \
+             patch.object(scraper, "current_kube_version", return_value="1.36"), \
+             patch.object(scraper, "update_compatibility_info") as writer:
+            scraper.scrape()
+            writer.assert_not_called()
+
+    def test_scrape_keeps_legacy_rows_and_adds_release_row(self):
+        def fetcher(url):
+            return TABLE.encode() if url == scraper.compatibility_url else fetch_constants(url)
+
+        with patch.object(scraper, "fetch_page", side_effect=fetcher), \
+             patch.object(scraper, "get_chart_versions", return_value={"1.12.0": "1.42.2", "1.13.1": "1.46.2"}), \
+             patch.object(scraper, "current_kube_version", return_value="1.36"), \
+             patch.object(scraper, "update_compatibility_info") as writer:
+            scraper.scrape()
+        writer.assert_called_once()
+        rows = {row["version"]: row for row in writer.call_args.args[1]}
+        self.assertEqual(set(rows), {"1.12.0", "1.13.1"})
+        self.assertEqual(rows["1.13.1"]["kube"], ["1.35"])
+
+    def test_reused_coredns_version_does_not_replace_legacy_row(self):
+        def fetcher(url):
+            return TABLE.encode() if url == scraper.compatibility_url else b'CoreDNSVersion = "v1.12.0"\n'
+
+        with patch.object(scraper, "fetch_page", side_effect=fetcher), \
+             patch.object(scraper, "get_chart_versions", return_value={"1.12.0": "1.42.2"}), \
+             patch.object(scraper, "current_kube_version", return_value="1.35"), \
+             patch.object(scraper, "update_compatibility_info") as writer:
+            scraper.scrape()
+        rows = writer.call_args.args[1]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["kube"], ["1.33", "1.34", "1.35"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds CoreDNS 1.13.1 compatibility metadata with official Helm chart 1.46.2 and its Kubernetes 1.35 kubeadm pairing. Updates both the per-application catalog and the aggregate compatibility catalog.

The existing upstream compatibility table stops at Kubernetes 1.33. The scraper now checks tagged kubeadm release constants for newer Kubernetes versions and adds CoreDNS versions when a matching official Helm chart exists.

New entries preserve exact bundled-version associations. Existing table entries remain intact when later Kubernetes releases reuse the same CoreDNS version. Missing or malformed source constants abort before catalog writes.

## Sources

- [Kubernetes v1.35.0 kubeadm constants](https://github.com/kubernetes/kubernetes/blob/66452049f3d692768c39c797b21b793dce80314e/cmd/kubeadm/app/constants/constants.go#L366)
- [Official CoreDNS Helm index](https://coredns.github.io/helm/index.yaml)
- [Upstream CoreDNS kubeadm-version table](https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md)

The Kubernetes 1.35 association documents the CoreDNS version bundled by kubeadm. It does not claim exhaustive runtime compatibility across Kubernetes releases.

## Test Plan

- 134 compatibility tests passed, including seven new regression tests.
- Tests cover version grouping, chart availability, malformed constants, missing-source handling, and preservation of existing entries.
- Schema validation and aggregate/catalog consistency checks passed.
- Python compilation and `git diff --check` passed.
- Official chart 1.46.2's archive digest matches its Helm index entry.

No cluster deployment was performed. Agent deployment testing is not applicable because no agent code changed.

## Checklist

- [x] Added a meaningful summary and supporting documentation links.
- [x] Updated both compatibility catalogs.
- [x] Added regression tests covering the changes.

## Contributor Program

This contribution was prepared and tested with OpenAI Codex. Please consider it for the contributor program's $50 application-version update award, subject to maintainer review, eligibility, and the monthly award limit.

Plural Flow: console