### PR TITLE
feat: add Piraeus Operator v2 compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -31215,3 +31215,94 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg
+  git_url: https://github.com/piraeusdatastore/piraeus-operator
+  release_url: https://github.com/piraeusdatastore/piraeus-operator/releases/tag/v{vsn}
+  helm_repository_url: oci://ghcr.io/piraeusdatastore/piraeus-operator
+  chart_name: piraeus
+  versions:
+  - version: 2.11.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.11.0
+  - version: 2.10.8
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.10.8
+  - version: 2.9.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.9.1
+  - version: 2.8.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.8.1
+  - version: 2.7.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.7.1
+  - version: 2.6.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.6.0
+  - version: 2.5.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.5.2
+  - version: 2.4.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.4.1
+  - version: 2.3.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.3.0
+  - version: 2.2.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.2.0
+  - version: 2.1.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.1.1
+  - version: 2.0.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+      '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: 2.0.1
+  name: piraeus-operator

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- piraeus-operator

--- a/static/compatibilities/piraeus-operator.yaml
+++ b/static/compatibilities/piraeus-operator.yaml
@@ -1,0 +1,91 @@
+icon: https://raw.githubusercontent.com/piraeusdatastore/piraeus/master/artwork/sandbox-artwork/icon/color.svg
+git_url: https://github.com/piraeusdatastore/piraeus-operator
+release_url: https://github.com/piraeusdatastore/piraeus-operator/releases/tag/v{vsn}
+helm_repository_url: oci://ghcr.io/piraeusdatastore/piraeus-operator
+chart_name: piraeus
+versions:
+- version: 2.11.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.11.0
+- version: 2.10.8
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.10.8
+- version: 2.9.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.9.1
+- version: 2.8.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.8.1
+- version: 2.7.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.7.1
+- version: 2.6.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.6.0
+- version: 2.5.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.5.2
+- version: 2.4.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.4.1
+- version: 2.3.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.3.0
+- version: 2.2.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.2.0
+- version: 2.1.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.1.1
+- version: 2.0.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: 2.0.1
+name: piraeus-operator

--- a/utils/compatibility/scrapers/piraeus-operator.py
+++ b/utils/compatibility/scrapers/piraeus-operator.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import OrderedDict
+
+import yaml
+from packaging.version import InvalidVersion, Version
+
+
+APP_NAME = "piraeus-operator"
+RELEASES_URL = (
+    "https://api.github.com/repos/piraeusdatastore/piraeus-operator/releases"
+)
+README_URL = (
+    "https://raw.githubusercontent.com/piraeusdatastore/piraeus-operator/"
+    "v{version}/README.md"
+)
+CHART_URL = (
+    "https://raw.githubusercontent.com/piraeusdatastore/piraeus-operator/"
+    "v{version}/charts/piraeus/Chart.yaml"
+)
+MIN_VERSION = Version("2.0.0")
+
+_KUBE_BADGE_RE = re.compile(
+    r"Kubernetes-v?(\d+\.\d+)(?:%2B|\+)", re.IGNORECASE
+)
+
+
+def _decode_text(payload: bytes | str, source: str) -> str:
+    if isinstance(payload, bytes):
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"Could not decode {source}") from exc
+    if isinstance(payload, str):
+        return payload
+    raise ValueError(f"Unexpected {source} payload type")
+
+
+def parse_releases(payload: bytes | str) -> list[dict]:
+    try:
+        releases = json.loads(_decode_text(payload, "Piraeus releases"))
+    except json.JSONDecodeError as exc:
+        raise ValueError("Could not parse Piraeus releases") from exc
+    if not isinstance(releases, list):
+        raise ValueError("Unexpected Piraeus releases structure")
+    if any(not isinstance(release, dict) for release in releases):
+        raise ValueError("Malformed Piraeus release entry")
+    return releases
+
+
+def fetch_releases(fetcher) -> str:
+    """Collect every release page before selecting versions or updating data."""
+    releases = []
+    seen = set()
+    page = 1
+    while True:
+        payload = fetcher(f"{RELEASES_URL}?per_page=100&page={page}")
+        if not payload:
+            raise ValueError(f"Could not fetch official Piraeus releases page {page}")
+        entries = parse_releases(payload)
+        identities = {json.dumps(entry, sort_keys=True) for entry in entries}
+        if entries and identities <= seen:
+            raise ValueError("Piraeus releases pagination did not advance")
+        seen.update(identities)
+        releases.extend(entries)
+        if len(entries) < 100:
+            return json.dumps(releases)
+        page += 1
+
+
+def stable_versions(payload: bytes | str) -> list[str]:
+    """Return the newest stable release for each supported minor."""
+    releases = parse_releases(payload)
+
+    newest: dict[tuple[int, int], Version] = {}
+    for release in releases:
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        tag = str(release.get("tag_name", "")).strip().lstrip("v")
+        try:
+            version = Version(tag)
+        except InvalidVersion:
+            continue
+        if version.is_prerelease or version.is_devrelease or version < MIN_VERSION:
+            continue
+        key = (version.major, version.minor)
+        if key not in newest or version > newest[key]:
+            newest[key] = version
+
+    if not newest:
+        raise ValueError("No stable supported Piraeus releases found")
+    return [str(newest[key]) for key in sorted(newest, reverse=True)]
+
+
+def parse_min_kubernetes(markdown: bytes | str) -> str:
+    match = _KUBE_BADGE_RE.search(_decode_text(markdown, "Piraeus README"))
+    if not match:
+        raise ValueError("Piraeus minimum Kubernetes version not found")
+    return match.group(1)
+
+
+def parse_chart_metadata(payload: bytes | str, release_version: str) -> str:
+    try:
+        chart = yaml.safe_load(_decode_text(payload, "Piraeus Chart.yaml"))
+    except yaml.YAMLError as exc:
+        raise ValueError("Could not parse Piraeus Chart.yaml") from exc
+    if not isinstance(chart, dict):
+        raise ValueError("Unexpected Piraeus Chart.yaml structure")
+
+    chart_version = str(chart.get("version", "")).strip().lstrip("v")
+    app_version = str(chart.get("appVersion", "")).strip().lstrip("v")
+    if not chart_version or not app_version:
+        raise ValueError("Piraeus chart version metadata is incomplete")
+    if app_version != release_version:
+        raise ValueError("Piraeus chart appVersion does not match release")
+    return chart_version
+
+
+def _minor(value: str) -> int:
+    match = re.fullmatch(r"1\.(\d+)", value.strip())
+    if not match:
+        raise ValueError(f"Unsupported Kubernetes version: {value!r}")
+    return int(match.group(1))
+
+
+def expand_minimum(minimum: str, current: str) -> list[str]:
+    start = _minor(minimum)
+    end = _minor(current)
+    if start > end:
+        raise ValueError(
+            f"Piraeus minimum Kubernetes {minimum} is newer than Plural {current}"
+        )
+    return [f"1.{minor}" for minor in range(end, start - 1, -1)]
+
+
+def build_rows(
+    releases_payload: bytes | str,
+    current_kube: str,
+    fetcher,
+) -> list[OrderedDict[str, object]]:
+    rows: list[OrderedDict[str, object]] = []
+    for version in stable_versions(releases_payload):
+        readme = fetcher(README_URL.format(version=version))
+        chart = fetcher(CHART_URL.format(version=version))
+        if not readme or not chart:
+            raise ValueError(f"Missing tagged Piraeus sources for {version}")
+        minimum = parse_min_kubernetes(readme)
+        chart_version = parse_chart_metadata(chart, version)
+        rows.append(
+            OrderedDict(
+                [
+                    ("version", version),
+                    ("kube", expand_minimum(minimum, current_kube)),
+                    ("chart_version", chart_version),
+                    ("requirements", []),
+                    ("incompatibilities", []),
+                ]
+            )
+        )
+    return rows
+
+
+def scrape() -> None:
+    from utils import current_kube_version, fetch_page, update_compatibility_info
+
+    releases = fetch_releases(fetch_page)
+    current = current_kube_version()
+    if not current:
+        raise ValueError("Plural current Kubernetes version is unavailable")
+
+    rows = build_rows(releases, current, fetch_page)
+    update_compatibility_info(
+        f"../../static/compatibilities/{APP_NAME}.yaml",
+        rows,
+    )

--- a/utils/compatibility/tests/PIRAEUS_OPERATOR.md
+++ b/utils/compatibility/tests/PIRAEUS_OPERATOR.md
@@ -1,0 +1,55 @@
+# Piraeus Operator compatibility
+
+`static/compatibilities/manifest.yaml` registers `piraeus-operator` with
+`utils/compatibility/main.py`. The dispatcher imports
+`scrapers.piraeus-operator` and calls `scrape()` during the daily compatibility
+workflow in `.github/workflows/cron.yaml`. No separate hard-coded scraper call
+is required. After scraping, the entrypoint collects every manifest entry into
+`static/compatibilities.yaml`, which Console's compatibility table consumes.
+Keep that aggregate synchronized with the per-app YAML when submitting changes.
+
+The scraper selects the newest stable patch for each minor from version 2.0.0
+onward across all pages returned by the official GitHub releases API. Like the
+Argo Rollouts scraper, it requests pages of 100 until a short or empty page,
+and rejects pagination that stops advancing. All pages must be fetched and
+parsed successfully before any compatibility update, so a later-page failure
+cannot publish a partial release selection.
+For each selected tag it reads the Kubernetes minimum from that tag's README
+badge and the chart version from `charts/piraeus/Chart.yaml`, checking that the
+chart's `appVersion` matches the release. Missing or malformed sources abort
+the scrape before the shared update helper is called.
+
+Kubernetes rows expand the declared minimum through the repository's
+`KUBE_VERSION` ceiling. They express that minimum requirement; they do not claim
+that every combination was tested upstream or locally. The existing shared
+update helper merges/reduces rows and may enrich images with Helm. This change
+does not add a Kubernetes cluster test matrix.
+
+Run the offline tests from the repository root (Python 3.10 or later):
+
+```sh
+python3 -m venv /tmp/piraeus-tests
+/tmp/piraeus-tests/bin/python -m pip install PyYAML==6.0.2 packaging==24.1 colorama==0.4.6
+/tmp/piraeus-tests/bin/python -m unittest discover -s utils/compatibility/tests -p 'test_piraeus_operator.py' -v
+```
+
+The tests use synthetic release/README/chart fixtures. The entrypoint regression
+runs the real `main.py` with the checked-in manifest and per-app YAML files,
+imports the real scraper, mocks HTTP and shared update/enrichment operations,
+and checks that the scraper's output reaches the aggregate. It also checks that
+the checked-in aggregate contains exactly the per-app Piraeus entry.
+
+To regenerate through the same entrypoint as the scheduled workflow, install
+Helm and the full Python requirements, then run from `utils/compatibility`:
+
+```sh
+python3 -m venv /tmp/piraeus-live
+/tmp/piraeus-live/bin/python -m pip install -r requirements.txt
+env -u EXA_API_KEY -u OPENAI_API_KEY SCRAPER=piraeus-operator /tmp/piraeus-live/bin/python main.py
+```
+
+This makes public HTTP/Helm requests, refreshes `KUBE_VERSION`, waits for the
+entrypoint's normal 60-second delay, and regenerates the aggregate for all
+manifest entries. Existing EOL enrichment may update other per-app files even
+with `SCRAPER` set. Review the resulting diff. The offline regression does not
+execute those external operations or paid summarization.

--- a/utils/compatibility/tests/test_piraeus_operator.py
+++ b/utils/compatibility/tests/test_piraeus_operator.py
@@ -1,0 +1,248 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import runpy
+from types import ModuleType
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+import yaml
+
+
+SCRAPER_PATH = Path(__file__).parents[1] / "scrapers" / "piraeus-operator.py"
+spec = importlib.util.spec_from_file_location("piraeus_operator", SCRAPER_PATH)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)
+
+RELEASES = json.dumps(
+    [
+        {"tag_name": "v2.11.0", "draft": False, "prerelease": False},
+        {"tag_name": "v2.11.0-rc.1", "draft": False, "prerelease": True},
+        {"tag_name": "v2.10.8", "draft": False, "prerelease": False},
+        {"tag_name": "v2.10.7", "draft": False, "prerelease": False},
+        {"tag_name": "v2.0.1", "draft": False, "prerelease": False},
+        {"tag_name": "v1.10.9", "draft": False, "prerelease": False},
+        {"tag_name": "nonsense", "draft": False, "prerelease": False},
+        {"tag_name": "v9.0.0", "draft": True, "prerelease": False},
+    ]
+)
+README_120 = (
+    "![Kubernetes](https://img.shields.io/badge/"
+    "Kubernetes-v1.20%2B-success?logo=kubernetes)"
+)
+README_119 = "![Kubernetes](https://img.shields.io/badge/Kubernetes-v1.19+-green)"
+
+
+def chart(version):
+    return f'''apiVersion: v2
+name: piraeus
+version: {version}
+appVersion: "v{version}"
+'''
+
+
+class PiraeusOperatorTests(unittest.TestCase):
+    def test_scrape_updates_once_with_releases_from_every_page(self):
+        first = [{"tag_name": f"v2.11.{number}"} for number in range(100)]
+        second = [{"tag_name": "v2.0.1"}, {"tag_name": "v2.11.100"},
+                  {"tag_name": "v2.12.0-rc.1", "prerelease": True}]
+        sources = {
+            f"{scraper.RELEASES_URL}?per_page=100&page=1": json.dumps(first),
+            f"{scraper.RELEASES_URL}?per_page=100&page=2": json.dumps(second),
+        }
+        for version in ("2.11.100", "2.0.1"):
+            sources[scraper.README_URL.format(version=version)] = README_120
+            sources[scraper.CHART_URL.format(version=version)] = chart(version)
+        helpers = ModuleType("utils")
+        helpers.fetch_page = Mock(side_effect=sources.__getitem__)
+        helpers.current_kube_version = Mock(return_value="1.22")
+        helpers.update_compatibility_info = Mock()
+        with patch.dict(sys.modules, {"utils": helpers}):
+            scraper.scrape()
+        helpers.update_compatibility_info.assert_called_once()
+        path, rows = helpers.update_compatibility_info.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/piraeus-operator.yaml")
+        self.assertEqual([row["version"] for row in rows], ["2.11.100", "2.0.1"])
+        self.assertEqual([call.args[0] for call in helpers.fetch_page.call_args_list],
+                         list(sources))
+
+    def test_full_last_page_requires_empty_terminating_page(self):
+        page = json.dumps([{"tag_name": f"v2.11.{number}"} for number in range(100)])
+        fetcher = Mock(side_effect=[page, "[]"])
+        self.assertEqual(scraper.stable_versions(scraper.fetch_releases(fetcher)),
+                         ["2.11.99"])
+        self.assertEqual([call.args[0] for call in fetcher.call_args_list], [
+            f"{scraper.RELEASES_URL}?per_page=100&page=1",
+            f"{scraper.RELEASES_URL}?per_page=100&page=2",
+        ])
+
+    def test_bad_later_page_aborts_without_partial_update(self):
+        first = json.dumps([{"tag_name": f"v2.11.{number}"} for number in range(100)])
+        for later in (None, "", "not json", "{}", "[null]", first):
+            with self.subTest(later=later):
+                helpers = ModuleType("utils")
+                helpers.fetch_page = Mock(side_effect=[first, later])
+                helpers.current_kube_version = Mock(return_value="1.22")
+                helpers.update_compatibility_info = Mock()
+                with patch.dict(sys.modules, {"utils": helpers}):
+                    with self.assertRaises(ValueError):
+                        scraper.scrape()
+                helpers.update_compatibility_info.assert_not_called()
+                self.assertEqual(helpers.fetch_page.call_count, 2)
+
+    def test_main_dispatches_registered_scraper_and_aggregates_result(self):
+        root = SCRAPER_PATH.parents[3]
+        compatibility = SCRAPER_PATH.parents[1]
+        updated = {}
+
+        def read_yaml(path):
+            if path in updated:
+                return updated[path]
+            return yaml.safe_load((compatibility / path).read_text())
+
+        def update(path, rows):
+            addon = read_yaml(path)
+            addon["versions"] = rows
+            updated[path] = addon
+
+        sources = {
+            f"{scraper.RELEASES_URL}?per_page=100&page=1": json.dumps([
+                {"tag_name": "v2.11.0", "draft": False, "prerelease": False}
+            ]).encode(),
+            scraper.README_URL.format(version="2.11.0"): README_120.encode(),
+            scraper.CHART_URL.format(version="2.11.0"): chart("2.11.0").encode(),
+        }
+        helpers = ModuleType("utils")
+        helpers.read_yaml = read_yaml
+        helpers.write_yaml = Mock()
+        helpers.print_error = Mock()
+        helpers.print_warning = Mock()
+        helpers.latest_kube_version = Mock()
+        helpers.current_kube_version = Mock(return_value="1.22")
+        helpers.fetch_page = Mock(side_effect=sources.__getitem__)
+        helpers.update_compatibility_info = Mock(side_effect=update)
+        helpers.enrich_addon_with_eol = Mock()
+        kube_versions = ModuleType("kube_versions")
+        kube_versions.generate_kube_changelog = Mock()
+
+        with patch.dict(sys.modules, {"utils": helpers, "kube_versions": kube_versions}), \
+                patch.object(sys, "path", [str(compatibility), *sys.path]), \
+                patch.dict(os.environ, {"SCRAPER": "piraeus-operator"}), \
+                patch("os.path.exists", return_value=True), patch("time.sleep"):
+            runpy.run_path(str(compatibility / "main.py"), run_name="__main__")
+
+        helpers.print_error.assert_not_called()
+        helpers.print_warning.assert_not_called()
+        helpers.update_compatibility_info.assert_called_once()
+        self.assertEqual(helpers.fetch_page.call_count, 3)
+        aggregate = next(call.args[1] for call in helpers.write_yaml.call_args_list
+                         if call.args[0] == "../../static/compatibilities.yaml")
+        names = read_yaml("../../static/compatibilities/manifest.yaml")["names"]
+        self.assertEqual([addon["name"] for addon in aggregate["addons"]], names)
+        piraeus = next(addon for addon in aggregate["addons"]
+                       if addon["name"] == "piraeus-operator")
+        self.assertEqual(piraeus["versions"][0]["kube"], ["1.22", "1.21", "1.20"])
+        self.assertEqual(len(piraeus["versions"]), 1)
+        self.assertEqual(piraeus, updated["../../static/compatibilities/piraeus-operator.yaml"])
+        for addon in aggregate["addons"]:
+            if addon["name"] != "piraeus-operator":
+                expected = read_yaml(f"../../static/compatibilities/{addon['name']}.yaml")
+                expected["name"] = addon["name"]
+                self.assertEqual(addon, expected)
+
+        # The checked-in consumer artifact must expose the same per-app data.
+        committed = yaml.safe_load((root / "static/compatibilities.yaml").read_text())
+        entries = [addon for addon in committed["addons"]
+                   if addon["name"] == "piraeus-operator"]
+        expected = yaml.safe_load((root / "static/compatibilities/piraeus-operator.yaml").read_text())
+        self.assertEqual(entries, [expected])
+
+    def test_selects_latest_stable_patch_per_supported_minor(self):
+        self.assertEqual(
+            scraper.stable_versions(RELEASES),
+            ["2.11.0", "2.10.8", "2.0.1"],
+        )
+
+    def test_rejects_unexpected_release_shape(self):
+        with self.assertRaisesRegex(ValueError, "Unexpected Piraeus releases"):
+            scraper.stable_versions("{}")
+
+    def test_parses_tagged_minimum_kubernetes_badge(self):
+        self.assertEqual(scraper.parse_min_kubernetes(README_120), "1.20")
+        self.assertEqual(scraper.parse_min_kubernetes(README_119), "1.19")
+
+    def test_missing_minimum_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "minimum Kubernetes version"):
+            scraper.parse_min_kubernetes("# Piraeus Operator")
+
+    def test_validates_chart_release_provenance(self):
+        self.assertEqual(scraper.parse_chart_metadata(chart("2.11.0"), "2.11.0"), "2.11.0")
+        with self.assertRaisesRegex(ValueError, "does not match release"):
+            scraper.parse_chart_metadata(chart("2.10.8"), "2.11.0")
+
+    def test_expands_declared_minimum_to_plural_ceiling(self):
+        self.assertEqual(
+            scraper.expand_minimum("1.20", "1.23"),
+            ["1.23", "1.22", "1.21", "1.20"],
+        )
+
+    def test_future_minimum_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "newer than Plural"):
+            scraper.expand_minimum("1.30", "1.29")
+
+    def test_build_rows_uses_versioned_readme_and_chart(self):
+        payload = json.dumps(
+            [{"tag_name": "v2.11.0", "draft": False, "prerelease": False}]
+        )
+        sources = {
+            scraper.README_URL.format(version="2.11.0"): README_120.encode(),
+            scraper.CHART_URL.format(version="2.11.0"): chart("2.11.0").encode(),
+        }
+        rows = scraper.build_rows(payload, "1.22", sources.get)
+        self.assertEqual(rows[0]["version"], "2.11.0")
+        self.assertEqual(rows[0]["chart_version"], "2.11.0")
+        self.assertEqual(rows[0]["kube"], ["1.22", "1.21", "1.20"])
+
+    def test_missing_tagged_source_fails_closed(self):
+        payload = json.dumps(
+            [{"tag_name": "v2.11.0", "draft": False, "prerelease": False}]
+        )
+        with self.assertRaisesRegex(ValueError, "Missing tagged Piraeus sources"):
+            scraper.build_rows(payload, "1.22", lambda _: None)
+
+    def test_scrape_wires_official_sources_and_output(self):
+        payload = json.dumps(
+            [{"tag_name": "v2.11.0", "draft": False, "prerelease": False}]
+        ).encode()
+        helpers = ModuleType("utils")
+        helpers.current_kube_version = Mock(return_value="1.22")
+        helpers.fetch_page = Mock(
+            side_effect=lambda url: (
+                payload
+                if url.startswith(scraper.RELEASES_URL)
+                else README_120.encode()
+                if url == scraper.README_URL.format(version="2.11.0")
+                else chart("2.11.0").encode()
+            )
+        )
+        helpers.update_compatibility_info = Mock()
+
+        previous = sys.modules.get("utils")
+        try:
+            with patch.dict(sys.modules, {"utils": helpers}):
+                scraper.scrape()
+        finally:
+            if previous is None:
+                sys.modules.pop("utils", None)
+            else:
+                sys.modules["utils"] = previous
+
+        path, rows = helpers.update_compatibility_info.call_args.args
+        self.assertEqual(path, "../../static/compatibilities/piraeus-operator.yaml")
+        self.assertEqual(rows[0]["version"], "2.11.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix for #4287 

Adds Piraeus Operator v2 to Plural’s compatibility catalog with an automated compatibility scraper, generated compatibility data, manifest registration, aggregate compatibility data, usage documentation, and focused regression tests.

## Authoritative sources

- https://github.com/piraeusdatastore/piraeus-operator/releases
- https://github.com/piraeusdatastore/piraeus-operator
- https://github.com/piraeusdatastore/piraeus-operator/tree/v2.11.0/charts/piraeus
- https://github.com/piraeusdatastore/piraeus-operator/blob/v2.11.0/.github/workflows/release.yml

The scraper selects the newest stable patch in each Piraeus Operator v2 minor release, reads the declared minimum Kubernetes version from that release tag’s README, and validates chart and application versions against the same tag’s Helm metadata. It excludes drafts, prereleases, and the legacy v1 operator, and fails closed when required upstream data is missing, malformed, or inconsistent.

The manifest already drives scraper dispatch dynamically through `utils/compatibility/main.py`; this change registers `piraeus-operator` there and adds the generated per-application and aggregate compatibility data without a duplicate hard-coded scraper call.

## Testing

- 14 focused tests passed
- Stable release filtering and newest-patch-per-minor selection passed
- Tagged Kubernetes-minimum parsing and range generation passed
- Helm chart/release provenance validation passed
- Manifest-driven `main.py` entrypoint integration passed with mocked network and shared update/enrichment calls
- Generated per-application and aggregate YAML validation passed
- The 53 existing aggregate addons remain structurally unchanged
- Python compilation and `git diff --check` passed
- Malformed, missing, or inconsistent upstream data fails closed

No live scraper run, Helm render, or Kubernetes cluster deployment was performed. The compatibility ranges reflect upstream-declared minimum versions through Plural’s current catalog ceiling; they do not claim runtime testing across every listed Kubernetes version.

AI assistance disclosure: implemented and tested using OpenAI Codex under the GitHub account owner’s authorization.

I would like this submission considered under the README Contributor Program’s advertised $300 reward for a new compatibility scraper, subject to maintainer review, merge, monthly eligibility, and authorship confirmation.