### PR TITLE
Add Couchbase Operator compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,48 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://couchbase-partners.github.io/helm-charts/assets/img/CB_Logomark_220.png
+  git_url: https://github.com/couchbase-partners/helm-charts
+  release_url: https://docs.couchbase.com/operator/current/release-notes.html
+  skip_release_summary: true
+  readme_url: https://raw.githubusercontent.com/couchbase-partners/helm-charts/master/README.md
+  helm_repository_url: https://couchbase-partners.github.io/helm-charts
+  chart_name: couchbase-operator
+  helm_values: install.couchbaseCluster=false,install.syncGateway=false
+  versions:
+  - version: 2.9.3
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.93.0
+    images: ['couchbase/admission-controller:2.9.3', 'couchbase/operator:2.9.3']
+  - version: 2.8.2
+    kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.82.0
+    images: ['couchbase/admission-controller:2.8.2', 'couchbase/operator:2.8.2']
+  - version: 2.7.1
+    kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.71.0
+    images: ['couchbase/admission-controller:2.7.1', 'couchbase/operator:2.7.1']
+  - version: 2.6.4
+    kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.64.1
+    images: ['couchbase/admission-controller:2.6.4', 'couchbase/operator:2.6.4']
+  - version: 2.5.0
+    kube: ['1.28', '1.27', '1.26', '1.25', '1.24']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.50.4
+    images: ['couchbase/admission-controller:2.5.0', 'couchbase/operator:2.5.0']
+  name: couchbase-operator

--- a/static/compatibilities/couchbase-operator.yaml
+++ b/static/compatibilities/couchbase-operator.yaml
@@ -1,0 +1,45 @@
+icon: https://couchbase-partners.github.io/helm-charts/assets/img/CB_Logomark_220.png
+git_url: https://github.com/couchbase-partners/helm-charts
+release_url: https://docs.couchbase.com/operator/current/release-notes.html
+# Release notes are minor-specific; do not use the current page for historical summaries.
+skip_release_summary: true
+readme_url: https://raw.githubusercontent.com/couchbase-partners/helm-charts/master/README.md
+helm_repository_url: https://couchbase-partners.github.io/helm-charts
+chart_name: couchbase-operator
+helm_values: install.couchbaseCluster=false,install.syncGateway=false
+versions:
+- version: 2.9.3
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.93.0
+  images: ['couchbase/admission-controller:2.9.3', 'couchbase/operator:2.9.3']
+- version: 2.8.2
+  kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.82.0
+  images: ['couchbase/admission-controller:2.8.2', 'couchbase/operator:2.8.2']
+- version: 2.7.1
+  kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.71.0
+  images: ['couchbase/admission-controller:2.7.1', 'couchbase/operator:2.7.1']
+- version: 2.6.4
+  kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.64.1
+  images: ['couchbase/admission-controller:2.6.4', 'couchbase/operator:2.6.4']
+- version: 2.5.0
+  kube: ['1.28', '1.27', '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.50.4
+  images: ['couchbase/admission-controller:2.5.0', 'couchbase/operator:2.5.0']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- couchbase-operator

--- a/utils/compatibility/scrapers/couchbase-operator.py
+++ b/utils/compatibility/scrapers/couchbase-operator.py
@@ -1,0 +1,121 @@
+import re
+
+from bs4 import BeautifulSoup
+import yaml
+
+from utils import fetch_page, print_error, read_yaml, update_compatibility_info
+
+
+app_name = "couchbase-operator"
+filepath = f"../../static/compatibilities/{app_name}.yaml"
+docs_url = "https://docs.couchbase.com/operator"
+page_name = "prerequisite-and-setup.html"
+helm_repository_url = "https://couchbase-partners.github.io/helm-charts"
+
+
+def stable_version(value):
+    text = str(value).strip().removeprefix("v")
+    if not re.fullmatch(r"\d+\.\d+\.\d+", text):
+        return None
+    return tuple(int(part) for part in text.split("."))
+
+
+def documented_versions(content):
+    soup = BeautifulSoup(content, "html.parser")
+    selector = soup.select_one('select[data-component="operator"]')
+    if selector is None:
+        raise ValueError("Couchbase documentation version selector not found")
+    versions = {
+        option.get("value", "") for option in selector.find_all("option")
+        if re.fullmatch(r"\d+\.\d+", option.get("value", ""))
+    }
+    if not versions:
+        raise ValueError("No released Couchbase documentation versions found")
+    return versions
+
+
+def latest_charts(content, doc_versions):
+    """Select actual stable appVersion/chart pairs, regardless of index order."""
+    index = yaml.safe_load(content)
+    entries = index.get("entries", {}).get(app_name, [])
+    selected = {}
+    for entry in entries:
+        app = stable_version(entry.get("appVersion", ""))
+        chart = stable_version(entry.get("version", ""))
+        if app is None or chart is None or entry.get("deprecated", False):
+            continue
+        minor = f"{app[0]}.{app[1]}"
+        if minor in doc_versions and (minor not in selected or (app, chart) > selected[minor]):
+            selected[minor] = (app, chart)
+    if not selected:
+        raise ValueError("No stable Couchbase charts match the documented releases")
+    return {
+        minor: (".".join(map(str, app)), ".".join(map(str, chart)))
+        for minor, (app, chart) in sorted(selected.items(), key=lambda item: item[1], reverse=True)
+    }
+
+
+def kubernetes_versions(content, minor):
+    soup = BeautifulSoup(content, "html.parser")
+    selected = soup.select_one('select[data-component="operator"] option[selected]')
+    # Versioned URLs may redirect to current when old documentation is removed.
+    if selected is None or selected.get("value") != minor:
+        raise ValueError(f"Couchbase documentation does not identify release {minor}")
+    table = soup.find("table", id="table-operator-compatibility")
+    if table is None:
+        raise ValueError(f"Couchbase {minor} Kubernetes compatibility table not found")
+    headers = [cell.get_text(" ", strip=True) for cell in table.find_all("th")]
+    if headers != ["Platform", "Version"]:
+        raise ValueError(f"Unexpected Couchbase {minor} compatibility table headers")
+    for row in table.find_all("tr"):
+        cells = row.find_all("td")
+        if not cells or cells[0].get_text(" ", strip=True) != "Open Source Kubernetes":
+            continue
+        if len(cells) != 2:
+            break
+        match = re.fullmatch(r"1\.(\d+)\s*[-–—]\s*1\.(\d+)", cells[1].get_text(" ", strip=True))
+        if match:
+            first, last = map(int, match.groups())
+            if first <= last:
+                return [f"1.{version}" for version in range(last, first - 1, -1)]
+        break
+    raise ValueError(f"No explicit Kubernetes version range for Couchbase {minor}")
+
+
+def scrape():
+    existing = read_yaml(filepath)
+    if not existing or not isinstance(existing.get("versions"), list):
+        print_error("Could not read Couchbase compatibility data")
+        return
+    recorded = {str(entry["version"]): entry for entry in existing["versions"]}
+    try:
+        landing = fetch_page(f"{docs_url}/current/{page_name}")
+        index = fetch_page(f"{helm_repository_url}/index.yaml")
+        if not landing or not index:
+            raise ValueError("Could not fetch Couchbase documentation or Helm index")
+        charts = latest_charts(index, documented_versions(landing))
+        versions = []
+        for minor, (version, chart_version) in charts.items():
+            # Moving release-family docs can gain support over time. Only add the
+            # latest concrete patch, retaining previously recorded release history.
+            if version in recorded:
+                previous = recorded[version]
+                previous_chart = stable_version(previous.get("chart_version", ""))
+                if previous_chart is None or stable_version(chart_version) > previous_chart:
+                    versions.append({**previous, "chart_version": chart_version})
+                continue
+            content = fetch_page(f"{docs_url}/{minor}/{page_name}")
+            if not content:
+                raise ValueError(f"Could not fetch Couchbase {minor} documentation")
+            versions.append({
+                "version": version,
+                "kube": kubernetes_versions(content, minor),
+                "chart_version": chart_version,
+                "requirements": [],
+                "incompatibilities": [],
+            })
+    except (ValueError, TypeError, AttributeError, yaml.YAMLError) as error:
+        print_error(str(error))
+        return
+    if versions:
+        update_compatibility_info(filepath, versions)

--- a/utils/compatibility/scrapers/couchbase-operator.py
+++ b/utils/compatibility/scrapers/couchbase-operator.py
@@ -102,7 +102,7 @@ def scrape():
                 previous = recorded[version]
                 previous_chart = stable_version(previous.get("chart_version", ""))
                 if previous_chart is None or stable_version(chart_version) > previous_chart:
-                    versions.append({**previous, "chart_version": chart_version})
+                    versions.append({**previous, "chart_version": chart_version, "images": []})
                 continue
             content = fetch_page(f"{docs_url}/{minor}/{page_name}")
             if not content:

--- a/utils/compatibility/summarizer.py
+++ b/utils/compatibility/summarizer.py
@@ -60,6 +60,8 @@ def _extract_requirement_changes(from_vsn, to_vsn):
     return changes
 
 def helm_summary(name, compatibility, from_vsn, to_vsn):
+  if compatibility.get('skip_release_summary') is True:
+      return None
   chart_url = compatibility.get('chart_changelog')
   release_url = compatibility.get('release_url')
   if not release_url and not chart_url:

--- a/utils/compatibility/tests/fixtures/couchbase-operator/2.5.html
+++ b/utils/compatibility/tests/fixtures/couchbase-operator/2.5.html
@@ -1,0 +1,31 @@
+<!-- Relevant upstream HTML fragments. Source: https://docs.couchbase.com/operator/2.5/prerequisite-and-setup.html; retrieved 2026-09-09. -->
+<meta content="2.5" name="dcterms.identifier"/>
+<select class="version_list" data-component="operator">
+<option data-url="../current/prerequisite-and-setup.html" value="2.9">2.9</option>
+<option data-url="../2.8/prerequisite-and-setup.html" value="2.8">2.8</option>
+<option data-url="../2.7/prerequisite-and-setup.html" value="2.7">2.7</option>
+<option data-url="../2.6/prerequisite-and-setup.html" value="2.6">2.6</option>
+<option data-url="prerequisite-and-setup.html" selected="" value="2.5">2.5</option>
+</select>
+<table class="tableblock frame-all grid-all stretch" id="table-operator-compatibility">
+<colgroup>
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Platform</th>
+<th class="tableblock halign-left valign-top">Version</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Open Source Kubernetes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.24 - 1.28</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Red Hat OpenShift Container Platform</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4.11 - 4.13</p></td>
+</tr>
+</tbody>
+</table>

--- a/utils/compatibility/tests/fixtures/couchbase-operator/2.6.html
+++ b/utils/compatibility/tests/fixtures/couchbase-operator/2.6.html
@@ -1,0 +1,31 @@
+<!-- Relevant upstream HTML fragments. Source: https://docs.couchbase.com/operator/2.6/prerequisite-and-setup.html; retrieved 2026-09-09. -->
+<meta content="2.6" name="dcterms.identifier"/>
+<select class="version_list" data-component="operator">
+<option data-url="../current/prerequisite-and-setup.html" value="2.9">2.9</option>
+<option data-url="../2.8/prerequisite-and-setup.html" value="2.8">2.8</option>
+<option data-url="../2.7/prerequisite-and-setup.html" value="2.7">2.7</option>
+<option data-url="prerequisite-and-setup.html" selected="" value="2.6">2.6</option>
+<option data-url="../2.5/prerequisite-and-setup.html" value="2.5">2.5</option>
+</select>
+<table class="tableblock frame-all grid-all stretch" id="table-operator-compatibility">
+<colgroup>
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Platform</th>
+<th class="tableblock halign-left valign-top">Version</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Open Source Kubernetes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.25 - 1.32</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Red Hat OpenShift Container Platform</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4.12 - 4.18</p></td>
+</tr>
+</tbody>
+</table>

--- a/utils/compatibility/tests/fixtures/couchbase-operator/2.7.html
+++ b/utils/compatibility/tests/fixtures/couchbase-operator/2.7.html
@@ -1,0 +1,31 @@
+<!-- Relevant upstream HTML fragments. Source: https://docs.couchbase.com/operator/2.7/prerequisite-and-setup.html; retrieved 2026-09-09. -->
+<meta content="2.7" name="dcterms.identifier"/>
+<select class="version_list" data-component="operator">
+<option data-url="../current/prerequisite-and-setup.html" value="2.9">2.9</option>
+<option data-url="../2.8/prerequisite-and-setup.html" value="2.8">2.8</option>
+<option data-url="prerequisite-and-setup.html" selected="" value="2.7">2.7</option>
+<option data-url="../2.6/prerequisite-and-setup.html" value="2.6">2.6</option>
+<option data-url="../2.5/prerequisite-and-setup.html" value="2.5">2.5</option>
+</select>
+<table class="tableblock frame-all grid-all stretch" id="table-operator-compatibility">
+<colgroup>
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Platform</th>
+<th class="tableblock halign-left valign-top">Version</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Open Source Kubernetes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.26 - 1.34</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Red Hat OpenShift Container Platform</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4.13 - 4.19</p></td>
+</tr>
+</tbody>
+</table>

--- a/utils/compatibility/tests/fixtures/couchbase-operator/2.8.html
+++ b/utils/compatibility/tests/fixtures/couchbase-operator/2.8.html
@@ -1,0 +1,31 @@
+<!-- Relevant upstream HTML fragments. Source: https://docs.couchbase.com/operator/2.8/prerequisite-and-setup.html; retrieved 2026-09-09. -->
+<meta content="2.8" name="dcterms.identifier"/>
+<select class="version_list" data-component="operator">
+<option data-url="../current/prerequisite-and-setup.html" value="2.9">2.9</option>
+<option data-url="prerequisite-and-setup.html" selected="" value="2.8">2.8</option>
+<option data-url="../2.7/prerequisite-and-setup.html" value="2.7">2.7</option>
+<option data-url="../2.6/prerequisite-and-setup.html" value="2.6">2.6</option>
+<option data-url="../2.5/prerequisite-and-setup.html" value="2.5">2.5</option>
+</select>
+<table class="tableblock frame-all grid-all stretch" id="table-operator-compatibility">
+<colgroup>
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Platform</th>
+<th class="tableblock halign-left valign-top">Version</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Open Source Kubernetes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.29 - 1.34</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Red Hat OpenShift Container Platform</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4.16 - 4.20</p></td>
+</tr>
+</tbody>
+</table>

--- a/utils/compatibility/tests/fixtures/couchbase-operator/2.9.html
+++ b/utils/compatibility/tests/fixtures/couchbase-operator/2.9.html
@@ -1,0 +1,31 @@
+<!-- Relevant upstream HTML fragments. Source: https://docs.couchbase.com/operator/2.9/prerequisite-and-setup.html; retrieved 2026-09-09. -->
+<meta content="2.9" name="dcterms.identifier"/>
+<select class="version_list" data-component="operator">
+<option data-url="prerequisite-and-setup.html" selected="" value="2.9">2.9</option>
+<option data-url="../2.8/prerequisite-and-setup.html" value="2.8">2.8</option>
+<option data-url="../2.7/prerequisite-and-setup.html" value="2.7">2.7</option>
+<option data-url="../2.6/prerequisite-and-setup.html" value="2.6">2.6</option>
+<option data-url="../2.5/prerequisite-and-setup.html" value="2.5">2.5</option>
+</select>
+<table class="tableblock frame-all grid-all stretch" id="table-operator-compatibility">
+<colgroup>
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Platform</th>
+<th class="tableblock halign-left valign-top">Version</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Open Source Kubernetes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.31 - 1.35</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Red Hat OpenShift Container Platform</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4.18 - 4.20</p></td>
+</tr>
+</tbody>
+</table>

--- a/utils/compatibility/tests/fixtures/couchbase-operator/README.md
+++ b/utils/compatibility/tests/fixtures/couchbase-operator/README.md
@@ -1,0 +1,32 @@
+# Couchbase Operator fixture sources
+
+Retrieved on 2026-09-09 from the official published documentation:
+
+- `2.9.html`: https://docs.couchbase.com/operator/2.9/prerequisite-and-setup.html
+- `2.8.html`: https://docs.couchbase.com/operator/2.8/prerequisite-and-setup.html
+- `2.7.html`: https://docs.couchbase.com/operator/2.7/prerequisite-and-setup.html
+- `2.6.html`: https://docs.couchbase.com/operator/2.6/prerequisite-and-setup.html
+- `2.5.html`: https://docs.couchbase.com/operator/2.5/prerequisite-and-setup.html
+- `index.yaml`: https://couchbase-partners.github.io/helm-charts/index.yaml
+
+The HTML fixtures retain only the release identifier, version selector and
+`table-operator-compatibility` table; surrounding navigation and product prose
+are omitted. The Helm fixture retains the application/chart identities and
+artifact fields for the 2.4–2.9 families. It includes the older 2.4 entries to
+verify that charts absent from the published documentation selector are skipped.
+
+The scraper records the latest stable chart/application pair in each currently
+published documentation family (2.5–2.9 at capture time). Each versioned page
+supplies its own **Open Source Kubernetes** interval. OpenShift and managed
+provider versions are not used as Kubernetes compatibility evidence. Previously
+recorded application versions are retained when the moving family docs change.
+New chart releases for an already recorded Operator refresh the chart and images
+without replacing the previously recorded Kubernetes interval.
+
+The catalog sets `skip_release_summary: true`: the vendor's release notes use
+minor-version URLs, so the global `current` navigation link cannot provide
+accurate historical upgrade summaries. Other add-ons retain the existing
+automatic summary behavior.
+
+These fixtures verify parsing and version mapping, not archive integrity or
+runtime compatibility. Live Helm rendering is a separate validation step.

--- a/utils/compatibility/tests/fixtures/couchbase-operator/index.yaml
+++ b/utils/compatibility/tests/fixtures/couchbase-operator/index.yaml
@@ -1,0 +1,200 @@
+# Relevant upstream entries. Source: https://couchbase-partners.github.io/helm-charts/index.yaml
+# Retrieved 2026-09-09; only app/chart identity and artifact fields retained.
+entries:
+  couchbase-operator:
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.93.0
+    appVersion: 2.9.3
+    digest: 09527e27484f44110607d31b857e8feb7649c7aebcbc51637e3b255231754f22
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.93.0/couchbase-operator-2.93.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.92.0
+    appVersion: 2.9.2
+    digest: cbc74e2fbfcd6a08ecc963a420806aed79cb2dad33846444b91ac7e340ac6681
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.92.0/couchbase-operator-2.92.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.91.0
+    appVersion: 2.9.1
+    digest: dfb8e5335f8d82b997ccd01bb57ab75c0c45fa5775323a596efcac8d87c6ad34
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.91.0/couchbase-operator-2.91.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.90.0
+    appVersion: 2.9.0
+    digest: 4ebcbfa9e53f35c08820281940611b965fd8aceea0f6f3805e21a690d8764464
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.90.0/couchbase-operator-2.90.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.82.0
+    appVersion: 2.8.2
+    digest: bcd07ae511febe9f6a814579fa9d325d59f6c3f44ff75482671b3aa94f4d5fff
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.82.0/couchbase-operator-2.82.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.81.1
+    appVersion: 2.8.1
+    digest: efa7d20b3907e5eb99a614f71a41d7457599ec08e10ae2e06266af83fa0ee48a
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.81.1/couchbase-operator-2.81.1.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.81.0
+    appVersion: 2.8.1
+    digest: b9c233ae07ce864ae48f5f392c4aea8956a6d31de6bd0840fe8548d0a6dc141b
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.81.0/couchbase-operator-2.81.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.80.3
+    appVersion: 2.8.0
+    digest: f482c497754d1e5cedbe7061687b6652ae1dd6f667b2c35b880c5c06ccc21702
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.80.3/couchbase-operator-2.80.3.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.80.2
+    appVersion: 2.8.0
+    digest: 80c1590c22d66910683458ce2683b469bf06feb7877c6d2992ef99d66ed4ee87
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.80.2/couchbase-operator-2.80.2.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.80.1
+    appVersion: 2.8.0
+    digest: 69d5bcc86848f068f7b3ae18b70226d8f0255f2456c03fd7ed5f2d6bf66df955
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.80.1/couchbase-operator-2.80.1.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.80.0
+    appVersion: 2.8.0
+    digest: a357b737c732e5b04aad4abcb959f14b2c078d776be5b7274651c5490fcef48a
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.80.0/couchbase-operator-2.80.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.71.0
+    appVersion: 2.7.1
+    digest: 8f92ca67a891a200f04058a114a1ed08317cc28f6523541b28359935f3659f7d
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.71.0/couchbase-operator-2.71.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.70.1
+    appVersion: 2.7.0
+    digest: 427c2432e565582664a9bae6a5580741f2a29a425e5a20496843730fe215bd54
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.70.1/couchbase-operator-2.70.1.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.70.0
+    appVersion: 2.7.0
+    digest: fde4dfeb9b77916a3535e7695bdfdb68d9dc3529e162f5a250050df7e8ab686f
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.70.0/couchbase-operator-2.70.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.64.1
+    appVersion: 2.6.4
+    digest: 0f5305ee83719fd832f184eda34f1a5ae8acb7088c5d3e45dde9b8149fd98699
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.64.1/couchbase-operator-2.64.1.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.64.0
+    appVersion: 2.6.4
+    digest: 3e5072b789c058148684bb2b7e5ba0b391c7596582dfa8e2cdd914dd04825c35
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.64.0/couchbase-operator-2.64.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.62.0
+    appVersion: 2.6.2
+    digest: 587d18c46b61a3f8be16ec6d6e3a8a67b3d484ac9ff7879672c1e8fb45efafbd
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.62.0/couchbase-operator-2.62.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.61.0
+    appVersion: 2.6.1
+    digest: 330af6abc5316d0be4e88f19b332a2644e73cb481c58f7a6a5d337efb6ac23be
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.61.0/couchbase-operator-2.61.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.60.0
+    appVersion: 2.6.0
+    digest: b2e8b2d9546e6ff23fc63a2ae2e090b58dca17a1cad28c0f3c3302a2c54db5e2
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.60.0/couchbase-operator-2.60.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.50.4
+    appVersion: 2.5.0
+    digest: 3be4bd46414d7cae15a48940d620395b83a7cb232f19a999c5185623aa0c52c1
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.50.4/couchbase-operator-2.50.4.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.50.3
+    appVersion: 2.5.0
+    digest: e39d483f16c68c0b9f9c62f0c526c76a964cf9ec032ca6c8df90607267647eb6
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.50.3/couchbase-operator-2.50.3.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.50.2
+    appVersion: 2.5.0
+    digest: 3eaf14ea48553590640a8ef34b9a5bb2c940cf84efd42e41eddc0a8f79a4298d
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.50.2/couchbase-operator-2.50.2.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.50.1
+    appVersion: 2.5.0
+    digest: 5a4c17c2e90f7477b9f2f71a89520c823ef347754c2fe8d388536698bd8b862a
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.50.1/couchbase-operator-2.50.1.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.42.1
+    appVersion: 2.4.2
+    digest: ed4a5f2d2a91da3f4e41a80a6012fa41bb6516c9bce65b6bbc3145ca57ef2e36
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.42.1/couchbase-operator-2.42.1.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.42.0
+    appVersion: 2.4.2
+    digest: dd00ec5519a456a0d6554c8f7ee44345023c20293f2e5af1eab9f6897f83f755
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.42.0/couchbase-operator-2.42.0.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.41.1
+    appVersion: 2.4.1
+    digest: 87f033ee403ef0b7acb1d8b92376b343ff9bb4ea90790a8f88e9f708b7c18c89
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.41.1/couchbase-operator-2.41.1.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.40.1
+    appVersion: 2.4.0
+    digest: e91e596fdd79de645bbf2c6b095ce02342dc2458a45204bc2db8ef6f012050af
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.40.1/couchbase-operator-2.40.1.tgz
+  - apiVersion: v2
+    name: couchbase-operator
+    version: 2.40.0
+    appVersion: 2.4.0
+    digest: 18f64ac154f0de1b1ceb8df5a7153c8724364cc1d6f28f4dc6a721da46de26f7
+    urls:
+    - https://github.com/couchbase-partners/helm-charts/releases/download/couchbase-operator-2.40.0/couchbase-operator-2.40.0.tgz

--- a/utils/compatibility/tests/test_couchbase_operator.py
+++ b/utils/compatibility/tests/test_couchbase_operator.py
@@ -1,0 +1,184 @@
+"""Offline checks: python -m unittest discover -s tests -p 'test_couchbase_operator.py'."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+import yaml
+
+COMPATIBILITY = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPATIBILITY))
+spec = importlib.util.spec_from_file_location(
+    "couchbase_operator_scraper", COMPATIBILITY / "scrapers/couchbase-operator.py"
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+import summarizer
+import utils
+FIXTURES = Path(__file__).parent / "fixtures/couchbase-operator"
+
+
+class CouchbaseOperatorTests(unittest.TestCase):
+    def setUp(self):
+        self.pages = {minor: (FIXTURES / f"{minor}.html").read_bytes()
+                      for minor in ("2.9", "2.8", "2.7", "2.6", "2.5")}
+        self.index = (FIXTURES / "index.yaml").read_bytes()
+        self.sources = {
+            f"{scraper.docs_url}/current/{scraper.page_name}": self.pages["2.9"],
+            f"{scraper.helm_repository_url}/index.yaml": self.index,
+            **{f"{scraper.docs_url}/{minor}/{scraper.page_name}": page
+               for minor, page in self.pages.items()},
+        }
+        self.existing = {"versions": []}
+
+    def run_scrape(self):
+        with patch.object(scraper, "fetch_page", side_effect=self.sources.get) as fetch, \
+                patch.object(scraper, "read_yaml", return_value=self.existing), \
+                patch.object(scraper, "update_compatibility_info") as update, \
+                patch.object(scraper, "print_error"):
+            scraper.scrape()
+        return update, fetch
+
+    def test_real_tables_keep_each_release_range_and_exclude_openshift(self):
+        limits = {"2.9": (31, 35), "2.8": (29, 34), "2.7": (26, 34),
+                  "2.6": (25, 32), "2.5": (24, 28)}
+        for minor, (first, last) in limits.items():
+            with self.subTest(minor=minor):
+                self.assertEqual(scraper.kubernetes_versions(self.pages[minor], minor),
+                                 [f"1.{n}" for n in range(last, first - 1, -1)])
+
+    def test_real_chart_pairs_select_latest_stable_patch_for_published_families(self):
+        minors = scraper.documented_versions(self.pages["2.9"])
+        self.assertEqual(minors, set(self.pages))
+        self.assertEqual(scraper.latest_charts(self.index, minors), {
+            "2.9": ("2.9.3", "2.93.0"), "2.8": ("2.8.2", "2.82.0"),
+            "2.7": ("2.7.1", "2.71.0"), "2.6": ("2.6.4", "2.64.1"),
+            "2.5": ("2.5.0", "2.50.4"),
+        })
+        # Older chart families remain in the index but are not published in the selector.
+        self.assertIn(b'appVersion: 2.4.2', self.index)
+
+    def test_chart_selection_is_order_independent_and_rejects_prereleases(self):
+        index = yaml.safe_load(self.index)
+        entries = index["entries"][scraper.app_name]
+        entries.reverse()
+        entries[:0] = [
+            {"appVersion": "2.9.4-rc.1", "version": "2.94.0"},
+            {"appVersion": "2.9.4", "version": "2.94.0-beta.1"},
+            {"appVersion": "2.9.4", "version": "2.94.0", "deprecated": True},
+            {"appVersion": "2.9.3", "version": "2.93.1-rc.1"},
+            {"appVersion": "2.10.0", "version": "2.100.0"},
+        ]
+        self.assertEqual(scraper.latest_charts(yaml.safe_dump(index), {"2.9"}),
+                         {"2.9": ("2.9.3", "2.93.0")})
+
+    def test_missing_wrong_and_unbounded_tables_fail_closed(self):
+        page = self.pages["2.9"]
+        variants = [
+            page.replace(b'id="table-operator-compatibility"', b'id="another-table"'),
+            page.replace(b'Open Source Kubernetes', b'Google Kubernetes Engine'),
+            page.replace(b'1.31 - 1.35', b'1.31+'),
+            page.replace(b'1.31 - 1.35', b'1.35 - 1.31'),
+            page.replace(b'1.31 - 1.35', b'1.31 - 1.35*'),
+        ]
+        for content in variants:
+            with self.subTest(content=content):
+                with self.assertRaises(ValueError):
+                    scraper.kubernetes_versions(content, "2.9")
+
+    def test_redirect_to_current_cannot_supply_historical_compatibility(self):
+        with self.assertRaises(ValueError):
+            scraper.kubernetes_versions(self.pages["2.9"], "2.8")
+
+    def test_full_scrape_adds_five_exact_versions(self):
+        update, fetch = self.run_scrape()
+        update.assert_called_once()
+        rows = update.call_args.args[1]
+        self.assertEqual([row["version"] for row in rows],
+                         ["2.9.3", "2.8.2", "2.7.1", "2.6.4", "2.5.0"])
+        self.assertEqual(rows[0]["chart_version"], "2.93.0")
+        self.assertEqual(rows[-1]["kube"], ["1.28", "1.27", "1.26", "1.25", "1.24"])
+        self.assertEqual(fetch.call_count, 7)
+
+    def test_failed_or_redirected_page_prevents_partial_write(self):
+        for content in (None, self.pages["2.9"]):
+            with self.subTest(content=content):
+                self.sources[f"{scraper.docs_url}/2.8/{scraper.page_name}"] = content
+                update, _ = self.run_scrape()
+                update.assert_not_called()
+
+    def test_discovery_failure_prevents_write(self):
+        self.sources[f"{scraper.docs_url}/current/{scraper.page_name}"] = b'<html>No versions</html>'
+        update, _ = self.run_scrape()
+        update.assert_not_called()
+
+    def test_empty_index_and_unreadable_catalog_prevent_write(self):
+        self.sources[f"{scraper.helm_repository_url}/index.yaml"] = b'entries: {}'
+        update, _ = self.run_scrape()
+        update.assert_not_called()
+        self.existing = None
+        update, fetch = self.run_scrape()
+        update.assert_not_called()
+        fetch.assert_not_called()
+
+    def test_recorded_release_is_preserved_when_family_docs_change(self):
+        old = {"version": "2.9.3", "chart_version": "2.93.0", "kube": ["1.31"]}
+        self.existing["versions"].append(old)
+        update, fetch = self.run_scrape()
+        self.assertNotIn("2.9.3", [row["version"] for row in update.call_args.args[1]])
+        self.assertEqual(old["kube"], ["1.31"])
+        self.assertNotIn(f"{scraper.docs_url}/2.9/{scraper.page_name}",
+                         [call.args[0] for call in fetch.call_args_list])
+
+    def test_new_chart_for_recorded_operator_preserves_historical_range(self):
+        old = {"version": "2.6.4", "chart_version": "2.64.0", "kube": ["1.25"],
+               "summary": {"features": ["Previously recorded"]}}
+        self.existing["versions"].append(old)
+        update, fetch = self.run_scrape()
+        row = next(row for row in update.call_args.args[1] if row["version"] == "2.6.4")
+        self.assertEqual(row, {**old, "chart_version": "2.64.1"})
+        self.assertEqual(old["chart_version"], "2.64.0")
+        self.assertNotIn(f"{scraper.docs_url}/2.6/{scraper.page_name}",
+                         [call.args[0] for call in fetch.call_args_list])
+
+    def test_catalog_writer_keeps_data_without_fetching_wrong_release_summaries(self):
+        catalog_path = COMPATIBILITY.parents[1] / "static/compatibilities/couchbase-operator.yaml"
+        catalog = yaml.safe_load(catalog_path.read_text(encoding="utf-8"))
+        rows = [{"version": "2.9.3", "chart_version": "2.93.0", "kube": ["1.35"]},
+                {"version": "2.8.2", "chart_version": "2.82.0", "kube": ["1.34"]}]
+        catalog["versions"] = []
+        with patch.object(utils, "read_yaml", return_value=catalog), \
+                patch.object(utils, "get_chart_images", return_value=[]), \
+                patch.object(utils, "summarization_enabled", return_value=True), \
+                patch.object(utils, "write_yaml", return_value=True) as write, \
+                patch.object(utils, "print_success"), \
+                patch.object(summarizer, "fetch_page") as fetch, \
+                patch.object(summarizer, "_get_exa") as exa, \
+                patch.object(summarizer, "_get_oai_client") as oai:
+            utils.update_compatibility_info(scraper.filepath, rows)
+        write.assert_called_once()
+        self.assertEqual(len(write.call_args.args[1]["versions"]), 2)
+        self.assertTrue(all(row["summary"] is None for row in write.call_args.args[1]["versions"]))
+        fetch.assert_not_called()
+        exa.assert_not_called()
+        oai.assert_not_called()
+
+    def test_other_addons_keep_the_existing_release_summary_fetch(self):
+        for extra in ({}, {"skip_release_summary": False}):
+            with self.subTest(extra=extra), patch.object(summarizer, "_get_exa") as exa, \
+                    patch.object(summarizer, "_get_oai_client") as oai:
+                exa.return_value.get_contents.return_value.results = []
+                summarizer.helm_summary("another-addon", {
+                    "release_url": "https://example.com/releases/{vsn}", **extra,
+                }, {"version": "1.0.0", "chart_version": "1.0.0"},
+                   {"version": "1.1.0", "chart_version": "1.1.0"})
+                urls = exa.return_value.get_contents.call_args.args[0]
+                self.assertEqual(set(urls), {"https://example.com/releases/1.0.0",
+                                             "https://example.com/releases/1.1.0"})
+                oai.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/compatibility/tests/test_couchbase_operator.py
+++ b/utils/compatibility/tests/test_couchbase_operator.py
@@ -134,14 +134,28 @@ class CouchbaseOperatorTests(unittest.TestCase):
 
     def test_new_chart_for_recorded_operator_preserves_historical_range(self):
         old = {"version": "2.6.4", "chart_version": "2.64.0", "kube": ["1.25"],
-               "summary": {"features": ["Previously recorded"]}}
+               "summary": {"features": ["Previously recorded"]}, "images": ["previous-chart:old"]}
         self.existing["versions"].append(old)
         update, fetch = self.run_scrape()
         row = next(row for row in update.call_args.args[1] if row["version"] == "2.6.4")
-        self.assertEqual(row, {**old, "chart_version": "2.64.1"})
+        self.assertEqual(row, {**old, "chart_version": "2.64.1", "images": []})
         self.assertEqual(old["chart_version"], "2.64.0")
+        self.assertEqual(old["images"], ["previous-chart:old"])
         self.assertNotIn(f"{scraper.docs_url}/2.6/{scraper.page_name}",
                          [call.args[0] for call in fetch.call_args_list])
+
+        # The shared writer keeps a row when rendering yields no images. It must
+        # not publish the previous chart's images alongside the new chart version.
+        with patch.object(utils, "read_yaml", return_value={
+            "versions": [old], "helm_repository_url": scraper.helm_repository_url,
+        }), patch.object(utils, "get_chart_images", return_value=None), \
+                patch.object(utils, "summarization_enabled", return_value=False), \
+                patch.object(utils, "write_yaml", return_value=True) as write, \
+                patch.object(utils, "print_success"), patch.object(utils, "print_warning"):
+            utils.update_compatibility_info(scraper.filepath, [row])
+        written = write.call_args.args[1]["versions"][0]
+        self.assertEqual(written["chart_version"], "2.64.1")
+        self.assertEqual(written["images"], [])
 
     def test_catalog_writer_keeps_data_without_fetching_wrong_release_summaries(self):
         catalog_path = COMPATIBILITY.parents[1] / "static/compatibilities/couchbase-operator.yaml"


### PR DESCRIPTION
Couchbase Kubernetes Operator is missing from the add-on compatibility catalog. This adds a scraper and generated entries for the latest stable Operator/chart pair in each currently published documentation family, with Operator and Admission Controller images obtained through the existing Helm renderer.

| Operator | Helm chart | Documented Kubernetes range |
| --- | --- | --- |
| 2.9.3 | 2.93.0 | 1.31–1.35 |
| 2.8.2 | 2.82.0 | 1.29–1.34 |
| 2.7.1 | 2.71.0 | 1.26–1.34 |
| 2.6.4 | 2.64.1 | 1.25–1.32 |
| 2.5.0 | 2.50.4 | 1.24–1.28 |

Sources are the official [versioned requirements](https://docs.couchbase.com/operator/2.9/prerequisite-and-setup.html) and [Helm index](https://couchbase-partners.github.io/helm-charts/index.yaml). The requirements state that patch releases inherit their family's support level unless otherwise noted. The fixture README links all five source pages. Coverage follows the currently published 2.5–2.9 documentation families; it does not claim every historical Operator release.

The scraper validates each page's release identifier and explicit `Open Source Kubernetes` interval before writing. Existing recorded intervals are preserved; a newer chart for the same Operator updates its chart and rendered images. Chart rendering disables creation of the Couchbase database cluster and Sync Gateway.

Couchbase's release notes use minor-specific URLs. Its catalog therefore explicitly skips automatic release summaries, with a small opt-out in `helm_summary()`, to avoid using the current 2.9 release page for historical upgrades. Existing add-ons retain their summary behavior.

## Test Plan

- `python -m unittest discover -s utils/compatibility/tests -p 'test_*.py' -q`: **114 passed**, including 13 new regressions.
- Live documentation/index scrape reproduced all five checked-in mappings.
- All five charts rendered through the existing writer with Helm 4.2.4; exact Operator/Admission image tags checked. A second scraper run left the catalog unchanged.
- JSON Schema validation passed for 58 YAML files; the existing 53 aggregate entries are unchanged.
- Validation ran locally on Windows/Python 3.14.6. No Kubernetes runtime deployment is claimed; compatibility ranges come from the vendor documentation.

Upstream packaging note: chart 2.71.0's downloaded archive digest differs from its Helm index digest. Its `Chart.yaml` is semantically identical and `values.yaml` byte-identical to the official chart tag; it rendered successfully. The other four archives matched their index digests.

## Checklist

- [x] Meaningful title and summary.
- [x] Source documentation and fixture provenance included.
- [x] Tests cover the new scraper and summary opt-out.
- [ ] Agent deployment to a test environment (not applicable to this scraper contribution).

Prepared using Codex. Submitted under the Contributor Program's new scraper category; please confirm reward eligibility after review.
