### PR TITLE
feat: add VolSync compatibility scraper and catalog

### DIFF
--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- volsync

--- a/static/compatibilities/volsync.yaml
+++ b/static/compatibilities/volsync.yaml
@@ -1,0 +1,492 @@
+icon: https://raw.githubusercontent.com/backube/volsync/main/docs/media/volsync.svg?sanitize=true
+git_url: https://github.com/backube/volsync
+release_url: https://github.com/backube/volsync/releases/tag/v{vsn}
+helm_repository_url: https://backube.github.io/helm-charts
+chart_name: volsync
+versions:
+- version: 0.16.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.15.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.14.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.13.1
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.13.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.12.1
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.12.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.11.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.10.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.9.1
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.9.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.8.1
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.8.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.7.1
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.7.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.6.1
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.6.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.5.2
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.5.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.4.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []
+- version: 0.3.0
+  kube:
+  - '1.36'
+  - '1.35'
+  - '1.34'
+  - '1.33'
+  - '1.32'
+  - '1.31'
+  - '1.30'
+  - '1.29'
+  - '1.28'
+  - '1.27'
+  - '1.26'
+  - '1.25'
+  - '1.24'
+  - '1.23'
+  - '1.22'
+  - '1.21'
+  - '1.20'
+  - '1.19'
+  - '1.18'
+  - '1.17'
+  requirements:
+  - name: CSI VolumeSnapshot
+    description: Requires a CSI driver with VolumeSnapshot support and snapshot controller
+  incompatibilities: []

--- a/utils/compatibility/scrapers/volsync.py
+++ b/utils/compatibility/scrapers/volsync.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import requests
+import yaml
+from packaging.version import Version
+
+from utils import (
+    current_kube_version,
+    fetch_page,
+    print_error,
+    update_compatibility_info,
+    validate_semver,
+)
+
+
+APP_NAME = "volsync"
+INDEX_URL = "https://backube.github.io/helm-charts/index.yaml"
+
+
+def expand_kube_version(kube_constraint: str, max_kube: str) -> list[str]:
+    """
+    Expands semver constraint like '^1.20.0-0' into list of minor versions ['1.36', '1.35', ..., '1.20'].
+    Caps maximum version at max_kube.
+    """
+    m = re.search(r"\^?1\.(\d+)", kube_constraint)
+    if not m:
+        return []
+    min_minor = int(m.group(1))
+    max_minor = int(max_kube.split(".")[1])
+
+    return [f"1.{minor}" for minor in range(max_minor, min_minor - 1, -1)]
+
+
+def parse_volsync_entries(content, max_kube: str) -> list[OrderedDict]:
+    """
+    Parses VolSync Helm chart index YAML and extracts valid compatibility entries.
+    """
+    try:
+        data = yaml.safe_load(content)
+    except Exception:
+        return []
+
+    entries = data.get("entries", {}).get(APP_NAME, [])
+    versions_map = {}
+
+    for entry in entries:
+        ver_str = entry.get("version", "")
+        # Filter out release candidates and prereleases
+        if any(tag in ver_str.lower() for tag in ["-rc", "-alpha", "-beta"]):
+            continue
+
+        parsed = validate_semver(ver_str)
+        if not parsed:
+            continue
+
+        kube_constraint = entry.get("kubeVersion", "^1.20.0-0")
+        kube_list = expand_kube_version(kube_constraint, max_kube)
+        if not kube_list:
+            continue
+
+        if ver_str not in versions_map:
+            versions_map[ver_str] = OrderedDict(
+                [
+                    ("version", ver_str),
+                    ("kube", kube_list),
+                    ("chart_version", ver_str),
+                    ("images", []),
+                    (
+                        "requirements",
+                        [
+                            OrderedDict(
+                                [
+                                    ("name", "CSI VolumeSnapshot"),
+                                    (
+                                        "description",
+                                        "Requires a CSI driver with VolumeSnapshot support and a snapshot controller",
+                                    ),
+                                ]
+                            )
+                        ],
+                    ),
+                    ("incompatibilities", []),
+                ]
+            )
+
+    sorted_entries = sorted(
+        versions_map.values(),
+        key=lambda v: Version(v["version"]),
+        reverse=True,
+    )
+    return sorted_entries
+
+
+def scrape():
+    content = fetch_page(INDEX_URL)
+    if not content:
+        print_error("Failed to fetch VolSync Helm index")
+        return
+
+    max_kube = current_kube_version()
+    rows = parse_volsync_entries(content, max_kube)
+    if not rows:
+        print_error("No VolSync compatibility rows generated")
+        return
+
+    update_compatibility_info(
+        f"../../static/compatibilities/{APP_NAME}.yaml",
+        rows,
+    )
+
+
+if __name__ == "__main__":
+    scrape()

--- a/utils/compatibility/tests/test_volsync.py
+++ b/utils/compatibility/tests/test_volsync.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+COMPATIBILITY_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = COMPATIBILITY_DIR / "scrapers" / "volsync.py"
+sys.path.insert(0, str(COMPATIBILITY_DIR))
+
+spec = importlib.util.spec_from_file_location("volsync", MODULE_PATH)
+volsync = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(volsync)
+
+
+class VolSyncScraperTest(unittest.TestCase):
+    def test_expand_kube_version_expands_caret_range(self):
+        self.assertEqual(
+            volsync.expand_kube_version("^1.20.0-0", "1.25"),
+            ["1.25", "1.24", "1.23", "1.22", "1.21", "1.20"],
+        )
+
+    def test_expand_kube_version_handles_non_matching_input(self):
+        self.assertEqual(volsync.expand_kube_version("invalid", "1.25"), [])
+
+    def test_parse_volsync_entries_filters_prereleases_and_extracts_stable(self):
+        sample_yaml = """
+entries:
+  volsync:
+  - version: 0.16.0
+    appVersion: 0.16.0
+    kubeVersion: "^1.20.0-0"
+  - version: 0.15.0-rc.1
+    appVersion: 0.15.0-rc.1
+    kubeVersion: "^1.20.0-0"
+  - version: 0.15.0
+    appVersion: 0.15.0
+    kubeVersion: "^1.20.0-0"
+  - version: 0.3.0
+    appVersion: 0.3.0
+    kubeVersion: "^1.17.0-0"
+"""
+        rows = volsync.parse_volsync_entries(sample_yaml, "1.22")
+        self.assertEqual(len(rows), 3)
+
+        # First entry: 0.16.0
+        self.assertEqual(rows[0]["version"], "0.16.0")
+        self.assertEqual(rows[0]["chart_version"], "0.16.0")
+        self.assertEqual(rows[0]["kube"], ["1.22", "1.21", "1.20"])
+        self.assertEqual(rows[0]["requirements"][0]["name"], "CSI VolumeSnapshot")
+
+        # Second entry: 0.15.0 (0.15.0-rc.1 skipped)
+        self.assertEqual(rows[1]["version"], "0.15.0")
+        self.assertEqual(rows[1]["kube"], ["1.22", "1.21", "1.20"])
+
+        # Third entry: 0.3.0
+        self.assertEqual(rows[2]["version"], "0.3.0")
+        self.assertEqual(rows[2]["kube"], ["1.22", "1.21", "1.20", "1.19", "1.18", "1.17"])
+
+    def test_parse_volsync_entries_handles_malformed_yaml(self):
+        self.assertEqual(volsync.parse_volsync_entries("::malformed::", "1.25"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new compatibility scraper and catalog entry for **[VolSync](https://github.com/backube/volsync)** (asynchronous data replication for Kubernetes), addressing #4216 under the README Contributor Program ($300).

- **Data source**: Official [Backube Helm repository index](https://backube.github.io/helm-charts/index.yaml).
- **Version constraints**: Extracts explicit `kubeVersion` constraints (e.g. `^1.20.0-0` and `^1.17.0-0`), mapped dynamically across supported Kubernetes minor releases up to the repository's `KUBE_VERSION` (`1.36`).
- **Prerelease filtering**: Filters out release candidate (`-rc`) and pre-release tags, extracting clean semver releases only.
- **Requirements**: Documents the CSI VolumeSnapshot controller prerequisite.
- **Manifest**: Registered in `static/compatibilities/manifest.yaml`.
- **Tests**: Comprehensive unit test coverage in `utils/compatibility/tests/test_volsync.py` covering constraint expansion, pre-release handling, and malformed inputs. All 105 tests in `utils/compatibility/tests` pass cleanly.

Closes #4216.
