### PR TITLE
Add Kube-OVN v2 chart compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,39 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/kube-ovn/icon/color/kube-ovn-icon-color.svg
+  git_url: https://github.com/kubeovn/kube-ovn
+  release_url: https://github.com/kubeovn/kube-ovn/releases/tag/v{vsn}
+  readme_url: https://github.com/kubeovn/kube-ovn/tree/master/charts/kube-ovn-v2
+  helm_repository_url: oci://ghcr.io/kubeovn/charts/kube-ovn-v2
+  chart_name: kube-ovn-v2
+  versions:
+  - version: 1.16.3
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v1.16.3
+    images: ['docker.io/kubeovn/kube-ovn:v1.16.3', 'docker.io/kubeovn/vpc-nat-gateway:v1.16.3']
+  - version: 1.16.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v1.16.0
+    images: ['docker.io/kubeovn/kube-ovn:v1.16.0', 'docker.io/kubeovn/vpc-nat-gateway:v1.16.0']
+  - version: 1.15.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v1.15.1
+    images: ['docker.io/kubeovn/kube-ovn:v1.15.1', 'docker.io/kubeovn/vpc-nat-gateway:v1.15.1']
+  - version: 1.14.14
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v1.14.14
+    images: ['docker.io/kubeovn/kube-ovn:v1.14.14', 'docker.io/kubeovn/vpc-nat-gateway:v1.14.14']
+  name: kube-ovn

--- a/static/compatibilities/kube-ovn.yaml
+++ b/static/compatibilities/kube-ovn.yaml
@@ -1,0 +1,35 @@
+icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/kube-ovn/icon/color/kube-ovn-icon-color.svg
+git_url: https://github.com/kubeovn/kube-ovn
+release_url: https://github.com/kubeovn/kube-ovn/releases/tag/v{vsn}
+readme_url: https://github.com/kubeovn/kube-ovn/tree/master/charts/kube-ovn-v2
+helm_repository_url: oci://ghcr.io/kubeovn/charts/kube-ovn-v2
+chart_name: kube-ovn-v2
+versions:
+- version: 1.16.3
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v1.16.3
+  images: ['docker.io/kubeovn/kube-ovn:v1.16.3', 'docker.io/kubeovn/vpc-nat-gateway:v1.16.3']
+- version: 1.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v1.16.0
+  images: ['docker.io/kubeovn/kube-ovn:v1.16.0', 'docker.io/kubeovn/vpc-nat-gateway:v1.16.0']
+- version: 1.15.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v1.15.1
+  images: ['docker.io/kubeovn/kube-ovn:v1.15.1', 'docker.io/kubeovn/vpc-nat-gateway:v1.15.1']
+- version: 1.14.14
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v1.14.14
+  images: ['docker.io/kubeovn/kube-ovn:v1.14.14', 'docker.io/kubeovn/vpc-nat-gateway:v1.14.14']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- kube-ovn

--- a/utils/compatibility/scrapers/kube-ovn.py
+++ b/utils/compatibility/scrapers/kube-ovn.py
@@ -1,0 +1,196 @@
+"""Read the installation constraints of published Kube-OVN v2 Helm charts.
+
+These are Helm-declared Kubernetes requirements, not a matrix of tested
+Kubernetes releases. The legacy kube-ovn chart is a separate chart family.
+"""
+
+import re
+import subprocess
+from urllib.parse import urljoin, urlsplit
+
+import requests
+import yaml
+from semantic_version import Version
+
+APP_NAME = "kube-ovn"
+CHART_NAME = "kube-ovn-v2"
+REGISTRY_PATH = f"kubeovn/charts/{CHART_NAME}"
+CHART_URL = f"oci://ghcr.io/{REGISTRY_PATH}"
+TAGS_URL = f"https://ghcr.io/v2/{REGISTRY_PATH}/tags/list"
+TOKEN_URL = "https://ghcr.io/token"
+TIMEOUT = 30
+
+
+def stable_version(value):
+    if not isinstance(value, str) or not re.fullmatch(r"v?\d+\.\d+\.\d+", value):
+        return None
+    try:
+        return Version(value.removeprefix("v"))
+    except ValueError:
+        return None
+
+
+def fetch_tags():
+    """List this public GHCR chart without requiring a GitHub account/token."""
+    response = requests.get(
+        TOKEN_URL,
+        params={"service": "ghcr.io", "scope": f"repository:{REGISTRY_PATH}:pull"},
+        timeout=TIMEOUT,
+    )
+    response.raise_for_status()
+    token = response.json().get("token")
+    if not isinstance(token, str) or not token:
+        raise ValueError("GHCR did not return an anonymous pull token")
+
+    tags = set()
+    url = TAGS_URL + "?n=1000"
+    visited = set()
+    while url:
+        parsed = urlsplit(url)
+        # Only the known tags endpoint may receive the anonymous pull token.
+        if (parsed.scheme, parsed.netloc, parsed.path) != (
+            "https", "ghcr.io", urlsplit(TAGS_URL).path
+        ) or url in visited:
+            raise ValueError("Invalid GHCR tags pagination link")
+        visited.add(url)
+        response = requests.get(
+            url, headers={"Authorization": f"Bearer {token}"}, timeout=TIMEOUT
+        )
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, dict) or data.get("name") != REGISTRY_PATH:
+            raise ValueError("Unexpected GHCR chart repository")
+        page_tags = data.get("tags")
+        if not isinstance(page_tags, list) or not all(
+            isinstance(tag, str) for tag in page_tags
+        ):
+            raise ValueError("Malformed GHCR chart tags")
+        tags.update(page_tags)
+        next_url = response.links.get("next", {}).get("url")
+        url = urljoin(url, next_url) if next_url else None
+
+    return sorted(
+        (tag for tag in tags if stable_version(tag) is not None),
+        key=lambda tag: (stable_version(tag), tag),
+        reverse=True,
+    )
+
+
+def fetch_chart(tag):
+    if stable_version(tag) is None:
+        raise ValueError(f"Invalid stable chart tag: {tag!r}")
+    result = subprocess.run(
+        ["helm", "show", "chart", CHART_URL, "--version", tag],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return yaml.safe_load(result.stdout)
+
+
+def kubernetes_versions(constraint, current):
+    """Expand the explicit minor floor used by these charts, capped by Plural.
+
+    Reject new constraint forms instead of silently ignoring upper bounds,
+    patch restrictions or disjunctions that the minor-only catalog cannot store.
+    """
+    floor = re.fullmatch(r">=\s*v?1\.(\d+)\.0(?:-0)?", str(constraint).strip())
+    ceiling = re.fullmatch(r"1\.(\d+)", str(current).strip())
+    if floor is None or ceiling is None:
+        raise ValueError(f"Unsupported Kubernetes constraint/current: {constraint!r}/{current!r}")
+    low, high = int(floor[1]), int(ceiling[1])
+    if low > high:
+        raise ValueError("Chart requires a newer Kubernetes minor than Plural tracks")
+    return [f"1.{minor}" for minor in range(high, low - 1, -1)]
+
+
+def build_rows(tags, current, chart_fetcher=None):
+    if chart_fetcher is None:
+        chart_fetcher = fetch_chart
+    rows = {}
+    for tag in tags:
+        chart_version = stable_version(tag)
+        if chart_version is None:
+            continue
+        metadata = chart_fetcher(tag)
+        if not isinstance(metadata, dict) or metadata.get("name") != CHART_NAME:
+            raise ValueError(f"Unexpected Kube-OVN chart metadata for {tag}")
+        if stable_version(metadata.get("version")) != chart_version:
+            raise ValueError(f"Chart version does not match registry tag {tag}")
+        app_version = stable_version(metadata.get("appVersion"))
+        if app_version is None:
+            raise ValueError(f"Missing stable Kube-OVN application version for {tag}")
+        row = {
+            "version": str(app_version),
+            "kube": kubernetes_versions(metadata.get("kubeVersion"), current),
+            # Keep the exact registry tag: historical tags have no v prefix.
+            "chart_version": tag,
+            "requirements": [],
+            "incompatibilities": [],
+        }
+        existing = rows.get(app_version)
+        if existing and stable_version(existing["chart_version"]) == chart_version:
+            if existing["kube"] != row["kube"]:
+                raise ValueError(f"Conflicting chart aliases for Kube-OVN {app_version}")
+        if existing is None or (chart_version, tag) > (
+            stable_version(existing["chart_version"]), existing["chart_version"]
+        ):
+            rows[app_version] = row
+    if not rows:
+        raise ValueError("No stable Kube-OVN v2 chart versions found")
+    return [rows[version] for version in sorted(rows, reverse=True)]
+
+
+def chart_images(tag, current):
+    from utils import find_nested_images
+
+    result = subprocess.run(
+        ["helm", "template", CHART_NAME, CHART_URL, "--version", tag,
+         "--kube-version", current],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return find_nested_images(list(yaml.safe_load_all(result.stdout)))
+
+
+def verify_images(rows, current, image_fetcher=None):
+    if image_fetcher is None:
+        image_fetcher = chart_images
+    verified = []
+    for row in rows:
+        images = image_fetcher(row["chart_version"], current)
+        versions = set()
+        for image in images:
+            match = re.search(r"(?:^|/)kube-ovn:([^@]+)$", image)
+            if match:
+                version = stable_version(match[1])
+                if version is None:
+                    raise ValueError(f"Unversioned Kube-OVN image: {image}")
+                versions.add(str(version))
+        if not versions:
+            raise ValueError(f"No Kube-OVN image found in chart {row['chart_version']}")
+        if versions != {row["version"]}:
+            # The published 1.14.2 and 1.15.0 charts deploy kube-ovn:v1.14.0
+            # despite their appVersion. Do not create a false application mapping.
+            print(f"Skipping chart {row['chart_version']}: appVersion {row['version']} "
+                  f"does not match rendered Kube-OVN versions {sorted(versions)}")
+            continue
+        verified.append({**row, "images": images})
+    if not verified:
+        raise ValueError("No Kube-OVN charts match their declared application version")
+    return verified
+
+
+def scrape():
+    from utils import current_kube_version, update_compatibility_info
+
+    current = current_kube_version()
+    if not current:
+        raise ValueError("Plural current Kubernetes version is unavailable")
+    # Finish all downloads and validation before modifying the existing table.
+    rows = build_rows(fetch_tags(), current)
+    rows = verify_images(rows, current)
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", rows)

--- a/utils/compatibility/scrapers/kube-ovn.py
+++ b/utils/compatibility/scrapers/kube-ovn.py
@@ -108,8 +108,9 @@ def kubernetes_versions(constraint, current):
 def build_rows(tags, current, chart_fetcher=None):
     if chart_fetcher is None:
         chart_fetcher = fetch_chart
-    rows = {}
-    for tag in tags:
+    rows = []
+    aliases = {}
+    for tag in dict.fromkeys(tags):
         chart_version = stable_version(tag)
         if chart_version is None:
             continue
@@ -129,17 +130,17 @@ def build_rows(tags, current, chart_fetcher=None):
             "requirements": [],
             "incompatibilities": [],
         }
-        existing = rows.get(app_version)
-        if existing and stable_version(existing["chart_version"]) == chart_version:
-            if existing["kube"] != row["kube"]:
-                raise ValueError(f"Conflicting chart aliases for Kube-OVN {app_version}")
-        if existing is None or (chart_version, tag) > (
-            stable_version(existing["chart_version"]), existing["chart_version"]
-        ):
-            rows[app_version] = row
+        existing = aliases.get(chart_version)
+        if existing and (existing["version"], existing["kube"]) != (row["version"], row["kube"]):
+            raise ValueError(f"Conflicting chart aliases for Kube-OVN {chart_version}")
+        aliases[chart_version] = row
+        # Keep every exact tag until its deployed application image is verified.
+        rows.append(row)
     if not rows:
         raise ValueError("No stable Kube-OVN v2 chart versions found")
-    return [rows[version] for version in sorted(rows, reverse=True)]
+    return sorted(rows, key=lambda row: (
+        stable_version(row["version"]), stable_version(row["chart_version"]), row["chart_version"]
+    ), reverse=True)
 
 
 def chart_images(tag, current):
@@ -159,7 +160,7 @@ def chart_images(tag, current):
 def verify_images(rows, current, image_fetcher=None):
     if image_fetcher is None:
         image_fetcher = chart_images
-    verified = []
+    verified = {}
     for row in rows:
         images = image_fetcher(row["chart_version"], current)
         versions = set()
@@ -178,10 +179,14 @@ def verify_images(rows, current, image_fetcher=None):
             print(f"Skipping chart {row['chart_version']}: appVersion {row['version']} "
                   f"does not match rendered Kube-OVN versions {sorted(versions)}")
             continue
-        verified.append({**row, "images": images})
+        existing = verified.get(row["version"])
+        if existing is None or (stable_version(row["chart_version"]), row["chart_version"]) > (
+            stable_version(existing["chart_version"]), existing["chart_version"]
+        ):
+            verified[row["version"]] = {**row, "images": images}
     if not verified:
         raise ValueError("No Kube-OVN charts match their declared application version")
-    return verified
+    return [verified[version] for version in sorted(verified, key=stable_version, reverse=True)]
 
 
 def scrape():

--- a/utils/compatibility/tests/test_kube_ovn.py
+++ b/utils/compatibility/tests/test_kube_ovn.py
@@ -1,0 +1,218 @@
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+from types import ModuleType
+import unittest
+from unittest.mock import Mock, patch
+
+import requests
+import yaml
+
+
+PATH = Path(__file__).parents[1] / "scrapers" / "kube-ovn.py"
+spec = importlib.util.spec_from_file_location("kube_ovn", PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+
+def chart(tag, app=None, constraint=">= 1.29.0-0"):
+    return {
+        "name": "kube-ovn-v2",
+        "version": tag,
+        "appVersion": app or tag.removeprefix("v"),
+        "kubeVersion": constraint,
+    }
+
+
+def response(data, next_url=None):
+    result = Mock()
+    result.json.return_value = data
+    result.links = {"next": {"url": next_url}} if next_url else {}
+    return result
+
+
+class KubeOvnTests(unittest.TestCase):
+    def test_minor_floor_is_inclusive_and_bounded_by_plural(self):
+        self.assertEqual(
+            scraper.kubernetes_versions(">= 1.29.0-0", "1.31"),
+            ["1.31", "1.30", "1.29"],
+        )
+        self.assertEqual(scraper.kubernetes_versions(">=v1.29.0", "1.29"), ["1.29"])
+
+    def test_unsupported_constraints_never_broaden_compatibility(self):
+        for value in [None, "", ">=1.29.1", ">1.29.0", ">=1.29.0 <1.31.0",
+                      ">=1.29.0 || >=2.0.0", "^1.29.0", ">=2.0.0", ">=1.29.0-rc.1"]:
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                scraper.kubernetes_versions(value, "1.36")
+
+    def test_missing_or_older_plural_ceiling_fails(self):
+        for current in [None, "latest", "1.28", "2.0", "1.36.1"]:
+            with self.subTest(current=current), self.assertRaises(ValueError):
+                scraper.kubernetes_versions(">=1.29.0-0", current)
+
+    def test_chart_application_versions_and_exact_tags_are_distinct(self):
+        fixtures = {
+            "1.14.2": chart("1.14.2"),
+            "v1.15.1": chart("v1.15.1"),
+            "v1.15.2": chart("v1.15.2", app="1.15.1"),
+            "v1.16.0": chart("v1.16.0", constraint=">=1.30.0-0"),
+        }
+        tags = ["latest", "v1.17.0-rc.1", *fixtures, "v1.16.0"]
+        rows = scraper.build_rows(tags, "1.31", fixtures.__getitem__)
+        self.assertEqual([r["version"] for r in rows], ["1.16.0", "1.15.1", "1.14.2"])
+        self.assertEqual([r["chart_version"] for r in rows], ["v1.16.0", "v1.15.2", "1.14.2"])
+        self.assertEqual(rows[0]["kube"], ["1.31", "1.30"])
+        self.assertEqual(rows[1]["kube"], ["1.31", "1.30", "1.29"])
+
+    def test_order_and_alias_selection_are_deterministic(self):
+        tags = ["1.15.0", "v1.15.0", "v1.16.0"]
+        self.assertEqual(
+            scraper.build_rows(tags, "1.30", chart),
+            scraper.build_rows(list(reversed(tags)), "1.30", chart),
+        )
+
+    def test_conflicting_aliases_fail(self):
+        with self.assertRaisesRegex(ValueError, "Conflicting"):
+            scraper.build_rows(
+                ["1.15.0", "v1.15.0"], "1.31",
+                lambda tag: chart(tag, constraint=">=1.29.0" if tag[0] == "v" else ">=1.30.0"),
+            )
+
+    def test_bad_chart_metadata_fails(self):
+        bad = [None, [], {}, {**chart("1.15.0"), "name": "kube-ovn"},
+               chart("1.14.0"), chart("1.15.0", app="1.15.0-rc.1"),
+               {**chart("1.15.0"), "appVersion": None}]
+        for metadata in bad:
+            with self.subTest(metadata=metadata), self.assertRaises(ValueError):
+                scraper.build_rows(["1.15.0"], "1.30", lambda _: metadata)
+
+    def test_no_stable_charts_is_an_error(self):
+        with self.assertRaises(ValueError):
+            scraper.build_rows(["latest", "v1.0.0-rc.1", "01.2.3"], "1.36", Mock())
+
+    def test_fetch_chart_uses_helm_and_preserves_registry_tag(self):
+        with patch.object(scraper.subprocess, "run", return_value=Mock(
+            stdout=yaml.safe_dump(chart("v1.16.3"))
+        )) as run:
+            self.assertEqual(scraper.fetch_chart("v1.16.3"), chart("v1.16.3"))
+        self.assertEqual(run.call_args.args[0], [
+            "helm", "show", "chart", scraper.CHART_URL, "--version", "v1.16.3"
+        ])
+        self.assertTrue(run.call_args.kwargs["check"])
+        self.assertEqual(run.call_args.kwargs["timeout"], 60)
+
+    def test_fetch_chart_propagates_download_failure(self):
+        with patch.object(scraper.subprocess, "run", side_effect=subprocess.CalledProcessError(1, "helm")):
+            with self.assertRaises(subprocess.CalledProcessError):
+                scraper.fetch_chart("1.15.0")
+
+    def test_tags_pagination_deduplicates_and_sorts_semantically(self):
+        pages = [
+            response({"token": "test-anonymous-token"}),
+            response({"name": scraper.REGISTRY_PATH, "tags": ["v1.9.0", "1.14.2", "latest"]},
+                     "?n=3&last=latest"),
+            response({"name": scraper.REGISTRY_PATH, "tags": ["v1.16.3", "1.14.2", "v1.17.0-rc.1"]}),
+        ]
+        with patch.object(scraper.requests, "get", side_effect=pages) as get:
+            self.assertEqual(scraper.fetch_tags(), ["v1.16.3", "1.14.2", "v1.9.0"])
+        self.assertEqual(get.call_count, 3)
+        self.assertEqual(get.call_args.args[0], scraper.TAGS_URL + "?n=3&last=latest")
+
+    def test_pagination_rejects_external_and_repeated_links(self):
+        for link in ["https://example.com/token", "/v2/another/repo/tags/list",
+                     scraper.TAGS_URL + "?n=1000"]:
+            pages = [response({"token": "test-anonymous-token"}),
+                     response({"name": scraper.REGISTRY_PATH, "tags": []}, link)]
+            with self.subTest(link=link), patch.object(scraper.requests, "get", side_effect=pages) as get:
+                with self.assertRaisesRegex(ValueError, "pagination"):
+                    scraper.fetch_tags()
+                self.assertEqual(get.call_count, 2)
+
+    def test_malformed_tags_or_token_fails(self):
+        for payload in [{"name": "different/repository", "tags": []},
+                        {"name": scraper.REGISTRY_PATH, "tags": None},
+                        {"name": scraper.REGISTRY_PATH, "tags": [3]}]:
+            with self.subTest(payload=payload), patch.object(scraper.requests, "get", side_effect=[
+                response({"token": "test-anonymous-token"}), response(payload)
+            ]), self.assertRaises(ValueError):
+                scraper.fetch_tags()
+        with patch.object(scraper.requests, "get", return_value=response({})), self.assertRaises(ValueError):
+            scraper.fetch_tags()
+
+    def test_http_failure_is_not_an_empty_success(self):
+        failed = response({})
+        failed.raise_for_status.side_effect = requests.HTTPError("rate limited")
+        with patch.object(scraper.requests, "get", return_value=failed), self.assertRaises(requests.HTTPError):
+            scraper.fetch_tags()
+
+    def test_scrape_validates_all_charts_before_update(self):
+        helpers = ModuleType("utils")
+        helpers.current_kube_version = Mock(return_value="1.30")
+        helpers.update_compatibility_info = Mock()
+        with patch.dict(sys.modules, {"utils": helpers}), patch.object(
+            scraper, "fetch_tags", return_value=["1.15.0", "v1.16.0"]
+        ), patch.object(scraper.subprocess, "run", side_effect=[
+            Mock(stdout=yaml.safe_dump(chart("1.15.0"))),
+            Mock(stdout=yaml.safe_dump(chart("v1.16.0", constraint=">=1.31.0"))),
+        ]), self.assertRaises(ValueError):
+            scraper.scrape()
+        helpers.update_compatibility_info.assert_not_called()
+
+    def test_scrape_passes_validated_rows_to_catalog_updater(self):
+        helpers = ModuleType("utils")
+        helpers.current_kube_version = Mock(return_value="1.30")
+        helpers.update_compatibility_info = Mock()
+        with patch.dict(sys.modules, {"utils": helpers}), patch.object(
+            scraper, "fetch_tags", return_value=["1.15.0"]
+        ), patch.object(scraper.subprocess, "run", return_value=Mock(stdout=yaml.safe_dump(chart("1.15.0")))), patch.object(
+            scraper, "chart_images", return_value=["docker.io/kubeovn/kube-ovn:v1.15.0"]
+        ):
+            scraper.scrape()
+        helpers.update_compatibility_info.assert_called_once_with(
+            "../../static/compatibilities/kube-ovn.yaml",
+            [{"version": "1.15.0", "kube": ["1.30", "1.29"], "chart_version": "1.15.0",
+              "requirements": [], "incompatibilities": [],
+              "images": ["docker.io/kubeovn/kube-ovn:v1.15.0"]}],
+        )
+
+    def test_mislabelled_historical_charts_are_excluded(self):
+        rows = scraper.build_rows(["1.14.2", "1.15.0", "v1.15.1"], "1.30", chart)
+        images = {
+            "1.14.2": ["docker.io/kubeovn/kube-ovn:v1.14.0"],
+            "1.15.0": ["docker.io/kubeovn/kube-ovn:v1.14.0",
+                       "docker.io/kubeovn/vpc-nat-gateway:v1.15.0"],
+            "v1.15.1": ["docker.io/kubeovn/kube-ovn:v1.15.1",
+                        "docker.io/kubeovn/vpc-nat-gateway:v1.15.1"],
+        }
+        verified = scraper.verify_images(rows, "1.30", lambda tag, _: images[tag])
+        self.assertEqual([r["version"] for r in verified], ["1.15.1"])
+        self.assertEqual(verified[0]["images"], images["v1.15.1"])
+
+    def test_missing_or_unversioned_image_is_a_failure(self):
+        rows = scraper.build_rows(["v1.16.0"], "1.30", chart)
+        for images in [[], ["docker.io/kubeovn/vpc-nat-gateway:v1.16.0"],
+                       ["docker.io/kubeovn/kube-ovn:latest"]]:
+            with self.subTest(images=images), self.assertRaises(ValueError):
+                scraper.verify_images(rows, "1.30", lambda *_: images)
+
+    def test_all_mismatched_charts_are_an_error(self):
+        rows = scraper.build_rows(["1.15.0"], "1.30", chart)
+        with self.assertRaises(ValueError):
+            scraper.verify_images(rows, "1.30", lambda *_: ["kubeovn/kube-ovn:v1.14.0"])
+
+    def test_chart_image_download_failure_prevents_catalog_update(self):
+        helpers = ModuleType("utils")
+        helpers.current_kube_version = Mock(return_value="1.30")
+        helpers.update_compatibility_info = Mock()
+        with patch.dict(sys.modules, {"utils": helpers}), patch.object(
+            scraper, "fetch_tags", return_value=["v1.16.0"]
+        ), patch.object(scraper, "fetch_chart", return_value=chart("v1.16.0")), patch.object(
+            scraper, "chart_images", side_effect=subprocess.CalledProcessError(1, "helm")
+        ), self.assertRaises(subprocess.CalledProcessError):
+            scraper.scrape()
+        helpers.update_compatibility_info.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_kube_ovn.py
+++ b/utils/compatibility/tests/test_kube_ovn.py
@@ -60,6 +60,10 @@ class KubeOvnTests(unittest.TestCase):
         }
         tags = ["latest", "v1.17.0-rc.1", *fixtures, "v1.16.0"]
         rows = scraper.build_rows(tags, "1.31", fixtures.__getitem__)
+        self.assertEqual([r["chart_version"] for r in rows], ["v1.16.0", "v1.15.2", "v1.15.1", "1.14.2"])
+        rows = scraper.verify_images(
+            rows, "1.31", lambda tag, _: [f"kubeovn/kube-ovn:v{fixtures[tag]['appVersion']}"]
+        )
         self.assertEqual([r["version"] for r in rows], ["1.16.0", "1.15.1", "1.14.2"])
         self.assertEqual([r["chart_version"] for r in rows], ["v1.16.0", "v1.15.2", "1.14.2"])
         self.assertEqual(rows[0]["kube"], ["1.31", "1.30"])
@@ -67,10 +71,45 @@ class KubeOvnTests(unittest.TestCase):
 
     def test_order_and_alias_selection_are_deterministic(self):
         tags = ["1.15.0", "v1.15.0", "v1.16.0"]
+        rows = scraper.build_rows(tags, "1.30", chart)
         self.assertEqual(
-            scraper.build_rows(tags, "1.30", chart),
+            rows,
             scraper.build_rows(list(reversed(tags)), "1.30", chart),
         )
+        images = lambda tag, _: [f"kubeovn/kube-ovn:v{tag.removeprefix('v')}"]
+        verified = scraper.verify_images(rows, "1.30", images)
+        self.assertEqual(verified, scraper.verify_images(list(reversed(rows)), "1.30", images))
+        self.assertEqual([row["chart_version"] for row in verified], ["v1.16.0", "v1.15.0"])
+
+    def test_valid_chart_survives_mismatched_newer_candidate(self):
+        fixtures = {
+            "v1.15.1": chart("v1.15.1", constraint=">=1.29.0"),
+            "v1.15.2": chart("v1.15.2", app="1.15.1", constraint=">=1.30.0"),
+        }
+        for tags in [list(fixtures), list(reversed(fixtures))]:
+            with self.subTest(tags=tags):
+                rows = scraper.build_rows(tags, "1.31", fixtures.__getitem__)
+                images = {
+                    "v1.15.1": ["docker.io/kubeovn/kube-ovn:v1.15.1"],
+                    "v1.15.2": ["docker.io/kubeovn/kube-ovn:v1.14.0"],
+                }
+                verified = scraper.verify_images(rows, "1.31", lambda tag, _: images[tag])
+                self.assertEqual(len(verified), 1)
+                self.assertEqual(verified[0]["chart_version"], "v1.15.1")
+                self.assertEqual(verified[0]["kube"], ["1.31", "1.30", "1.29"])
+                self.assertEqual(verified[0]["images"], images["v1.15.1"])
+
+    def test_valid_exact_tag_survives_mismatched_alias(self):
+        for tags in [["1.15.0", "v1.15.0"], ["v1.15.0", "1.15.0"]]:
+            with self.subTest(tags=tags):
+                rows = scraper.build_rows(tags, "1.30", chart)
+                images = {
+                    "1.15.0": ["docker.io/kubeovn/kube-ovn:v1.15.0"],
+                    "v1.15.0": ["docker.io/kubeovn/kube-ovn:v1.14.0"],
+                }
+                verified = scraper.verify_images(rows, "1.30", lambda tag, _: images[tag])
+                self.assertEqual(len(verified), 1)
+                self.assertEqual(verified[0]["chart_version"], "1.15.0")
 
     def test_conflicting_aliases_fail(self):
         with self.assertRaisesRegex(ValueError, "Conflicting"):


### PR DESCRIPTION
Adds Kube-OVN to the compatibility catalog using the published `kube-ovn-v2` charts at `oci://ghcr.io/kubeovn/charts/kube-ovn-v2`. The contribution includes the scraper, generated compatibility data, manifest/aggregate registration and focused tests.

The scraper enumerates the public registry with pagination, reads each stable chart with Helm and checks its declared `kubeVersion` constraint. It expands the chart’s explicit Kubernetes minor floor through this repository’s `KUBE_VERSION`. These are Helm-declared installation requirements; no Kubernetes runtime certification is claimed. Unsupported constraint forms fail before the existing table is updated.

Each chart is also rendered locally to check its Kube-OVN image against `appVersion`. The historical `1.14.2` and `1.15.0` packages advertise newer application versions but deploy `kube-ovn:v1.14.0`; such mismatches are excluded. Exact registry tags are preserved, including historical tags without a `v` prefix. The legacy `kube-ovn` chart family is outside this catalog entry.

Related proposal #4250 covers the legacy chart and explicitly excludes the v2 chart implemented here.

Sources:

- [Official v2 chart installation instructions](https://github.com/kubeovn/kube-ovn/tree/v1.16.3/charts/kube-ovn-v2)
- [Tagged chart requirements](https://github.com/kubeovn/kube-ovn/blob/v1.16.3/charts/kube-ovn-v2/Chart.yaml)
- [Upstream operating-system and network prerequisites](https://kubeovn.github.io/docs/stable/en/start/prepare/)

This contribution was prepared with OpenAI Codex. I would like to request the advertised $300 new-scraper award under the Contributor Program if the contribution is accepted and merged, and will follow the program’s Discord verification process. Please confirm reward eligibility and the available payout method.

## Test Plan

Environment: Python 3.11.15, Helm 4.2.4, macOS arm64. No cluster or paid API was used.

- Full compatibility suite: 147 tests and 111 subtests pass, including 20 focused Kube-OVN tests.
- Read and rendered all 58 stable published charts; 56 match their declared application version and two mismatches are excluded.
- Two complete live runs produce byte-identical catalog output.
- All 58 compatibility YAML files pass the repository schema. Manifest, per-app table and aggregate data agree; previous aggregate content is unchanged.
- `git diff --check` passes.

The generated catalog contains four entries after the existing reducer combines equivalent patch releases. The latest application version is 1.16.3.

```sh
python -m pytest utils/compatibility/tests -q
python -m unittest discover -s utils/compatibility/tests -p 'test_kube_ovn.py' -v
```

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] I have included upstream documentation confirming the source of the compatibility information.
- [x] I have added tests to cover my changes.
- [ ] Agent deployment verification: not applicable to this scraper and static catalog contribution.

Plural Flow: console
