### PR TITLE
Add Trident Operator release-specific compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,174 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://raw.githubusercontent.com/NetApp/trident/master/logo/trident.png
+  git_url: https://github.com/NetApp/trident
+  release_url: https://github.com/NetApp/trident/releases
+  readme_url: https://docs.netapp.com/us-en/trident/trident-get-started/requirements.html
+  helm_repository_url: https://netapp.github.io/trident-helm-chart
+  chart_name: trident-operator
+  versions:
+  - version: 26.6.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2606.1
+    images: ['docker.io/netapp/trident-operator:26.06.1']
+  - version: 26.6.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2606.0
+    images: ['docker.io/netapp/trident-operator:26.06.0']
+  - version: 26.2.0
+    kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2602.0
+    images: ['docker.io/netapp/trident-operator:26.02.0']
+  - version: 25.10.0
+    kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2510.0
+    images: ['docker.io/netapp/trident-operator:25.10.0']
+  - version: 25.6.0
+    kube: ['1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2506.0
+    images: ['docker.io/netapp/trident-operator:25.06.0']
+  - version: 25.2.0
+    kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2502.0
+    images: ['docker.io/netapp/trident-operator:25.02.0']
+  - version: 24.10.1
+    kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2410.1
+    images: ['docker.io/netapp/trident-operator:24.10.1']
+  - version: 24.10.0
+    kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2410.0
+    images: ['docker.io/netapp/trident-operator:24.10.0']
+  - version: 24.6.0
+    kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2406.0
+    images: ['docker.io/netapp/trident-operator:24.06.0']
+  - version: 24.2.0
+    kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 100.2402.0
+    images: ['docker.io/netapp/trident-operator:24.02.0']
+  - version: 23.10.0
+    kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 23.10.0
+    images: ['docker.io/netapp/trident-operator:23.10.0']
+  - version: 23.7.0
+    kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 23.07.0
+    images: ['docker.io/netapp/trident-operator:23.07.0']
+  - version: 23.4.0
+    kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 23.04.0
+    images: ['docker.io/netapp/trident-operator:23.04.0']
+  - version: 23.1.0
+    kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 23.01.0
+    images: ['docker.io/netapp/trident-operator:23.01.0']
+  - version: 22.10.0
+    kube: ['1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 22.10.0
+    images: ['docker.io/netapp/trident-operator:22.10.0']
+  - version: 22.7.0
+    kube: ['1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 22.07.0
+    images: ['docker.io/netapp/trident-operator:22.07.0']
+  - version: 22.4.0
+    kube: ['1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 22.04.0
+    images: ['netapp/trident-operator:22.04.0']
+  - version: 22.1.0
+    kube: ['1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 22.01.0
+    images: ['netapp/trident-operator:22.01.0']
+  - version: 21.10.0
+    kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 21.10.0
+    images: ['netapp/trident-operator:21.10.0']
+  - version: 21.7.2
+    kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 21.07.2
+    images: ['netapp/trident-operator:21.07.2']
+  - version: 21.7.1
+    kube: ['1.21', '1.20', '1.19', '1.18', '1.17']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 21.07.1
+    images: ['netapp/trident-operator:21.07.1']
+  - version: 21.4.0
+    kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 21.04.0
+    images: ['netapp/trident-operator:21.04.0']
+  - version: 21.1.0
+    kube: ['1.20', '1.19', '1.18', '1.17', '1.16']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 21.01.0
+    images: ['netapp/trident-operator:21.01.0']
+  name: trident-operator

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- trident-operator

--- a/static/compatibilities/trident-operator.yaml
+++ b/static/compatibilities/trident-operator.yaml
@@ -1,0 +1,168 @@
+icon: https://raw.githubusercontent.com/NetApp/trident/master/logo/trident.png
+git_url: https://github.com/NetApp/trident
+release_url: https://github.com/NetApp/trident/releases
+readme_url: https://docs.netapp.com/us-en/trident/trident-get-started/requirements.html
+helm_repository_url: https://netapp.github.io/trident-helm-chart
+chart_name: trident-operator
+versions:
+- version: 26.6.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2606.1
+  images: ['docker.io/netapp/trident-operator:26.06.1']
+- version: 26.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2606.0
+  images: ['docker.io/netapp/trident-operator:26.06.0']
+- version: 26.2.0
+  kube: ['1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2602.0
+  images: ['docker.io/netapp/trident-operator:26.02.0']
+- version: 25.10.0
+  kube: ['1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2510.0
+  images: ['docker.io/netapp/trident-operator:25.10.0']
+- version: 25.6.0
+  kube: ['1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2506.0
+  images: ['docker.io/netapp/trident-operator:25.06.0']
+- version: 25.2.0
+  kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2502.0
+  images: ['docker.io/netapp/trident-operator:25.02.0']
+- version: 24.10.1
+  kube: ['1.32', '1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2410.1
+  images: ['docker.io/netapp/trident-operator:24.10.1']
+- version: 24.10.0
+  kube: ['1.31', '1.30', '1.29', '1.28', '1.27', '1.26', '1.25']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2410.0
+  images: ['docker.io/netapp/trident-operator:24.10.0']
+- version: 24.6.0
+  kube: ['1.30', '1.29', '1.28', '1.27', '1.26', '1.25', '1.24']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2406.0
+  images: ['docker.io/netapp/trident-operator:24.06.0']
+- version: 24.2.0
+  kube: ['1.29', '1.28', '1.27', '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 100.2402.0
+  images: ['docker.io/netapp/trident-operator:24.02.0']
+- version: 23.10.0
+  kube: ['1.28', '1.27', '1.26', '1.25', '1.24', '1.23']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 23.10.0
+  images: ['docker.io/netapp/trident-operator:23.10.0']
+- version: 23.7.0
+  kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 23.07.0
+  images: ['docker.io/netapp/trident-operator:23.07.0']
+- version: 23.4.0
+  kube: ['1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 23.04.0
+  images: ['docker.io/netapp/trident-operator:23.04.0']
+- version: 23.1.0
+  kube: ['1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 23.01.0
+  images: ['docker.io/netapp/trident-operator:23.01.0']
+- version: 22.10.0
+  kube: ['1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 22.10.0
+  images: ['docker.io/netapp/trident-operator:22.10.0']
+- version: 22.7.0
+  kube: ['1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 22.07.0
+  images: ['docker.io/netapp/trident-operator:22.07.0']
+- version: 22.4.0
+  kube: ['1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 22.04.0
+  images: ['netapp/trident-operator:22.04.0']
+- version: 22.1.0
+  kube: ['1.23', '1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 22.01.0
+  images: ['netapp/trident-operator:22.01.0']
+- version: 21.10.0
+  kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 21.10.0
+  images: ['netapp/trident-operator:21.10.0']
+- version: 21.7.2
+  kube: ['1.22', '1.21', '1.20', '1.19', '1.18', '1.17']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 21.07.2
+  images: ['netapp/trident-operator:21.07.2']
+- version: 21.7.1
+  kube: ['1.21', '1.20', '1.19', '1.18', '1.17']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 21.07.1
+  images: ['netapp/trident-operator:21.07.1']
+- version: 21.4.0
+  kube: ['1.21', '1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 21.04.0
+  images: ['netapp/trident-operator:21.04.0']
+- version: 21.1.0
+  kube: ['1.20', '1.19', '1.18', '1.17', '1.16']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 21.01.0
+  images: ['netapp/trident-operator:21.01.0']

--- a/utils/compatibility/scrapers/trident-operator.py
+++ b/utils/compatibility/scrapers/trident-operator.py
@@ -16,8 +16,24 @@ CONFIG_URL = "https://raw.githubusercontent.com/NetApp/trident/v{version}/config
 
 def version_parts(value):
     # Trident uses zero-padded calendar versions, including historical chart versions.
-    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", str(value))
-    return tuple(map(int, match.groups())) if match else None
+    if not isinstance(value, str):
+        raise ValueError(f"Expected a release version string, got {value!r}")
+    match = re.fullmatch(r"v?([0-9]+)\.([0-9]+)\.([0-9]+)([-+].*)?", value)
+    if not match:
+        raise ValueError(f"Invalid release version: {value!r}")
+    parts = tuple(map(int, match.group(1, 2, 3)))
+    suffix = match.group(4) or ""
+    # Validate suffixes after normalizing the calendar-version core. Only a
+    # well-formed prerelease may be skipped; malformed metadata must stop a refresh.
+    try:
+        parsed = semantic_version.Version(".".join(map(str, parts)) + suffix)
+    except ValueError as exc:
+        raise ValueError(f"Invalid release version: {value!r}") from exc
+    if parsed.prerelease:
+        return None
+    if parsed.build:
+        raise ValueError(f"Unsupported build metadata in release version: {value!r}")
+    return parts
 
 
 def parse_charts(content):

--- a/utils/compatibility/scrapers/trident-operator.py
+++ b/utils/compatibility/scrapers/trident-operator.py
@@ -1,0 +1,115 @@
+"""Trident support bounds from release-tagged code, intersected with Helm constraints."""
+
+import re
+from collections import OrderedDict
+
+import semantic_version
+import requests
+import yaml
+
+from utils import fetch_page, print_error, update_compatibility_info
+
+APP_NAME = "trident-operator"
+INDEX_URL = "https://netapp.github.io/trident-helm-chart/index.yaml"
+CONFIG_URL = "https://raw.githubusercontent.com/NetApp/trident/v{version}/config/config.go"
+
+
+def version_parts(value):
+    # Trident uses zero-padded calendar versions, including historical chart versions.
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", str(value))
+    return tuple(map(int, match.groups())) if match else None
+
+
+def parse_charts(content):
+    index = yaml.safe_load(content)
+    entries = index.get("entries", {}).get(APP_NAME) if isinstance(index, dict) else None
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("Trident chart entries not found")
+    selected = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("Malformed Trident chart entry")
+        app = version_parts(entry.get("appVersion"))
+        chart = version_parts(entry.get("version"))
+        if not app or not chart:
+            continue
+        if entry.get("name") != APP_NAME:
+            raise ValueError("Unexpected chart name")
+        if not isinstance(entry.get("kubeVersion"), str):
+            raise ValueError("Missing chart Kubernetes constraint")
+        old = selected.get(app)
+        if old is None or chart > version_parts(old["version"]):
+            selected[app] = entry
+        elif chart == version_parts(old["version"]) and entry != old:
+            raise ValueError("Conflicting duplicate chart entries")
+    if not selected:
+        raise ValueError("No stable Trident chart releases")
+    return [selected[key] for key in sorted(selected, reverse=True)]
+
+
+def parse_supported_versions(content, chart_constraint):
+    text = content.decode("utf-8") if isinstance(content, bytes) else content
+    # Ignore comments so commented-out or explanatory assignments cannot become support data.
+    text = re.sub(r"/\*.*?\*/|//[^\n]*", "", text, flags=re.DOTALL)
+    bounds = {}
+    for name in ("Min", "Max"):
+        matches = re.findall(
+            rf'^\s*KubernetesVersion{name}\s*=\s*"v?(\d+)\.(\d+)(?:\.0)?"\s*$',
+            text,
+            re.MULTILINE,
+        )
+        if len(matches) != 1:
+            raise ValueError(f"Expected one KubernetesVersion{name} assignment")
+        bounds[name] = tuple(map(int, matches[0]))
+    lower, upper = bounds["Min"], bounds["Max"]
+    if lower[0] != 1 or upper[0] != 1 or lower > upper:
+        raise ValueError("Unsupported or reversed Kubernetes range")
+    # Only minor-version constraints can be represented by this catalog. Refuse a
+    # future patch-sensitive constraint instead of advertising an entire minor.
+    token = r"(?:>=|<)\s*v?\d+\.\d+\.0(?:-0)?"
+    if not re.fullmatch(rf"\s*{token}(?:\s+{token})*\s*", chart_constraint):
+        raise ValueError("Unsupported chart Kubernetes constraint")
+    normalized = " ".join(re.sub(r"\s+", "", part) for part in re.findall(token, chart_constraint))
+    spec = semantic_version.NpmSpec(normalized)
+    versions = [
+        f"1.{minor}"
+        for minor in range(upper[1], lower[1] - 1, -1)
+        if spec.match(semantic_version.Version(f"1.{minor}.0"))
+        and spec.match(semantic_version.Version(f"1.{minor}.1"))
+    ]
+    if not versions:
+        raise ValueError("Chart and application Kubernetes ranges do not overlap")
+    return versions
+
+
+def build_rows(content, fetch):
+    rows = []
+    for chart in parse_charts(content):
+        original = str(chart["appVersion"]).removeprefix("v")
+        url = CONFIG_URL.format(version=original)
+        config = fetch(url)
+        if not config:
+            # Build everything before invoking the writer: a failed release fetch
+            # must not publish a partially refreshed table.
+            raise ValueError(f"Could not fetch release configuration: {url}")
+        kube = parse_supported_versions(config, chart["kubeVersion"])
+        rows.append(OrderedDict([
+            ("version", ".".join(map(str, version_parts(original)))),
+            ("kube", kube),
+            ("chart_version", str(chart["version"])),
+            ("requirements", []),
+            ("incompatibilities", []),
+        ]))
+    return rows
+
+
+def scrape():
+    try:
+        content = fetch_page(INDEX_URL)
+        if not content:
+            raise ValueError("Could not fetch Trident Helm index")
+        rows = build_rows(content, fetch_page)
+    except (ValueError, TypeError, yaml.YAMLError, requests.RequestException) as exc:
+        print_error(f"Trident compatibility scrape failed: {exc}")
+        return
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", rows)

--- a/utils/compatibility/tests/TRIDENT.md
+++ b/utils/compatibility/tests/TRIDENT.md
@@ -1,0 +1,57 @@
+# Trident Operator compatibility sources
+
+The scraper uses the official [Trident Helm index](https://netapp.github.io/trident-helm-chart/index.yaml)
+to discover released application/chart pairs. Each pair is joined to the
+application's **exact release tag** in `NetApp/trident/config/config.go`.
+`KubernetesVersionMin` and `KubernetesVersionMax` specify its supported range.
+The result is intersected with that chart's `kubeVersion` constraint.
+
+This matters in both directions:
+
+- [26.06.1](https://github.com/NetApp/trident/blob/v26.06.1/config/config.go)
+  supports 1.27–1.36; the chart's permissive `>= 1.24.0-0` alone overstates support.
+  NetApp's [26.06 requirements](https://docs.netapp.com/us-en/trident/trident-get-started/requirements.html)
+  independently document the same supported frontend range.
+- [21.04.0](https://github.com/NetApp/trident/blob/v21.04.0/config/config.go)
+  has a legacy application minimum of 1.11, but its operator chart requires
+  `>= 1.16.0 < 1.22.0`. Only the intersection, 1.16–1.21, is advertised.
+- [24.10.0](https://github.com/NetApp/trident/blob/v24.10.0/config/config.go)
+  ends at Kubernetes 1.31; [24.10.1](https://github.com/NetApp/trident/blob/v24.10.1/config/config.go)
+  adds 1.32. Reading only one configuration per release family would miss this.
+
+All 36 stable application versions in the index at validation time (2026-09-09)
+were checked. The repository's normal reduction retains 23 rows, including
+patch-level changes in support. The range is not extended to Plural's current
+Kubernetes version: old releases retain their own explicit upper bounds.
+
+Trident's zero-padded calendar versions are normalized to repository-compatible
+semantic versions (`26.06.1` → `26.6.1`). Original strings are retained for source
+tag lookups and chart versions. The release link points to the upstream release
+list because substituting normalized versions into its tag URLs would break them.
+
+Prereleases are excluded. Missing or malformed release evidence aborts before
+the catalog writer runs. Chart constraints involving patch-level bounds or
+unsupported syntax are rejected instead of guessed. A future upstream syntax
+change will need a parser update.
+
+## Validation
+
+From `utils/compatibility`, with its requirements and pytest installed:
+
+```sh
+PYTHONPATH=. python -m pytest tests -q
+```
+
+The new tests cover release/chart intersections, historical bounds, calendar
+version mapping, patch-level support changes, duplicate handling, malformed
+inputs, network failures, standard writer integration, and repeat-run stability.
+
+The local integration check also verified every downloaded Helm chart against
+the index SHA256 and compared its packaged Chart.yaml metadata with the index.
+Helm 4.2.4 rendered all 36 packages at both supported endpoints (72 renders).
+Rendered image references populated the catalog. Catalog, manifest and aggregate
+passed `schema.json`; a second run of the shared writer was byte-identical.
+
+These checks validate metadata and manifest generation, not a live Kubernetes
+installation or storage I/O. NetApp backend, node and feature prerequisites
+still apply; the Kubernetes table is not a complete deployment readiness check.

--- a/utils/compatibility/tests/TRIDENT.md
+++ b/utils/compatibility/tests/TRIDENT.md
@@ -29,7 +29,10 @@ semantic versions (`26.06.1` → `26.6.1`). Original strings are retained for so
 tag lookups and chart versions. The release link points to the upstream release
 list because substituting normalized versions into its tag URLs would break them.
 
-Prereleases are excluded. Missing or malformed release evidence aborts before
+Only syntactically valid prereleases are excluded. Both application and chart
+versions are validated before an entry is skipped. Missing or malformed version
+metadata, and stable versions with unsupported build metadata, abort before the
+catalog writer runs. Missing or malformed release evidence also aborts before
 the catalog writer runs. Chart constraints involving patch-level bounds or
 unsupported syntax are rejected instead of guessed. A future upstream syntax
 change will need a parser update.

--- a/utils/compatibility/tests/test_trident_operator.py
+++ b/utils/compatibility/tests/test_trident_operator.py
@@ -62,6 +62,39 @@ def test_chart_selection_skips_prereleases_and_chooses_newest_chart():
     assert [(x["appVersion"], x["version"]) for x in charts] == [("26.06.1", "100.2606.2"), ("25.10.0", "100.2510.0")]
 
 
+@pytest.mark.parametrize("field", ["appVersion", "version"])
+@pytest.mark.parametrize("value", [None, "", "garbage", "26.06", "26.06.1-", "26.06.1-rc..1", "26.06.1-01", "26.06.1+build.1", 26.06])
+def test_malformed_release_alongside_valid_release_aborts_before_writing(field, value):
+    invalid = chart()
+    invalid[field] = value
+    content = index(chart(), invalid)
+    with pytest.raises(ValueError, match="version"):
+        scraper.parse_charts(content)
+    with patch.object(scraper, "fetch_page", return_value=content), patch.object(scraper, "update_compatibility_info") as write:
+        scraper.scrape()
+        write.assert_not_called()
+
+
+@pytest.mark.parametrize("field", ["appVersion", "version"])
+def test_missing_release_version_is_rejected(field):
+    invalid = chart()
+    del invalid[field]
+    with pytest.raises(ValueError, match="version"):
+        scraper.parse_charts(index(chart(), invalid))
+
+
+@pytest.mark.parametrize("suffix", ["-rc.1", "-beta.2+build.7", "-0"])
+def test_recognized_prereleases_are_skipped(suffix):
+    result = scraper.parse_charts(index(chart(), chart(app="v26.06.2" + suffix), chart(version="100.2606.2" + suffix)))
+    assert result == [chart()]
+
+
+@pytest.mark.parametrize("invalid", [chart(app="26.06.1-rc.1", version="broken"), chart(app="broken", version="100.2606.1-rc.1")])
+def test_prerelease_does_not_hide_malformed_partner_version(invalid):
+    with pytest.raises(ValueError, match="version"):
+        scraper.parse_charts(index(chart(), invalid))
+
+
 def test_conflicting_duplicate_is_rejected():
     with pytest.raises(ValueError, match="Conflicting"):
         scraper.parse_charts(index(chart(), chart(constraint=">=1.28.0")))

--- a/utils/compatibility/tests/test_trident_operator.py
+++ b/utils/compatibility/tests/test_trident_operator.py
@@ -1,0 +1,130 @@
+import importlib
+from unittest.mock import patch
+
+import pytest
+import requests
+import yaml
+
+from utils import reduce_versions, update_compatibility_info
+
+scraper = importlib.import_module("scrapers.trident-operator")
+
+
+def config(low="v1.27", high="v1.36"):
+    return f'const (\n KubernetesVersionMin = "{low}"\n KubernetesVersionMax = "{high}"\n)'
+
+
+def chart(app="26.06.1", version="100.2606.1", constraint=">= 1.24.0-0"):
+    return dict(name="trident-operator", appVersion=app, version=version, kubeVersion=constraint)
+
+
+def index(*charts):
+    return yaml.safe_dump({"entries": {"trident-operator": list(charts)}})
+
+
+def test_release_limits_override_looser_installer_minimum():
+    versions = scraper.parse_supported_versions(config(), ">= 1.24.0-0")
+    assert versions == [f"1.{n}" for n in range(36, 26, -1)]
+
+
+def test_historical_operator_chart_excludes_legacy_application_versions():
+    versions = scraper.parse_supported_versions(config("v1.11.0", "v1.21.0"), ">= 1.16.0 < 1.22.0")
+    assert versions == [f"1.{n}" for n in range(21, 15, -1)]
+
+
+def test_exclusive_upper_chart_bound():
+    assert scraper.parse_supported_versions(config("v1.20", "v1.22"), ">=1.20.0 <1.22.0-0") == ["1.21", "1.20"]
+
+
+def test_single_supported_minor():
+    assert scraper.parse_supported_versions(config("v1.36", "v1.36"), ">=1.36.0-0") == ["1.36"]
+
+
+@pytest.mark.parametrize("content", ["", config().replace("KubernetesVersionMax", "OtherMax"), config() + config(), config("v1.36", "v1.27"), config("v1.36", "v2.0"), config("v1.27.3")])
+def test_malformed_source_is_rejected(content):
+    with pytest.raises(ValueError):
+        scraper.parse_supported_versions(content, ">=1.24.0-0")
+
+
+def test_commented_assignments_are_ignored():
+    text = '// KubernetesVersionMin = "v1.1"\n/*\nKubernetesVersionMax = "v1.99"\n*/\n' + config()
+    assert scraper.parse_supported_versions(text, ">=1.24.0-0")[0] == "1.36"
+
+
+@pytest.mark.parametrize("constraint", [">=1.27.1", "<1.20.0", "nonsense", "<=1.30.0", "^1.27.0", ">=1.27.0 || >=2.0.0"])
+def test_unrepresentable_or_disjoint_chart_constraints_are_rejected(constraint):
+    with pytest.raises(ValueError):
+        scraper.parse_supported_versions(config(), constraint)
+
+
+def test_chart_selection_skips_prereleases_and_chooses_newest_chart():
+    charts = scraper.parse_charts(index(chart(), chart("26.06.1", "100.2606.2"), chart("26.10.0-rc.1"), chart(version="100.2610.0-beta.1"), chart("25.10.0", "100.2510.0")))
+    assert [(x["appVersion"], x["version"]) for x in charts] == [("26.06.1", "100.2606.2"), ("25.10.0", "100.2510.0")]
+
+
+def test_conflicting_duplicate_is_rejected():
+    with pytest.raises(ValueError, match="Conflicting"):
+        scraper.parse_charts(index(chart(), chart(constraint=">=1.28.0")))
+
+
+@pytest.mark.parametrize("content", ["[]", "entries: {}", "entries: {trident-operator: []}"])
+def test_missing_index_is_rejected(content):
+    with pytest.raises(ValueError):
+        scraper.parse_charts(content)
+
+
+def test_calver_normalization_preserves_original_tag_and_chart():
+    urls = []
+    def fetch(url):
+        urls.append(url)
+        return config()
+    row = scraper.build_rows(index(chart()), fetch)[0]
+    assert row["version"] == "26.6.1"
+    assert row["chart_version"] == "100.2606.1"
+    assert urls == [scraper.CONFIG_URL.format(version="26.06.1")]
+
+
+def test_patch_level_support_change_survives_repository_reduction():
+    charts = index(chart("24.10.0", "100.2410.0"), chart("24.10.1", "100.2410.1"))
+    rows = scraper.build_rows(charts, lambda url: config("v1.25", "v1.32" if "24.10.1" in url else "v1.31"))
+    reduced = reduce_versions(rows)
+    assert len(reduced) == 2
+    assert "1.32" in reduced[0]["kube"]
+    assert "1.32" not in reduced[1]["kube"]
+
+
+@pytest.mark.parametrize("failure", [None, "bad config", requests.Timeout("timeout")])
+def test_fetch_or_parse_failure_never_calls_writer(failure):
+    def fetch(url):
+        if url == scraper.INDEX_URL:
+            return index(chart(), chart("25.10.0", "100.2510.0"))
+        if "26.06.1" in url:
+            return config()
+        if isinstance(failure, Exception):
+            raise failure
+        return failure
+    with patch.object(scraper, "fetch_page", side_effect=fetch), patch.object(scraper, "update_compatibility_info") as write:
+        scraper.scrape()
+        write.assert_not_called()
+
+
+def test_real_writer_preserves_metadata_and_is_idempotent(tmp_path):
+    path = tmp_path / "trident-operator.yaml"
+    metadata = {"icon": "https://example.org/icon.png", "git_url": "https://github.com/NetApp/trident", "versions": []}
+    path.write_text(yaml.safe_dump(metadata))
+    rows = scraper.build_rows(index(chart()), lambda url: config())
+    with patch("utils.summarization_enabled", return_value=False):
+        update_compatibility_info(str(path), rows)
+        first = path.read_bytes()
+        update_compatibility_info(str(path), rows)
+    assert first == path.read_bytes()
+    data = yaml.safe_load(first)
+    assert data["icon"] == metadata["icon"]
+    assert data["versions"][0]["version"] == "26.6.1"
+
+
+def test_success_uses_standard_catalog_writer():
+    with patch.object(scraper, "fetch_page", side_effect=[index(chart()), config()]), patch.object(scraper, "update_compatibility_info") as write:
+        scraper.scrape()
+        assert write.call_args.args[0] == "../../static/compatibilities/trident-operator.yaml"
+        assert write.call_args.args[1][0]["version"] == "26.6.1"


### PR DESCRIPTION
Trident Operator is missing from the compatibility catalog. This adds its scraper, metadata, generated table and aggregate entry, covering all 36 stable application releases in the official Helm index (23 rows after the existing reduction).

The scraper intersects each exact release's supported Kubernetes bounds with its chart constraints. For example, 26.06.1 supports 1.27–1.36 despite its chart permitting 1.24+, and 24.10.1 adds support for 1.32 that 24.10.0 lacks. Historical chart minimums are also respected. Original calendar-version strings are preserved for release lookups and chart identifiers.

Evidence:
- [Official chart index](https://netapp.github.io/trident-helm-chart/index.yaml)
- [26.06.1 supported bounds](https://github.com/NetApp/trident/blob/v26.06.1/config/config.go)
- [NetApp requirements](https://docs.netapp.com/us-en/trident/trident-get-started/requirements.html)
- [24.10.0](https://github.com/NetApp/trident/blob/v24.10.0/config/config.go) and [24.10.1](https://github.com/NetApp/trident/blob/v24.10.1/config/config.go)

## Test Plan

- Compatibility suite: **181 tests and 81 subtests passed**, including 54 new Trident test cases.
- Verified SHA256 and packaged Chart.yaml identity for **36 official chart archives**.
- **72 Helm renders passed**, covering both supported endpoints for every archive; generated image references included.
- Catalog, manifest and aggregate validated against the repository schema; shared writer repeat run was byte-identical.
- `git diff --check` passed.
- No live Kubernetes deployment or storage I/O test was performed. Source selection and limitations are documented in `utils/compatibility/tests/TRIDENT.md`.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] If required, I have updated the Plural documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have deployed the agent to a test environment and verified that it works as expected (not applicable: no agent code changes).

This contribution was implemented and tested with OpenAI Codex. No personal human code review is claimed. I am submitting it for consideration under the README's $300 new-scraper contributor program, subject to your acceptance, eligibility checks and one-award-per-month limit. No reward is assumed before acceptance. Please confirm the available payout method when reviewing eligibility; Discord identity linkage can be completed for the claim.

Plural Flow: console
