### PR TITLE
Add K8up compatibility scraper from release-specific support

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,37 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- name: k8up
+  icon: https://raw.githubusercontent.com/k8up-io/k8up/master/docs/modules/ROOT/assets/images/k8up-logo.svg
+  git_url: https://github.com/k8up-io/k8up
+  release_url: https://github.com/k8up-io/k8up/releases/tag/v{vsn}
+  helm_repository_url: https://k8up-io.github.io/k8up
+  versions:
+  - version: 2.16.0
+    kube:
+    - '1.36'
+    - '1.35'
+    - '1.34'
+    - '1.33'
+    - '1.32'
+    - '1.31'
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 4.10.0
+    images:
+    - ghcr.io/k8up-io/k8up:v2.16.0
+  - version: 2.15.0
+    kube:
+    - '1.36'
+    - '1.35'
+    - '1.34'
+    - '1.33'
+    - '1.32'
+    - '1.31'
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 4.9.0
+    images:
+    - ghcr.io/k8up-io/k8up:v2.15.0

--- a/static/compatibilities/k8up.yaml
+++ b/static/compatibilities/k8up.yaml
@@ -1,0 +1,20 @@
+name: k8up
+icon: https://raw.githubusercontent.com/k8up-io/k8up/master/docs/modules/ROOT/assets/images/k8up-logo.svg
+git_url: https://github.com/k8up-io/k8up
+release_url: https://github.com/k8up-io/k8up/releases/tag/v{vsn}
+helm_repository_url: https://k8up-io.github.io/k8up
+versions:
+- version: 2.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 4.10.0
+  images: ['ghcr.io/k8up-io/k8up:v2.16.0']
+- version: 2.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 4.9.0
+  images: ['ghcr.io/k8up-io/k8up:v2.15.0']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- k8up

--- a/utils/compatibility/scrapers/k8up.py
+++ b/utils/compatibility/scrapers/k8up.py
@@ -1,0 +1,137 @@
+"""K8up support requirements from released charts and matching operator tags."""
+
+import hashlib
+import io
+import re
+import tarfile
+
+import requests
+import yaml
+from packaging.version import Version
+
+app_name = "k8up"
+HELM_REPOSITORY = "https://k8up-io.github.io/k8up"
+REPOSITORY = "https://github.com/k8up-io/k8up"
+RAW_REPOSITORY = "https://raw.githubusercontent.com/k8up-io/k8up"
+# 4.9.0 installs 2.15.0, the first release with an explicit supported
+# Kubernetes minimum. Earlier docs only say "recent stable" versions.
+MIN_CHART = Version("4.9.0")
+REQUIREMENTS_PATH = "docs/modules/ROOT/pages/explanations/system-requirements.adoc"
+
+
+def stable_version(value):
+    if not isinstance(value, str) or not re.fullmatch(r"v?\d+\.\d+\.\d+", value):
+        raise ValueError(f"Expected a stable release version, got {value!r}")
+    return Version(value.lstrip("v"))
+
+
+def chart_entries(payload):
+    index = yaml.safe_load(payload)
+    if not isinstance(index, dict) or not isinstance(index.get("entries"), dict):
+        raise ValueError("Invalid K8up Helm index")
+    entries = index["entries"].get(app_name)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("No K8up charts in Helm index")
+    selected = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Invalid K8up chart entry")
+        raw = entry.get("version")
+        # Do not treat release candidates or development builds as releases.
+        if not isinstance(raw, str) or not re.fullmatch(r"\d+\.\d+\.\d+", raw):
+            continue
+        version = stable_version(raw)
+        if version < MIN_CHART:
+            continue
+        url = f"{REPOSITORY}/releases/download/k8up-{raw}/k8up-{raw}.tgz"
+        digest = entry.get("digest", "")
+        if url not in entry.get("urls", []) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+            raise ValueError(f"Missing release archive or digest for chart {raw}")
+        if version in selected and selected[version] != (url, digest):
+            raise ValueError(f"Conflicting metadata for chart {raw}")
+        selected[version] = (url, digest)
+    if not selected:
+        raise ValueError("No K8up charts with documented support")
+    return [(str(v), *selected[v]) for v in sorted(selected, reverse=True)]
+
+
+def operator_version(archive, chart_version, digest):
+    """Read exact packaged defaults; the Helm index has no appVersion."""
+    if hashlib.sha256(archive).hexdigest() != digest:
+        raise ValueError(f"Digest mismatch for K8up chart {chart_version}")
+    with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as chart:
+        documents = {}
+        for name in ("Chart.yaml", "values.yaml"):
+            member = chart.getmember(f"k8up/{name}")
+            if not member.isfile() or member.size > 1024 * 1024:
+                raise ValueError(f"Invalid K8up chart member: {name}")
+            documents[name] = yaml.safe_load(chart.extractfile(member).read())
+    metadata, values = documents["Chart.yaml"], documents["values.yaml"]
+    if (
+        not isinstance(metadata, dict)
+        or metadata.get("name") != app_name
+        or metadata.get("version") != chart_version
+    ):
+        raise ValueError("Packaged chart metadata does not match the index")
+    if not isinstance(values, dict) or not isinstance(values.get("image"), dict):
+        raise ValueError("K8up operator image defaults are missing")
+    image = values["image"]
+    if image.get("registry") != "ghcr.io" or image.get("repository") != "k8up-io/k8up":
+        raise ValueError("Unexpected K8up operator image repository")
+    return str(stable_version(image.get("tag")))
+
+
+def supported_kubernetes(document, current):
+    text = document.decode("utf-8") if isinstance(document, bytes) else document
+    # Match the supported v2+ statement, never the legacy v1/OpenShift example
+    # or the unsupported SPDY fallback. A changed statement needs review.
+    matches = re.findall(
+        r"K8up \(v2 or later\) officially only supports recent stable Kubernetes "
+        r"versions with support for WebSocket connections in the API server "
+        r"\(`(1\.\d+)` or later\)\.",
+        " ".join(text.split()),
+    )
+    if len(matches) != 1:
+        raise ValueError("Explicit K8up supported Kubernetes minimum not found")
+    if not isinstance(current, str) or not re.fullmatch(r"1\.\d+", current):
+        raise ValueError("Invalid Plural Kubernetes ceiling")
+    first, last = int(matches[0].split(".")[1]), int(current.split(".")[1])
+    if first > last:
+        raise ValueError("K8up minimum is newer than Plural's Kubernetes ceiling")
+    return [f"1.{minor}" for minor in range(last, first - 1, -1)]
+
+
+def fetch_source(url):
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
+def build_rows(index, current, fetcher):
+    rows = {}
+    for chart_version, url, digest in chart_entries(index):
+        version = operator_version(fetcher(url), chart_version, digest)
+        if version in rows:
+            # Prefer the newest chart when several charts install one version.
+            continue
+        source = f"{RAW_REPOSITORY}/v{version}/{REQUIREMENTS_PATH}"
+        rows[version] = {
+            "version": version,
+            "kube": supported_kubernetes(fetcher(source), current),
+            "chart_version": chart_version,
+            "requirements": [],
+            "incompatibilities": [],
+        }
+    return [rows[v] for v in sorted(rows, key=Version, reverse=True)]
+
+
+def scrape():
+    from utils import current_kube_version, update_compatibility_info
+
+    # Finish every retrieval and validation before the shared writer runs.
+    rows = build_rows(
+        fetch_source(f"{HELM_REPOSITORY}/index.yaml"),
+        current_kube_version(),
+        fetch_source,
+    )
+    update_compatibility_info("../../static/compatibilities/k8up.yaml", rows)

--- a/utils/compatibility/tests/test_k8up.py
+++ b/utils/compatibility/tests/test_k8up.py
@@ -1,0 +1,206 @@
+"""Offline tests; archives are synthetic, with released chart/operator mappings.
+
+The support-statement fixture follows the versioned upstream document:
+https://github.com/k8up-io/k8up/blob/v2.16.0/docs/modules/ROOT/pages/explanations/system-requirements.adoc
+The simplified archives exercise parsing and validation, not Helm rendering.
+"""
+
+import copy
+import hashlib
+import importlib
+import io
+from pathlib import Path
+import sys
+import tarfile
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import requests
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+k8up = importlib.import_module("scrapers.k8up")
+
+REQUIREMENTS = """
+= System Requirements
+== Supported Kubernetes Versions
+K8up (v2 or later) officially only supports recent stable Kubernetes versions
+with support for WebSocket connections in the API server (`1.31` or later).
+Older Kubernetes versions may work by setting
+`--insecure-allow-podexec-spdy-fallback=true`, but are not officially supported.
+K8up v1 supports legacy OpenShift `3.11` (Kubernetes 1.11).
+"""
+
+
+def archive(chart="4.9.0", app="v2.15.0", **image_overrides):
+    image = {"registry": "ghcr.io", "repository": "k8up-io/k8up", "tag": app}
+    image.update(image_overrides)
+    documents = {
+        "Chart.yaml": {"name": "k8up", "version": chart},
+        "values.yaml": {"image": image},
+    }
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        for name, content in documents.items():
+            payload = yaml.safe_dump(content).encode()
+            member = tarfile.TarInfo(f"k8up/{name}")
+            member.size = len(payload)
+            tar.addfile(member, io.BytesIO(payload))
+    return buffer.getvalue()
+
+
+def fixture(releases=(("4.9.0", "v2.15.0"), ("4.10.0", "v2.16.0"))):
+    entries, sources = [], {}
+    for chart, app in releases:
+        url = f"{k8up.REPOSITORY}/releases/download/k8up-{chart}/k8up-{chart}.tgz"
+        payload = archive(chart, app)
+        sources[url] = payload
+        sources[f"{k8up.RAW_REPOSITORY}/{app}/{k8up.REQUIREMENTS_PATH}"] = REQUIREMENTS
+        entries.append({
+            "version": chart, "urls": [url],
+            "digest": hashlib.sha256(payload).hexdigest(),
+        })
+    return {"entries": {"k8up": entries}}, sources
+
+
+class K8upTests(unittest.TestCase):
+    def test_chart_and_operator_versions_are_distinct(self):
+        index, sources = fixture()
+        rows = k8up.build_rows(yaml.safe_dump(index), "1.36", sources.__getitem__)
+        self.assertEqual(
+            [(r["version"], r["chart_version"]) for r in rows],
+            [("2.16.0", "4.10.0"), ("2.15.0", "4.9.0")],
+        )
+        self.assertEqual(rows[0]["kube"], ["1.36", "1.35", "1.34", "1.33", "1.32", "1.31"])
+
+    def test_newest_chart_for_same_operator_wins(self):
+        index, sources = fixture((("4.9.0", "v2.15.0"), ("4.9.1", "v2.15.0")))
+        rows = k8up.build_rows(yaml.safe_dump(index), "1.31", sources.__getitem__)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["chart_version"], "4.9.1")
+
+    def test_older_and_prerelease_charts_are_excluded(self):
+        index, _ = fixture()
+        index["entries"]["k8up"] += [
+            {"version": "4.8.7"}, {"version": "4.11.0-rc.1"}, {"version": "garbage"}
+        ]
+        self.assertEqual(
+            [v for v, _, _ in k8up.chart_entries(yaml.safe_dump(index))],
+            ["4.10.0", "4.9.0"],
+        )
+
+    def test_empty_or_malformed_index_is_rejected(self):
+        for value in (None, [], {}, {"entries": {"k8up": []}}, {"entries": {"k8up": [None]}}):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                k8up.chart_entries(yaml.safe_dump(value))
+
+    def test_conflicting_chart_records_are_rejected(self):
+        index, _ = fixture()
+        duplicate = copy.deepcopy(index["entries"]["k8up"][0])
+        duplicate["digest"] = "0" * 64
+        index["entries"]["k8up"].append(duplicate)
+        with self.assertRaisesRegex(ValueError, "Conflicting"):
+            k8up.chart_entries(yaml.safe_dump(index))
+
+    def test_unexpected_archive_url_is_rejected(self):
+        index, _ = fixture()
+        index["entries"]["k8up"][0]["urls"] = ["https://example.com/chart.tgz"]
+        with self.assertRaises(ValueError):
+            k8up.chart_entries(yaml.safe_dump(index))
+
+    def test_archive_digest_is_verified(self):
+        with self.assertRaisesRegex(ValueError, "Digest"):
+            k8up.operator_version(archive(), "4.9.0", "0" * 64)
+
+    def test_packaged_chart_version_is_verified(self):
+        data = archive()
+        with self.assertRaisesRegex(ValueError, "metadata"):
+            k8up.operator_version(data, "4.10.0", hashlib.sha256(data).hexdigest())
+
+    def test_mutable_or_prerelease_image_tags_are_rejected(self):
+        for tag in ("latest", "v2.17.0-rc.1", "v2.15", ""):
+            data = archive(app=tag)
+            with self.subTest(tag=tag), self.assertRaises(ValueError):
+                k8up.operator_version(data, "4.9.0", hashlib.sha256(data).hexdigest())
+
+    def test_unrelated_image_is_rejected(self):
+        data = archive(repository="unrelated/operator")
+        with self.assertRaisesRegex(ValueError, "image repository"):
+            k8up.operator_version(data, "4.9.0", hashlib.sha256(data).hexdigest())
+
+    def test_legacy_or_vague_requirements_are_not_used(self):
+        for text in (
+            "K8up v1 supports Kubernetes 1.11.",
+            "K8up (v2 or later) officially only supports recent stable Kubernetes versions.",
+            REQUIREMENTS.replace("1.31", "1.31.1"),
+        ):
+            with self.subTest(text=text), self.assertRaises(ValueError):
+                k8up.supported_kubernetes(text, "1.36")
+
+    def test_ceiling_is_validated(self):
+        for ceiling in ("1.30", "1.36.0", "latest", None):
+            with self.subTest(ceiling=ceiling), self.assertRaises(ValueError):
+                k8up.supported_kubernetes(REQUIREMENTS, ceiling)
+
+    def test_changed_support_minimum_is_respected(self):
+        self.assertEqual(
+            k8up.supported_kubernetes(REQUIREMENTS.replace("1.31", "1.35"), "1.36"),
+            ["1.36", "1.35"],
+        )
+
+    def test_network_failure_prevents_any_write(self):
+        index, sources = fixture()
+        sources[f"{k8up.HELM_REPOSITORY}/index.yaml"] = yaml.safe_dump(index)
+        def fetch(url):
+            if "/v2.15.0/" in url:
+                raise requests.HTTPError("upstream unavailable")
+            return sources[url]
+        with patch.object(k8up, "fetch_source", side_effect=fetch), \
+             patch("utils.current_kube_version", return_value="1.36"), \
+             patch("utils.update_compatibility_info") as writer:
+            with self.assertRaises(requests.HTTPError):
+                k8up.scrape()
+            writer.assert_not_called()
+
+    def test_changed_document_prevents_any_write(self):
+        index, sources = fixture()
+        sources[f"{k8up.HELM_REPOSITORY}/index.yaml"] = yaml.safe_dump(index)
+        sources[f"{k8up.RAW_REPOSITORY}/v2.16.0/{k8up.REQUIREMENTS_PATH}"] = "unknown"
+        with patch.object(k8up, "fetch_source", side_effect=sources.__getitem__), \
+             patch("utils.current_kube_version", return_value="1.36"), \
+             patch("utils.update_compatibility_info") as writer:
+            with self.assertRaises(ValueError):
+                k8up.scrape()
+            writer.assert_not_called()
+
+    def test_fetch_timeout_and_http_error(self):
+        with patch.object(k8up.requests, "get") as get:
+            get.return_value.raise_for_status.side_effect = requests.HTTPError()
+            with self.assertRaises(requests.HTTPError):
+                k8up.fetch_source("https://example.com")
+            get.assert_called_once_with("https://example.com", timeout=30)
+
+    def test_shared_writer_preserves_metadata_and_is_repeatable(self):
+        from utils import update_compatibility_info
+        index, sources = fixture()
+        rows = k8up.build_rows(yaml.safe_dump(index), "1.36", sources.__getitem__)
+        with tempfile.TemporaryDirectory() as directory, \
+             patch("utils.get_chart_images", return_value=["ghcr.io/k8up-io/k8up:v2.16.0"]), \
+             patch("utils.summarization_enabled", return_value=False):
+            path = Path(directory) / "k8up.yaml"
+            path.write_text(yaml.safe_dump({
+                "name": "k8up", "helm_repository_url": k8up.HELM_REPOSITORY,
+                "icon": "existing-icon", "versions": [],
+            }))
+            update_compatibility_info(str(path), rows)
+            first = path.read_text()
+            result = yaml.safe_load(first)
+            self.assertEqual(result["icon"], "existing-icon")
+            self.assertEqual(len(result["versions"]), 2)
+            update_compatibility_info(str(path), rows)
+            self.assertEqual(path.read_text(), first)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
K8up is absent from the add-on catalog. This adds its compatibility scraper and generated entries for operator 2.15.0 and 2.16.0, using the Kubernetes 1.31+ support statement at each exact operator tag, capped at the repository's Kubernetes 1.36 ceiling.

K8up's Helm index omits `appVersion`, and chart versions differ from operator versions: 4.9.0 installs 2.15.0; 4.10.0 installs 2.16.0. The scraper verifies each released chart against its index SHA-256, reads the packaged image tag, and fetches that operator release's system requirements. It excludes prereleases, legacy OpenShift examples and the unsupported SPDY fallback. Charts before 4.9.0 are excluded because their operator docs only specify “recent stable” Kubernetes releases without a numeric support range.

Retrieval, digest, package metadata or documentation failures stop before the catalog writer runs. When multiple charts package the same operator release, the newest chart is selected. The existing 53 add-ons are preserved.

Sources:

- [Official Helm index](https://k8up-io.github.io/k8up/index.yaml)
- [Chart 4.9.0](https://github.com/k8up-io/k8up/releases/tag/k8up-4.9.0) and [chart 4.10.0](https://github.com/k8up-io/k8up/releases/tag/k8up-4.10.0)
- Versioned system requirements: [2.15.0](https://github.com/k8up-io/k8up/blob/v2.15.0/docs/modules/ROOT/pages/explanations/system-requirements.adoc), [2.16.0](https://github.com/k8up-io/k8up/blob/v2.16.0/docs/modules/ROOT/pages/explanations/system-requirements.adoc), and [2.14.0's ambiguous historical requirement](https://github.com/k8up-io/k8up/blob/v2.14.0/docs/modules/ROOT/pages/explanations/system-requirements.adoc)

## Test Plan

- `python -m unittest discover -s utils/compatibility/tests -p test_k8up.py -v`: 17 offline tests pass. Covers version mapping, duplicate chart selection, malformed/mutable inputs, digest validation, support parsing, error paths, and the shared writer's metadata preservation and repeatability. Test chart archives are synthetic.
- Ran the actual scraper against the official chart index, release archives and tagged documentation. Both chart digests match.
- Helm 4.2.4 successfully rendered both real charts at Kubernetes 1.36. The generated image references match each operator release.
- Validated the per-app YAML, manifest and aggregate against `static/compatibilities/schema.json`; compared all previous aggregate entries for preservation.
- `git diff --check` passes.

This records upstream-declared support. No Kubernetes clusters were deployed and no runtime test matrix is claimed.

Related to #4259. Submitted for consideration under the README Contributor Program; eligibility and payment remain subject to maintainer acceptance. AI-assisted implementation and verification.

## Checklist

- [x] Meaningful title and description.
- [x] Focused tests and verification evidence.
- [x] Catalog metadata, scraper and generated table included.
- No agent deployment or product documentation change is needed.
