### PR TITLE
Add K8GB Helm compatibility scraper

### DIFF
--- a/static/compatibilities.yaml
+++ b/static/compatibilities.yaml
@@ -32696,3 +32696,114 @@ addons:
     chart_version: 1.0.0
     images: ['quay.io/mongodb/mongodb-kubernetes:1.0.0']
   name: mongodb-kubernetes
+- icon: https://www.k8gb.io/images/k8gb-icon-color.svg
+  git_url: https://github.com/k8gb-io/k8gb
+  release_url: https://github.com/k8gb-io/k8gb/releases/tag/v{vsn}
+  helm_repository_url: https://www.k8gb.io
+  chart_name: k8gb
+  versions:
+  - version: 1.0.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v1.0.0
+    images: ['registry.k8gb.io/k8gb-io/k8gb:v1.0.0', 'registry.k8gb.io/k8gb-io/k8s_crd:v0.6.0']
+  - version: 0.20.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.20.0
+    images: ['registry.k8gb.io/k8gb-io/k8gb:v0.20.0', 'registry.k8gb.io/k8gb-io/k8s_crd:v0.5.0']
+  - version: 0.19.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.19.0
+    images: ['registry.k8gb.io/k8gb-io/k8gb:v0.19.0', 'registry.k8gb.io/k8gb-io/k8s_crd:v0.4.0']
+  - version: 0.18.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.18.0
+    images: ['k8gb-io.gateway.scarf.sh/absaoss/k8gb:v0.18.0', 'k8gb-io.gateway.scarf.sh/absaoss/k8s_crd:v0.2.0']
+  - version: 0.17.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.17.0
+    images: ['absaoss/k8s_crd:v0.1.2', 'docker.io/absaoss/k8gb:v0.17.0']
+  - version: 0.16.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.16.0
+    images: ['absaoss/k8s_crd:v0.1.2', 'docker.io/absaoss/k8gb:v0.16.0']
+  - version: 0.15.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.15.0
+    images: ['absaoss/k8s_crd:v0.1.2', 'docker.io/absaoss/k8gb:v0.15.0']
+  - version: 0.14.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.14.0
+    images: ['absaoss/k8s_crd:v0.1.0', 'docker.io/absaoss/k8gb:v0.14.0']
+  - version: 0.13.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.13.0
+    images: ['absaoss/k8s_crd:v0.0.11', 'docker.io/absaoss/k8gb:v0.13.0']
+  - version: 0.12.2
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.12.2
+    images: ['absaoss/k8s_crd:v0.0.11', 'docker.io/absaoss/k8gb:v0.12.2']
+  - version: 0.11.1
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.11.1
+    images: ['absaoss/k8s_crd:v0.0.10', 'docker.io/absaoss/k8gb:v0.11.1']
+  - version: 0.10.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.10.0
+    images: ['absaoss/k8gb:v0.10.0', 'absaoss/k8s_crd:v0.0.8']
+  - version: 0.9.0
+    kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28',
+      '1.27', '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+    requirements: []
+    incompatibilities: []
+    summary: null
+    chart_version: v0.9.0
+    images: ['absaoss/k8gb:v0.9.0', 'absaoss/k8s_crd:v0.0.8']
+  name: k8gb

--- a/static/compatibilities/k8gb.yaml
+++ b/static/compatibilities/k8gb.yaml
@@ -1,0 +1,110 @@
+icon: https://www.k8gb.io/images/k8gb-icon-color.svg
+git_url: https://github.com/k8gb-io/k8gb
+release_url: https://github.com/k8gb-io/k8gb/releases/tag/v{vsn}
+helm_repository_url: https://www.k8gb.io
+chart_name: k8gb
+versions:
+- version: 1.0.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v1.0.0
+  images: ['registry.k8gb.io/k8gb-io/k8gb:v1.0.0', 'registry.k8gb.io/k8gb-io/k8s_crd:v0.6.0']
+- version: 0.20.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.20.0
+  images: ['registry.k8gb.io/k8gb-io/k8gb:v0.20.0', 'registry.k8gb.io/k8gb-io/k8s_crd:v0.5.0']
+- version: 0.19.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.19.0
+  images: ['registry.k8gb.io/k8gb-io/k8gb:v0.19.0', 'registry.k8gb.io/k8gb-io/k8s_crd:v0.4.0']
+- version: 0.18.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.18.0
+  images: ['k8gb-io.gateway.scarf.sh/absaoss/k8gb:v0.18.0', 'k8gb-io.gateway.scarf.sh/absaoss/k8s_crd:v0.2.0']
+- version: 0.17.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.17.0
+  images: ['absaoss/k8s_crd:v0.1.2', 'docker.io/absaoss/k8gb:v0.17.0']
+- version: 0.16.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.16.0
+  images: ['absaoss/k8s_crd:v0.1.2', 'docker.io/absaoss/k8gb:v0.16.0']
+- version: 0.15.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.15.0
+  images: ['absaoss/k8s_crd:v0.1.2', 'docker.io/absaoss/k8gb:v0.15.0']
+- version: 0.14.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.14.0
+  images: ['absaoss/k8s_crd:v0.1.0', 'docker.io/absaoss/k8gb:v0.14.0']
+- version: 0.13.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.13.0
+  images: ['absaoss/k8s_crd:v0.0.11', 'docker.io/absaoss/k8gb:v0.13.0']
+- version: 0.12.2
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.12.2
+  images: ['absaoss/k8s_crd:v0.0.11', 'docker.io/absaoss/k8gb:v0.12.2']
+- version: 0.11.1
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.11.1
+  images: ['absaoss/k8s_crd:v0.0.10', 'docker.io/absaoss/k8gb:v0.11.1']
+- version: 0.10.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.10.0
+  images: ['absaoss/k8gb:v0.10.0', 'absaoss/k8s_crd:v0.0.8']
+- version: 0.9.0
+  kube: ['1.36', '1.35', '1.34', '1.33', '1.32', '1.31', '1.30', '1.29', '1.28', '1.27',
+    '1.26', '1.25', '1.24', '1.23', '1.22', '1.21', '1.20', '1.19']
+  requirements: []
+  incompatibilities: []
+  summary: null
+  chart_version: v0.9.0
+  images: ['absaoss/k8gb:v0.9.0', 'absaoss/k8s_crd:v0.0.8']

--- a/static/compatibilities/manifest.yaml
+++ b/static/compatibilities/manifest.yaml
@@ -53,3 +53,4 @@ names:
 - wiz-network-analyzer
 - kuberay-operator
 - mongodb-kubernetes
+- k8gb

--- a/utils/compatibility/scrapers/k8gb.py
+++ b/utils/compatibility/scrapers/k8gb.py
@@ -1,0 +1,153 @@
+"""K8GB's published Helm requirements, not a Kubernetes runtime certification."""
+
+from collections import OrderedDict
+from copy import deepcopy
+import hashlib
+import io
+from pathlib import Path
+import re
+import subprocess
+import tarfile
+import tempfile
+from urllib.parse import urljoin, urlsplit
+
+import requests
+import yaml
+
+APP = "k8gb"
+HELM_REPOSITORY = "https://www.k8gb.io"
+INDEX_URL = f"{HELM_REPOSITORY}/index.yaml"
+TARGET_FILE = "../../static/compatibilities/k8gb.yaml"
+_VERSION = re.compile(r"v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)")
+
+
+def stable_version(value):
+    match = _VERSION.fullmatch(value) if isinstance(value, str) else None
+    return tuple(map(int, match.groups())) if match else None
+
+
+def kube_minors(requirement, latest):
+    """Expand a declared whole-minor floor only through Plural's KUBE_VERSION."""
+    bound = re.fullmatch(r"1\.(0|[1-9]\d*)", latest or "")
+    floor = re.fullmatch(r"\s*>=\s*1\.(0|[1-9]\d*)\.0(?:-0)?\s*", requirement or "")
+    if not bound or not floor:
+        raise ValueError("Unsupported Kubernetes requirement or KUBE_VERSION")
+    low, high = int(floor[1]), int(bound[1])
+    return [f"1.{minor}" for minor in range(high, low - 1, -1)]
+
+
+def parse_index(content, latest):
+    index = yaml.safe_load(content)
+    entries = index.get("entries", {}).get(APP) if isinstance(index, dict) else None
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("K8GB chart index is missing or empty")
+    selected, chart_ids = {}, {}
+    for entry in entries:
+        if not isinstance(entry, dict) or entry.get("name") != APP:
+            raise ValueError("Invalid K8GB chart entry")
+        app_version = stable_version(entry.get("appVersion"))
+        chart_version = stable_version(entry.get("version"))
+        # Legacy packages omit requirements; never invent a support range for them.
+        if not app_version or not chart_version or entry.get("deprecated"):
+            continue
+        if not entry.get("kubeVersion"):
+            continue
+        if not re.fullmatch(r"[0-9a-fA-F]{64}", entry.get("digest", "")):
+            raise ValueError("Chart is missing a SHA-256 digest")
+        urls = entry.get("urls")
+        if not isinstance(urls, list) or not urls or not isinstance(urls[0], str):
+            raise ValueError("Chart is missing its download URL")
+        url = urljoin(INDEX_URL, urls[0])
+        parsed_url = urlsplit(url)
+        if (parsed_url.scheme != "https" or parsed_url.hostname not in ("www.k8gb.io", "k8gb.io")
+                or parsed_url.username or parsed_url.password or parsed_url.port not in (None, 443)):
+            raise ValueError("Chart URL must use the official HTTPS repository")
+        kube = kube_minors(entry["kubeVersion"], latest)
+        if not kube:
+            continue
+        identity = (entry["appVersion"], entry["kubeVersion"], entry["digest"].lower(), url)
+        if chart_version in chart_ids and chart_ids[chart_version] != identity:
+            raise ValueError("Conflicting duplicate chart version")
+        chart_ids[chart_version] = identity
+        candidate = dict(entry, download_url=url, kube=kube)
+        previous = selected.get(app_version)
+        if previous is None or chart_version > stable_version(previous["version"]):
+            selected[app_version] = candidate
+    if not selected:
+        raise ValueError("No stable charts with explicit representable requirements")
+    return [selected[version] for version in sorted(selected, reverse=True)]
+
+
+def fetch_bytes(url):
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
+def verify_chart(content, entry):
+    if hashlib.sha256(content).hexdigest() != entry["digest"].lower():
+        raise ValueError("Downloaded chart does not match the index digest")
+    # Read exactly one regular member, never extract an untrusted archive to disk.
+    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as archive:
+        members = [m for m in archive.getmembers() if m.name == "k8gb/Chart.yaml"]
+        if len(members) != 1 or not members[0].isfile() or members[0].size > 100_000:
+            raise ValueError("Chart.yaml must be a unique small regular file")
+        metadata = yaml.safe_load(archive.extractfile(members[0]).read())
+    if not isinstance(metadata, dict):
+        raise ValueError("Invalid chart metadata")
+    for key in ("name", "version", "appVersion", "kubeVersion"):
+        if metadata.get(key) != entry[key]:
+            raise ValueError(f"Published chart disagrees with index: {key}")
+
+
+def chart_images(content, latest):
+    from utils import find_nested_images
+
+    with tempfile.TemporaryDirectory(prefix="k8gb-chart-") as directory:
+        chart = Path(directory) / "k8gb.tgz"
+        chart.write_bytes(content)
+        result = subprocess.run(
+            ["helm", "template", APP, str(chart), "--kube-version", latest],
+            capture_output=True, text=True, timeout=60, check=True,
+        )
+    images = find_nested_images(list(yaml.safe_load_all(result.stdout)))
+    if not images:
+        raise ValueError("Published chart rendered no container images")
+    return images
+
+
+def scrape():
+    from utils import current_kube_version, read_yaml, reduce_versions, update_versions_data, write_yaml
+
+    existing = read_yaml(TARGET_FILE)
+    if not isinstance(existing, dict) or not isinstance(existing.get("versions"), list):
+        raise ValueError("Existing K8GB metadata is missing or invalid")
+    latest = current_kube_version()
+    entries = parse_index(fetch_bytes(INDEX_URL), latest)
+    rows, by_version = [], {}
+    for entry in entries:
+        version = ".".join(map(str, stable_version(entry["appVersion"])))
+        by_version[(version, entry["version"])] = entry
+        rows.append(OrderedDict([
+            ("version", version), ("kube", entry["kube"]),
+            ("chart_version", entry["version"]),
+            ("requirements", []), ("incompatibilities", []),
+        ]))
+    candidate = deepcopy(existing)
+    update_versions_data(candidate, rows)
+    candidate["versions"] = reduce_versions(candidate["versions"])
+    for row in candidate["versions"]:
+        entry = by_version.get((row["version"], row["chart_version"]))
+        if entry is None:
+            raise ValueError("An existing catalog version cannot be verified against the index")
+        content = fetch_bytes(entry["download_url"])
+        verify_chart(content, entry)
+        row["images"] = chart_images(content, latest)
+    # All charts must succeed before the only write. No summarization/paid API.
+    if candidate != existing and not write_yaml(TARGET_FILE, candidate):
+        raise OSError("Cannot write K8GB compatibility data")
+    return candidate
+
+
+if __name__ == "__main__":
+    scrape()

--- a/utils/compatibility/tests/K8GB.md
+++ b/utils/compatibility/tests/K8GB.md
@@ -1,0 +1,66 @@
+# K8GB compatibility scraper
+
+Run the offline tests from the repository root:
+
+```sh
+python -m unittest discover -s utils/compatibility/tests -p 'test_k8gb.py' -v
+python -m pytest utils/compatibility/tests -q
+```
+
+Run this scraper without invoking the global updater or any summarization API:
+
+```sh
+cd utils/compatibility
+python -m scrapers.k8gb
+```
+
+Helm must be installed for live generation. The existing `KUBE_VERSION` file is
+used as the upper bound; this scraper does not fetch or modify that file.
+
+## What the compatibility entries mean
+
+The source is the **published** Helm repository at
+https://www.k8gb.io/index.yaml, documented in the upstream deployment guides:
+https://github.com/k8gb-io/k8gb/blob/v1.0.0/docs/deploy_ns1.md.
+
+A chart's explicit `kubeVersion` whole-minor lower bound is expanded through
+Plural's checked-in `KUBE_VERSION`. This records declared Helm installation
+requirements, **not** certification from deploying every Kubernetes version.
+It follows the existing bounded-range representation in the catalog. It does
+not infer support from Kubernetes client dependencies or apply today's moving
+README to historical releases.
+
+For example, the published v1.0.0 chart and its release-tag README both state
+Kubernetes >=1.21, even though the later development branch now says >=1.32:
+https://github.com/k8gb-io/k8gb/blob/v1.0.0/README.md#production-readiness.
+
+Only stable chart/application versions with explicit requirements are eligible.
+Older charts without `kubeVersion`, prereleases and deprecated charts are
+excluded. Complex or patch-level constraints are rejected rather than rounded
+into falsely supported whole minors. Literal chart version prefixes are
+preserved for Helm; application versions are normalized for the catalog.
+
+The full chart index is read once. A downloaded archive must match its SHA-256
+digest and its packaged Chart.yaml must agree with the index. The existing
+boundary/latest reducer selects catalog rows. Every retained chart must render
+successfully and yield container images before the first table write; an error
+cannot write the first half of a batch. There is no cluster deployment, Helm
+installation, or paid summarization/model call.
+
+## Fixtures and test boundaries
+
+`fixtures/k8gb/index.yaml` contains unchanged selected fields from four actual
+index entries retrieved on 2026-09-09: v1.0.0, v0.14.0, v0.21.0-rc4 and v0.8.8.
+Only name/version/appVersion/kubeVersion/digest/urls are retained. The original
+full index and archive digests are recorded in the validation artifacts.
+Synthetic archives in the tests are clearly test inputs, not live results.
+
+Offline tests substitute only the HTTP and Helm process boundaries; production
+parsing, archive digest/metadata verification, image extraction, reduction,
+merge and YAML writing are executed. Failure cases check that existing file
+bytes remain unchanged. A separate live audit runs the actual scraper with
+real HTTP and Helm twice, without these substitutes.
+
+The aggregate registration adds only the K8GB block. It intentionally does not
+rewrite the unrelated pre-existing differences between the per-app files and
+`static/compatibilities.yaml`.

--- a/utils/compatibility/tests/fixtures/k8gb/index.yaml
+++ b/utils/compatibility/tests/fixtures/k8gb/index.yaml
@@ -1,0 +1,29 @@
+entries:
+  k8gb:
+  - name: k8gb
+    version: v1.0.0
+    appVersion: v1.0.0
+    kubeVersion: '>= 1.21.0-0'
+    digest: 2e545146de6daf7c7e4e925385ba287301888e73a82864229dfa92dd69a2bd49
+    urls:
+    - charts/k8gb-v1.0.0.tgz
+  - name: k8gb
+    version: v0.21.0-rc4
+    appVersion: v0.21.0-rc4
+    kubeVersion: '>= 1.21.0-0'
+    digest: 4691f63869aa56a341bf3c2837bcec63a19d07d2ab25249ba861df661de91021
+    urls:
+    - charts/k8gb-v0.21.0-rc4.tgz
+  - name: k8gb
+    version: v0.14.0
+    appVersion: v0.14.0
+    kubeVersion: '>= 1.19.0-0'
+    digest: 607083337cc06976e6bf1202ff6ffc877718faff3d5478571ce1b43703c38af5
+    urls:
+    - charts/k8gb-v0.14.0.tgz
+  - name: k8gb
+    version: v0.8.8
+    appVersion: v0.8.8
+    digest: 4ce691e607688ca1454611ebdf84ffe601f56206534beb31586d1a70b423a27c
+    urls:
+    - charts/k8gb-v0.8.8.tgz

--- a/utils/compatibility/tests/test_k8gb.py
+++ b/utils/compatibility/tests/test_k8gb.py
@@ -1,0 +1,207 @@
+"""Offline behavior tests: network and Helm boundaries only are substituted."""
+import hashlib
+import io
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from unittest.mock import patch
+from copy import deepcopy
+
+import yaml
+
+COMPAT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(COMPAT))
+from scrapers import k8gb
+import utils
+
+FIXTURE = Path(__file__).parent / "fixtures/k8gb/index.yaml"
+
+
+def archive(entry, **changes):
+    metadata = {key: entry[key] for key in ("name", "version", "appVersion", "kubeVersion")}
+    metadata.update(changes)
+    body = yaml.safe_dump(metadata).encode()
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as tar:
+        member = tarfile.TarInfo("k8gb/Chart.yaml")
+        member.size = len(body)
+        tar.addfile(member, io.BytesIO(body))
+    return output.getvalue()
+
+
+def entry(version="v1.0.0", floor=">= 1.21.0-0"):
+    value = {"name": "k8gb", "version": version, "appVersion": version,
+             "kubeVersion": floor, "urls": [f"charts/k8gb-{version}.tgz"]}
+    body = archive(value)
+    value["digest"] = hashlib.sha256(body).hexdigest()
+    return value, body
+
+
+def index(entries):
+    return yaml.safe_dump({"entries": {"k8gb": entries}}).encode()
+
+
+class K8GBTests(unittest.TestCase):
+    def test_strict_stable_versions(self):
+        self.assertEqual(k8gb.stable_version("v1.10.2"), (1, 10, 2))
+        for value in (None, 1, "1.0", "01.0.0", "1.0.0-rc1", "1.0.0+build", "main", "next v1.0.0"):
+            with self.subTest(value=value):
+                self.assertIsNone(k8gb.stable_version(value))
+
+    def test_floor_is_bounded_and_includes_equal_endpoint(self):
+        self.assertEqual(k8gb.kube_minors(">= 1.34.0-0", "1.36"), ["1.36", "1.35", "1.34"])
+        self.assertEqual(k8gb.kube_minors(">=1.36.0", "1.36"), ["1.36"])
+        self.assertEqual(k8gb.kube_minors(">=1.37.0", "1.36"), [])
+
+    def test_patch_bounds_and_complex_ranges_are_not_rounded(self):
+        for requirement in (">=1.32.1", ">1.32.0", ">=1.32.0 <1.34", "^1.32.0", "1.32", "*", ""):
+            with self.subTest(requirement=requirement):
+                with self.assertRaises(ValueError):
+                    k8gb.kube_minors(requirement, "1.36")
+        with self.assertRaises(ValueError):
+            k8gb.kube_minors(">=1.32.0", "1.36.1")
+
+    def test_real_index_formats_and_legacy_exclusions(self):
+        rows = k8gb.parse_index(FIXTURE.read_bytes(), "1.36")
+        self.assertEqual([x["appVersion"] for x in rows], ["v1.0.0", "v0.14.0"])
+        self.assertEqual(rows[0]["kube"][-1], "1.21")
+        self.assertEqual(rows[1]["kube"][-1], "1.19")
+        self.assertEqual(rows[0]["version"], "v1.0.0")
+        self.assertEqual(rows[0]["download_url"], "https://www.k8gb.io/charts/k8gb-v1.0.0.tgz")
+
+    def test_chart_selection_uses_numeric_versions_not_input_order(self):
+        a, _ = entry(); b = dict(a, version="v2.0.0")
+        c = dict(a, version="v10.0.0")
+        for order in ([c,a,b], [a,b,c]):
+            self.assertEqual(k8gb.parse_index(index(order), "1.36")[0]["version"], "v10.0.0")
+
+    def test_deprecated_and_future_only_charts_are_not_promoted(self):
+        a, _ = entry(); b, _ = entry("v2.0.0", ">=1.37.0")
+        c, _ = entry("v3.0.0"); c["deprecated"] = True
+        self.assertEqual(len(k8gb.parse_index(index([c,b,a]), "1.36")), 1)
+
+    def test_conflicting_duplicate_chart_version_is_rejected(self):
+        a, _ = entry(); b = dict(a, kubeVersion=">=1.32.0")
+        with self.assertRaises(ValueError):
+            k8gb.parse_index(index([a,b]), "1.36")
+        self.assertEqual(len(k8gb.parse_index(index([a,a]), "1.36")), 1)
+
+    def test_missing_metadata_or_external_url_cannot_become_a_row(self):
+        a, _ = entry()
+        for change in ({"digest":"bad"}, {"urls":[]}, {"urls":["http://www.k8gb.io/a"]},
+                       {"urls":["https://example.com/a"]}, {"urls":["https://x@www.k8gb.io/a"]},
+                       {"name":"other"}):
+            with self.subTest(change=change):
+                with self.assertRaises(ValueError):
+                    k8gb.parse_index(index([dict(a, **change)]), "1.36")
+
+    def test_empty_missing_or_nonstable_index_does_not_succeed(self):
+        for content in (b"null", b"{}", index([]), index([entry("v1.0.0-rc1")[0]])):
+            with self.subTest(content=content):
+                with self.assertRaises(ValueError):
+                    k8gb.parse_index(content, "1.36")
+
+    def test_verified_archive_is_read_without_extraction(self):
+        a, body = entry()
+        k8gb.verify_chart(body, a)
+        with self.assertRaises(ValueError):
+            k8gb.verify_chart(body+b"x", a)
+
+    def test_matching_digest_does_not_hide_chart_metadata_mismatch(self):
+        a, _ = entry(); body = archive(a, appVersion="v2.0.0")
+        a["digest"] = hashlib.sha256(body).hexdigest()
+        with self.assertRaisesRegex(ValueError, "appVersion"):
+            k8gb.verify_chart(body, a)
+
+    def test_symlink_chart_metadata_is_rejected(self):
+        a, _ = entry(); output = io.BytesIO()
+        with tarfile.open(fileobj=output, mode="w:gz") as tar:
+            m = tarfile.TarInfo("k8gb/Chart.yaml"); m.type = tarfile.SYMTYPE; m.linkname = "/etc/passwd"; tar.addfile(m)
+        body = output.getvalue(); a["digest"] = hashlib.sha256(body).hexdigest()
+        with self.assertRaises(ValueError):
+            k8gb.verify_chart(body, a)
+
+    def test_render_boundary_keeps_arguments_and_reads_real_yaml(self):
+        result = subprocess.CompletedProcess([], 0, stdout="spec:\n  containers:\n    - image: example/k8gb:v1.0.0\n", stderr="")
+        with patch.object(k8gb.subprocess, "run", return_value=result) as run:
+            self.assertEqual(k8gb.chart_images(b"chart", "1.36"), ["example/k8gb:v1.0.0"])
+            self.assertEqual(run.call_args.args[0][-2:], ["--kube-version", "1.36"])
+            self.assertTrue(run.call_args.kwargs["check"])
+            self.assertFalse(Path(run.call_args.args[0][3]).exists())
+
+    def test_empty_render_is_an_error(self):
+        result = subprocess.CompletedProcess([], 0, stdout="apiVersion: v1\nkind: ConfigMap\n", stderr="")
+        with patch.object(k8gb.subprocess, "run", return_value=result):
+            with self.assertRaises(ValueError):
+                k8gb.chart_images(b"chart", "1.36")
+
+
+class ScrapeTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(); self.addCleanup(self.temp.cleanup)
+        self.file = Path(self.temp.name)/"k8gb.yaml"
+        self.original = {"icon":"https://www.k8gb.io/images/k8gb-icon-color.svg", "helm_repository_url":k8gb.HELM_REPOSITORY, "versions":[]}
+        self.file.write_text(yaml.safe_dump(self.original))
+        self.before = self.file.read_bytes()
+        a, body_a = entry(); b, body_b = entry("v0.14.0", ">=1.19.0-0")
+        self.entries = [a,b]
+        self.sources = {k8gb.INDEX_URL:index(self.entries), **{
+            f"{k8gb.HELM_REPOSITORY}/charts/k8gb-{v['version']}.tgz":body
+            for v,body in ((a,body_a),(b,body_b))}}
+        self.results = subprocess.CompletedProcess([], 0, stdout="spec:\n  containers:\n    - image: example/k8gb:v1.0.0\n", stderr="")
+
+    def execute(self, results=None):
+        with patch.object(k8gb,"TARGET_FILE", str(self.file)), \
+                patch.object(utils,"current_kube_version", return_value="1.36"), \
+                patch.object(k8gb,"fetch_bytes", side_effect=self.sources.__getitem__), \
+                patch.object(k8gb.subprocess,"run", side_effect=results) if results is not None else patch.object(k8gb.subprocess,"run", return_value=self.results):
+            return k8gb.scrape()
+
+    def test_real_writer_reducer_and_second_run_are_consistent(self):
+        result = self.execute()
+        self.assertEqual([r["version"] for r in result["versions"]], ["1.0.0", "0.14.0"])
+        self.assertEqual(yaml.safe_load(self.file.read_text()), result)
+        self.assertEqual(result["versions"][0]["chart_version"], "v1.0.0")
+        self.assertEqual(result["icon"], self.original["icon"])
+        once=self.file.read_bytes(); stamp=self.file.stat().st_mtime_ns
+        self.assertEqual(self.execute(), result)
+        self.assertEqual(self.file.read_bytes(), once)
+        self.assertEqual(self.file.stat().st_mtime_ns, stamp)
+
+    def test_second_render_failure_leaves_existing_file_unchanged(self):
+        error = subprocess.CalledProcessError(1, ["helm"], stderr="bad chart")
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.execute([self.results, error])
+        self.assertEqual(self.file.read_bytes(), self.before)
+
+    def test_second_archive_failure_leaves_existing_file_unchanged(self):
+        self.sources[f"{k8gb.HELM_REPOSITORY}/charts/k8gb-v0.14.0.tgz"] = b"corrupt"
+        with self.assertRaises(ValueError):
+            self.execute()
+        self.assertEqual(self.file.read_bytes(), self.before)
+
+    def test_malformed_second_index_entry_leaves_file_unchanged(self):
+        self.entries[1]["kubeVersion"] = ">=1.19.1"
+        self.sources[k8gb.INDEX_URL] = index(self.entries)
+        with self.assertRaises(ValueError):
+            self.execute()
+        self.assertEqual(self.file.read_bytes(), self.before)
+
+    def test_existing_summary_is_preserved(self):
+        self.original["versions"] = [{"version":"1.0.0","summary":{"features":["Existing note"]}}]
+        self.file.write_text(yaml.safe_dump(self.original))
+        self.assertEqual(self.execute()["versions"][0]["summary"], {"features":["Existing note"]})
+
+    def test_missing_target_never_creates_a_metadata_less_table(self):
+        self.file.unlink()
+        with self.assertRaises(ValueError):
+            self.execute()
+        self.assertFalse(self.file.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds K8GB to the compatibility catalog using its published Helm index and digest-verified chart archives. Includes the scraper, generated per-application table, manifest and aggregate entry, fixture provenance, and 20 offline tests.

Only stable chart/application versions with an explicit whole-minor `kubeVersion` floor are included. Floors are expanded through the repository's `KUBE_VERSION`, not indefinitely. These represent declared Helm installation requirements, not independently certified Kubernetes runtime compatibility. Prereleases, deprecated charts, and legacy charts without requirements are excluded; complex or patch-level constraints fail rather than being rounded.

The packaged name/version/appVersion/kubeVersion must agree with the index. Every retained archive must pass its SHA-256 check, render successfully with Helm, and yield images before the first table write. Existing reduction, merge, image extraction, and YAML-writing utilities are reused without changing shared behavior or invoking summarization APIs.

The aggregate receives only the new K8GB block. All 54 existing aggregate entries and their original bytes are preserved; unrelated catalog differences are not regenerated.

## Sources

- [Official Helm index](https://www.k8gb.io/index.yaml)
- [Official installation instructions](https://github.com/k8gb-io/k8gb/blob/v1.0.0/docs/deploy_ns1.md)
- [Release-tag support policy](https://github.com/k8gb-io/k8gb/blob/v1.0.0/README.md#production-readiness)
- [Prior published-chart verification](https://github.com/ugin-man/dsnts/actions/runs/34339860963)

The published v1.0.0 package and its tagged README declare Kubernetes >=1.21. The moving development branch's >=1.32 floor is not applied retrospectively to that released package.

## Test Plan

Submission base: `66bad0cd9d6b11215a2b35f4672441ec19671320`.
Verified contribution head: `2bb08ae105339390a56d673a2630252c21c2769d`.

[Fresh fork verification run](https://github.com/ugin-man/console/actions/runs/34421449283), Python 3.12.3 and Helm v3.21.4:

- `python -m pytest utils/compatibility/tests -q`: **147 tests and 106 subtests passed**, no failures or skips. This includes all 20 new K8GB tests.
- The real scraper ran twice with HTTP and Helm enabled: byte-identical output, 13 reduced catalog rows. Generated table SHA-256: `4260640d520e2692197acb8250af7613558f0f376185bbdfadc7efa053c95a8d`.
- All **58** aggregate/per-application/manifest YAML schema checks passed.
- The previous **54** aggregate entries were preserved unchanged; the manifest adds only `k8gb`.
- `git diff --cached --check` passed. The commit changes exactly seven files, with 677 added lines and no deletions.
- The earlier chart audit independently downloaded, digest-checked, compared packaged metadata, and rendered all 17 stable requirement-bearing published chart versions.

Offline tests substitute the HTTP and Helm process boundaries, while exercising production parsing, archive validation, reducer/merge, image extraction, and file writing. Tests also check that a failed second chart or render leaves the existing file unchanged. The separate live run does not substitute HTTP or Helm.

No Kubernetes cluster was deployed, no whole Console application build was run, and fork verification is not a claim that this PR's upstream checks have already passed. The validation harness is isolated on a fork-only staging branch and is not included in the contribution.

Prepared with ChatGPT assistance on behalf of `ugin-man`; the verification above was automated. Submitted under the published **$300 new compatibility scraper** contributor-program tier. No award is represented as earned before maintainer acceptance and the program's required process.

## Checklist

- [x] I have added a meaningful title and summary to convey the impact of this PR to a user.
- [x] Source documentation and fixture provenance are included.
- [x] I have added tests to cover my changes.
- Agent deployment verification: not applicable; no agent code changed.

Plural Flow: console
