### PR TITLE
Add KubeBlocks compatibility scraper and catalog

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,91 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://kubeblocks.io/img/logo.png
+  git_url: https://github.com/apecloud/kubeblocks
+  release_url: https://github.com/apecloud/kubeblocks/releases/tag/v{vsn}
+  helm_repository_url: https://apecloud.github.io/helm-charts
+  versions:
+  - version: 1.0.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.2
+    images: ['apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:1.0.2',
+      'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:1.0.2',
+      'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:1.0.2']
+  - version: 1.0.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.0
+    images: ['apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:1.0.0',
+      'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:1.0.0',
+      'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:1.0.0']
+  - version: 0.9.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.9.0
+    images: ['apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:0.9.0',
+      'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.9.0',
+      'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.9.0',
+      'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.9.0']
+  - version: 0.8.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.8.2
+    images: [busybox, 'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:0.8.2',
+      'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.8.2',
+      'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.2',
+      'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.8.2']
+  - version: 0.8.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.8.0
+    images: [busybox, 'docker.io/apecloud/kubeblocks-tools:latest', 'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:0.8.0',
+      'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.8.0',
+      'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.0',
+      'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.8.0']
+  - version: 0.7.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.7.0
+    images: [busybox, 'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:0.7.0',
+      'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.7.0',
+      'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.7.0',
+      'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.7.0']
+  - version: 0.6.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.6.0
+    images: [busybox, 'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks-datascript:0.6.0',
+      'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks-tools:0.6.0', 'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks:0.6.0']
+  - version: 0.5.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.5.1
+    images: [busybox, 'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks-tools:0.5.1',
+      'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks:0.5.1']
+  name: kubeblocks

--- a/static/compatibilities/kubeblocks.yaml
+++ b/static/compatibilities/kubeblocks.yaml
@@ -1,0 +1,87 @@
+icon: https://kubeblocks.io/img/logo.png
+git_url: https://github.com/apecloud/kubeblocks
+release_url: https://github.com/apecloud/kubeblocks/releases/tag/v{vsn}
+helm_repository_url: https://apecloud.github.io/helm-charts
+versions:
+- version: 1.0.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.2
+  images: ['apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:1.0.2',
+    'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:1.0.2',
+    'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:1.0.2']
+- version: 1.0.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.0
+  images: ['apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:1.0.0',
+    'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:1.0.0',
+    'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:1.0.0']
+- version: 0.9.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.9.0
+  images: ['apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:0.9.0',
+    'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.9.0',
+    'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.9.0',
+    'apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.9.0']
+- version: 0.8.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.2
+  images: [busybox, 'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:0.8.2',
+    'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.8.2',
+    'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.2',
+    'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.8.2']
+- version: 0.8.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.0
+  images: [busybox, 'docker.io/apecloud/kubeblocks-tools:latest', 'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:0.8.0',
+    'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.8.0',
+    'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.8.0',
+    'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.8.0']
+- version: 0.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.7.0
+  images: [busybox, 'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-dataprotection:0.7.0',
+    'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-datascript:0.7.0',
+    'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks-tools:0.7.0',
+    'infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:0.7.0']
+- version: 0.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.6.0
+  images: [busybox, 'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks-datascript:0.6.0',
+    'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks-tools:0.6.0', 'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks:0.6.0']
+- version: 0.5.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.5.1
+  images: [busybox, 'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks-tools:0.5.1',
+    'registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks:0.5.1']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- kubeblocks

--- a/utils/compatibility/scrapers/kubeblocks.py
+++ b/utils/compatibility/scrapers/kubeblocks.py
@@ -1,0 +1,91 @@
+"""Read release-specific Kubernetes requirements from KubeBlocks Helm metadata."""
+
+import re
+
+import yaml
+from semantic_version import Version
+
+APP_NAME = "kubeblocks"
+HELM_INDEX_URL = "https://apecloud.github.io/helm-charts/index.yaml"
+
+
+def _stable_version(value):
+    if not isinstance(value, str):
+        return None
+    try:
+        version = Version(value.removeprefix("v"))
+    except ValueError:
+        return None
+    return version if not version.prerelease and not version.build else None
+
+
+def build_rows(content, current_kube):
+    """Expand declared Helm lower bounds, not a cluster-tested support matrix.
+
+    Keep every application patch so the shared reducer can preserve requirement
+    changes within a minor release. Unsupported constraints abort before writing.
+    """
+    current = re.fullmatch(r"1\.(\d+)", current_kube or "")
+    if not current:
+        raise ValueError("Invalid current Kubernetes minor version")
+    try:
+        data = yaml.safe_load(content)
+    except (yaml.YAMLError, UnicodeError) as exc:
+        raise ValueError("Invalid KubeBlocks Helm index") from exc
+    entries = data.get("entries") if isinstance(data, dict) else None
+    charts = entries.get(APP_NAME) if isinstance(entries, dict) else None
+    if not isinstance(charts, list) or not charts:
+        raise ValueError("KubeBlocks chart entries not found")
+
+    latest = {}
+    for chart in charts:
+        if not isinstance(chart, dict) or chart.get("deprecated"):
+            continue
+        app_version = _stable_version(chart.get("appVersion"))
+        chart_version = _stable_version(chart.get("version"))
+        if app_version is None or chart_version is None:
+            continue
+        previous = latest.get(app_version)
+        if previous is None or chart_version > previous[0]:
+            latest[app_version] = (chart_version, chart)
+
+    rows = []
+    for app_version, (chart_version, chart) in sorted(latest.items(), reverse=True):
+        constraint = chart.get("kubeVersion")
+        # Current published stable charts use >=1.20.0-0 or >=1.22.0-0.
+        # A patch-level floor or compound range cannot be approximated safely.
+        minimum = (
+            re.fullmatch(r">=\s*1\.(\d+)\.0(?:-0)?", constraint.strip())
+            if isinstance(constraint, str) else None
+        )
+        if not minimum:
+            raise ValueError(
+                f"Unsupported Kubernetes constraint in KubeBlocks chart "
+                f"{chart_version}: {constraint!r}"
+            )
+        low, high = int(minimum[1]), int(current[1])
+        if low > high:
+            raise ValueError(
+                f"KubeBlocks chart {chart_version} requires a newer "
+                f"Kubernetes version than {current_kube}"
+            )
+        rows.append({
+            "version": str(app_version),
+            "kube": [f"1.{minor}" for minor in range(high, low - 1, -1)],
+            "chart_version": str(chart_version),
+            "requirements": [],
+            "incompatibilities": [],
+        })
+    if not rows:
+        raise ValueError("No stable KubeBlocks charts found")
+    return rows
+
+
+def scrape():
+    from utils import current_kube_version, fetch_page, update_compatibility_info
+
+    content = fetch_page(HELM_INDEX_URL)
+    if not content:
+        raise ValueError("Could not fetch KubeBlocks Helm index")
+    rows = build_rows(content, current_kube_version())
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", rows)

--- a/utils/compatibility/tests/KUBEBLOCKS.md
+++ b/utils/compatibility/tests/KUBEBLOCKS.md
@@ -1,0 +1,58 @@
+# KubeBlocks compatibility source
+
+The scraper reads `kubeVersion` from each released chart entry in the
+[official Helm index](https://apecloud.github.io/helm-charts/index.yaml).
+It records declared Helm installation lower bounds, capped at this repository's
+`KUBE_VERSION`. This is not a claim that every Kubernetes minor was cluster-tested,
+nor a compatibility promise for every optional database add-on.
+
+Application and chart versions are parsed independently and compared semantically.
+Prerelease/build versions and deprecated chart entries are excluded. Every
+application patch remains available to the shared reducer, since requirements
+change within a minor: chart 0.8.0 declares `>=1.22.0-0`, while 0.8.2 declares
+`>=1.20.0-0`. Selecting just the latest patch in each minor would lose that boundary.
+Unknown or patch-specific Kubernetes constraints stop generation before writing;
+they are not approximated as complete minor-version support.
+
+The official stable 1.0.2 release still carries the legacy
+`artifacthub.io/prerelease: "true"` chart annotation. Version filtering therefore
+uses the semantic version fields, consistently with the published stable release:
+[v1.0.2](https://github.com/apecloud/kubeblocks/releases/tag/v1.0.2).
+
+## Validation
+
+From the repository root, run:
+
+```sh
+python -m pytest utils/compatibility/tests -q
+```
+
+From `utils/compatibility`, with Helm available and API summarization disabled:
+
+```sh
+env -u EXA_API_KEY -u OPENAI_API_KEY python -c \
+  'import importlib; importlib.import_module("scrapers.kubeblocks").scrape()'
+```
+
+The September 9, 2026 index contains 29 entries with stable semantic versions.
+The shared pipeline retains eight rows, renders their charts to extract images,
+and preserves the 0.8.0/0.8.2 requirement transition. Local validation used Python
+3.14 and Helm 4.2.4. No live Kubernetes cluster, database deployment, or full
+Console integration test was run.
+
+## Upstream archive-integrity discrepancy
+
+A supplemental audit of all 29 stable-version archives confirms that packaged
+`name`, `version`, `appVersion`, and `kubeVersion` fields match the index.
+Twenty archive digests match; nine differ: 1.0.0, 0.9.1, 0.9.0, 0.8.4, 0.8.3,
+0.8.0, 0.5.3, 0.5.2, and 0.5.1. For example, 1.0.0 has a reproducible discrepancy:
+
+- [Official archive](https://github.com/apecloud/helm-charts/releases/download/kubeblocks-1.0.0/kubeblocks-1.0.0.tgz)
+- Index SHA256: `7cc7d54a3b6a1325833813122f4115fc265b17b19a5ed59e31ec9a4ed29f230a`
+- Download SHA256: `70076d0843ed9104aeac6bb35c5297cd253d8e50ccbfb75e478b44449300aa37`
+
+Two downloads returned the same 25,568-byte archive, matching the release asset's
+published size. Its relevant metadata matches the index. This does not resolve
+the integrity discrepancies; archive authenticity for those versions is not claimed
+on the basis of the index checksum. The scraper follows the existing index/shared
+Helm-rendering pipeline and does not introduce or bypass an integrity check.

--- a/utils/compatibility/tests/test_kubeblocks.py
+++ b/utils/compatibility/tests/test_kubeblocks.py
@@ -1,0 +1,96 @@
+import copy
+import importlib.util
+from pathlib import Path
+import unittest
+
+import yaml
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "kubeblocks.py"
+spec = importlib.util.spec_from_file_location("kubeblocks", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+# Synthetic index entries isolate the release-specific lower-bound transition
+# present in the official 0.8.0 and 0.8.2 charts.
+ENTRIES = [
+    {"version": "0.8.0", "appVersion": "0.8.0", "kubeVersion": ">=1.22.0-0"},
+    {"version": "0.8.2", "appVersion": "0.8.2", "kubeVersion": ">=1.20.0-0"},
+    {"version": "1.0.9", "appVersion": "1.0.1", "kubeVersion": ">=1.22.0-0"},
+    {"version": "1.0.10", "appVersion": "1.0.1", "kubeVersion": ">=1.20.0-0"},
+]
+
+
+def index(entries):
+    return yaml.safe_dump({"entries": {"kubeblocks": entries}})
+
+
+class KubeBlocksTests(unittest.TestCase):
+    def test_preserves_patch_level_kubernetes_requirement_changes(self):
+        rows = scraper.build_rows(index(ENTRIES), "1.23")
+        self.assertEqual(
+            [(row["version"], row["kube"]) for row in rows],
+            [
+                ("1.0.1", ["1.23", "1.22", "1.21", "1.20"]),
+                ("0.8.2", ["1.23", "1.22", "1.21", "1.20"]),
+                ("0.8.0", ["1.23", "1.22"]),
+            ],
+        )
+
+    def test_selects_newest_chart_semantically_without_conflating_app_version(self):
+        rows = scraper.build_rows(index(list(reversed(ENTRIES))), "1.23")
+        self.assertEqual(rows[0]["version"], "1.0.1")
+        self.assertEqual(rows[0]["chart_version"], "1.0.10")
+
+    def test_excludes_prereleases_build_metadata_deprecated_and_invalid_versions(self):
+        entries = copy.deepcopy(ENTRIES[:1])
+        for chart, app in [
+            ("2.0.0-rc.1", "2.0.0"),
+            ("2.0.0", "2.0.0-beta.1"),
+            ("2.0.0+test", "2.0.0"),
+            ("2.0.0", "2.0.0+test"),
+            ("invalid", "2.0.0"),
+            ("2.0.0", None),
+        ]:
+            entries.append({"version": chart, "appVersion": app, "kubeVersion": ">=1.20.0-0"})
+        entries.append({"version": "2.0.0", "appVersion": "2.0.0", "deprecated": True})
+        rows = scraper.build_rows(index(entries), "1.23")
+        self.assertEqual([row["version"] for row in rows], ["0.8.0"])
+
+    def test_accepts_bytes_and_v_prefixed_versions(self):
+        entry = {"version": "v0.8.0", "appVersion": "v0.8.0", "kubeVersion": ">= 1.22.0"}
+        rows = scraper.build_rows(index([entry]).encode(), "1.22")
+        self.assertEqual(rows[0]["version"], "0.8.0")
+        self.assertEqual(rows[0]["kube"], ["1.22"])
+
+    def test_cannot_express_unsupported_constraints_as_full_minor_compatibility(self):
+        for constraint in [None, "", ">=1.20.5", ">1.20.0", ">=1.20.0 <1.30.0", "garbage"]:
+            with self.subTest(constraint=constraint):
+                entry = dict(ENTRIES[0], kubeVersion=constraint)
+                with self.assertRaises(ValueError):
+                    scraper.build_rows(index([entry]), "1.23")
+
+    def test_bad_latest_chart_does_not_silently_fall_back_to_old_requirements(self):
+        entries = copy.deepcopy(ENTRIES)
+        entries[-1]["kubeVersion"] = None
+        with self.assertRaises(ValueError):
+            scraper.build_rows(index(entries), "1.23")
+
+    def test_future_minimum_does_not_generate_out_of_range_versions(self):
+        with self.assertRaises(ValueError):
+            scraper.build_rows(index(ENTRIES[:1]), "1.21")
+
+    def test_empty_or_malformed_index_fails_instead_of_producing_empty_table(self):
+        for content in ["null", "[]", "entries: {}", "entries: {kubeblocks: null}", "[", index([])]:
+            with self.subTest(content=content):
+                with self.assertRaises(ValueError):
+                    scraper.build_rows(content, "1.23")
+
+    def test_invalid_current_kubernetes_version_fails(self):
+        for current in [None, "latest", "1.23.0", "2.0"]:
+            with self.subTest(current=current):
+                with self.assertRaises(ValueError):
+                    scraper.build_rows(index(ENTRIES), current)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
KubeBlocks is missing from the compatibility catalog. This adds a scraper that reads release-specific Kubernetes installation bounds from the [official Helm index](https://apecloud.github.io/helm-charts/index.yaml), plus the generated application table, manifest registration, and aggregate catalog entry.

The scraper compares chart and application versions semantically, excludes prerelease/build and deprecated entries, and preserves patch-level requirement changes before the shared reducer runs. For example, 0.8.0 declares >=1.22.0-0 while 0.8.2 declares >=1.20.0-0. Unsupported constraints abort before writing. These are declared Helm installation bounds, not a cluster-tested matrix or guarantees for optional database add-ons.

## Test Plan

- Python 3.14: `python -m pytest utils/compatibility/tests -q` — 136 tests and 97 subtests passed, including nine new KubeBlocks tests.
- Ran the shared generation pipeline with Helm 4.2.4: 29 stable versions produce eight retained rows with rendered image references.
- Application, manifest, and aggregate schema validation passed; existing 53 aggregate entries are unchanged.
- Checked packaged Chart.yaml identity and constraint fields for all 29 versions.
- Verified all six uploaded files match the tested local patch byte-for-byte. No live cluster or full Console integration test was run.

## Source caveat

A supplemental archive audit found 20 of 29 SHA256 values match the official index and nine differ: 1.0.0, 0.9.1, 0.9.0, 0.8.4, 0.8.3, 0.8.0, 0.5.3, 0.5.2, and 0.5.1. Relevant packaged metadata matches, but archive authenticity is not established by those mismatching checksums. A reproducible example and limitations are documented in [KUBEBLOCKS.md](https://github.com/ZiluOvO-png/console/blob/0789d4502ed4b0200aff0f5e57f2378339fd1c18/utils/compatibility/tests/KUBEBLOCKS.md). Maintainer review of this source is needed; this change does not bypass an integrity check.

## Checklist

- [x] Added a meaningful title and summary.
- [x] Documented source logic and validation limits.
- [x] Added tests covering the scraper changes.
- Agent deployment test: not applicable; no agent code changed.

Implementation, tests, and supplemental review were performed with Codex on behalf of this account's owner. I would like this contribution considered under the published contributor program; eligibility and payment remain subject to maintainer confirmation and merge. Related eligibility inquiry: https://github.com/pluralsh/console/issues/4244#issuecomment-5598105097

Plural Flow: console
