### PR TITLE
Add trust-manager Helm compatibility scraper and catalog

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- trust-manager

--- a/static/compatibilities/trust-manager.yaml
+++ b/static/compatibilities/trust-manager.yaml
@@ -1,0 +1,178 @@
+icon: https://raw.githubusercontent.com/cert-manager/community/4d35a69437d21b76322157e6284be4cd64e6d2b7/logo/logo-small.png
+git_url: https://github.com/cert-manager/trust-manager
+release_url: https://github.com/cert-manager/trust-manager/releases/tag/v{vsn}
+helm_repository_url: https://charts.jetstack.io
+readme_url: https://cert-manager.io/docs/trust/trust-manager/
+compatibility_source: https://charts.jetstack.io/index.yaml
+compatibility_notes: Helm-declared Kubernetes minimum expanded through the catalog
+  KUBE_VERSION ceiling; not a runtime-tested support matrix. Charts without an explicit
+  constraint are omitted.
+versions:
+- version: 0.24.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.24.0
+  images: []
+- version: 0.23.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.23.0
+  images: []
+- version: 0.22.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.22.0
+  images: []
+- version: 0.21.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.21.0
+  images: []
+- version: 0.20.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.20.0
+  images: []
+- version: 0.19.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.19.0
+  images: []
+- version: 0.18.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.18.0
+  images: []
+- version: 0.17.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.17.0
+  images: []
+- version: 0.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.16.0
+  images: []
+- version: 0.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.15.0
+  images: []
+- version: 0.14.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.14.0
+  images: []
+- version: 0.13.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.13.0
+  images: []
+- version: 0.12.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.12.0
+  images: []
+- version: 0.11.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.11.0
+  images: []
+- version: 0.10.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.10.0
+  images: []
+- version: 0.9.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.9.0
+  images: []
+- version: 0.8.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.8.0
+  images: []
+- version: 0.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.7.0
+  images: []
+- version: 0.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.6.0
+  images: []
+- version: 0.5.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.5.0
+  images: []
+- version: 0.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.4.0
+  images: []

--- a/utils/compatibility/scrapers/trust-manager.py
+++ b/utils/compatibility/scrapers/trust-manager.py
@@ -1,0 +1,82 @@
+"""Read per-release Helm requirements, not a runtime-tested support matrix."""
+
+import re
+from collections import OrderedDict
+
+import yaml
+from semantic_version import Version
+
+APP_NAME = "trust-manager"
+INDEX_URL = "https://charts.jetstack.io/index.yaml"
+TARGET_FILE = f"../../static/compatibilities/{APP_NAME}.yaml"
+
+
+def stable_version(value):
+    if not isinstance(value, str):
+        return None
+    try:
+        version = Version(value.removeprefix("v"))
+    except ValueError:
+        return None
+    return None if version.prerelease or version.build else version
+
+
+def extract_rows(content, ceiling):
+    """Bound explicit Helm minima by the catalog ceiling; never infer missing ones."""
+    if not re.fullmatch(r"1\.\d+", ceiling or ""):
+        raise ValueError("Expected a Kubernetes 1.x catalog ceiling")
+    index = yaml.safe_load(content)
+    if not isinstance(index, dict):
+        raise ValueError("Invalid Helm index")
+    entries = index.get("entries", {}).get(APP_NAME)
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("No trust-manager charts in Helm index")
+
+    selected = {}
+    for chart in entries:
+        if not isinstance(chart, dict):
+            raise ValueError("Invalid chart entry")
+        app = stable_version(chart.get("appVersion"))
+        version = stable_version(chart.get("version"))
+        if app is None or version is None or chart.get("deprecated"):
+            continue
+        if app not in selected or version > selected[app][0]:
+            selected[app] = (version, chart)
+
+    rows = []
+    for app, (version, chart) in sorted(selected.items(), reverse=True):
+        constraint = chart.get("kubeVersion")
+        if constraint is None:
+            continue
+        # All current upstream constraints use this form. Fail on new forms
+        # rather than silently broadening a bounded or patch-specific range.
+        match = re.fullmatch(r">=\s*1\.(\d+)\.0(?:-0)?", str(constraint).strip())
+        if not match:
+            raise ValueError(f"Unsupported kubeVersion for {app}: {constraint}")
+        minimum, maximum = int(match[1]), int(ceiling.split(".")[1])
+        if minimum > maximum:
+            continue
+        rows.append(OrderedDict([
+            ("version", str(app)),
+            ("kube", [f"1.{minor}" for minor in range(maximum, minimum - 1, -1)]),
+            ("chart_version", str(chart["version"])),
+            ("requirements", []),
+            ("incompatibilities", []),
+            ("kube_constraint", str(constraint)),
+            ("compatibility_source", INDEX_URL),
+        ]))
+    if not rows:
+        raise ValueError("No explicit trust-manager compatibility rows found")
+    return rows
+
+
+def scrape():
+    from utils import current_kube_version, fetch_page, update_compatibility_info
+
+    content = fetch_page(INDEX_URL)
+    if not content:
+        return
+    # Parse completely before invoking the writer so malformed upstream input
+    # cannot replace the last known data with a partially parsed result.
+    rows = extract_rows(content, current_kube_version())
+    update_compatibility_info(TARGET_FILE, rows)

--- a/utils/compatibility/tests/test_trust_manager.py
+++ b/utils/compatibility/tests/test_trust_manager.py
@@ -1,0 +1,71 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+import yaml
+
+SPEC = importlib.util.spec_from_file_location(
+    "trust_manager", Path(__file__).parents[1] / "scrapers/trust-manager.py"
+)
+scraper = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(scraper)
+
+
+def chart(app="v0.24.0", version="v0.24.0", constraint=">= 1.25.0-0"):
+    result = {"appVersion": app, "version": version}
+    if constraint is not None:
+        result["kubeVersion"] = constraint
+    return result
+
+
+def parse(entries, ceiling="1.35"):
+    return scraper.extract_rows(yaml.safe_dump({"entries": {"trust-manager": entries}}), ceiling)
+
+
+class TrustManagerTests(unittest.TestCase):
+    def test_historical_minima_are_independent(self):
+        rows = parse([chart(), chart("v0.6.0", "v0.6.0", ">= 1.22.0-0")])
+        self.assertEqual(rows[0]["kube"][-1], "1.25")
+        self.assertEqual(rows[1]["kube"][-1], "1.22")
+        self.assertEqual(rows[0]["chart_version"], "v0.24.0")
+
+    def test_equal_ceiling(self):
+        self.assertEqual(parse([chart()], "1.25")[0]["kube"], ["1.25"])
+
+    def test_skip_prereleases(self):
+        rows = parse([chart(), chart("v0.25.0-rc.1", "v0.25.0-rc.1")])
+        self.assertEqual(len(rows), 1)
+
+    def test_skip_missing_constraint(self):
+        self.assertEqual(len(parse([chart(), chart("v0.3.0", "v0.3.0", None)])), 1)
+
+    def test_newest_chart_for_app(self):
+        rows = parse([chart(), chart(version="v0.24.1", constraint=">= 1.26.0")])
+        self.assertEqual(rows[0]["chart_version"], "v0.24.1")
+        self.assertEqual(rows[0]["kube"][-1], "1.26")
+
+    def test_no_fallback_to_old_chart_when_latest_has_no_constraint(self):
+        with self.assertRaises(ValueError):
+            parse([chart(), chart(version="v0.24.1", constraint=None)])
+
+    def test_fail_closed_for_unrecognized_constraint(self):
+        for value in [">=1.25.1", ">=1.25.0 <1.30.0", "garbage"]:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                parse([chart(constraint=value)])
+
+    def test_below_minimum_does_not_invent_versions(self):
+        with self.assertRaises(ValueError):
+            parse([chart()], "1.24")
+
+    def test_invalid_index(self):
+        for content in ["[]", "{}", "entries: {}"]:
+            with self.subTest(content=content), self.assertRaises(ValueError):
+                scraper.extract_rows(content, "1.35")
+
+    def test_order_does_not_change_result(self):
+        entries = [chart(), chart("v0.6.0", "v0.6.0", ">= 1.22.0-0")]
+        self.assertEqual(parse(entries), parse(list(reversed(entries))))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a trust-manager scraper and catalog entry using each stable release's Kubernetes constraint from the official Jetstack Helm index. Older charts without an explicit constraint are omitted. Unsupported constraint forms fail before writing, and chart/app prereleases are excluded.

**Draft: source-policy approval requested in #4263.** The `kube` values represent Helm-declared minima expanded through the repository's `KUBE_VERSION` ceiling, not a runtime-tested Kubernetes support matrix. The catalog preserves this distinction in its metadata. Please confirm whether this source policy fits the catalog before merging.

Includes Helm repository, icon, Git repository and release metadata, manifest registration, and ten offline parser regression tests. The generated table uses the repository's `reduce_versions` and `write_yaml` helpers.

Sources:
- https://charts.jetstack.io/index.yaml
- https://github.com/cert-manager/trust-manager/blob/v0.24.0/deploy/charts/trust-manager/Chart.yaml
- https://github.com/cert-manager/trust-manager/issues/227

Validation:
- `python -m unittest discover -s utils/compatibility/tests -p test_trust_manager.py -v`: 10 passed.
- Parsed the downloaded official index: 33 stable releases with explicit constraints, reduced to 21 catalog rows using repository helpers.
- Generated table validated against `static/compatibilities/schema.json`.
- No Kubernetes cluster deployment or runtime compatibility tests were performed. The complete Helm image-enrichment pipeline has not been run locally; this remains a draft verification item.

Development was AI-assisted using OpenAI Codex. This is a proposed contribution under the README's new-scraper program; eligibility and payout method remain unconfirmed in #4263. No reward is claimed as earned.

Discord username for contributor identity verification: `yidux_`.
