### PR TITLE
compatibility: add Falco Operator scraper

### DIFF
--- a/static/compatibilities/falco-operator.yaml
+++ b/static/compatibilities/falco-operator.yaml
@@ -1,0 +1,25 @@
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/falco/horizontal/color/falco-horizontal-color.svg
+git_url: https://github.com/falcosecurity/falco-operator
+release_url: https://github.com/falcosecurity/falco-operator/releases/tag/v{vsn}
+readme_url: https://raw.githubusercontent.com/falcosecurity/falco-operator/v{vsn}/README.md
+helm_repository_url: https://falcosecurity.github.io/charts
+chart_name: falco-operator
+versions:
+- version: 0.4.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.3.1
+- version: 0.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.2.0
+- version: 0.2.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.1.0

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -17,6 +17,7 @@ names:
 - descheduler
 - external-dns
 - external-secrets
+- falco-operator
 - flux
 - ingress-nginx
 - istio

--- a/utils/compatibility/scrapers/falco-operator.py
+++ b/utils/compatibility/scrapers/falco-operator.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import yaml
+from packaging.version import InvalidVersion, Version
+
+app_name = "falco-operator"
+helm_index_url = "https://falcosecurity.github.io/charts/index.yaml"
+release_readme_url = (
+    "https://raw.githubusercontent.com/falcosecurity/falco-operator/"
+    "v{version}/README.md"
+)
+MIN_APP_VERSION = Version("0.2.2")
+
+_MIN_KUBE_RE = re.compile(
+    r"native sidecar\s*\(Kubernetes\s+(1\.\d+)\+\)",
+    re.IGNORECASE,
+)
+
+
+def _decode_text(payload: bytes | str, source: str) -> str:
+    if isinstance(payload, bytes):
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"Could not decode {source}") from exc
+    if isinstance(payload, str):
+        return payload
+    raise ValueError(f"Unexpected {source} payload type")
+
+def parse_min_kubernetes(markdown: str) -> str:
+    match = _MIN_KUBE_RE.search(markdown)
+    if not match:
+        raise ValueError("Falco Operator minimum Kubernetes version not found")
+    return match.group(1)
+
+
+def expand_minimum(minimum: str, current: str) -> list[str]:
+    start_match = re.fullmatch(r"1\.(\d+)", minimum.strip())
+    end_match = re.fullmatch(r"1\.(\d+)", current.strip())
+    if not start_match or not end_match:
+        raise ValueError("Unsupported Kubernetes version format")
+    start = int(start_match.group(1))
+    end = int(end_match.group(1))
+    if start > end:
+        raise ValueError(
+            f"Falco Operator minimum Kubernetes {minimum} is newer than Plural {current}"
+        )
+    return [f"1.{minor}" for minor in range(end, start - 1, -1)]
+
+
+def stable_charts_by_app_minor(index_payload: bytes | str):
+    index_text = _decode_text(index_payload, "Falco Helm index")
+    try:
+        index = yaml.safe_load(index_text)
+    except yaml.YAMLError as exc:
+        raise ValueError("Could not parse Falco Helm index") from exc
+    if not isinstance(index, dict):
+        raise ValueError("Unexpected Falco Helm index structure")
+    entries = index.get("entries", {}).get(app_name)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Falco Operator chart entries not found")
+
+    grouped = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Malformed Falco Operator chart entry")
+        raw_chart = str(entry.get("version", "")).strip().lstrip("v")
+        raw_app = str(entry.get("appVersion", "")).strip().lstrip("v")
+        try:
+            chart_version = Version(raw_chart)
+            app_version = Version(raw_app)
+        except InvalidVersion:
+            continue
+        if chart_version.is_prerelease or app_version.is_prerelease:
+            continue
+        if app_version < MIN_APP_VERSION:
+            continue
+        key = (app_version.major, app_version.minor)
+        grouped.setdefault(key, []).append((app_version, chart_version))
+
+    if not grouped:
+        raise ValueError("No stable supported Falco Operator charts found")
+
+    result = []
+    for key in sorted(grouped, reverse=True):
+        result.append(sorted(grouped[key], reverse=True))
+    return result
+
+def build_rows(index_payload: bytes | str, current_kube: str, fetcher):
+    rows: list[OrderedDict[str, object]] = []
+    for candidates in stable_charts_by_app_minor(index_payload):
+        documented = None
+        for app_version, chart_version in candidates:
+            url = release_readme_url.format(version=app_version)
+            page = fetcher(url)
+            if not page:
+                continue
+            markdown = _decode_text(page, f"Falco Operator {app_version} README")
+            minimum = parse_min_kubernetes(markdown)
+            documented = (app_version, chart_version, minimum)
+            break
+        if documented is None:
+            continue
+
+        app_version, chart_version, minimum = documented
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", str(app_version)),
+                    ("kube", expand_minimum(minimum, current_kube)),
+                    ("chart_version", str(chart_version)),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+
+    if not rows:
+        raise ValueError("No documented Falco Operator compatibility rows generated")
+    return rows
+
+def scrape() -> None:
+    from utils import current_kube_version, fetch_page, update_compatibility_info
+
+    index = fetch_page(helm_index_url)
+    if not index:
+        raise ValueError("Could not fetch official Falco Helm index")
+    current = current_kube_version()
+    if not current:
+        raise ValueError("Plural current Kubernetes version is unavailable")
+
+    rows = build_rows(index, current, fetch_page)
+    update_compatibility_info(
+        f"../../static/compatibilities/{app_name}.yaml",
+        rows,
+    )

--- a/utils/compatibility/tests/test_falco_operator.py
+++ b/utils/compatibility/tests/test_falco_operator.py
@@ -1,0 +1,88 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "falco-operator.py"
+spec = importlib.util.spec_from_file_location("falco_operator", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+INDEX = """entries:
+  falco-operator:
+  - version: 0.4.0-rc1
+    appVersion: 0.5.0-rc1
+  - version: 0.3.1
+    appVersion: 0.4.1
+  - version: 0.3.0
+    appVersion: 0.4.0
+  - version: 0.2.0
+    appVersion: 0.3.0
+  - version: 0.1.0
+    appVersion: 0.2.2
+"""
+
+README_129 = """# Falco Operator
+The Artifact Operator is automatically deployed as a native sidecar (Kubernetes 1.29+)
+alongside each Falco instance.
+"""
+
+
+class FalcoOperatorTests(unittest.TestCase):
+    def test_parses_release_minimum_kubernetes(self):
+        self.assertEqual(scraper.parse_min_kubernetes(README_129), "1.29")
+    def test_missing_minimum_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "minimum Kubernetes version not found"):
+            scraper.parse_min_kubernetes("# Falco Operator\nUse Kubernetes.")
+
+    def test_expands_minimum_through_current_version(self):
+        self.assertEqual(
+            scraper.expand_minimum("1.29", "1.32"),
+            ["1.32", "1.31", "1.30", "1.29"],
+        )
+
+    def test_skips_prerelease_and_groups_by_app_minor(self):
+        groups = scraper.stable_charts_by_app_minor(INDEX)
+        self.assertEqual(
+            [[(str(app), str(chart)) for app, chart in group] for group in groups],
+            [
+                [("0.4.1", "0.3.1"), ("0.4.0", "0.3.0")],
+                [("0.3.0", "0.2.0")],
+                [("0.2.2", "0.1.0")],
+            ],
+        )
+
+    def test_build_rows_uses_tagged_release_evidence(self):
+        docs = {
+            scraper.release_readme_url.format(version="0.4.1"): README_129,
+            scraper.release_readme_url.format(version="0.3.0"): README_129,
+            scraper.release_readme_url.format(version="0.2.2"): README_129,
+        }
+        rows = scraper.build_rows(INDEX, "1.32", docs.get)
+        by_version = {row["version"]: row for row in rows}
+        self.assertEqual(list(by_version), ["0.4.1", "0.3.0", "0.2.2"])
+        self.assertEqual(by_version["0.4.1"]["chart_version"], "0.3.1")
+        self.assertEqual(
+            by_version["0.4.1"]["kube"],
+            ["1.32", "1.31", "1.30", "1.29"],
+        )
+
+    def test_missing_latest_patch_falls_back_within_app_minor(self):
+        docs = {
+            scraper.release_readme_url.format(version="0.4.0"): README_129,
+            scraper.release_readme_url.format(version="0.3.0"): README_129,
+            scraper.release_readme_url.format(version="0.2.2"): README_129,
+        }
+        rows = scraper.build_rows(INDEX, "1.32", docs.get)
+        self.assertEqual(rows[0]["version"], "0.4.0")
+        self.assertEqual(rows[0]["chart_version"], "0.3.0")
+
+    def test_missing_all_tagged_docs_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "No documented Falco Operator"):
+            scraper.build_rows(INDEX, "1.32", lambda _: None)
+
+    def test_bad_index_payload_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Unexpected Falco Helm index"):
+            scraper.stable_charts_by_app_minor(object())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Falco Operator as a new compatibility application.

The scraper reads the official Falco Helm index to map stable chart releases to Falco Operator app versions, skips prereleases, and uses the README from each exact Falco Operator release tag as the Kubernetes compatibility source. It fails closed when tagged compatibility evidence is missing instead of guessing support.

Compatibility evidence:
- Helm repository/index: https://falcosecurity.github.io/charts/index.yaml
- Falco Operator v0.4.1 README (`Kubernetes 1.29+` native-sidecar requirement): https://github.com/falcosecurity/falco-operator/blob/v0.4.1/README.md
- v0.3.0 README: https://github.com/falcosecurity/falco-operator/blob/v0.3.0/README.md
- v0.2.2 README: https://github.com/falcosecurity/falco-operator/blob/v0.2.2/README.md
- Current Falco Operator install docs: https://falco.org/docs/setup/operator/

Also registers the required Git, release, Helm repository, README, and icon metadata and adds focused parser/fallback tests.

Testing:
- `python -m unittest tests.test_falco_operator tests.test_kuberay_operator -v` — 21 tests passed
- live parser check against the official Helm index/release READMEs
- `git diff --check`

Assisted-by: GPT-5.6 Sol