### PR TITLE
feat(compatibility): add chart-backed Kuadrant operator scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -32696,3 +32696,74 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://raw.githubusercontent.com/Kuadrant/kuadrant.github.io/main/static/img/apple-touch-icon.png
+  git_url: https://github.com/Kuadrant/kuadrant-operator
+  release_url: https://github.com/Kuadrant/kuadrant-operator/releases/tag/v{vsn}
+  readme_url: https://github.com/Kuadrant/helm-charts/blob/main/README.md
+  helm_repository_url: https://kuadrant.io/helm-charts/
+  chart_name: kuadrant-operator
+  versions:
+  - version: 1.5.3
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.5.3
+    images: ['quay.io/kuadrant/authorino-operator:v0.25.3', 'quay.io/kuadrant/dns-operator:v0.17.2',
+      'quay.io/kuadrant/kuadrant-operator:v1.5.3', 'quay.io/kuadrant/limitador-operator:v0.18.4']
+  - version: 1.5.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.5.0
+    images: ['quay.io/kuadrant/authorino-operator:v0.25.1', 'quay.io/kuadrant/dns-operator:v0.17.0',
+      'quay.io/kuadrant/kuadrant-operator:v1.5.0', 'quay.io/kuadrant/limitador-operator:v0.18.2']
+  - version: 1.4.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.4.0
+    images: ['quay.io/kuadrant/authorino-operator:v0.23.0', 'quay.io/kuadrant/dns-operator:v0.16.0',
+      'quay.io/kuadrant/kuadrant-operator:v1.4.0', 'quay.io/kuadrant/limitador-operator:v0.17.0']
+  - version: 1.3.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.3.0
+    images: ['quay.io/kuadrant/authorino-operator:v0.22.0', 'quay.io/kuadrant/dns-operator:v0.15.0',
+      'quay.io/kuadrant/kuadrant-operator:v1.3.0', 'quay.io/kuadrant/limitador-operator:v0.16.0']
+  - version: 1.2.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.2.0
+    images: ['quay.io/kuadrant/authorino-operator:v0.18.0', 'quay.io/kuadrant/dns-operator:v0.14.0',
+      'quay.io/kuadrant/kuadrant-operator:v1.2.0', 'quay.io/kuadrant/limitador-operator:v0.14.0']
+  - version: 1.1.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.1.0
+    images: ['quay.io/kuadrant/authorino-operator:v0.18.0', 'quay.io/kuadrant/dns-operator:v0.13.0',
+      'quay.io/kuadrant/kuadrant-operator:v1.1.0', 'quay.io/kuadrant/limitador-operator:v0.13.1']
+  - version: 1.0.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 1.0.0
+    images: ['quay.io/kuadrant/authorino-operator:v0.16.0', 'quay.io/kuadrant/dns-operator:v0.12.0',
+      'quay.io/kuadrant/kuadrant-operator:v1.0.0', 'quay.io/kuadrant/limitador-operator:v0.12.1']
+  name: kuadrant-operator

--- a/static/compatibilities/kuadrant-operator.yaml
+++ b/static/compatibilities/kuadrant-operator.yaml
@@ -1,0 +1,70 @@
+icon: https://raw.githubusercontent.com/Kuadrant/kuadrant.github.io/main/static/img/apple-touch-icon.png
+git_url: https://github.com/Kuadrant/kuadrant-operator
+release_url: https://github.com/Kuadrant/kuadrant-operator/releases/tag/v{vsn}
+readme_url: https://github.com/Kuadrant/helm-charts/blob/main/README.md
+helm_repository_url: https://kuadrant.io/helm-charts/
+chart_name: kuadrant-operator
+versions:
+- version: 1.5.3
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.3
+  images: ['quay.io/kuadrant/authorino-operator:v0.25.3', 'quay.io/kuadrant/dns-operator:v0.17.2',
+    'quay.io/kuadrant/kuadrant-operator:v1.5.3', 'quay.io/kuadrant/limitador-operator:v0.18.4']
+- version: 1.5.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.5.0
+  images: ['quay.io/kuadrant/authorino-operator:v0.25.1', 'quay.io/kuadrant/dns-operator:v0.17.0',
+    'quay.io/kuadrant/kuadrant-operator:v1.5.0', 'quay.io/kuadrant/limitador-operator:v0.18.2']
+- version: 1.4.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.4.0
+  images: ['quay.io/kuadrant/authorino-operator:v0.23.0', 'quay.io/kuadrant/dns-operator:v0.16.0',
+    'quay.io/kuadrant/kuadrant-operator:v1.4.0', 'quay.io/kuadrant/limitador-operator:v0.17.0']
+- version: 1.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.3.0
+  images: ['quay.io/kuadrant/authorino-operator:v0.22.0', 'quay.io/kuadrant/dns-operator:v0.15.0',
+    'quay.io/kuadrant/kuadrant-operator:v1.3.0', 'quay.io/kuadrant/limitador-operator:v0.16.0']
+- version: 1.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.2.0
+  images: ['quay.io/kuadrant/authorino-operator:v0.18.0', 'quay.io/kuadrant/dns-operator:v0.14.0',
+    'quay.io/kuadrant/kuadrant-operator:v1.2.0', 'quay.io/kuadrant/limitador-operator:v0.14.0']
+- version: 1.1.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.1.0
+  images: ['quay.io/kuadrant/authorino-operator:v0.18.0', 'quay.io/kuadrant/dns-operator:v0.13.0',
+    'quay.io/kuadrant/kuadrant-operator:v1.1.0', 'quay.io/kuadrant/limitador-operator:v0.13.1']
+- version: 1.0.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 1.0.0
+  images: ['quay.io/kuadrant/authorino-operator:v0.16.0', 'quay.io/kuadrant/dns-operator:v0.12.0',
+    'quay.io/kuadrant/kuadrant-operator:v1.0.0', 'quay.io/kuadrant/limitador-operator:v0.12.1']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- kuadrant-operator

--- a/utils/compatibility/scrapers/kuadrant-operator.py
+++ b/utils/compatibility/scrapers/kuadrant-operator.py
@@ -1,0 +1,74 @@
+"""Chart-declared Kuadrant operator Kubernetes floors, bounded by Plural's catalog."""
+import re
+
+import yaml
+
+from utils import (
+    current_kube_version,
+    expand_kube_versions,
+    fetch_page,
+    update_compatibility_info,
+    validate_semver,
+)
+
+APP_NAME = "kuadrant-operator"
+INDEX_URL = "https://kuadrant.io/helm-charts/index.yaml"
+
+
+def stable_version(value):
+    # Exact app/chart identities only: do not coerce partial versions into releases.
+    if not isinstance(value, str) or not re.fullmatch(r"v?\d+\.\d+\.\d+", value):
+        return None
+    return validate_semver(value.removeprefix("v"))
+
+
+def kubernetes_versions(spec, latest):
+    # This is the grammar published in this chart's history, not a general Helm
+    # constraint parser. Reject unknown ranges instead of silently widening them.
+    match = re.fullmatch(r">=\s*v?(1)\.(\d+)\.0(?:-0)?", spec or "")
+    current = re.fullmatch(r"1\.(\d+)", latest or "")
+    if not match or not current:
+        raise ValueError(f"Unsupported Kubernetes constraint/catalog version: {spec!r}, {latest!r}")
+    floor, ceiling = int(match[2]), int(current[1])
+    if floor > ceiling:
+        raise ValueError("Chart minimum is newer than the catalog Kubernetes version")
+    if floor == ceiling:
+        return [latest]
+    return list(reversed(expand_kube_versions(f"1.{floor}", latest)))
+
+
+def extract_versions(index, latest):
+    versions = {}
+    for entry in index.get("entries", {}).get(APP_NAME, []):
+        app = stable_version(entry.get("appVersion"))
+        chart = stable_version(entry.get("version"))
+        if app is None or chart is None:
+            continue
+        # Missing constraints are not compatibility evidence.
+        if not entry.get("kubeVersion"):
+            continue
+        kube = kubernetes_versions(entry["kubeVersion"], latest)
+        previous = versions.get(str(app))
+        if previous and stable_version(previous["chart_version"]) >= chart:
+            continue
+        versions[str(app)] = {
+            "version": str(app),
+            "kube": kube,
+            "chart_version": str(chart),
+            "requirements": [],
+            "incompatibilities": [],
+        }
+    return sorted(versions.values(), key=lambda row: stable_version(row["version"]), reverse=True)
+
+
+def scrape():
+    latest = current_kube_version()
+    if not latest:
+        raise ValueError("Cannot generate Kuadrant compatibility without KUBE_VERSION")
+    content = fetch_page(INDEX_URL)
+    if not content:
+        raise ValueError("Could not fetch the official Kuadrant chart index")
+    rows = extract_versions(yaml.safe_load(content), latest)
+    if not rows:
+        raise ValueError("No stable chart-backed Kuadrant application versions found")
+    update_compatibility_info(f"../../static/compatibilities/{APP_NAME}.yaml", rows)

--- a/utils/compatibility/tests/KUADRANT_OPERATOR.md
+++ b/utils/compatibility/tests/KUADRANT_OPERATOR.md
@@ -1,0 +1,35 @@
+# Kuadrant operator compatibility
+
+The scraper reads the official https://kuadrant.io/helm-charts/index.yaml,
+selecting stable exact application/chart version pairs from `kuadrant-operator`.
+The fixture is a projection of that index fetched 2026-09-09 (only identity and
+Kubernetes constraint fields); it retains prereleases and missing app versions
+to exercise exclusions. The historical stable chart 0.11.0 has no `appVersion`,
+so we do not invent its application mapping.
+
+Each row uses that chart's `kubeVersion`. The currently published history uses
+`>=1.19.0-0`; supported floor syntax is deliberately narrow. Unknown ranges fail
+closed. The upper endpoint is Plural's `KUBE_VERSION`, following the Longhorn
+chart-floor convention, **not an upstream EOL or tested whole-stack support
+ceiling**. The shared reducer retains compatibility boundaries, the first
+release of each minor, and the latest release. Newest stable chart wins when
+multiple chart releases map to the same exact application version.
+
+Gateway API, cert-manager, and a supported gateway implementation (Istio OR
+Envoy Gateway) must be installed as described by the linked official Helm
+README. Empty `requirements` does not mean dependency-free: the flat reference
+schema cannot express gateway alternatives, and installation-example pins are
+not asserted as universal version requirements. Operand deployment additionally
+requires a Kuadrant custom resource. Images are obtained by the existing Helm
+render/extraction helper, not by deploying workloads.
+
+From `utils/compatibility`, run:
+
+```
+python -m unittest discover -s tests -p test_kuadrant_operator.py -v
+python -c 'import importlib; importlib.import_module("scrapers.kuadrant-operator").scrape()'
+```
+
+Generation needs the existing Python dependencies, Helm on PATH, network access,
+and the root `KUBE_VERSION`. No new dependencies are added. Standard `main.py`
+registration also includes the application in the combined compatibility table.

--- a/utils/compatibility/tests/fixtures/kuadrant-index.yaml
+++ b/utils/compatibility/tests/fixtures/kuadrant-index.yaml
@@ -1,0 +1,112 @@
+entries:
+  kuadrant-operator:
+  - name: kuadrant-operator
+    version: 1.5.3
+    appVersion: 1.5.3
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.5.2
+    appVersion: 1.5.2
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.5.2-rc1
+    appVersion: 1.5.2-rc1
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.5.1
+    appVersion: 1.5.1
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.5.0
+    appVersion: 1.5.0
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.5.0-rc3
+    appVersion: 1.5.0-rc3
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.4.7
+    appVersion: 1.4.7
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.4.7-rc1
+    appVersion: 1.4.7-rc1
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.4.3
+    appVersion: 1.4.3
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.4.2
+    appVersion: 1.4.2
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.4.1
+    appVersion: 1.4.1
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.4.0
+    appVersion: 1.4.0
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.3.1
+    appVersion: 1.3.1
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.3.0
+    appVersion: 1.3.0
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.3.0-rc2
+    appVersion: 1.3.0-rc2
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.3.0-alpha2
+    appVersion: 1.3.0-alpha2
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.3.0-alpha1
+    appVersion: 1.3.0-alpha1
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.2.0
+    appVersion: 1.2.0
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.1.0
+    appVersion: 1.1.0
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.0.2
+    appVersion: 1.0.2
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.0.1
+    appVersion: 1.0.1
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.0.0
+    appVersion: 1.0.0
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.0.0-rc8
+    appVersion: 1.0.0-rc8
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.0.0-rc4
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.0.0-rc3
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.0.0-rc2
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 1.0.0-rc1
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 0.11.0
+    kubeVersion: '>=1.19.0-0'
+  - name: kuadrant-operator
+    version: 0.9.0-alpha1
+    kubeVersion: '>=1.19.0-0'

--- a/utils/compatibility/tests/test_kuadrant_operator.py
+++ b/utils/compatibility/tests/test_kuadrant_operator.py
@@ -1,0 +1,64 @@
+import importlib
+import unittest
+
+scraper = importlib.import_module("scrapers.kuadrant-operator")
+
+
+def entry(app="1.5.3", chart="1.5.3", kube=">=1.19.0-0"):
+    return {"appVersion": app, "version": chart, "kubeVersion": kube}
+
+
+def extract(*entries):
+    return scraper.extract_versions({"entries": {"kuadrant-operator": entries}}, "1.36")
+
+
+class KuadrantTests(unittest.TestCase):
+    def test_stable_exact_identities_only(self):
+        rows = extract(entry(), entry("1.6.0-rc1"), entry(chart="1.6.0-rc1"), entry(None), entry("1.5"))
+        self.assertEqual([x["version"] for x in rows], ["1.5.3"])
+
+    def test_app_chart_mapping_and_latest_chart(self):
+        rows = extract(entry("1.5.3", "2.0.0"), entry("1.5.3", "2.1.0"))
+        self.assertEqual(rows[0]["chart_version"], "2.1.0")
+        self.assertEqual(rows[0]["version"], "1.5.3")
+
+    def test_per_release_floor_and_catalog_cap(self):
+        rows = extract(entry(), entry("1.4.7", "1.4.7", ">=1.25.0-0"))
+        self.assertEqual(rows[0]["kube"], [f"1.{i}" for i in range(36, 18, -1)])
+        self.assertEqual(rows[1]["kube"][-1], "1.25")
+
+    def test_equal_floor(self):
+        self.assertEqual(scraper.kubernetes_versions(">=1.36.0-0", "1.36"), ["1.36"])
+
+    def test_unknown_ranges_and_future_floor_rejected(self):
+        for spec in [">=1.37.0-0", ">=1.19.0 <1.30.0", ">=1.19.0 || >=1.35.0", ">=1.19.2", "garbage"]:
+            with self.subTest(spec=spec), self.assertRaises(ValueError):
+                scraper.kubernetes_versions(spec, "1.36")
+
+    def test_missing_constraint_excluded(self):
+        self.assertEqual(extract(entry(kube=None)), [])
+
+    def test_order_independent_and_repeatable(self):
+        entries = [entry(), entry("1.4.7", "1.4.7"), entry("1.5.3", "1.5.4")]
+        self.assertEqual(extract(*entries), extract(*reversed(entries)))
+        self.assertEqual(extract(*entries), extract(*entries))
+
+    def test_unrelated_chart_ignored(self):
+        self.assertEqual(scraper.extract_versions({"entries": {"other": [entry()]}}, "1.36"), [])
+
+    def test_official_index_snapshot(self):
+        from pathlib import Path
+        import yaml
+        index = yaml.safe_load((Path(__file__).parent / "fixtures/kuadrant-index.yaml").read_text())
+        rows = scraper.extract_versions(index, "1.36")
+        self.assertEqual(len(rows), 16)
+        self.assertEqual(rows[0]["version"], "1.5.3")
+        self.assertEqual(rows[-1]["version"], "1.0.0")
+        self.assertTrue(all(row["version"] == row["chart_version"] for row in rows))
+
+    def test_shared_reducer_retains_floor_change(self):
+        from utils import reduce_versions
+        rows = extract(entry("1.5.0", "1.5.0"), entry("1.5.1", "1.5.1", ">=1.25.0-0"), entry())
+        reduced = reduce_versions(rows)
+        self.assertEqual([row["version"] for row in reduced], ["1.5.3", "1.5.1", "1.5.0"])
+        self.assertEqual(reduce_versions(reduced), reduced)


### PR DESCRIPTION
## Summary
- Add a `kuadrant-operator` scraper using the official Kuadrant Helm index and per-chart Kubernetes minimum constraints.
- Register application metadata and generate both compatibility tables, with exact stable application/chart identities and Helm-rendered images.
- Add focused tests and source/installation notes.

## Compatibility scope
This follows the existing chart-floor convention: the catalog's current Kubernetes minor bounds the output, not an upstream support/EOL promise for the whole Kuadrant stack. Only known minimum-constraint grammar is accepted; missing constraints and missing application mappings are not guessed. The older stable 0.11.0 chart lacks `appVersion` and is excluded. Shared reduction preserves minor-release/compatibility boundaries and the latest release.

The linked installation README remains authoritative for Gateway API, cert-manager, and the choice of Istio **or** Envoy Gateway. Empty structured requirements do not mean a dependency-free installation: the flat schema cannot represent that alternative. A Kuadrant custom resource is also needed to deploy operands.

## Validation
- 10 focused unittest cases passed, including projected official-index history, exact chart mapping, prerelease/missing exclusion, per-release floors, future/equal bounds and reducer behavior.
- Real Helm render/image extraction succeeded for all 7 generated rows; repeated generation was byte-identical.
- Individual and regenerated aggregate compatibility tables pass the repository JSON schema; whitespace check passes.
- No Kubernetes deployment or whole-stack support test is claimed.

## Source evidence

- [Official Kuadrant Helm index](https://github.com/Kuadrant/helm-charts/blob/gh-pages/index.yaml) supplies exact per-chart application versions and Kubernetes constraints.
- [Release-tagged 1.5.3 operator metadata](https://github.com/Kuadrant/kuadrant-operator/blob/v1.5.3/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml) independently declares minimum Kubernetes 1.19.0.
- [Official installation prerequisites](https://github.com/Kuadrant/helm-charts/blob/main/README.md) describe the required gateway stack.

## Contributor program

Submitted under the published new compatibility scraper program. Correctness/usefulness review and merge are required; no award or payment is claimed.

## Checklist

- [x] Meaningful title and summary.
- [x] Source/compatibility scope documentation included.
- [x] Focused tests added and passed.
- Agent deployment check: not applicable; no agent code changed.

Plural Flow: console
