### PR TITLE
feat: add Apache APISIX compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31337,15 +31337,15 @@ addons:
     summary: null
     chart_version: 2.2.0
     images: ['apache/apisix:3.5.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
-  - version: 3.4.0
+  - version: 3.4.1
     kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
       '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
       '1.16', '1.15', '1.14']
     requirements: []
     incompatibilities: []
     summary: null
-    chart_version: 2.1.0
-    images: ['apache/apisix:3.4.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+    chart_version: 1.5.1
+    images: ['apache/apisix:3.4.1-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
   - version: 3.3.0
     kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
       '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',

--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,225 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://apache.org/logos/res/apisix/apisix.png
+  git_url: https://github.com/apache/apisix
+  release_url: https://github.com/apache/apisix/releases/tag/{vsn}
+  helm_repository_url: https://apache.github.io/apisix-helm-chart
+  versions:
+  - version: 3.18.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.17.0
+    images: ['apache/apisix:3.18.0-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+  - version: 3.17.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.16.1
+    images: ['apache/apisix:3.17.0-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+  - version: 3.16.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.14.1
+    images: ['apache/apisix:3.16.0-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+  - version: 3.15.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.13.0
+    images: ['apache/apisix:3.15.0-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+  - version: 3.14.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.12.6
+    images: ['apache/apisix:3.14.1-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+  - version: 3.13.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.11.6
+    images: ['apache/apisix:3.13.0-ubuntu', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.10-debian-11-r2']
+  - version: 3.11.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.10.1
+    images: ['apache/apisix:3.11.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.10-debian-11-r2']
+  - version: 3.10.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.9.0
+    images: ['apache/apisix:3.10.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.10-debian-11-r2']
+  - version: 3.9.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.8.1
+    images: ['apache/apisix:3.9.1-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.10-debian-11-r2']
+  - version: 3.8.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.6.1
+    images: ['apache/apisix:3.8.1-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+  - version: 3.7.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.5.0
+    images: ['apache/apisix:3.7.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+  - version: 3.6.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.3.1
+    images: ['apache/apisix:3.6.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+  - version: 3.5.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.2.0
+    images: ['apache/apisix:3.5.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+  - version: 3.4.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.1.0
+    images: ['apache/apisix:3.4.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+  - version: 3.3.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.0.0
+    images: ['apache/apisix:3.3.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+  - version: 3.2.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.3.1
+    images: ['apache/apisix:3.2.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+  - version: 3.1.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.1.1
+    images: ['apache/apisix:3.1.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.4-debian-11-r14']
+  - version: 2.15.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.13.1
+    images: ['apache/apisix:2.15.2-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.4-debian-11-r14']
+  - version: 2.14.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.10.2
+    images: ['apache/apisix:2.14.1-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.4-debian-11-r14']
+  - version: 2.13.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.9.4
+    images: ['apache/apisix:2.13.1-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.18-debian-10-r14']
+  - version: 2.12.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.8.4
+    images: ['apache/apisix:2.12.1-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.16-debian-10-r14']
+  - version: 2.10.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.7.3
+    images: ['apache/apisix:2.10.0-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.16-debian-10-r14']
+  - version: 2.9.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.5.0
+    images: ['apache/apisix:2.9-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.16-debian-10-r14']
+  - version: 2.7.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+      '1.16', '1.15', '1.14']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 0.4.0
+    images: ['apache/apisix:2.7-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.16-debian-10-r14']
+  name: apisix

--- a/static/compatibilities/apisix.yaml
+++ b/static/compatibilities/apisix.yaml
@@ -120,15 +120,15 @@ versions:
   summary: null
   chart_version: 2.2.0
   images: ['apache/apisix:3.5.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
-- version: 3.4.0
+- version: 3.4.1
   kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
     '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
     '1.16', '1.15', '1.14']
   requirements: []
   incompatibilities: []
   summary: null
-  chart_version: 2.1.0
-  images: ['apache/apisix:3.4.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+  chart_version: 1.5.1
+  images: ['apache/apisix:3.4.1-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
 - version: 3.3.0
   kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
     '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',

--- a/static/compatibilities/apisix.yaml
+++ b/static/compatibilities/apisix.yaml
@@ -1,0 +1,221 @@
+icon: https://apache.org/logos/res/apisix/apisix.png
+git_url: https://github.com/apache/apisix
+release_url: https://github.com/apache/apisix/releases/tag/{vsn}
+helm_repository_url: https://apache.github.io/apisix-helm-chart
+versions:
+- version: 3.18.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.17.0
+  images: ['apache/apisix:3.18.0-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+- version: 3.17.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.16.1
+  images: ['apache/apisix:3.17.0-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+- version: 3.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.14.1
+  images: ['apache/apisix:3.16.0-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+- version: 3.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.13.0
+  images: ['apache/apisix:3.15.0-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+- version: 3.14.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.12.6
+  images: ['apache/apisix:3.14.1-ubuntu', 'busybox:1.28', 'docker.io/bitnamilegacy/etcd:latest']
+- version: 3.13.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.11.6
+  images: ['apache/apisix:3.13.0-ubuntu', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.10-debian-11-r2']
+- version: 3.11.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.10.1
+  images: ['apache/apisix:3.11.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.10-debian-11-r2']
+- version: 3.10.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.9.0
+  images: ['apache/apisix:3.10.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.10-debian-11-r2']
+- version: 3.9.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.8.1
+  images: ['apache/apisix:3.9.1-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.10-debian-11-r2']
+- version: 3.8.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.6.1
+  images: ['apache/apisix:3.8.1-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+- version: 3.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.5.0
+  images: ['apache/apisix:3.7.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+- version: 3.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.3.1
+  images: ['apache/apisix:3.6.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+- version: 3.5.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.2.0
+  images: ['apache/apisix:3.5.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+- version: 3.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.1.0
+  images: ['apache/apisix:3.4.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+- version: 3.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.0.0
+  images: ['apache/apisix:3.3.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+- version: 3.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.1
+  images: ['apache/apisix:3.2.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.7-debian-11-r14']
+- version: 3.1.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.1
+  images: ['apache/apisix:3.1.0-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.4-debian-11-r14']
+- version: 2.15.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.13.1
+  images: ['apache/apisix:2.15.2-debian', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.4-debian-11-r14']
+- version: 2.14.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.10.2
+  images: ['apache/apisix:2.14.1-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.5.4-debian-11-r14']
+- version: 2.13.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.9.4
+  images: ['apache/apisix:2.13.1-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.18-debian-10-r14']
+- version: 2.12.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.8.4
+  images: ['apache/apisix:2.12.1-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.16-debian-10-r14']
+- version: 2.10.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.7.3
+  images: ['apache/apisix:2.10.0-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.16-debian-10-r14']
+- version: 2.9.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.5.0
+  images: ['apache/apisix:2.9-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.16-debian-10-r14']
+- version: 2.7.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17',
+    '1.16', '1.15', '1.14']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 0.4.0
+  images: ['apache/apisix:2.7-alpine', 'busybox:1.28', 'docker.io/bitnami/etcd:3.4.16-debian-10-r14']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- apisix

--- a/utils/compatibility/scrapers/apisix.py
+++ b/utils/compatibility/scrapers/apisix.py
@@ -1,0 +1,144 @@
+import re
+from collections import OrderedDict
+
+import yaml
+from packaging.version import InvalidVersion, Version
+
+app_name = "apisix"
+helm_index_url = "https://apache.github.io/apisix-helm-chart/index.yaml"
+chart_readme_url = (
+    "https://raw.githubusercontent.com/apache/apisix-helm-chart/"
+    "apisix-{chart_version}/charts/apisix/README.md"
+)
+
+
+_MIN_KUBE_RE = re.compile(r"Kubernetes\s+v?(1\.\d+)\+", re.IGNORECASE)
+
+
+def _decode_text(payload: bytes | str, source: str) -> str:
+    if isinstance(payload, bytes):
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"Could not decode {source}") from exc
+    if isinstance(payload, str):
+        return payload
+    raise ValueError(f"Unexpected {source} payload type")
+
+
+def parse_min_kubernetes(markdown: str) -> str:
+    match = _MIN_KUBE_RE.search(markdown)
+    if not match:
+        raise ValueError("APISIX minimum Kubernetes version not found")
+    return match.group(1)
+
+
+def expand_minimum(minimum: str, current: str) -> list[str]:
+    start = int(minimum.split(".")[1])
+    end = int(current.split(".")[1])
+    if start > end:
+        raise ValueError(
+            f"APISIX minimum Kubernetes {minimum} is newer than Plural {current}"
+        )
+    return [f"1.{minor}" for minor in range(end, start - 1, -1)]
+
+
+def stable_charts_by_app_minor(index_payload: bytes | str):
+    try:
+        index = yaml.safe_load(_decode_text(index_payload, "APISIX Helm index"))
+    except yaml.YAMLError as exc:
+        raise ValueError("Could not parse APISIX Helm index") from exc
+    if not isinstance(index, dict):
+        raise ValueError("Unexpected APISIX Helm index structure")
+    entry_groups = index.get("entries", {})
+    if not isinstance(entry_groups, dict):
+        raise ValueError("Unexpected APISIX Helm index entries structure")
+    entries = entry_groups.get("apisix")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("APISIX chart entries not found")
+    grouped = {}
+    seen = set()
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        chart_raw = str(entry.get("version", "")).strip().lstrip("v")
+        app_raw = str(entry.get("appVersion", "")).strip().lstrip("v")
+        if not chart_raw or not app_raw or chart_raw in seen:
+            continue
+        try:
+            chart = Version(chart_raw)
+            app = Version(app_raw)
+        except InvalidVersion:
+            continue
+        annotations = entry.get("annotations", {})
+        if not isinstance(annotations, dict):
+            continue
+        prerelease = str(
+            annotations.get("artifacthub.io/prerelease", "false")
+        ).lower() == "true"
+        if (
+            chart.is_prerelease
+            or chart.is_devrelease
+            or app.is_prerelease
+            or prerelease
+        ):
+            continue
+
+        seen.add(chart_raw)
+        grouped.setdefault((app.major, app.minor), []).append(
+            (chart, str(app), chart_raw)
+        )
+
+    if not grouped:
+        raise ValueError("No stable APISIX charts found")
+
+    result = []
+    for key in sorted(grouped, reverse=True):
+        candidates = sorted(grouped[key], key=lambda item: item[0], reverse=True)
+        result.append([(app, chart_raw) for _, app, chart_raw in candidates])
+    return result
+
+
+def build_rows(index_payload: bytes | str, current_kube: str, fetcher):
+    rows = []
+    for candidates in stable_charts_by_app_minor(index_payload):
+        for app_version, chart_version in candidates:
+            page = fetcher(chart_readme_url.format(chart_version=chart_version))
+            if not page:
+                continue
+            markdown = _decode_text(page, f"APISIX chart {chart_version} README")
+            minimum = parse_min_kubernetes(markdown)
+            rows.append(
+                OrderedDict(
+                    [
+                        ("version", app_version),
+                        ("kube", expand_minimum(minimum, current_kube)),
+                        ("chart_version", chart_version),
+                        ("requirements", []),
+                        ("incompatibilities", []),
+                    ]
+                )
+            )
+            break
+    if not rows:
+        raise ValueError("No documented APISIX compatibility rows generated")
+    return rows
+
+
+def scrape() -> None:
+    from utils import current_kube_version, fetch_page, update_compatibility_info
+
+    index = fetch_page(helm_index_url)
+    if not index:
+        raise ValueError("Could not fetch official APISIX Helm index")
+
+    current = current_kube_version()
+    if not current:
+        raise ValueError("Plural current Kubernetes version is unavailable")
+
+    rows = build_rows(index, current, fetch_page)
+    update_compatibility_info(
+        f"../../static/compatibilities/{app_name}.yaml",
+        rows,
+    )

--- a/utils/compatibility/scrapers/apisix.py
+++ b/utils/compatibility/scrapers/apisix.py
@@ -13,6 +13,7 @@ chart_readme_url = (
 
 
 _MIN_KUBE_RE = re.compile(r"Kubernetes\s+v?(1\.\d+)\+", re.IGNORECASE)
+_RELEASE_VERSION_RE = re.compile(r"\d+\.\d+\.\d+")
 
 
 def _decode_text(payload: bytes | str, source: str) -> str:
@@ -66,6 +67,10 @@ def stable_charts_by_app_minor(index_payload: bytes | str):
         app_raw = str(entry.get("appVersion", "")).strip().lstrip("v")
         if not chart_raw or not app_raw or chart_raw in seen:
             continue
+        if not _RELEASE_VERSION_RE.fullmatch(chart_raw) or not _RELEASE_VERSION_RE.fullmatch(
+            app_raw
+        ):
+            continue
         try:
             chart = Version(chart_raw)
             app = Version(app_raw)
@@ -87,7 +92,7 @@ def stable_charts_by_app_minor(index_payload: bytes | str):
 
         seen.add(chart_raw)
         grouped.setdefault((app.major, app.minor), []).append(
-            (chart, str(app), chart_raw)
+            (app, chart, app_raw, chart_raw)
         )
 
     if not grouped:
@@ -95,8 +100,12 @@ def stable_charts_by_app_minor(index_payload: bytes | str):
 
     result = []
     for key in sorted(grouped, reverse=True):
-        candidates = sorted(grouped[key], key=lambda item: item[0], reverse=True)
-        result.append([(app, chart_raw) for _, app, chart_raw in candidates])
+        candidates = sorted(
+            grouped[key], key=lambda item: (item[0], item[1]), reverse=True
+        )
+        result.append(
+            [(app_raw, chart_raw) for _, _, app_raw, chart_raw in candidates]
+        )
     return result
 
 
@@ -108,7 +117,10 @@ def build_rows(index_payload: bytes | str, current_kube: str, fetcher):
             if not page:
                 continue
             markdown = _decode_text(page, f"APISIX chart {chart_version} README")
-            minimum = parse_min_kubernetes(markdown)
+            try:
+                minimum = parse_min_kubernetes(markdown)
+            except ValueError:
+                continue
             rows.append(
                 OrderedDict(
                     [

--- a/utils/compatibility/scrapers/apisix.py
+++ b/utils/compatibility/scrapers/apisix.py
@@ -57,15 +57,15 @@ def stable_charts_by_app_minor(index_payload: bytes | str):
     entries = entry_groups.get("apisix")
     if not isinstance(entries, list) or not entries:
         raise ValueError("APISIX chart entries not found")
-    grouped = {}
-    seen = set()
+    candidates_by_chart = {}
+    conflicting_charts = set()
 
     for entry in entries:
         if not isinstance(entry, dict):
             continue
         chart_raw = str(entry.get("version", "")).strip().lstrip("v")
         app_raw = str(entry.get("appVersion", "")).strip().lstrip("v")
-        if not chart_raw or not app_raw or chart_raw in seen:
+        if not chart_raw or not app_raw or chart_raw in conflicting_charts:
             continue
         if not _RELEASE_VERSION_RE.fullmatch(chart_raw) or not _RELEASE_VERSION_RE.fullmatch(
             app_raw
@@ -90,10 +90,18 @@ def stable_charts_by_app_minor(index_payload: bytes | str):
         ):
             continue
 
-        seen.add(chart_raw)
-        grouped.setdefault((app.major, app.minor), []).append(
-            (app, chart, app_raw, chart_raw)
-        )
+        previous = candidates_by_chart.get(chart_raw)
+        if previous:
+            if previous[2] != app_raw:
+                del candidates_by_chart[chart_raw]
+                conflicting_charts.add(chart_raw)
+            continue
+        candidates_by_chart[chart_raw] = (app, chart, app_raw, chart_raw)
+
+    grouped = {}
+    for candidate in candidates_by_chart.values():
+        app = candidate[0]
+        grouped.setdefault((app.major, app.minor), []).append(candidate)
 
     if not grouped:
         raise ValueError("No stable APISIX charts found")

--- a/utils/compatibility/tests/test_apisix.py
+++ b/utils/compatibility/tests/test_apisix.py
@@ -1,0 +1,281 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import yaml
+
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "apisix.py"
+spec = importlib.util.spec_from_file_location("apisix", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+class ApisixTests(unittest.TestCase):
+    def test_parses_tagged_minimum_kubernetes_version(self):
+        markdown = """# Apache APISIX for Kubernetes
+
+## Prerequisites
+
+* Kubernetes v1.14+
+* Helm v3+
+"""
+        self.assertEqual(scraper.parse_min_kubernetes(markdown), "1.14")
+
+    def test_missing_minimum_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "minimum Kubernetes version not found"):
+            scraper.parse_min_kubernetes("# Install\nUse a Kubernetes cluster.")
+
+    def test_expands_minimum_through_plural_current_version(self):
+        self.assertEqual(
+            scraper.expand_minimum("1.14", "1.17"),
+            ["1.17", "1.16", "1.15", "1.14"],
+        )
+
+    def test_future_minimum_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "newer than Plural"):
+            scraper.expand_minimum("1.18", "1.17")
+
+    def test_groups_stable_charts_by_application_minor_newest_first(self):
+        index = """apiVersion: v1
+entries:
+  apisix:
+  - version: 2.16.0
+    appVersion: 3.17.0
+    annotations: {artifacthub.io/prerelease: "false"}
+  - version: 2.17.0
+    appVersion: 3.18.0
+    annotations: {artifacthub.io/prerelease: "false"}
+  - version: 2.16.1
+    appVersion: 3.17.0
+    annotations: {artifacthub.io/prerelease: "false"}
+  - version: 2.15.0-rc1
+    appVersion: 3.17.0-rc1
+    annotations: {artifacthub.io/prerelease: "true"}
+  - version: 2.14.1
+    appVersion: 3.16.0
+    annotations: {artifacthub.io/prerelease: "false"}
+  - version: garbage
+    appVersion: unknown
+  - version: 2.16.1
+    appVersion: 3.17.0
+    annotations: {artifacthub.io/prerelease: "false"}
+"""
+        self.assertEqual(
+            scraper.stable_charts_by_app_minor(index),
+            [
+                [("3.18.0", "2.17.0")],
+                [("3.17.0", "2.16.1"), ("3.17.0", "2.16.0")],
+                [("3.16.0", "2.14.1")],
+            ],
+        )
+
+    def test_malformed_chart_metadata_is_ignored(self):
+        index = """entries:
+  apisix:
+  - version: 9.0.0
+    appVersion: 9.0.0
+    annotations: []
+  - version: 2.17.0
+    appVersion: 3.18.0
+    annotations: {artifacthub.io/prerelease: "false"}
+"""
+        self.assertEqual(
+            scraper.stable_charts_by_app_minor(index),
+            [[("3.18.0", "2.17.0")]],
+        )
+
+    def test_missing_chart_entries_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "APISIX chart entries not found"):
+            scraper.stable_charts_by_app_minor("entries: {}")
+
+    def test_unexpected_entries_structure_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Unexpected APISIX Helm index"):
+            scraper.stable_charts_by_app_minor("entries: []")
+
+    def test_malformed_index_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Could not parse APISIX Helm index"):
+            scraper.stable_charts_by_app_minor("entries: [")
+
+    def test_index_without_stable_releases_fails_closed(self):
+        index = """entries:
+  apisix:
+  - version: 2.18.0-rc1
+    appVersion: 3.19.0-rc1
+    annotations: {artifacthub.io/prerelease: "true"}
+"""
+        with self.assertRaisesRegex(ValueError, "No stable APISIX charts found"):
+            scraper.stable_charts_by_app_minor(index)
+
+    def test_builds_rows_from_each_matching_chart_tag(self):
+        index = """entries:
+  apisix:
+  - version: 2.17.0
+    appVersion: 3.18.0
+    annotations: {artifacthub.io/prerelease: "false"}
+  - version: 2.16.1
+    appVersion: 3.17.0
+    annotations: {artifacthub.io/prerelease: "false"}
+"""
+        documentation = {
+            scraper.chart_readme_url.format(chart_version="2.17.0"):
+                b"## Prerequisites\n* Kubernetes v1.14+\n",
+            scraper.chart_readme_url.format(chart_version="2.16.1"):
+                b"## Prerequisites\n* Kubernetes v1.14+\n",
+        }
+
+        rows = scraper.build_rows(index, "1.16", documentation.get)
+
+        self.assertEqual(
+            rows,
+            [
+                {
+                    "version": "3.18.0",
+                    "kube": ["1.16", "1.15", "1.14"],
+                    "chart_version": "2.17.0",
+                    "requirements": [],
+                    "incompatibilities": [],
+                },
+                {
+                    "version": "3.17.0",
+                    "kube": ["1.16", "1.15", "1.14"],
+                    "chart_version": "2.16.1",
+                    "requirements": [],
+                    "incompatibilities": [],
+                },
+            ],
+        )
+
+    def test_missing_latest_chart_document_falls_back_within_application_minor(self):
+        index = """entries:
+  apisix:
+  - version: 2.16.1
+    appVersion: 3.17.0
+  - version: 2.16.0
+    appVersion: 3.17.0
+"""
+        older_url = scraper.chart_readme_url.format(chart_version="2.16.0")
+        rows = scraper.build_rows(
+            index,
+            "1.15",
+            lambda url: b"* Kubernetes v1.14+" if url == older_url else None,
+        )
+
+        self.assertEqual(
+            rows,
+            [
+                {
+                    "version": "3.17.0",
+                    "kube": ["1.15", "1.14"],
+                    "chart_version": "2.16.0",
+                    "requirements": [],
+                    "incompatibilities": [],
+                }
+            ],
+        )
+
+    def test_all_tagged_documentation_missing_fails_closed(self):
+        index = """entries:
+  apisix:
+  - version: 2.17.0
+    appVersion: 3.18.0
+"""
+        with self.assertRaisesRegex(ValueError, "No documented APISIX"):
+            scraper.build_rows(index, "1.16", lambda _: None)
+
+    def test_invalid_utf8_document_fails_closed(self):
+        index = """entries:
+  apisix:
+  - version: 2.17.0
+    appVersion: 3.18.0
+"""
+        with self.assertRaisesRegex(ValueError, "Could not decode APISIX"):
+            scraper.build_rows(index, "1.16", lambda _: b"\xff")
+
+    def test_scrape_writes_rows_from_official_sources(self):
+        index = """entries:
+  apisix:
+  - version: 2.17.0
+    appVersion: 3.18.0
+"""
+        helpers = ModuleType("utils")
+        helpers.fetch_page = Mock(
+            side_effect=lambda url: (
+                index.encode()
+                if url == scraper.helm_index_url
+                else b"* Kubernetes v1.14+"
+            )
+        )
+        helpers.current_kube_version = Mock(return_value="1.16")
+        helpers.update_compatibility_info = Mock()
+
+        with patch.dict(sys.modules, {"utils": helpers}):
+            scraper.scrape()
+
+        self.assertIsNotNone(helpers.update_compatibility_info.call_args)
+        self.assertEqual(
+            helpers.update_compatibility_info.call_args.args,
+            (
+                "../../static/compatibilities/apisix.yaml",
+                [
+                    {
+                        "version": "3.18.0",
+                        "kube": ["1.16", "1.15", "1.14"],
+                        "chart_version": "2.17.0",
+                        "requirements": [],
+                        "incompatibilities": [],
+                    }
+                ],
+            ),
+        )
+
+    def test_scrape_does_not_write_when_sources_are_incomplete(self):
+        index = """entries:
+  apisix:
+  - version: 2.17.0
+    appVersion: 3.18.0
+"""
+        helpers = ModuleType("utils")
+        helpers.fetch_page = Mock(
+            side_effect=lambda url: (
+                index.encode() if url == scraper.helm_index_url else None
+            )
+        )
+        helpers.current_kube_version = Mock(return_value="1.16")
+        helpers.update_compatibility_info = Mock()
+
+        with patch.dict(sys.modules, {"utils": helpers}):
+            with self.assertRaisesRegex(ValueError, "No documented APISIX"):
+                scraper.scrape()
+
+        helpers.update_compatibility_info.assert_not_called()
+
+    def test_catalog_entry_is_registered_and_aggregated(self):
+        root = Path(__file__).parents[3]
+        manifest = yaml.safe_load(
+            (root / "static/compatibilities/manifest.yaml").read_text()
+        )
+        addon = yaml.safe_load(
+            (root / "static/compatibilities/apisix.yaml").read_text()
+        )
+        aggregate = yaml.safe_load(
+            (root / "static/compatibilities.yaml").read_text()
+        )
+
+        self.assertIn("apisix", manifest["names"])
+        aggregated = next(
+            (item for item in aggregate["addons"] if item["name"] == "apisix"),
+            None,
+        )
+        self.assertIsNotNone(aggregated)
+        self.assertEqual(
+            {key: value for key, value in aggregated.items() if key != "name"},
+            addon,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_apisix.py
+++ b/utils/compatibility/tests/test_apisix.py
@@ -73,6 +73,19 @@ entries:
             ],
         )
 
+    def test_prefers_newest_application_patch_over_newer_chart_version(self):
+        index = """entries:
+  apisix:
+  - version: 2.1.0
+    appVersion: 3.4.0
+  - version: 1.5.1
+    appVersion: 3.4.1
+"""
+        self.assertEqual(
+            scraper.stable_charts_by_app_minor(index),
+            [[("3.4.1", "1.5.1"), ("3.4.0", "2.1.0")]],
+        )
+
     def test_malformed_chart_metadata_is_ignored(self):
         index = """entries:
   apisix:
@@ -82,6 +95,25 @@ entries:
   - version: 2.17.0
     appVersion: 3.18.0
     annotations: {artifacthub.io/prerelease: "false"}
+"""
+        self.assertEqual(
+            scraper.stable_charts_by_app_minor(index),
+            [[("3.18.0", "2.17.0")]],
+        )
+
+    def test_rejects_non_release_version_forms(self):
+        index = """entries:
+  apisix:
+  - version: 2.17.0.post1
+    appVersion: 3.18.0
+  - version: 2.16.1
+    appVersion: 3.18
+  - version: 1!2.15.0
+    appVersion: 1!3.18.0
+  - version: 2.14.1+local
+    appVersion: 3.18.0+local
+  - version: 2.17.0
+    appVersion: 3.18.0
 """
         self.assertEqual(
             scraper.stable_charts_by_app_minor(index),
@@ -163,6 +195,36 @@ entries:
             "1.15",
             lambda url: b"* Kubernetes v1.14+" if url == older_url else None,
         )
+
+        self.assertEqual(
+            rows,
+            [
+                {
+                    "version": "3.17.0",
+                    "kube": ["1.15", "1.14"],
+                    "chart_version": "2.16.0",
+                    "requirements": [],
+                    "incompatibilities": [],
+                }
+            ],
+        )
+
+    def test_unparseable_latest_document_falls_back_within_application_minor(self):
+        index = """entries:
+  apisix:
+  - version: 2.16.1
+    appVersion: 3.17.1
+  - version: 2.16.0
+    appVersion: 3.17.0
+"""
+        newest_url = scraper.chart_readme_url.format(chart_version="2.16.1")
+        older_url = scraper.chart_readme_url.format(chart_version="2.16.0")
+        documentation = {
+            newest_url: b"## Prerequisites\nUse Kubernetes.\n",
+            older_url: b"## Prerequisites\n* Kubernetes v1.14+\n",
+        }
+
+        rows = scraper.build_rows(index, "1.15", documentation.get)
 
         self.assertEqual(
             rows,

--- a/utils/compatibility/tests/test_apisix.py
+++ b/utils/compatibility/tests/test_apisix.py
@@ -86,6 +86,20 @@ entries:
             [[("3.4.1", "1.5.1"), ("3.4.0", "2.1.0")]],
         )
 
+    def test_conflicting_duplicate_chart_metadata_is_ignored_deterministically(self):
+        entries = [
+            "  - version: 2.17.0\n    appVersion: 3.18.0",
+            "  - version: 2.17.0\n    appVersion: 3.17.0",
+            "  - version: 2.16.0\n    appVersion: 3.17.1",
+        ]
+
+        forward = "entries:\n  apisix:\n" + "\n".join(entries) + "\n"
+        reverse = "entries:\n  apisix:\n" + "\n".join(reversed(entries)) + "\n"
+
+        expected = [[("3.17.1", "2.16.0")]]
+        self.assertEqual(scraper.stable_charts_by_app_minor(forward), expected)
+        self.assertEqual(scraper.stable_charts_by_app_minor(reverse), expected)
+
     def test_malformed_chart_metadata_is_ignored(self):
         index = """entries:
   apisix:


### PR DESCRIPTION
## Problem

Plural's compatibility catalog does not currently include Apache APISIX, so the upgrade assistant cannot report Kubernetes compatibility for APISIX installations.

## Change

This adds an APISIX compatibility scraper and generated catalog data. The scraper:

- reads chart and application versions from the official APISIX Helm index;
- rejects semantic prereleases and entries marked as prereleases by Artifact Hub;
- groups releases by APISIX application minor, prioritizes the newest application patch, and then selects its newest chart independently of index order;
- reads the Kubernetes minimum from the README at each matching official chart tag, with fallback only to an older documented chart in the same application minor;
- fails without writing when no authoritative compatibility rows can be generated.

The generated table covers 24 documented APISIX release lines from 2.7.0 through 3.18.0 and includes images rendered from each selected Helm chart.

## Sources

- Official Helm index: https://apache.github.io/apisix-helm-chart/index.yaml
- Current tagged chart prerequisites (`Kubernetes v1.14+`): https://github.com/apache/apisix-helm-chart/blob/apisix-2.17.0/charts/apisix/README.md#prerequisites
- Chart releases: https://github.com/apache/apisix-helm-chart/releases
- APISIX releases: https://github.com/apache/apisix/releases

## Test Plan

- Local Windows validation using Python 3.13.15 (matching the scheduled updater's Python minor version): `python -m pytest utils/compatibility/tests -q` — 148 passed, 81 subtests passed
- All 58 files matched by the compatibility-schema workflow validate against `static/compatibilities/schema.json`
- `python -m py_compile utils/compatibility/scrapers/apisix.py utils/compatibility/tests/test_apisix.py`
- `git diff --check`
- Four live scraper runs, including two on Python 3.13.15 and one after the review fix, produced identical APISIX YAML (SHA-256 `E110BB3BA2727A252387FC0168298377C1E1D2E675AC377628F02622B4A72D82`)

No live Kubernetes cluster deployment was performed; this change validates upstream-declared compatibility metadata, parser behavior, and official Helm chart resolution.

AI assistance disclosure: implemented and tested using OpenAI ChatGPT/Codex under the GitHub account owner's authorization.

I would like this submission considered under the README Contributor Program's advertised $300 reward for a new compatibility scraper, subject to maintainer review, merge, and eligibility confirmation.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have deployed the agent to a test environment and verified that it works as expected (required only when changing agent code). Not applicable; this changes only the compatibility utility and generated data.

Plural Flow: console
